### PR TITLE
Revert "601_Statemachine_Event_$Args_for_Php"

### DIFF
--- a/UmpleToPhp/src/cruise/umple/compiler/php/PhpClassGenerator.java
+++ b/UmpleToPhp/src/cruise/umple/compiler/php/PhpClassGenerator.java
@@ -380,9 +380,9 @@ public class PhpClassGenerator implements ILang
   protected final String TEXT_360 = NL + "  ";
   protected final String TEXT_361 = " function ";
   protected final String TEXT_362 = "(";
-  protected final String TEXT_363 = ")" + NL + "$wasEventProcessed = false;";
-  protected final String TEXT_364 = NL;
-  protected final String TEXT_365 = NL + "return $wasEventProcessed;" + NL + "}" + NL;
+  protected final String TEXT_363 = ")" + NL + "  {" + NL + "    $wasEventProcessed = false;";
+  protected final String TEXT_364 = NL + "    ";
+  protected final String TEXT_365 = NL + "    return $wasEventProcessed;" + NL + "  }" + NL;
   protected final String TEXT_366 = NL + "  public function ";
   protected final String TEXT_367 = "($";
   protected final String TEXT_368 = ")" + NL + "  {";
@@ -3715,7 +3715,6 @@ public class PhpClassGenerator implements ILang
     
   StringBuffer allCases = new StringBuffer();
   StringBuffer allDeclarations = new StringBuffer();
-  StringBuffer allArgs = new StringBuffer();
 
   boolean firstStateMachine = true;
   for(StateMachine sm : uClass.getStateMachines(e))
@@ -3799,27 +3798,15 @@ public class PhpClassGenerator implements ILang
     }
     firstStateMachine = false;
   }
-  String[] split = e.getArgs().split(",");
-  if (split[0] != null && split[0] != "")
-  {
-    for (int i = 0; i < split.length; i++) {
-      if (i > 0)
-      {
-        allArgs.append(", ");
-      }
-      allArgs.append(StringFormatter.format("${0}",split[i].substring(split[i].indexOf(" ")+1)));
-    }
-  }
   String scope = e.getIsInternal() || e.isAutoTransition() ? "private" : "public";
   String eventOutput = allDeclarations.toString() + allCases.toString();
-  String argsOutput = allArgs.toString();
 
     stringBuffer.append(TEXT_360);
     stringBuffer.append( scope );
     stringBuffer.append(TEXT_361);
     stringBuffer.append(gen.translate("eventMethod",e));
     stringBuffer.append(TEXT_362);
-    stringBuffer.append( argsOutput );
+    stringBuffer.append( (e.getArgs()==null?"":e.getArgs()));
     stringBuffer.append(TEXT_363);
     stringBuffer.append(TEXT_364);
     stringBuffer.append( eventOutput );

--- a/UmpleToPhp/templates/state_machine_Event.jet
+++ b/UmpleToPhp/templates/state_machine_Event.jet
@@ -2,7 +2,6 @@
 <%
   StringBuffer allCases = new StringBuffer();
   StringBuffer allDeclarations = new StringBuffer();
-  StringBuffer allArgs = new StringBuffer();
 
   boolean firstStateMachine = true;
   for(StateMachine sm : uClass.getStateMachines(e))
@@ -86,24 +85,13 @@
     }
     firstStateMachine = false;
   }
-  String[] split = e.getArgs().split(",");
-  if (split[0] != null && split[0] != "")
-  {
-    for (int i = 0; i < split.length; i++) {
-      if (i > 0)
-      {
-        allArgs.append(", ");
-      }
-      allArgs.append(StringFormatter.format("${0}",split[i].substring(split[i].indexOf(" ")+1)));
-    }
-  }
   String scope = e.getIsInternal() || e.isAutoTransition() ? "private" : "public";
   String eventOutput = allDeclarations.toString() + allCases.toString();
-  String argsOutput = allArgs.toString();
 %>
-  <%= scope %> function <%=gen.translate("eventMethod",e)%>(<%= argsOutput %>)
-$wasEventProcessed = false;
-<%= eventOutput %>
-return $wasEventProcessed;
-}
+  <%= scope %> function <%=gen.translate("eventMethod",e)%>(<%= (e.getArgs()==null?"":e.getArgs())%>)
+  {
+    $wasEventProcessed = false;
+    <%= eventOutput %>
+    return $wasEventProcessed;
+  }
 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/eventWithArguments_1.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/eventWithArguments_1.php.txt
@@ -59,7 +59,7 @@ class LightFixture
     return null;
   }
 
-  public function turnDimmer($lightval, $lightval_1)
+  public function turnDimmer(Integer lightval,Double lightval_1)
   {
     $wasEventProcessed = false;
     

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/eventWithArguments_2.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/eventWithArguments_2.php.txt
@@ -38,7 +38,7 @@ class Course
     return null;
   }
 
-  public function register($name, $age, $grades)
+  public function register(String name,Integer age,Double grades)
   {
     $wasEventProcessed = false;
     


### PR DESCRIPTION
Reverts umple/umple#657

This caused a test failure

Test Failures (1)
cruise.umple.implementation.php.PhpCodeInjectionTest (1)
TestName: StateMachines Duration: 0.016
                                Failed at:44 expected:<[  {]> but was:<[$wasEventProcessed = false;]>

```
                            junit.framework.AssertionFailedError: Failed at:44 expected:<[  {]> but was:<[$wasEventProcessed = false;]>
at cruise.umple.util.SampleFileWriter.assertFileContent(SampleFileWriter.java:216)
```

The code 

class Example
{
  light
  {
    On { flip -> Off; }
    Off { flip -> On; }
  }  

  after setLight {
    System.out.println("Just flipped");
  }

  before setLight {
    System.out.println("About to flip");
  }

}

was generating bad php
