### PR TITLE
Re-enable Tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 
-# jdk:
-#   - oraclejdk8
 
 sudo: false
 
@@ -13,12 +11,34 @@ cache:
 before_install:
   - ./travis/deps.sh # run linux or osx depending on environment
 
+env:
+  global:
+    - ANT_FIRST='ant -f build.umple.xml -Dmyenv=travis -Donline=true'
+    - ANT_BUILD='ant -f build.umple.xml -Dmyenv=travis -Dfirst.build=false'
+
 script:
   - cd build/
   - ant -Dmyenv=travis bootstrap
-  - ant -Dmyenv=travis first-build
-  # TODO https://github.com/umple/umple/issues/616
-  # - ant -Dmyenv=travis build
+  # We resolve all of the dependencies before, this way the command will be unlikely to time out
+  - echo 'DEPS: Resolving all dependencies'
+  - ant -Dmyenv=travis deps-resolve-all
+  # Do the a modified version of `first-build`
+  - echo 'FIRST-BUILD: Code Generation'
+  - $ANT_FIRST clean init codegen rtcpp template.setVersion resetUmpleSelf
+  - echo 'FIRST-BUILD: Compiling'
+  - $ANT_FIRST compile compileValidator compileUmplificator
+  - echo 'FIRST-BUILD: Packaging'
+  - $ANT_FIRST package template.resetVersion
+
+  # Do the a modified version of `build`
+  - echo 'BUILD: Code Generation'
+  - $ANT_BUILD clean init codegen rtcpp template.setVersion resetUmpleSelf
+  - echo 'BUILD: Compiling'
+  - $ANT_BUILD compile compileValidator compileUmplificator
+  - echo 'BUILD: Packaging'
+  - $ANT_BUILD package 
+  - echo 'BUILD: Testing..'
+  - $ANT_BUILD template.test template.resetVersion
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 
-
-sudo: false
+# Use the trusty environment, this gives us OpenJDK8
+# Down the road, we really need to remove this and instead use container based.
+sudo: required
+dist: trusty
 
 cache:
   directories:
@@ -20,30 +22,25 @@ script:
   - cd build/
   - ant -Dmyenv=travis bootstrap
   # We resolve all of the dependencies before, this way the command will be unlikely to time out
-  - echo 'DEPS: Resolving all dependencies'
   - ant -Dmyenv=travis deps-resolve-all
   # Do the a modified version of `first-build`
-  - echo 'FIRST-BUILD: Code Generation'
   - $ANT_FIRST clean init codegen rtcpp template.setVersion resetUmpleSelf
-  - echo 'FIRST-BUILD: Compiling'
   - $ANT_FIRST compile compileValidator compileUmplificator
-  - echo 'FIRST-BUILD: Packaging'
   - $ANT_FIRST package template.resetVersion
 
   # Do the a modified version of `build`
-  - echo 'BUILD: Code Generation'
   - $ANT_BUILD clean init codegen rtcpp template.setVersion resetUmpleSelf
-  - echo 'BUILD: Compiling'
   - $ANT_BUILD compile compileValidator compileUmplificator
-  - echo 'BUILD: Packaging'
   - $ANT_BUILD package 
-  - echo 'BUILD: Testing..'
   - $ANT_BUILD template.test template.resetVersion
 
 matrix:
+  exclude:
+    - os: osx
+
   include:
     - os: linux
-      language: java
       jdk: oraclejdk8
+    - os: linux
+      jdk: openjdk8
     - os: osx
-      language: java

--- a/build/_template.xml
+++ b/build/_template.xml
@@ -53,8 +53,6 @@
         <length file="${temp.file}" when="gt" length="0" />
       </condition>
 
-      <echo>@{property} = ${@{property}}</echo>
-
       <delete file="${temp.file}" 
               deleteonexit="true" 
               quiet="true"/>

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -475,7 +475,9 @@
   <!--
     First Build
     run this the very first time, it will package up your system
-    and generate a
+    and generate a built JAR.
+
+    If changing this target, be sure to update .travis.yml
   -->
   <target name="first-build">
     <property name="first.build" value="true" />
@@ -521,6 +523,8 @@
     Build
     run by the build machine, should work as-is on your machine, but be careful
     as your code will be run against the "latest" Umpled Umple.
+
+    If changing this target, be sure to update .travis.yml
    -->
   <target name="build" >
     <property name="first.build" value="false" />
@@ -544,7 +548,7 @@
   </target>
 
   <target name="build-umplificator" >
-    <property name="first.build" value="fals" />
+    <property name="first.build" value="false" />
     <check-connectivity />
 
     <antcall target="clean" />

--- a/travis/deps.linux.sh
+++ b/travis/deps.linux.sh
@@ -10,4 +10,3 @@ export JAVA_HOME=/usr/lib/jvm/java-8-oracle
 export PATH=$JAVA_HOME/bin:$PATH
 
 java -version
-echo $PATH

--- a/travis/deps.linux.sh
+++ b/travis/deps.linux.sh
@@ -6,7 +6,4 @@ set -e
 # check for linux
 test "$TRAVIS_OS_NAME" == "linux"
 
-export JAVA_HOME=/usr/lib/jvm/java-8-oracle
-export PATH=$JAVA_HOME/bin:$PATH
 
-java -version


### PR DESCRIPTION
This commit will re-enable tests to run on Travis.

Changes:
- Broke down the build steps to stop Travis from timing out
- Added testing back! 
- Enabled openjdk8 testing on Linux (we do _not_ use the container infrastructure any more, this will slow down initial builds because dependency caching is not enabled)

This does **not** address #591. 
