### PR TITLE
Fixed methods in Abstract class from Interface.

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1304,11 +1304,31 @@ class UmpleInternalParser
       }
     }
     for(UmpleClass uClass: getModel().getUmpleClasses()) {
-    	for (UmpleInterface uInterface : uClass.getParentInterface()) {
-    		addImplementedMethodsFromInterface(uInterface, uClass);
-    	}
+      for (UmpleInterface uInterface : getAllParentInterface(uClass)) {
+        addImplementedMethodsFromInterface(uInterface, uClass);
+      }
     }
   }  
+
+  private java.util.List<UmpleInterface> getAllParentInterface(UmpleClass uClass){
+
+    java.util.ArrayList<UmpleInterface> temp = new java.util.ArrayList<UmpleInterface>(uClass.getParentInterface());
+    java.util.ArrayList<UmpleClass> uClassChain = new java.util.ArrayList<UmpleClass>();
+
+    for (UmpleClass uClassCurrent = uClass; uClassCurrent != null && !uClassChain.contains(uClassCurrent); uClassCurrent = uClassCurrent.getExtendsClass())
+    {
+      uClassChain.add(uClassCurrent);
+      for (UmpleInterface uInterface : uClassCurrent.getParentInterface())
+      {
+        if (!temp.contains(uInterface))
+        {
+          temp.add(uInterface);
+        }
+      }
+    }
+
+    return temp;
+  }
 
   private void addImplementedMethodsFromInterface(UmpleInterface parentInterface, UmpleClass uClass)
   {
@@ -1318,7 +1338,8 @@ class UmpleInternalParser
       for (Method aMethod : parentInterface.getMethods())
       {
         boolean shouldAddMethod = verifyIfMethodIsConstructorOrGetSet(uClass, aMethod);
-        if (!(uClass.hasImplementedMethodIncludingWithinParentClasses(aMethod)) && !(uClass.hasMethodInTraits(aMethod)) && shouldAddMethod)
+        if (!(uClass.hasImplementedMethodIncludingWithinParentClasses(aMethod))
+        && !(uClass.hasMethodInTraits(aMethod)) && !(uClass.isIsAbstract()) && shouldAddMethod)
         {
           aMethod.setIsImplemented("".equals(aMethod.getMethodBody().getExtraCode("")));
           

--- a/cruise.umple/test/cruise/umple/compiler/423_interfaceInheritanceAbstract.ump
+++ b/cruise.umple/test/cruise/umple/compiler/423_interfaceInheritanceAbstract.ump
@@ -1,0 +1,20 @@
+interface I {
+  Integer I1();
+}
+
+class A {
+  isA I;
+}
+
+class B {
+  isA A;
+}
+
+class C {
+  abstract;
+  isA I;
+}
+
+class D {
+  isA C;
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -416,6 +416,21 @@ public class UmpleParserTest
   }
 
   @Test
+  public void abstractInterfaceExtends()
+  {
+    assertSimpleParse("423_interfaceInheritanceAbstract.ump");
+
+    Assert.assertEquals(1,model.getUmpleInterface("I").numberOfMethods());
+    Assert.assertEquals("I1",model.getUmpleInterface("I").getMethod(0).getName());
+    Assert.assertEquals(1,model.getUmpleClass("A").numberOfMethods());
+    Assert.assertEquals("I1",model.getUmpleClass("A").getMethod(0).getName());
+    Assert.assertEquals(0,model.getUmpleClass("B").numberOfMethods());
+    Assert.assertEquals(0,model.getUmpleClass("C").numberOfMethods());
+    Assert.assertEquals(1,model.getUmpleClass("D").numberOfMethods());
+    Assert.assertEquals("I1",model.getUmpleClass("D").getMethod(0).getName());
+  }
+
+  @Test
   public void immutableClass()
   {
     assertParse("022_immutableClass.ump");


### PR DESCRIPTION
Resolved an issue where Umple was incorrectly generating default implementation of an interface's methods in abstract child classes. In the old behaviour, a class would always be forced to implement the methods from an interface. In the new behaviour, abstract classes will not implement the interface methods, and instead Umple will search for unimplemented methods for both the current class' parent interfaces and the whole chain of superclasses when determining unimplemented interface methods for non-abstract classes.

Fixes #608
