### PR TITLE
Issue #411 - tabs for generated code in umpleonline

### DIFF
--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -533,8 +533,8 @@ class PlaygroundMain
         {
           answer += "\n\n\n\n";
         }
-	answer += "//%% NEW FILE " + generatedCode.getKey() + " BEGINS HERE %%\n\n";
-        answer += generatedCode.getValue();
+				answer += "//%% NEW FILE " + generatedCode.getKey() + " BEGINS HERE %%\n\n";
+				answer += generatedCode.getValue();
       }
     }
     else if ("-generate".equals(args[0]))

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -292,7 +292,7 @@ class UmpleConsoleMain
     
     optparser.acceptsAll(Arrays.asList("version", "v"), "Print out the current Umple version number");
     optparser.acceptsAll(Arrays.asList("help"), "Display the help message");
-    optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: Java,Cpp,RTCpp,SimpleCpp,Php,Ruby,SQL,Json,Ecore,TextUml,GvStateDiagram,StructureDiagram,GvClassDiagram,GvClassTraitDiagram,GvEntityRelationshipDiagram,Alloy,NuSMV,Yuml,SimpleMetrics,Uigu2").withRequiredArg().ofType(String.class);
+    optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: Java,Cpp,RTCpp,SimpleCpp,Php,Ruby,SQL,Ruby,Json,Ecore,TextUml,GvStateDiagram,StructureDiagram,GvClassDiagram,GvClassTraitDiagram,GvEntityRelationshipDiagram,Alloy,NuSMV,Yuml,SimpleMetrics,Uigu2").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("override"), "If a output language <lang> is specified using option -g, output will only generate language <lang>");
     optparser.acceptsAll(Arrays.asList("path"), "If a output language is specified using option -g, output source code will be placed to path").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles").withRequiredArg().ofType(String.class);
@@ -433,6 +433,7 @@ class PlaygroundMain
   depend cruise.umple.compiler.exceptions.*;
   depend cruise.umple.util.*;
   depend java.io.*;
+  depend java.util.*;
 
   public static void main(String[] args)
   {
@@ -527,12 +528,13 @@ class PlaygroundMain
     }
     else if ("-source".equals(args[0]))
     {
-      for (String generatedCode : model.getGeneratedCode().values()) {
+      for (Map.Entry<String, String> generatedCode : model.getGeneratedCode().entrySet()) {
         if (answer.length() > 0)
         {
           answer += "\n\n\n\n";
         }
-        answer += generatedCode;
+	answer += "//%% NEW FILE " + generatedCode.getKey() + " BEGINS HERE %%\n\n";
+        answer += generatedCode.getValue();
       }
     }
     else if ("-generate".equals(args[0]))

--- a/cruise.umple/test/cruise/umple/PlaygroundMainTest.java
+++ b/cruise.umple/test/cruise/umple/PlaygroundMainTest.java
@@ -90,7 +90,7 @@ public class PlaygroundMainTest
     String[] args = new String[] {"-source","myfile.ump"};
     
     PlaygroundMain.main(args);
-    Assert.assertEquals(true,outErrIntercept.toString().startsWith("/*PLEASE DO NOT EDIT THIS CODE*/"));
+    Assert.assertEquals(true,outErrIntercept.toString().startsWith("//%% NEW FILE One BEGINS HERE %%\n\n/*PLEASE DO NOT EDIT THIS CODE*/"));
   }
 
   

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -246,11 +246,7 @@ function extractFilename()
     {
       file_put_contents($destfile, file_get_contents("http://" . $_REQUEST["filename"]));
       if(substr($http_response_header[0],-2)!="OK") {
-         // try https
-        file_put_contents($destfile, file_get_contents("https://" . $_REQUEST["filename"]));
-        if(substr($http_response_header[0],-2)!="OK") {         
-          file_put_contents($destfile, "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"]);
-        }
+        file_put_contents($destfile, "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"]);
       }
     }
   }

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -2067,7 +2067,7 @@ Action.toggleTabsCheckbox = function(language)
 	}
 
 	if(language == "java" || language == "php" || language == "cpp" 
-    || language == "ruby"){
+    || language == "ruby" || language == "sql"){
 		jQuery("#ttTabsCheckbox").show();
 		jQuery("#tabRow").show();
 	}
@@ -2118,6 +2118,7 @@ Action.generateTabsCode = function()
 	var strFileContents = "";
 	var arrFileNames = [];
 	var strNewLine = "";
+	var skipSpace = false;
 
 	// Read full code output line by line
   jQuery('.content').each(function(){
@@ -2129,12 +2130,17 @@ Action.generateTabsCode = function()
 			arrCodeFiles[intFileCounter] = strFileContents;
 			intFileCounter++;
 			jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
-    	strFileContents = "";
-			strFileContents += "<a href=\"umpleonline/../ump/tmp238804/JavaFromUmple.zip\" class=\"zipDownloadLink\">Download the following as a zip file</a>&nbsp;<p>URL_SPLIT";
+			strFileContents = "<p>URL_SPLIT";
+			skipSpace = true;
     }
 		else{
-			strFileContents += strNewLine + jQuery(this).text();
-			strNewLine = "\n";
+			if(!skipSpace){
+				strFileContents += strNewLine + jQuery(this).text();
+				strNewLine = "\n";
+			}
+			else{
+				skipSpace = false;
+			}
 		}
 
   });
@@ -2154,8 +2160,9 @@ function showTab(event)
 		// Show only relevant file codeblock
 		jQuery('#innerGeneratedCodeRow' + event.data.tabnumber).show();
 
-		// Generate code for specific file only
+		// Highlight code for specific file only
   	Page.showGeneratedCode(event.data.code, $("inputGenerateCode").value.split(":")[0], event.data.tabnumber);
+		jQuery('.line').last().hide();
 		jQuery('.line').last().hide();
 
 		// Hide main code window with glommed files

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -174,6 +174,10 @@ Action.clicked = function(event)
   {
     Action.generateStructureDiagramFile();
   }
+  else if(action == "TabsCheckbox")
+  {
+    Action.toggleTabs();
+  }
 }
 
 Action.focusOn = function(id, gained)
@@ -681,6 +685,8 @@ Action.generateCode = function(languageStyle, languageName)
     format("language={0}&languageStyle={1}", actualLanguage, languageStyle),
     "true"
   );
+	jQuery("#buttonTabsCheckbox").prop('checked', false);
+	jQuery("#tabRow").hide();
 }
 
 Action.photoReady = function()
@@ -2054,4 +2060,80 @@ Mousetrap.bind(['c'], function(e){
     }        
   }
 });
+
+// Function for splitting code into tabs for every new file, activated when checking the Show Tabs checkbox
+Action.toggleTabs = function()
+{
+  // Checking on the checkbox
+  if(jQuery('#buttonTabsCheckbox').is(':checked')){
+
+		// Show row with buttons for each filename
+		jQuery('#tabRow').html('');
+		jQuery('#tabRow').show();
+
+		// Hide main code window with glommed files
+		jQuery('#innerGeneratedCodeRow').nextAll().remove();
+		jQuery('#innerGeneratedCodeRow').hide();
+
+    var arrCodeFiles = [];
+		var intFileCounter = 0;
+		var strFileContents = "";
+		var arrFileNames = [];
+
+		// Read full code output line by line
+    jQuery('.content').each(function(){
+
+			// If New File Beginning
+      if(jQuery(this).text().indexOf("//%%") >= 0){
+				strFileName = jQuery(this).text().slice(14);
+				strFileName = strFileName.substr(0, strFileName.indexOf(' '));
+				arrFileNames[intFileCounter] = strFileName;
+				arrCodeFiles[intFileCounter] = strFileContents;
+				intFileCounter++;
+				jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
+      	strFileContents = "";
+				strFileContents += "<a href=\"umpleonline/../ump/tmp238804/JavaFromUmple.zip\" class=\"zipDownloadLink\">Download the following as a zip file</a>&nbsp;<p>URL_SPLIT";
+				strFileContents += jQuery(this).text() + "\n";
+      }
+			else{
+				strFileContents += jQuery(this).text() + "\n";
+			}
+
+    });
+
+		// Output buttons for number of files found
+		for (i=1; i < intFileCounter; i++){
+			jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i-1] + "</button>");
+			jQuery('#tabButton' + i).click({code: arrCodeFiles[i], tabnumber: i}, showTab);
+		}
+
+  }
+  // Checking off the checkbox
+  else{
+		// Hide row with buttons
+    jQuery('#tabRow').html('');
+
+		// Show main code window with glommed files
+		jQuery('#innerGeneratedCodeRow').show();
+
+		// Hide all file codeblocks
+		jQuery('#innerGeneratedCodeRow').nextAll().remove();
+  }
+}
+
+function showTab(event)
+{
+		// Hide all file codeblocks
+		jQuery('#innerGeneratedCodeRow').nextAll().hide();
+
+		// Show only relevant file codeblock
+		jQuery('#innerGeneratedCodeRow' + event.data.tabnumber).show();
+
+		// Generate code for specific file only
+  	Page.showGeneratedCode(event.data.code, $("inputGenerateCode").value.split(":")[0], event.data.tabnumber);
+		jQuery('.line').last().hide();
+
+		// Hide main code window with glommed files
+		jQuery('#innerGeneratedCodeRow').hide();
+}
 

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -685,8 +685,6 @@ Action.generateCode = function(languageStyle, languageName)
     format("language={0}&languageStyle={1}", actualLanguage, languageStyle),
     "true"
   );
-	jQuery("#buttonTabsCheckbox").prop('checked', false);
-	jQuery("#tabRow").hide();
 }
 
 Action.photoReady = function()
@@ -2061,6 +2059,27 @@ Mousetrap.bind(['c'], function(e){
   }
 });
 
+Action.toggleTabsCheckbox = function(language)
+{
+	// Workaround for TextUml having java prefix
+	if($("inputGenerateCode").value.split(":")[1] == "TextUml"){
+		language = "TextUml";
+	}
+
+	if(language == "java" || language == "php" || language == "cpp" 
+    || language == "ruby"){
+		jQuery("#ttTabsCheckbox").show();
+		jQuery("#tabRow").show();
+	}
+	else{
+		jQuery("#ttTabsCheckbox").hide();
+		jQuery("#tabRow").hide();
+		if(jQuery('#buttonTabsCheckbox').is(':checked')){
+			jQuery('#buttonTabsCheckbox').click();
+		}
+	}
+}
+
 // Function for splitting code into tabs for every new file, activated when checking the Show Tabs checkbox
 Action.toggleTabs = function()
 {
@@ -2068,57 +2087,63 @@ Action.toggleTabs = function()
   if(jQuery('#buttonTabsCheckbox').is(':checked')){
 
 		// Show row with buttons for each filename
-		jQuery('#tabRow').html('');
 		jQuery('#tabRow').show();
 
 		// Hide main code window with glommed files
-		jQuery('#innerGeneratedCodeRow').nextAll().remove();
 		jQuery('#innerGeneratedCodeRow').hide();
 
-    var arrCodeFiles = [];
-		var intFileCounter = 0;
-		var strFileContents = "";
-		var arrFileNames = [];
-
-		// Read full code output line by line
-    jQuery('.content').each(function(){
-
-			// If New File Beginning
-      if(jQuery(this).text().indexOf("//%%") >= 0){
-				strFileName = jQuery(this).text().slice(14);
-				strFileName = strFileName.substr(0, strFileName.indexOf(' '));
-				arrFileNames[intFileCounter] = strFileName;
-				arrCodeFiles[intFileCounter] = strFileContents;
-				intFileCounter++;
-				jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
-      	strFileContents = "";
-				strFileContents += "<a href=\"umpleonline/../ump/tmp238804/JavaFromUmple.zip\" class=\"zipDownloadLink\">Download the following as a zip file</a>&nbsp;<p>URL_SPLIT";
-				strFileContents += jQuery(this).text() + "\n";
-      }
-			else{
-				strFileContents += jQuery(this).text() + "\n";
-			}
-
-    });
-
-		// Output buttons for number of files found
-		for (i=1; i < intFileCounter; i++){
-			jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i-1] + "</button>");
-			jQuery('#tabButton' + i).click({code: arrCodeFiles[i], tabnumber: i}, showTab);
-		}
+		// Show first file codeblock
+		jQuery('#tabButton1').click();
 
   }
   // Checking off the checkbox
   else{
+
 		// Hide row with buttons
-    jQuery('#tabRow').html('');
+    jQuery('#tabRow').hide();
 
 		// Show main code window with glommed files
 		jQuery('#innerGeneratedCodeRow').show();
 
 		// Hide all file codeblocks
-		jQuery('#innerGeneratedCodeRow').nextAll().remove();
+		jQuery('#innerGeneratedCodeRow').nextAll().hide();
+
   }
+}
+
+Action.generateTabsCode = function()
+{
+	var arrCodeFiles = [];
+	var intFileCounter = 0;
+	var strFileContents = "";
+	var arrFileNames = [];
+	var strNewLine = "";
+
+	// Read full code output line by line
+  jQuery('.content').each(function(){
+		// If New File Beginning
+    if(jQuery(this).text().indexOf("//%%") >= 0){
+			strFileName = jQuery(this).text().slice(14);
+			strFileName = strFileName.substr(0, strFileName.indexOf(' '));
+			arrFileNames[intFileCounter] = strFileName;
+			arrCodeFiles[intFileCounter] = strFileContents;
+			intFileCounter++;
+			jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
+    	strFileContents = "";
+			strFileContents += "<a href=\"umpleonline/../ump/tmp238804/JavaFromUmple.zip\" class=\"zipDownloadLink\">Download the following as a zip file</a>&nbsp;<p>URL_SPLIT";
+    }
+		else{
+			strFileContents += strNewLine + jQuery(this).text();
+			strNewLine = "\n";
+		}
+
+  });
+
+	// Output buttons for number of files found
+	for (i=1; i < intFileCounter; i++){
+		jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i-1] + "</button>");
+		jQuery('#tabButton' + i).click({code: arrCodeFiles[i], tabnumber: i}, showTab);
+	}
 }
 
 function showTab(event)

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -197,6 +197,8 @@ Page.initOptions = function()
   jQuery("#buttonShowHideTextEditor").prop('checked', Layout.isTextVisible);
   jQuery("#buttonShowHideCanvas").prop('checked', Layout.isDiagramVisible);
 	jQuery("#buttonTabsCheckbox").prop('checked', false);
+	jQuery("#tabRow").hide();
+	jQuery("#ttTabsCheckbox").hide();
   jQuery("#buttonToggleAttributes").prop('checked',true);
   jQuery("#buttonToggleActions").prop('checked',true);
   jQuery("#buttonToggleTraits").prop('checked',false);
@@ -820,6 +822,8 @@ Page.showGeneratedCode = function(code,language,tabnumber)
 	// Default "tabnumber" parameter to null, ie. only output to the main codeblock
 	if (typeof(tabnumber)==='undefined') tabnumber = "";
 
+	Action.toggleTabsCheckbox(language);
+
   Page.applyGeneratedCodeAreaStyles(language);
   
   var errorMarkup = Page.getErrorMarkup(code, language);
@@ -836,6 +840,16 @@ Page.showGeneratedCode = function(code,language,tabnumber)
 			formatOnce('<pre class="brush: {1};">{0}</pre>',generatedMarkup,language)
 		)
     SyntaxHighlighter.highlight("code");
+
+		if(tabnumber == ""){
+			// Remove all previous file codeblocks
+			jQuery('#innerGeneratedCodeRow').nextAll().remove();
+			// Clear tab row contents
+			jQuery('#tabRow').html('');
+			// Generate tabs
+			Action.generateTabsCode();
+			Action.toggleTabs();
+		}
   }
   else if(language == "structureDiagram")
   {

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -830,7 +830,9 @@ Page.showGeneratedCode = function(code,language,tabnumber)
   var generatedMarkup = Page.getGeneratedMarkup(code, language);
 
   //Set any error or warning messages
-  jQuery("#messageArea").html(errorMarkup);
+	if(errorMarkup != ""){
+ 		jQuery("#messageArea").html(errorMarkup);
+	}
 
   //Set the generated content
   if(language == "java" || language == "php" || language == "cpp" 
@@ -861,7 +863,9 @@ Page.showGeneratedCode = function(code,language,tabnumber)
     var downloadLink = '<div id="diagramLinkContainer"></div>';
     errorMarkup = downloadLink + errorMarkup;
 
-    jQuery("#messageArea").html(errorMarkup);
+		if(errorMarkup != ""){
+    	jQuery("#messageArea").html(errorMarkup);
+		}
     Page.toggleStructureDiagramLink(false);
   }
   else

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -145,6 +145,7 @@ Page.initPaletteArea = function()
   Page.initAction("buttonUigu");
   Page.initAction("buttonStartOver");
   Page.initAction("buttonGenerateCode");
+  Page.initAction("buttonTabsCheckbox");
   Page.initAction("buttonSmaller");
   Page.initAction("buttonLarger");
   Page.initAction("buttonSyncCode");
@@ -195,6 +196,7 @@ Page.initOptions = function()
   jQuery("#buttonShowHideLayoutEditor").prop('checked', Layout.isLayoutVisible);
   jQuery("#buttonShowHideTextEditor").prop('checked', Layout.isTextVisible);
   jQuery("#buttonShowHideCanvas").prop('checked', Layout.isDiagramVisible);
+	jQuery("#buttonTabsCheckbox").prop('checked', false);
   jQuery("#buttonToggleAttributes").prop('checked',true);
   jQuery("#buttonToggleActions").prop('checked',true);
   jQuery("#buttonToggleTraits").prop('checked',false);
@@ -813,8 +815,11 @@ Page.showViewDone = function()
   setTimeout(function() {jQuery(selector).dialog("close");}, 2000);
 }
 
-Page.showGeneratedCode = function(code,language)
+Page.showGeneratedCode = function(code,language,tabnumber)
 {
+	// Default "tabnumber" parameter to null, ie. only output to the main codeblock
+	if (typeof(tabnumber)==='undefined') tabnumber = "";
+
   Page.applyGeneratedCodeAreaStyles(language);
   
   var errorMarkup = Page.getErrorMarkup(code, language);
@@ -827,9 +832,9 @@ Page.showGeneratedCode = function(code,language)
   if(language == "java" || language == "php" || language == "cpp" 
     || language == "ruby" || language == "xml" || language == "sql")
   {
-    jQuery("#innerGeneratedCodeRow").html(
-        formatOnce('<pre class="brush: {1};">{0}</pre>',generatedMarkup,language)
-        )
+		jQuery("#innerGeneratedCodeRow" + tabnumber).html(
+			formatOnce('<pre class="brush: {1};">{0}</pre>',generatedMarkup,language)
+		)
     SyntaxHighlighter.highlight("code");
   }
   else if(language == "structureDiagram")
@@ -847,7 +852,7 @@ Page.showGeneratedCode = function(code,language)
   }
   else
   {
-    jQuery("#innerGeneratedCodeRow").html(generatedMarkup);
+    jQuery("#innerGeneratedCodeRow" + tabnumber).html(generatedMarkup);
   }
 }
 

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -435,7 +435,12 @@ $output = readTemporaryFile("ump/" . $filename);
   </div>
   
   <div id="generatedCodeRow" class="row">
+		<li id="ttTabsCheckbox">
+			<input id="buttonTabsCheckbox" type="checkbox" class="checkbox" name="buttonTabsCheckbox" value="buttonTabsCheckbox"/>
+			<a id="labelTabsCheckbox" class="buttonExtend">Show Files in Separate Tabs</a>
+		</li>
     <div id="messageArea"></div>
+    <div id="tabRow"></div>
     <div id="innerGeneratedCodeRow"></div>
   </div>
 


### PR DESCRIPTION
The feature to output generated codes in separate code blocks for every file was requested. I have added a checkbox to UmpleOnline after the code is generated called "Show Files in Separate Tabs". Clicking this will bring up buttons with the corresponding file names, and clicking on one of these will show only the code that is found in that file. Unchecking this checkbox will revert to showing one code block with all the files glommed together.

Closes Issue #411 
