### PR TITLE
Fixed Compiler-generated files lying around build directory after testing UmpleModel

### DIFF
--- a/cruise.umple/test/cruise/umple/compiler/UmpleModelTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleModelTest.java
@@ -55,6 +55,9 @@ public class UmpleModelTest
     SampleFileWriter.destroy("Course.java");
     SampleFileWriter.destroy("Teacher.java");
     SampleFileWriter.destroy("sub/");
+    SampleFileWriter.destroy("Student2.php");
+    SampleFileWriter.destroy("Teacher.php");
+    SampleFileWriter.destroy("teachercdt.gv");
   }
 
   @Test


### PR DESCRIPTION
Cleans up the files `Student2.php`, `Teacher.php`, and `teachercdt.gv` generated when running UmpleModelTest. 
