### PR TITLE
Add testbed to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: java
 
-# Use the trusty environment, this gives us OpenJDK8
-# Down the road, we really need to remove this and instead use container based.
-sudo: required
-dist: trusty
+# Notes:
+# To enabled openjdk8 we need to use the `trusty` environment which is currently in Beta
+# We do not use this due to the length of time required to start-up the builds 
 
 cache:
   directories:
     - $HOME/.ant/lib/
     - $TRAVIS_BUILD_DIR/dist/libs
+
+addons:
+  apt:
+    packages:
+    - php5-common
+    - php5-cli
 
 before_install:
   - ./travis/deps.sh # run linux or osx depending on environment
@@ -17,12 +22,15 @@ env:
   global:
     - ANT_FIRST='ant -f build.umple.xml -Dmyenv=travis -Donline=true'
     - ANT_BUILD='ant -f build.umple.xml -Dmyenv=travis -Dfirst.build=false'
+    - ANT_TESTBED='ant -f build.testbed.xml -Dmyenv=travis -Dfirst.build=false'
 
 script:
+  - php --version ; ruby -v
   - cd build/
   - ant -Dmyenv=travis bootstrap
   # We resolve all of the dependencies before, this way the command will be unlikely to time out
   - ant -Dmyenv=travis deps-resolve-all
+
   # Do the a modified version of `first-build`
   - $ANT_FIRST clean init codegen rtcpp template.setVersion resetUmpleSelf
   - $ANT_FIRST compile compileValidator compileUmplificator
@@ -34,13 +42,16 @@ script:
   - $ANT_BUILD package 
   - $ANT_BUILD template.test template.resetVersion
 
-matrix:
-  exclude:
-    - os: osx
+  # Build the testbed
+  - $ANT_TESTBED clean template.clean init
+  - $ANT_TESTBED compile 
+  - $ANT_TESTBED test 
+  - $ANT_TESTBED template.resetVersion 
 
+matrix:
   include:
     - os: linux
       jdk: oraclejdk8
-    - os: linux
-      jdk: openjdk8
+    # - os: linux
+    #   jdk: openjdk8
     - os: osx

--- a/travis/deps.linux.sh
+++ b/travis/deps.linux.sh
@@ -6,4 +6,8 @@ set -e
 # check for linux
 test "$TRAVIS_OS_NAME" == "linux"
 
+rvm install 2.1
+rvm use 2.1
+
+
 


### PR DESCRIPTION
This commit makes Travis properly build and run the entire testbed.
- Add testbed to the test chain.
- Revert back to containers.
- Properly add php/ruby

This closes #616.
