### PR TITLE
Generators displayed with --help are now generated from umple_core.grammar

### DIFF
--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -290,9 +290,10 @@ class UmpleConsoleMain
   {
     OptionParser optparser = new OptionParser();
     
+    String languages = String.join(",", UmpleModel.validLanguages );
     optparser.acceptsAll(Arrays.asList("version", "v"), "Print out the current Umple version number");
     optparser.acceptsAll(Arrays.asList("help"), "Display the help message");
-    optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: Java,Cpp,RTCpp,SimpleCpp,Php,Ruby,SQL,Ruby,Json,Ecore,TextUml,GvStateDiagram,StructureDiagram,GvClassDiagram,GvClassTraitDiagram,GvEntityRelationshipDiagram,Alloy,NuSMV,Yuml,SimpleMetrics,Uigu2").withRequiredArg().ofType(String.class);
+    optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: " + languages).withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("override"), "If a output language <lang> is specified using option -g, output will only generate language <lang>");
     optparser.acceptsAll(Arrays.asList("path"), "If a output language is specified using option -g, output source code will be placed to path").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles").withRequiredArg().ofType(String.class);

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -57,6 +57,7 @@ class UmpleModel
     }catch( IOException e ){
       throw new RuntimeException("Error opening '/umple_core.grammar' resource", e);
     }
+    Arrays.sort(result);
     return result;
   }
 
@@ -232,7 +233,6 @@ class UmpleModel
     
     // Ensure the target is specified in the proper case.
     VALIDATE_GENERATE:
-    //for( String lang : UmpleModel.validLanguages ){
     for( String lang : UmpleModel.validLanguages ){
       if(lang.equalsIgnoreCase(language)){
         realLanguage = lang;

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -32,7 +32,7 @@ strictnessMessage : [=message:allow|ignore|expect|disallow] [messageNumber]
 
 // The generate clause can be used to generate multiple outputs
 // The --override is used to say that subsequent generate statements will be ignored
-generate : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|Papyrus|Ecore|Xmi|Xtext|Sql|Umple|UmpleSelf|USE|Test] ( [=suboptionIndicator:-s|--suboption] " [**suboption] " )* ;
+generate : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|Papyrus|Ecore|Xmi|Xtext|Sql|Umple|UmpleSelf|USE|Test|SimpleMetrics|Uigu2] ( [=suboptionIndicator:-s|--suboption] " [**suboption] " )* ;
 
 generate_path : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|Papyrus|Ecore|Xmi|Xtext|Sql|UmpleSelf|USE|test] " [**output] " [=override:--override|--override-all]? ( [=suboptionIndicator:-s|--suboption]  " [**suboption] " )* ;
 


### PR DESCRIPTION
Changed the list of generators displayed with `--help` to now display alphabetically-sorted languages from `umple_core.grammar`. The list is sorted to organize the generates for readability, since they don't seem to have a specific order in the grammar file.

Added `SimpleMetrics` and `Uigu2` to `umple_core.grammar`'s list of generates. Previously, these were generate options hard-coded in the help, but not mentioned in the grammar file.
