### PR TITLE
601 Statemachine Event $Args for Php (fix missising '{')

### DIFF
--- a/UmpleToPhp/src/cruise/umple/compiler/php/PhpClassGenerator.java
+++ b/UmpleToPhp/src/cruise/umple/compiler/php/PhpClassGenerator.java
@@ -380,9 +380,9 @@ public class PhpClassGenerator implements ILang
   protected final String TEXT_360 = NL + "  ";
   protected final String TEXT_361 = " function ";
   protected final String TEXT_362 = "(";
-  protected final String TEXT_363 = ")" + NL + "$wasEventProcessed = false;";
-  protected final String TEXT_364 = NL;
-  protected final String TEXT_365 = NL + "return $wasEventProcessed;" + NL + "}" + NL;
+  protected final String TEXT_363 = ")" + NL + "  {" + NL + "    $wasEventProcessed = false;";
+  protected final String TEXT_364 = NL + "    ";
+  protected final String TEXT_365 = NL + "    return $wasEventProcessed;" + NL + "  }" + NL;
   protected final String TEXT_366 = NL + "  public function ";
   protected final String TEXT_367 = "($";
   protected final String TEXT_368 = ")" + NL + "  {";

--- a/UmpleToPhp/templates/state_machine_Event.jet
+++ b/UmpleToPhp/templates/state_machine_Event.jet
@@ -102,8 +102,9 @@
   String argsOutput = allArgs.toString();
 %>
   <%= scope %> function <%=gen.translate("eventMethod",e)%>(<%= argsOutput %>)
-$wasEventProcessed = false;
-<%= eventOutput %>
-return $wasEventProcessed;
-}
+  {
+    $wasEventProcessed = false;
+    <%= eventOutput %>
+    return $wasEventProcessed;
+  }
 


### PR DESCRIPTION
Had a copy paste error after hard resetting my branch which resulted in a missing '{' and some spaces 
missing which are now corrected. All errors gone from complete build.
