### PR TITLE
Build now creates *.zip and *.jar packages.

### DIFF
--- a/build/_template.xml
+++ b/build/_template.xml
@@ -13,6 +13,41 @@
   <import file="build.deps.xml" />
   <deps-declare-taskdef />
 
+  <property name="dist.dir"                     value="${basedir}/dist/" />
+
+  <property name="dist.umple.zip"               value="umple-${umple.version}.zip" />
+  <property name="dist.umple.all.zip"           value="umple-all-${umple.version}.zip" />
+  <property name="dist.umple.deps.zip"          value="umple-deps-${umple.version}.zip" />
+  <property name="dist.umple.core.zip"          value="umple-core-${umple.version}.zip" />
+  <property name="dist.umple.umplificator.zip"  value="umple-umplificator-${umple.version}.zip" />
+  <property name="dist.umple.validator.zip"     value="umple-validator-${umple.version}.zip" />
+  <property name="dist.umple.extras.zip"        value="umple-extras-${umple.version}.zip" />
+
+  <property name="dist.umple.jar"               value="umple-${umple.version}.jar" />
+  <property name="dist.umple.umplificator.jar"  value="umplificator-${umple.version}.jar" />
+  <property name="dist.umple.validator.jar"     value="validator-${umple.version}.jar" />
+  <property name="dist.umple.vml.jar"           value="vml-${umple.version}.jar" />
+  <property name="dist.umple.stats.jar"         value="umplestats-${umple.version}.jar" />
+  <property name="dist.umple.docs.jar"          value="umpledocs-${umple.version}.jar" />
+  <property name="dist.umple.sync.jar"          value="umplesync-${umple.version}.jar" />
+  <property name="dist.umple.run.jar"           value="umplerun-${umple.version}.jar" />
+
+  <macrodef name="build-zip">
+    <attribute  name="name"     description="Name of zipped archive" />
+    <attribute  name="includes" description="Included files relative to `dist.dir`" 
+                default="" />
+    <element    name="fileset"  description="Files to include in zip archive" 
+                optional="true" implicit="true" />
+
+    <sequential>
+      <zip  destfile="${dist.dir}/@{name}"
+          basedir="${dist.dir}"
+          includes="@{includes}">
+          <fileset/>
+      </zip>
+    </sequential>
+  </macrodef>
+
   <!-- ```````````````````````````
     Clean up and initialize any potential byproduct
   ``````````````````````````` -->

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -135,7 +135,7 @@
       <!-- Compile in umple to Java -->
       <trycatch>
         <try>
-          <java jar="dist/umple.jar" fork="true" failonerror="true" dir="${java.path}">
+          <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true" dir="${java.path}">
             <arg value="-g" />
             <arg value="Java" />
             <arg value="--path" />
@@ -252,7 +252,7 @@
       <!-- Compile in umple to Cpp -->
       <trycatch>
         <try>
-          <java jar="dist/umple.jar" fork="true" failonerror="true" dir="${cpp.path}">
+          <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true" dir="${cpp.path}">
             <arg value="-g" />
             <arg value="RTCpp" />
             <arg value="--path" />
@@ -392,7 +392,7 @@
       <!-- Compile in umple to Php -->
       <trycatch>
         <try>
-          <java jar="dist/umple.jar" fork="true" failonerror="true" dir="${php.path}">
+          <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true" dir="${php.path}">
             <arg value="-g" />
             <arg value="Php" />
             <arg value="--path" />
@@ -522,7 +522,7 @@
       <!-- Compile in umple to Ruby -->
       <trycatch>
         <try>
-          <java jar="dist/umple.jar" fork="true" failonerror="true" dir="${ruby.path}">
+          <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true" dir="${ruby.path}">
             <arg value="-g" />
             <arg value="Ruby" />
             <arg value="--path" />

--- a/build/build.sandbox.xml
+++ b/build/build.sandbox.xml
@@ -21,7 +21,8 @@
   ``````````````````````````` -->
 
   <target name="umpleSandbox">
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <echo>${dist.dir}/${dist.umple.jar}</echo>
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="sandbox/src/sandbox.ump"/>
     </java>
   </target>

--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -77,7 +77,7 @@
     <deps-resolve conf="core" pathid="core.ivy.classpath" />
     <deps-resolve conf="test" pathid="test.ivy.classpath" />
 
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="testbed/src/TestHarness.ump"/>
     </java>
 
@@ -98,7 +98,7 @@
   <target name="compilePhp">
     <deps-resolve conf="core" pathid="core.ivy.classpath" />
 
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="testbed_php/src/TestHarnessPhp.ump"/>
     </java>
 
@@ -125,7 +125,7 @@
   <target name="compileRuby">
     <deps-resolve conf="core" pathid="core.ivy.classpath" />
 
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="testbed_ruby/src/TestHarnessRuby.ump"/>
     </java>
   </target>

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -52,7 +52,7 @@
     <java jar="${umple.last.jar.file}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
     </java>
-     <java jar="${umple.last.jar.file}" fork="true" failonerror="true">
+    <java jar="${umple.last.jar.file}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
     </java>
   </target>
@@ -63,13 +63,13 @@
 
     <deps-resolve conf="core" pathid="core.ivy.classpath" />
 
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple/src/Master.ump"/>
     </java>
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
     </java>
-    <java jar="dist/umple.jar" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
     </java>
   </target>
@@ -97,20 +97,6 @@
     <copy todir="UmpleToCpp/templates" overwrite="true">
       <fileset dir="UmpleToTemplate/templates" excludes=".git*" />
     </copy>
-  </target>
-
-  <!-- Unzip JDT libraries into the jar construction folder -->
-  <target name="validatorJar">
-    <unjar src="lib/umplificatorplugins/org.eclipse.core.contenttype_3.4.200.v20130326-1255.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.core.jobs_3.5.300.v20130429-1813.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.core.resources_3.8.100.v20130521-2026.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.core.runtime_3.9.0.v20130326-1255.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.equinox.preferences_3.5.100.v20130422-1538.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.equinox.common_3.6.200.v20130402-1505.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.jdt.core_3.9.1.v20130905-0837.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-    <unjar src="lib/umplificatorplugins/org.eclipse.osgi_3.9.0.v20130529-1710.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-	  <unjar src="lib/umplificatorplugins/org.eclipse.cdt.core_5.5.0.201309180223.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
-	  <unjar src="lib/umplificatorplugins/com.ibm.icu_50.1.1.v201304230130.jar" dest="cruise.umple.validator/bin/" overwrite="true"/>
   </target>
     
   <!-- Move the generated code from UmpleTo* to cruise.umple -->
@@ -167,10 +153,12 @@
       <classpath refid="core.ivy.classpath" />
       <classpath refid="test.ivy.classpath" />
     </javac>
+
     <copy todir="${bin.path}" overwrite="true">
 	    <fileset dir="${project.path}/src"><include name="**/*.grammar"/></fileset>
 	    <fileset dir="${project.path}/src"><include name="**/*.error"/></fileset>
     </copy>
+
     <delete file="cruise.umple/src/rules.grammar"/>
     <delete file="cruise.umple/bin/rules.grammar"/>
   </target>
@@ -186,7 +174,12 @@
     <deps-resolve conf="validator"    pathid="validator.ivy.classpath" />
     <deps-resolve conf="test"         pathid="test.ivy.classpath" />
 
-    <javac debug="true" includeantruntime="false" debuglevel="source,lines,vars" destdir="cruise.umple.validator/bin" source="1.8" target="1.8">
+    <javac  debug="true" 
+            includeantruntime="false" 
+            debuglevel="source,lines,vars" 
+            destdir="cruise.umple.validator/bin" 
+            source="1.8" 
+            target="1.8">
       <src path="${project.path}/src"/>
       <src path="${project.path}/src-gen-jet"/>
       <src path="${project.path}/src-gen-umple"/>
@@ -214,7 +207,12 @@
     <deps-resolve conf="umplificator" pathid="umplificator.ivy.classpath" />
     <deps-resolve conf="test"         pathid="test.ivy.classpath" />
 
-    <javac debug="true" includeantruntime="false" debuglevel="source,lines,vars" destdir="cruise.umplificator/bin" source="1.8" target="1.8">
+    <javac  debug="true" 
+            includeantruntime="false" 
+            debuglevel="source,lines,vars" 
+            destdir="cruise.umplificator/bin" 
+            source="1.8" 
+            target="1.8">
       <src path="${project.path}/src"/>
       <src path="${project.path}/src-gen-jet"/>
       <src path="${project.path}/src-gen-umple"/>
@@ -240,7 +238,7 @@
   ``````````````````````````` -->
 
   <target name="packageDocs">
-    <java classname="cruise.umple.docs.DocumenterMain" fork="true" classpath="dist/umpledocs.jar">
+    <java classname="cruise.umple.docs.DocumenterMain" fork="true" classpath="${dist.dir}/${dist.umple.docs.jar}">
       <arg value="build/reference"/>
       <arg value="${dist.path}/reference"/>
     </java>
@@ -250,145 +248,145 @@
   </target>
   
   <target name="packageUmpleonline" if="${shouldPackageUmpleOnline}">
-    <copy file="dist/umplesync.jar" tofile="umpleonline/scripts/umplesync.jar" overwrite="true" />
-    <copy file="dist/umple.jar" tofile="umpleonline/scripts/umple.jar" overwrite="true" />
-    <copy file="dist/vml.jar" tofile="umpleonline/scripts/vml.jar" overwrite="true" />
+    <copy file="${dist.dir}/${dist.umple.sync.jar}" 
+          tofile="umpleonline/scripts/umplesync.jar"  
+          overwrite="true" />
+
+    <copy file="${dist.dir}/${dist.umple.jar}"      
+          tofile="umpleonline/scripts/umple.jar"      
+          overwrite="true" />
+
+    <copy file="${dist.dir}/${dist.umple.vml.jar}"  
+          tofile="umpleonline/scripts/vml.jar"        
+          overwrite="true" />
   </target>
 
-<!-- The Umplificator jar-->
-<target name="packageUmplificator">
+  <!-- The Umplificator jar-->
+  <target name="packageUmplificator">
 
+    <deps-resolve conf="umplificator" pathid="umplificator.ivy.classpath" />
+    <manifestclasspath property="umple.umplificator.jar.classpath" jarfile="${dist.dir}/${dist.umple.jar}" >
+      <classpath refid="umplificator.ivy.classpath"/>
+    </manifestclasspath>
 
-  <jar destfile="dist/umplificator_${umple.version}.jar" filesetmanifest="mergewithoutmain">
-    <manifest>
-     <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-     <attribute name="Version" value="${umple.version}"/>
-     <attribute name="Main-Class" value="cruise.umplificator.UmplificatorMain"/>
-     <attribute name="Class-Path" value="."/>
-   </manifest>
-   <fileset dir="cruise.umplificator/bin"/>
-<!--    <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/com.ibm.icu_50.1.1.v201304230130.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/commons-collections4-4.0.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/commons-configuration-1.10.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/commons-lang-2.5.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/commons-logging-1.1.3.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.cdt.core_5.5.0.201309180223.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.core.contenttype_3.4.200.v20130326-1255.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.core.jobs_3.5.300.v20130429-1813.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.core.resources_3.8.100.v20130521-2026.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.core.runtime_3.9.0.v20130326-1255.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.equinox.common_3.6.200.v20130402-1505.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.equinox.preferences_3.5.100.v20130422-1538.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.jdt.core_3.9.1.v20130905-0837.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.osgi_3.9.0.v20130529-1710.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.jface_3.10.0.v20140604-0740.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/org.eclipse.text_3.5.300.v20130515-1451.jar"/>
+    <jar  destfile="${dist.dir}/${dist.umple.umplificator.jar}" 
+          filesetmanifest="mergewithoutmain">
+      <manifest>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umplificator.UmplificatorMain"/>
+        <attribute name="Class-Path"  value="${umple.umplificator.jar.classpath}"/>
+      </manifest>
+      <fileset dir="cruise.umplificator/bin"/>
+    </jar>
 
-   <zipfileset excludes="META-INF/*.SF" src="lib/junit.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/antlr-runtime-3.5.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/drools-compiler-6.0.1.Final.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/drools-core-6.0.1.Final.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/drools-jsr94-6.0.1.Final.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/kie-api-6.0.1.Final.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/kie-internal-6.0.1.Final.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/mvel2-2.1.8.Final.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/protobuf-java-2.5.0.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/xstream-1.4.3.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/slf4j-api-1.7.6.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/droolsplugins/slf4j-simple-1.7.6.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/commons-io-2.4.jar"/>
-
-   <zipfileset excludes="META-INF/*.SF" src="dist/umple.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/log4j-core-2.0.1.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/log4j-api-2.0.1.jar"/>
-   <zipfileset excludes="META-INF/*.SF" src="lib/umplificatorplugins/perf4j-0.9.16.jar"/> -->
- </jar>
-</target>
+    <build-zip name="${dist.umple.umplificator.zip}"
+               includes="${umple.umplificator.jar.classpath} ${dist.umple.umplificator.jar}" />
+  </target>
 
   <target name="packageValidator">
-    <antcall target="validatorJar"/>
     <echo message="Package: Umplificator and Validator jar" />
 
     <deps-get-path conf="validator" pathid="validator.ivy.classpath" />
 
-    <manifestclasspath property="umple.validator.jar.classpath" jarfile="dist/umple.jar" >
+    <manifestclasspath property="umple.validator.jar.classpath" jarfile="${dist.dir}/${dist.umple.jar}" >
       <classpath refid="validator.ivy.classpath"/>
     </manifestclasspath>
     
     <!-- The validator jar-->
     <echo message="Package: Umple validator jar used in Umple " />
-    <jar destfile="dist/umplevalidator_${umple.version}.jar" 
+    <jar destfile="${dist.dir}/${dist.umple.validator.jar}" 
          basedir="cruise.umple.validator/bin" 
          includes="cruise/umple/** cruise/umple/validator** org/eclipse/** en.error org/** *.grammar *.error templates/** org/apache/**" >
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.umple.CodeGenValidatorMainConsole"/>
-        <attribute name="Class-Path" value="${validator.project.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umple.CodeGenValidatorMainConsole"/>
+        <attribute name="Class-Path"  value="${umple.validator.jar.classpath}"/>
       </manifest>
     </jar>
+
+    <build-zip name="${dist.umple.validator.zip}"
+               includes="${umple.validator.jar.classpath} ${dist.umple.validator.jar}" />
   </target>
 
   <target name="packageMainJar">
     <echo message="Package: Main command line jar" />
 
     <deps-get-path conf="core" pathid="core.ivy.classpath" />
-
-    <manifestclasspath property="umple.jar.classpath" jarfile="dist/umple.jar" >
+    <manifestclasspath property="umple.jar.classpath" jarfile="${dist.dir}/${dist.umple.jar}" >
       <classpath refid="core.ivy.classpath"/>
     </manifestclasspath>
 
-    <jar destfile="dist/umple.jar" 
+    <deps-get-path conf="test" pathid="test.ivy.classpath" />
+    <manifestclasspath property="umple.test.jar.classpath" jarfile="${dist.dir}/${dist.umple.jar}" >
+      <classpath refid="test.ivy.classpath"/>
+    </manifestclasspath>
+
+    <jar destfile="${dist.dir}/${dist.umple.jar}" 
          basedir="${bin.path}" 
          includes="cruise/umple/** en.error *.grammar *.error templates/** org/apache/**" 
          excludes="**/*Test.class">
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.umple.UmpleConsoleMain"/>
-        <attribute name="Class-Path" value="${umple.jar.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umple.UmpleConsoleMain"/>
+        <attribute name="Class-Path"  value="${umple.jar.classpath} ${umple.test.jar.classpath}"/>
       </manifest>
-
     </jar>  
+
+    <build-zip name="${dist.umple.core.zip}"
+               includes="${umple.jar.classpath} ${umple.test.jar.classpath} ${dist.umple.jar}" />
   </target>
 
   <target name="packageJars">
     <antcall target="packageMainJar" />
+    <antcall target="packageValidator" />
+    <antcall target="packageUmplificator" />
 
     <deps-get-path conf="core" pathid="core.ivy.classpath" />
-
-    <manifestclasspath property="umple.jar.classpath" jarfile="dist/umple.jar" >
+    <manifestclasspath property="umple.jar.classpath" jarfile="${dist.dir}/${dist.umple.jar}" >
       <classpath refid="core.ivy.classpath"/>
     </manifestclasspath>
 
+    <deps-get-path conf="test" pathid="test.ivy.classpath" />
+    <manifestclasspath property="umple.test.jar.classpath" jarfile="${dist.dir}/${dist.umple.jar}" >
+      <classpath refid="test.ivy.classpath"/>
+    </manifestclasspath>
 
     <echo message="Package: Umple statistics jar" />
-    <jar destfile="dist/umplestats.jar" basedir="${bin.path}" includes="cruise/umple/** *.grammar *.error templates/** org/apache/**">
+    <jar  destfile="${dist.dir}/${dist.umple.stats.jar}"  
+          basedir="${bin.path}" 
+          includes="cruise/umple/** *.grammar *.error templates/** org/apache/**">
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.umple.stats.StatsMain"/>
-        <attribute name="Class-Path" value="${umple.jar.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umple.stats.StatsMain"/>
+        <attribute name="Class-Path"  value="${umple.jar.classpath}"/>
       </manifest>
     </jar>
 
     <echo message="Package: Umple documenter jar used to build the user manual" />
-    <jar destfile="dist/umpledocs.jar" basedir="${bin.path}" includes="cruise/umple/** en.error *.grammar *.error templates/** org/apache/**">
+    <jar  destfile="${dist.dir}/${dist.umple.docs.jar}"  
+          basedir="${bin.path}" 
+          includes="cruise/umple/** en.error *.grammar *.error templates/** org/apache/**">
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.umple.docs.DocumenterMain"/>
-        <attribute name="Class-Path" value="${umple.jar.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umple.docs.DocumenterMain"/>
+        <attribute name="Class-Path"  value="${umple.jar.classpath}"/>
       </manifest>
     </jar>
 
     <echo message="Package: Umple sync jar used in UmpleOnline to compile and sync diagram - See PlaygroundMain" />
-    <jar destfile="dist/umplesync.jar" basedir="${bin.path}" includes="cruise/umple/** en.error org/apache/tools/ant/** *.grammar *.error templates/** org/apache/**">
+    <jar  destfile="${dist.dir}/${dist.umple.sync.jar}"  
+          basedir="${bin.path}" 
+          includes="cruise/umple/** en.error org/apache/tools/ant/** *.grammar *.error templates/** org/apache/**">
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.umple.PlaygroundMain"/>
-        <attribute name="Class-Path" value="${umple.jar.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umple.PlaygroundMain"/>
+        <attribute name="Class-Path"  value="${umple.jar.classpath}"/>
       </manifest>
     </jar>
  
@@ -397,24 +395,34 @@
       <fileset dir="lib/umplerun"/>
     </copy>
 
-    <jar destfile="dist/umplerun.jar" basedir="${bin.path}" includes="cruise/umple/** en.error org/** *.grammar *.error templates/** org/apache/**">
+    <jar  destfile="${dist.dir}/${dist.umple.run.jar}"  
+          basedir="${bin.path}" 
+          includes="cruise/umple/** en.error org/** *.grammar *.error templates/** org/apache/**">
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.umple.UmpleRunMain"/>
-        <attribute name="Class-Path" value="${umple.jar.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.umple.UmpleRunMain"/>
+        <attribute name="Class-Path"  value="${umple.jar.classpath}"/>
       </manifest>
     </jar>
 
     <echo message="Package: VML - Tool for variability modeling" />
-    <jar destfile="dist/vml.jar" basedir="${bin.path}" includes="cruise/umple/** en.error cruise/vml/** *.grammar *.error templates/** org/apache/**">
+    <jar  destfile="${dist.dir}/${dist.umple.vml.jar}" 
+          basedir="${bin.path}" 
+          includes="cruise/umple/** en.error cruise/vml/** *.grammar *.error templates/** org/apache/**">
       <manifest>
-        <attribute name="Built-By" value="Cruise - University of Ottawa"/>
-        <attribute name="Version" value="${umple.version}"/>
-        <attribute name="Main-Class" value="cruise.vml.VmlConsole"/>
-        <attribute name="Class-Path" value="${umple.jar.classpath}"/>
+        <attribute name="Built-By"    value="Cruise - University of Ottawa"/>
+        <attribute name="Version"     value="${umple.version}"/>
+        <attribute name="Main-Class"  value="cruise.vml.VmlConsole"/>
+        <attribute name="Class-Path"  value="${umple.jar.classpath}"/>
       </manifest>
     </jar>
+
+    <property name="dist.umple.extras.jars" 
+              value="${dist.umple.vml.jar} ${dist.umple.sync.jar} ${dist.umple.docs.jar} ${dist.umple.run.jar} ${dist.umple.stats.jar}" />
+
+    <build-zip name="${dist.umple.extras.zip}"
+               includes="${umple.jar.classpath} ${umple.test.jar.classpath} ${dist.umple.extras.jars}" />
 
 	  <!-- TODO: UNCOMMENT ONCE XTEXT IN THE MIX -->
     <!-- <copy todir="dist/update">
@@ -444,13 +452,13 @@
   
   <target name="deployUmpleonlineJars" >
     <copy file="dist/umplesync.jar" tofile="/h/ralph/sites/www/html/umpleonline/scripts/umplesync.jar" overwrite="true" />
-    <copy file="dist/umple.jar" tofile="/h/ralph/sites/www/html/umpleonline/scripts/umple.jar" overwrite="true" />
+    <copy file="${dist.dir}/${dist.umple.jar}" tofile="/h/ralph/sites/www/html/umpleonline/scripts/umple.jar" overwrite="true" />
     <copy file="dist/vml.jar" tofile="/h/ralph/sites/www/html/umpleonline/scripts/vml.jar" overwrite="true" />
   </target>
 
   <target name="deployUpdatedLib">
     <copy file="dist/umplesync.jar" tofile="lib/umplesync.jar" overwrite="true" />
-    <copy file="dist/umple.jar" tofile="lib/umple.jar" overwrite="true" />
+    <copy file="${dist.dir}/${dist.umple.jar}" tofile="lib/umple.jar" overwrite="true" />
     <copy file="dist/vml.jar" tofile="lib/vml.jar" overwrite="true" />
   </target>
 

--- a/build/build.umplificatorplugin.xml
+++ b/build/build.umplificatorplugin.xml
@@ -108,7 +108,7 @@
     Compile Umple files 
   ``````````````````````````` -->
   <target name="umpleSelf">
-     <java jar="dist/umple.jar" fork="true" failonerror="true">
+     <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
     </java>
   </target>


### PR DESCRIPTION
 The zip packages can be unpacked and ran immediately.

The zips contain the listed jars + the dependencies required to run the contained jars. Please verify that this is true. 
- umple-core-1.22.0-4e42e14.zip
  - umple-1.22.0-4e42e14.jar
- umple-umplificator-1.22.0-4e42e14.zip
  - umplificator-1.22.0-4e42e14.jar
- umple-validator-1.22.0-4e42e14.zip
  - validator-1.22.0-4e42e14.jar
- umple-extras-1.22.0-4e42e14.zip
  - umpledocs-1.22.0-4e42e14.jar
  - umplerun-1.22.0-4e42e14.jar
  - umplestats-1.22.0-4e42e14.jar
  - umplesync-1.22.0-4e42e14.jar
  - vml-1.22.0-4e42e14.jar
