### PR TITLE
Fixed Ruby block-commenting issue

### DIFF
--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -230,7 +230,7 @@ class UmpleModel
   {
     String realLanguage = language;
     
-        // Ensure the target is specified in the proper case.
+    // Ensure the target is specified in the proper case.
     VALIDATE_GENERATE:
     //for( String lang : UmpleModel.validLanguages ){
     for( String lang : UmpleModel.validLanguages ){
@@ -3398,11 +3398,11 @@ class Comment
     }
     else if (type == "RubyMultiline")
     {
-      commentDelimiter = "";
+      commentDelimiter = " ";
     }
     else if (type == "RubyMultiline Internal")
     {
-      commentDelimiter = "  ";
+      commentDelimiter = " ";
     }
     else if (type == "Multiline")
     {
@@ -3472,11 +3472,33 @@ class Comment
     }
     else if (type == "RubyMultiline")
     {
-      output = "=begin\n" + output + "=end";
+      // initialize sb at least as large as the output with 1 comment
+      StringBuilder sb = new StringBuilder( output.length() + 2 ); 
+      sb.append("#");
+      char c;
+      for( int i=0; i < output.length(); ++i ){
+        c = output.charAt(i);
+        sb.append(c);
+        if( (c == '\n') && (i != output.length()-1) ){
+          sb.append("#");
+        }
+      }
+      output = sb.toString();
     }
     else if (type == "RubyMultiline Internal")
     {
-      output = "  =begin\n" + output + "  =end";
+      // initialize sb at least as large as the output with 1 comment
+      StringBuilder sb = new StringBuilder( output.length() + 2 ); 
+      sb.append("#");
+      char c;
+      for( int i=0; i < output.length(); ++i ){
+        c = output.charAt(i);
+        sb.append(c);
+        if( (c == '\n') && (i != output.length()-1) ){
+          sb.append("  #");
+        }
+      }
+      output = sb.toString();
     }
     else if (type == "Multiline")
     {

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AssociationInlineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AssociationInlineComment.ruby.txt
@@ -14,9 +14,7 @@ class Foo
 
   #Foo Associations - for documentation purposes
 
-  =begin
-  I am a inline comment above an association.
-  =end
+  # I am a inline comment above an association.
   #attr_reader :bars
 
   #------------------------

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AssociationMultilineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AssociationMultilineComment.ruby.txt
@@ -14,9 +14,7 @@ class Foo
 
   #Foo Associations - for documentation purposes
 
-  =begin
-  I am a multiline comment above an association.
-  =end
+  # I am a multiline comment above an association.
   #attr_reader :bars
 
   #------------------------

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AttributeInlineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AttributeInlineComment.ruby.txt
@@ -14,9 +14,7 @@ class Foo
 
   #Foo Attributes - for documentation purposes
 
-  =begin
-  I am a inline comment above an attribute.
-  =end
+  # I am a inline comment above an attribute.
   #attr_reader :bar
 
   #------------------------

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AttributeMultilineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_AttributeMultilineComment.ruby.txt
@@ -14,9 +14,7 @@ class Foo
 
   #Foo Attributes - for documentation purposes
 
-  =begin
-  I am a multiline comment above an attribute.
-  =end
+  # I am a multiline comment above an attribute.
   #attr_reader :name
 
   #------------------------

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_ClassCommentWithEmptyLines.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_ClassCommentWithEmptyLines.ruby.txt
@@ -5,20 +5,18 @@
 
 
 
-=begin
-I am a class comment.
-
-Notice how there are 4 empty lines below me.
-
-
-
-
-And 2 below me.
-
-
-These lines should come out as we see here.
-Comments such as these are often used to improve readability through whitespace clarity.
-=end
+# I am a class comment.
+# 
+# Notice how there are 4 empty lines below me.
+# 
+# 
+# 
+# 
+# And 2 below me.
+# 
+# 
+# These lines should come out as we see here.
+# Comments such as these are often used to improve readability through whitespace clarity.
 class Foo
 
 

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MethodCommentWithEmptyLines.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MethodCommentWithEmptyLines.ruby.txt
@@ -27,20 +27,18 @@ class Foo
   end
 
 
-  =begin
-  I am a method comment.
-  
-  Notice how there are 4 empty lines below me.
-  
-  
-  
-  
-  And 2 below me.
-  
-  
-  These lines should come out as we see here.
-  Comments such as these are often used to improve readability through whitespace clarity.
-  =end
+  # I am a method comment.
+  # 
+  # Notice how there are 4 empty lines below me.
+  # 
+  # 
+  # 
+  # 
+  # And 2 below me.
+  # 
+  # 
+  # These lines should come out as we see here.
+  # Comments such as these are often used to improve readability through whitespace clarity.
   def testMethod ()
     // I am a test method.
   end

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MethodInlineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MethodInlineComment.ruby.txt
@@ -27,9 +27,7 @@ class Foo
   end
 
 
-  =begin
-  I am a comment above a method.
-  =end
+  # I am a comment above a method.
   def testMethod ()
     // I am a comment inside a method.
   end

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MethodMultilineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MethodMultilineComment.ruby.txt
@@ -27,9 +27,7 @@ class Foo
   end
 
 
-  =begin
-  I am a comment above a method.
-  =end
+  # I am a comment above a method.
   def testMethod ()
     // I am a comment inside a method.
   end

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultiLineComment.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultiLineComment.ruby.txt
@@ -5,11 +5,9 @@
 
 module Example
 
-=begin
-This is a student
-Multiple comments
-on several lines
-=end
+# This is a student
+# Multiple comments
+# on several lines
 class Student
 
 

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultipleAssociationComments.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultipleAssociationComments.ruby.txt
@@ -14,9 +14,7 @@ class Foo
 
   #Foo Associations - for documentation purposes
 
-  =begin
-  Inline comment above association.
-  =end
+  # Inline comment above association.
   #attr_reader :bar1s, :bar2s, :bar3s, :bar4s
 
   #------------------------

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultipleAttributeComments.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultipleAttributeComments.ruby.txt
@@ -14,9 +14,7 @@ class Foo
 
   #Foo Attributes - for documentation purposes
 
-  =begin
-  Inline comment above attribute.
-  =end
+  # Inline comment above attribute.
   #attr_reader :testAttribute1, :testAttribute2, :testAttribute3, :testAttribute4
 
   #------------------------

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultipleMethodComments.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_MultipleMethodComments.ruby.txt
@@ -27,35 +27,27 @@ class Foo
   end
 
 
-  =begin
-  Inline comment above method.
-  =end
+  # Inline comment above method.
   def testMethod1 ()
     // I am a comment inside a method.
   end
 
 
-  =begin
-  Multiple inline comments
-  above method.
-  =end
+  # Multiple inline comments
+  # above method.
   def testMethod2 ()
     // I am a comment inside a method.
   end
 
 
-  =begin
-  Multiline comment above method.
-  =end
+  # Multiline comment above method.
   def testMethod3 ()
     // I am a comment inside a method.
   end
 
 
-  =begin
-  Multiple multiline comments
-  above method.
-  =end
+  # Multiple multiline comments
+  # above method.
   def testMethod4 ()
     // I am a comment inside a method.
   end


### PR DESCRIPTION
Fixed Ruby block-commenting issue by replacing `=begin` and `=end` with the more common/reader-friendly inline comments, `#`.

Updated test-cases to reflect this change.

Fixes #592  
