### PR TITLE
Tab Display

### DIFF
--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -2132,30 +2132,29 @@ Action.generateTabsCode = function()
   jQuery('.content').each(function(){
     // If New File Beginning
     if(jQuery(this).text().indexOf("//%%") >= 0){
+      intFileCounter++;
+      if(intFileCounter > 1){ arrCodeFiles[intFileCounter] += "</p>"; }
       strFileName = jQuery(this).text().slice(14);
       strFileName = strFileName.substr(0, strFileName.indexOf(' '));
       arrFileNames[intFileCounter] = strFileName;
-      arrCodeFiles[intFileCounter] = strFileContents;
-      intFileCounter++;
       jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
-      strFileContents = "<p>URL_SPLIT";
+      arrCodeFiles[intFileCounter] = "<p>URL_SPLIT";
       skipSpace = true;
     }
     else{
       if(!skipSpace){
-        strFileContents += strNewLine + jQuery(this).text();
-        strNewLine = "\n";
+        arrCodeFiles[intFileCounter] += jQuery(this).text() + "\n";
       }
       else{
         skipSpace = false;
       }
     }
-
   });
+  arrCodeFiles[intFileCounter] += "</p>";
 
   // Output buttons for number of files found
-  for (i=1; i < intFileCounter; i++){
-    jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i-1] + "</button>");
+  for (i=1; i <= intFileCounter; i++){
+    jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i] + "</button>");
     jQuery('#tabButton' + i).click({code: arrCodeFiles[i], tabnumber: i}, showTab);
   }
 }

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -840,7 +840,7 @@ Action.umpleCanvasClicked = function(event)
   {
     if (Page.clickCount > 1)
     {
-    	DiagramEdit.removeNewAssociation();
+      DiagramEdit.removeNewAssociation();
     }
   }
   else if (Page.selectedItem == "AddGeneralization" && DiagramEdit.newGeneralization != null)
@@ -2094,86 +2094,86 @@ Action.toggleTabs = function()
   // Checking on the checkbox
   if(jQuery('#buttonTabsCheckbox').is(':checked')){
 
-		// Show row with buttons for each filename
-		jQuery('#tabRow').show();
+    // Show row with buttons for each filename
+    jQuery('#tabRow').show();
 
-		// Hide main code window with glommed files
-		jQuery('#innerGeneratedCodeRow').hide();
+    // Hide main code window with glommed files
+    jQuery('#innerGeneratedCodeRow').hide();
 
-		// Show first file codeblock
-		jQuery('#tabButton1').click();
+    // Show first file codeblock
+    jQuery('#tabButton1').click();
 
   }
   // Checking off the checkbox
   else{
 
-		// Hide row with buttons
+    // Hide row with buttons
     jQuery('#tabRow').hide();
 
-		// Show main code window with glommed files
-		jQuery('#innerGeneratedCodeRow').show();
+    // Show main code window with glommed files
+    jQuery('#innerGeneratedCodeRow').show();
 
-		// Hide all file codeblocks
-		jQuery('#innerGeneratedCodeRow').nextAll().hide();
+    // Hide all file codeblocks
+    jQuery('#innerGeneratedCodeRow').nextAll().hide();
 
   }
 }
 
 Action.generateTabsCode = function()
 {
-	var arrCodeFiles = [];
-	var intFileCounter = 0;
-	var strFileContents = "";
-	var arrFileNames = [];
-	var strNewLine = "";
-	var skipSpace = false;
+  var arrCodeFiles = [];
+  var intFileCounter = 0;
+  var strFileContents = "";
+  var arrFileNames = [];
+  var strNewLine = "";
+  var skipSpace = false;
 
-	// Read full code output line by line
+  // Read full code output line by line
   jQuery('.content').each(function(){
-		// If New File Beginning
+    // If New File Beginning
     if(jQuery(this).text().indexOf("//%%") >= 0){
-			strFileName = jQuery(this).text().slice(14);
-			strFileName = strFileName.substr(0, strFileName.indexOf(' '));
-			arrFileNames[intFileCounter] = strFileName;
-			arrCodeFiles[intFileCounter] = strFileContents;
-			intFileCounter++;
-			jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
-			strFileContents = "<p>URL_SPLIT";
-			skipSpace = true;
+      strFileName = jQuery(this).text().slice(14);
+      strFileName = strFileName.substr(0, strFileName.indexOf(' '));
+      arrFileNames[intFileCounter] = strFileName;
+      arrCodeFiles[intFileCounter] = strFileContents;
+      intFileCounter++;
+      jQuery('#generatedCodeRow').append("<div id='innerGeneratedCodeRow" + intFileCounter + "'></div>");
+      strFileContents = "<p>URL_SPLIT";
+      skipSpace = true;
     }
-		else{
-			if(!skipSpace){
-				strFileContents += strNewLine + jQuery(this).text();
-				strNewLine = "\n";
-			}
-			else{
-				skipSpace = false;
-			}
-		}
+    else{
+      if(!skipSpace){
+        strFileContents += strNewLine + jQuery(this).text();
+        strNewLine = "\n";
+      }
+      else{
+        skipSpace = false;
+      }
+    }
 
   });
 
-	// Output buttons for number of files found
-	for (i=1; i < intFileCounter; i++){
-		jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i-1] + "</button>");
-		jQuery('#tabButton' + i).click({code: arrCodeFiles[i], tabnumber: i}, showTab);
-	}
+  // Output buttons for number of files found
+  for (i=1; i < intFileCounter; i++){
+    jQuery('#tabRow').append("<button type='button' id='tabButton" + i + "'>" + arrFileNames[i-1] + "</button>");
+    jQuery('#tabButton' + i).click({code: arrCodeFiles[i], tabnumber: i}, showTab);
+  }
 }
 
 function showTab(event)
 {
-		// Hide all file codeblocks
-		jQuery('#innerGeneratedCodeRow').nextAll().hide();
+  // Hide all file codeblocks
+  jQuery('#innerGeneratedCodeRow').nextAll().hide();
 
-		// Show only relevant file codeblock
-		jQuery('#innerGeneratedCodeRow' + event.data.tabnumber).show();
+  // Show only relevant file codeblock
+  jQuery('#innerGeneratedCodeRow' + event.data.tabnumber).show();
 
-		// Highlight code for specific file only
-  	Page.showGeneratedCode(event.data.code, $("inputGenerateCode").value.split(":")[0], event.data.tabnumber);
-		jQuery('.line').last().hide();
-		jQuery('.line').last().hide();
+  // Highlight code for specific file only
+  Page.showGeneratedCode(event.data.code, $("inputGenerateCode").value.split(":")[0], event.data.tabnumber);
+  jQuery('.line').last().hide();
+  jQuery('.line').last().hide();
 
-		// Hide main code window with glommed files
-		jQuery('#innerGeneratedCodeRow').hide();
+  // Hide main code window with glommed files
+  jQuery('#innerGeneratedCodeRow').hide();
 }
 


### PR DESCRIPTION
This is my fix for the issue of tabs not displaying in UmpleOnline when viewing individual files. The problem was that each class file was added to a &lt;div&gt; on the page only when the next class was found, meaning the last class would be dropped as there is no next class after the final one.

The fix involves just re-ordering the logic so that each line in the full file is added to the &lt;div&gt; as it's processed, instead of adding the whole class once the next one is found.
