### PR TITLE
Update travis badge from umple-ucosp to just umple

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Umple Modelling Language
 
-[![Build Status](https://travis-ci.org/umple-ucosp/umple.svg?branch=master)](https://travis-ci.org/umple-ucosp/umple)
+[![Build Status](https://travis-ci.org/umple/umple.svg?branch=master)](https://travis-ci.org/umple/umple)
 
 ##Introduction
 


### PR DESCRIPTION
This will get the travis badge to work against the correct umple repo (renamed from umple-ucosp during our merge from google code)
