### PR TITLE
Issue 449 fix and test

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2626,8 +2626,22 @@ class UmpleInternalParser
       {
         setFailedPosition(keyToken.getPosition(), 26, tokenVal, keyToken.getParentToken().getValue("name"));
       }
+      
+      //Issue #449
+	UmpleClass child = aClass;
+	while(unlinkedExtends.get(child) != null){
+		for(Attribute parentAttribute : model.getUmpleClass(unlinkedExtends.get(child).get(0)).getAttributes())
+		{
+			if(parentAttribute.getName().equals(tokenVal))
+		    {
+			tokenMatch = true;
+			break;
+			}
+		}
+		child = model.getUmpleClass(unlinkedExtends.get(child).get(0));  
+	}
    
-    if(!aClass.hasAttributes() && !aClass.hasAssociations() && !aClass.hasStateMachines())
+    if(!aClass.hasAttributes() && !aClass.hasAssociations() && !aClass.hasStateMachines() && !tokenMatch)
       {
         setFailedPosition(keyToken.getPosition(), 27, tokenVal, keyToken.getParentToken().getValue("name"));
       }

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -1984,9 +1984,7 @@ public class UmpleParserTest
   public void inheritedKeys()
   {
     assertParse("018_inheritedKeys.ump");
-    // TODO: getting the warnings removed had more
-    // affects so I backed out the change, but what to fix it again
-    // assertHasNoWarningsParse("018_inheritedKeys.ump");
+    assertHasNoWarningsParse("018_inheritedKeys.ump");
     UmpleClass mentor = model.getUmpleClass("Mentor");
     Key key = mentor.getKey();
     Assert.assertEquals(2,key.numberOfMembers());


### PR DESCRIPTION
Summary of issue fix:
- Changed to analyzeKey() method in UmpleInternalParser_CodeClass to check if the current class key token(s) is/are among the list of the parent’s attributes. This is done by iterating over all the parents until the matching attribute is found or until there is no more parent. When the attribute is found, the tokenMatch variable is set to true which would prevent issuing the warning.
- Concerning the test, I just had to uncomment a //TODO labeled test which was already existing in the UmpleParserTest file
- This closes [#449](https://github.com/umple/umple/issues/449)
