### PR TITLE
594 using immutable key gnerates invalid java code

### DIFF
--- a/UmpleToJava/templates/equals.jet
+++ b/UmpleToJava/templates/equals.jet
@@ -12,7 +12,7 @@
     if (av != null)
     {
       String avString = av.getIsDerived()?(gen.translate("getMethod",av)+"()"):gen.translate("attributeOne",av);
-      canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("attributeCanSet",av)));
+      if (!av.isImmutable()) canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("attributeCanSet",av)));
       if (av.getIsList())
       {
         checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",gen.translate("attributeMany",av)));

--- a/cruise.umple/src-gen-jet/cruise/umple/compiler/java/JavaClassGenerator.java
+++ b/cruise.umple/src-gen-jet/cruise/umple/compiler/java/JavaClassGenerator.java
@@ -9977,7 +9977,7 @@ for (StateMachine smq : uClass.getStateMachines())
     if (av != null)
     {
       String avString = av.getIsDerived()?(gen.translate("getMethod",av)+"()"):gen.translate("attributeOne",av);
-      canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("attributeCanSet",av)));
+      if(!av.isImmutable()) canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("attributeCanSet",av)));
       if (av.getIsList())
       {
         checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",gen.translate("attributeMany",av)));

--- a/dev-tools/ReadMe.txt
+++ b/dev-tools/ReadMe.txt
@@ -27,6 +27,9 @@ For Unix, Mac and Linux users:
   - Does not rebuild the compiler (a bit testcase) nor run the testbed tests
   - Used when you want to do a basic test after doing qbumple
 
+pumple
+  - Propagates the umple jars to umpleonline
+
  mumple
   - packages the user manual
   

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -246,7 +246,11 @@ function extractFilename()
     {
       file_put_contents($destfile, file_get_contents("http://" . $_REQUEST["filename"]));
       if(substr($http_response_header[0],-2)!="OK") {
-        file_put_contents($destfile, "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"]);
+         // try https
+        file_put_contents($destfile, file_get_contents("https://" . $_REQUEST["filename"]));
+        if(substr($http_response_header[0],-2)!="OK") {         
+          file_put_contents($destfile, "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"]);
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #594 
The variable canSetK is not generated anymore for immutable keys, in the java code under the hashCode() method. Changed the equals.jet file to generate java code that checks if the key is immutable before appending the "canSetKey" string.
