### PR TITLE
Fixed the injection of code into multiple methods at once.

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2556,10 +2556,10 @@ class UmpleInternalParser
     return value;
   }
 
-	//TODO I changed the parameter's type. please remove this comment;
+  //TODO I changed the parameter's type. please remove this comment;
   private void analyzeInjectionCode(Token injectToken, UmpleClassifier uClassifier)
   {
-    String type = injectToken.is("beforeCode") ? "before" : "after";    
+    String type = injectToken.is("beforeCode") ? "before" : "after";
     CodeBlock cb = new CodeBlock();
     StringBuilder operationName = new StringBuilder();
     String comma = "";
@@ -2571,15 +2571,15 @@ class UmpleInternalParser
         comma = ",";
       }
     }
-    CodeInjection injection = new CodeInjection(type,injectToken.getValue("operationName"),"",uClassifier);
+    CodeInjection injection = new CodeInjection(type,operationName.toString(),"",uClassifier);
     makeCodeInject(injectToken,injection,cb,uClassifier);
     injection.setSnippet(cb);
     if (uClassifier instanceof UmpleClass) {
       checkCodeInjectionValidity(injectToken, operationName.toString(), uClassifier);
-    	((UmpleClass)uClassifier).addCodeInjection(injection);
+      ((UmpleClass)uClassifier).addCodeInjection(injection);
     } else if (uClassifier instanceof UmpleTrait){
-    	((UmpleTrait)uClassifier).addCodeInjection(injection);
-    }  
+      ((UmpleTrait)uClassifier).addCodeInjection(injection);
+    }
   }
 
   private boolean checkCodeInjectionValidity(Token injectToken, String operationName, UmpleClassifier uClassifier) {

--- a/cruise.umple/test/cruise/umple/compiler/680_injectMultipleMethods.ump
+++ b/cruise.umple/test/cruise/umple/compiler/680_injectMultipleMethods.ump
@@ -1,0 +1,15 @@
+class A{
+  Integer x;
+  Integer y;
+  after setX,setY {
+    //this code will be injected
+  }
+}
+
+class B{
+  Integer x;
+  Integer y;
+  before setX,setY {
+    //this code will be injected
+  }
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2067,6 +2067,28 @@ public class UmpleParserTest
   }
 
   @Test
+  public void multiInject()
+  {
+    assertSimpleParse("680_injectMultipleMethods.ump");
+
+    UmpleClass a = model.getUmpleClass("A");
+    Assert.assertEquals(1,a.numberOfCodeInjections());
+
+    CodeInjection aInject = a.getCodeInjection(0);
+    Assert.assertEquals("after",aInject.getType());
+    Assert.assertEquals("setX,setY", aInject.getOperation());
+    Assert.assertEquals("//this code will be injected",aInject.getCode());
+
+    UmpleClass b = model.getUmpleClass("B");
+    Assert.assertEquals(1,b.numberOfCodeInjections());
+
+    CodeInjection bInject = b.getCodeInjection(0);
+    Assert.assertEquals("before",bInject.getType());
+    Assert.assertEquals("setX,setY",bInject.getOperation());
+    Assert.assertEquals("//this code will be injected",bInject.getCode());
+  }
+
+  @Test
   public void upperCaseAssociationKey()
   {
 	assertSimpleParse("284_keyAssociationUpper.ump");


### PR DESCRIPTION
The issue was that the StringBuilder token wasn't properly used by Umple's Internal Parser. It had the target methods in separate tokens, which a StringBuilder was intended to fix. Passing the StringBuilder's result into new CodeInjection() fixed the issue.

Fixes #680

Signed-off-by: Victoria Lacroix victoria.a.lacroix@gmail.com
