### PR TITLE
Corrected case-sensitive command-line parameters (Issue 602)

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -28,6 +28,7 @@ class UmpleModel
   depend cruise.umple.analysis.*;
   depend cruise.umple.util.*;
   depend cruise.umple.compiler.exceptions.*;
+  depend java.util.zip.*; // new
   isA Runnable;
 
   // The Umple file (.ump) that was used to populate the model.
@@ -41,6 +42,7 @@ class UmpleModel
   String code = null;
   Boolean debugMode = false;
   ParseResult lastResult = null;
+  public static final String[] validLanguages = findValidLanguages();
 
   Map<String,String> generatedCode = new HashMap<String,String>();
   Map<String,Analyzer> analyzers = new HashMap<String,Analyzer>();

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -17,6 +17,49 @@ namespace cruise.umple.compiler;
  */
 class UmpleModel
 {
+
+  public static String[] findValidLanguages()
+  {
+    final String NONTERMINAL = "generate";
+    final String START_TOKEN = "[=language:";
+    final String END_TOKEN   = "]";
+    final String DELIMITER   = "\\|";
+    
+    
+    String[] result = new String[0];
+    
+    boolean lineFound = false;
+    try
+    {
+      InputStream in = null;
+      BufferedReader reader = null;
+      try
+      {
+        in     = UmpleModel.class.getResourceAsStream("/umple_core.grammar");
+        reader = new BufferedReader(new InputStreamReader(in));
+        String line;
+        while (((line = reader.readLine()) != null) && !lineFound ) 
+        {
+           if( line.startsWith(NONTERMINAL) && line.contains(START_TOKEN))
+           {
+             int start_index = line.indexOf(START_TOKEN) + START_TOKEN.length();
+             int end_index = line.indexOf(END_TOKEN);
+             String languages = line.substring( start_index, end_index );
+             result = languages.split(DELIMITER);
+             lineFound = true;
+           }
+        }
+      }finally
+      {
+        in.close();
+        reader.close();
+      }
+    }catch( IOException e ){
+      throw new RuntimeException("Error opening '/umple_core.grammar' resource", e);
+    }
+    return result;
+  }
+
   public List<UmpleElement> getUmpleElements()
   {
     List<UmpleElement> all = new ArrayList<UmpleElement>();
@@ -185,12 +228,22 @@ class UmpleModel
  */
   public CodeGenerator newGenerator(String language)
   {
-    boolean foundGenerator;
-
     String realLanguage = language;
+    
+        // Ensure the target is specified in the proper case.
+    VALIDATE_GENERATE:
+    //for( String lang : UmpleModel.validLanguages ){
+    for( String lang : UmpleModel.validLanguages ){
+      if(lang.equalsIgnoreCase(language)){
+        realLanguage = lang;
+        break VALIDATE_GENERATE;
+      }
+    }
+
+		
     if (language.equals("Cpp")) realLanguage="RTCpp";
     else if (language.equals("SimpleCpp")) realLanguage="Cpp";
-
+    
     String className = StringFormatter.format("cruise.umple.compiler.{0}Generator",realLanguage);
     Class<?> classDefinition = null;
     try {
@@ -205,6 +258,9 @@ class UmpleModel
       throw new RuntimeException(cnf);
     }
     catch (Exception ex2) {
+	  System.err.println("Code generator "+realLanguage+ " not found. Check spelling. Specify --help.");
+      System.exit(-1);
+
       throw new RuntimeException("Unable to instantiate "+realLanguage+ ".",ex2);
     }
   }
@@ -237,7 +293,6 @@ class UmpleModel
       System.exit(-1);
     }
    }
-
 
   public Coordinate getDefaultClassPosition(int numDefaults)
   {
@@ -3976,6 +4031,7 @@ class Filter
   }
 
 }
+
 
 
 use Umple_Code_Trait.ump;

--- a/cruise.umple/test/cruise/umple/compiler/UmpleModelTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleModelTest.java
@@ -26,8 +26,6 @@ import org.junit.Test;
 
 import cruise.umple.util.SampleFileWriter;
 
-
-
 public class UmpleModelTest
 {
 
@@ -472,6 +470,28 @@ public class UmpleModelTest
 
     assertTrue(allTranslators.isEmpty());
   }
+  
+  @Test
+  public void correctLowercaseTest (){
+    
+    
+    uFile.addLinkedFiles("sub/student2.ump");
+    model = new UmpleModel(uFile);
+    model.addGenerate("php"); // lowercase PHP
+    model.run();
 
+    assertTrue(model.getLastResult().getWasSuccess());
+  }
+  
+  @Test
+  public void correctUppercaseTest (){
+	uFile.addLinkedFiles("sub/student2.ump");
+    model = new UmpleModel(uFile);
+    model.addGenerate("GVCLASSTRAITDIAGRAM"); // uppercase GvClassTraitDiagram
+    model.run();
+
+    assertTrue(model.getLastResult().getWasSuccess());
+  }
+  
 }
 


### PR DESCRIPTION
Corrected [Issue #602](https://github.com/umple/umple/issues/602) by reading in `umple_core.grammar` as a resource stream, parsing the `generate` nonterminal, and reading the languages into a list (made accessible as a static in `UmpleModel`).
Correction is made in `newGenerator(...)` prior to selecting the Generator.

Testcases were added in `UmpleModelTest.java` to test that case-sensitivity works correctly.

Also added an error message for the obscure case of a user specifying an internal class as a generator (e.g. `-g php.PhpClass`). ([Issue #679](https://github.com/umple/umple/issues/679))
