### PR TITLE
Add two more cache directories to `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ language: java
 cache:
   directories:
     - $HOME/.ant/lib/
+    - $HOME/.ivy2/
+    - $HOME/.m2/
     - $TRAVIS_BUILD_DIR/dist/libs
 
 addons:
@@ -22,7 +24,7 @@ before_install:
 
 env:
   global:
-    - ANT_FIRST='ant -f build.umple.xml -Dmyenv=travis -Donline=true'
+    - ANT_FIRST='ant -f build.umple.xml -Dmyenv=travis'
     - ANT_BUILD='ant -f build.umple.xml -Dmyenv=travis -Dfirst.build=false'
     - ANT_TESTBED='ant -f build.testbed.xml -Dmyenv=travis -Dfirst.build=false'
 
@@ -33,12 +35,12 @@ script:
   # We resolve all of the dependencies before, this way the command will be unlikely to time out
   - ant -Dmyenv=travis deps-resolve-all
 
-  # Do the a modified version of `first-build`
+  # Do a modified version of `first-build`
   - $ANT_FIRST clean init codegen rtcpp template.setVersion resetUmpleSelf
   - $ANT_FIRST compile compileValidator compileUmplificator
   - $ANT_FIRST package template.resetVersion
 
-  # Do the a modified version of `build`
+  # Do a modified version of `build`
   - $ANT_BUILD clean init codegen rtcpp template.setVersion resetUmpleSelf
   - $ANT_BUILD compile compileValidator compileUmplificator
   - $ANT_BUILD package 

--- a/travis/deps.osx.sh
+++ b/travis/deps.osx.sh
@@ -12,8 +12,6 @@ echo "brew update ..."
 brew update > /dev/null # There is no need for all of this output to be seen
 
 brew install ant
-
-brew tap caskroom/cask
 brew cask install java
 
 java -version

--- a/travis/deps.osx.sh
+++ b/travis/deps.osx.sh
@@ -8,8 +8,12 @@ fi
 
 brew tap caskroom/cask
 
-brew update #; brew doctor; brew update
+echo "brew update ..."
+brew update > /dev/null # There is no need for all of this output to be seen
 
-brew install ant brew-cask && brew cask install java
+brew install ant
+
+brew tap caskroom/cask
+brew cask install java
 
 java -version


### PR DESCRIPTION
I added the two following directories:
- `$HOME/.ivy2/` - This is where Ivy downloads it's dependencies to
- `$HOME/.m2/` - This is where Maven downloads, while I don't think it's used, it's not worse for wear to have it

I also removed the `-Donline=true` marker from the `first-build` command. I would rather see this fail to detect than overriding it.

Additionally, I cleaned up the output on OSX by removing the `brew update` output (it's not useful to begin with). 

You can see the improved output from caching by comparing the `first-build` steps from: [Build #242.1](https://travis-ci.org/umple/umple/jobs/105486000) to [Build #244.1](https://travis-ci.org/umple/umple/jobs/105488194)
