### PR TITLE
Making the documenter be less verbose

### DIFF
--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -95,6 +95,8 @@ class Documenter
     int numContents = 0;
 
     Hashtable<String,String> referenceLookup = createReferenceLookup();
+    String filename="";
+    int totPages=0;
     for (int gi=0; gi<numGroups; gi++)
     {
       group = getParser().getGroup(gi);
@@ -134,11 +136,12 @@ class Documenter
           return false;
         }
         
-        String filename = path + File.separator + content.getTitleFilename();
+        filename = path + File.separator + content.getTitleFilename();
         SampleFileWriter.createFile(filename,htmlOutput);
-        addMessage("Created: " + filename);
       }
+      totPages+=numContents;
     }
+    addMessage("Created "+totPages+" manual pages, in "+numGroups+" groups, including "+filename);
     return true;
   }
   

--- a/cruise.umple/test/cruise/umple/docs/DocumenterTest.java
+++ b/cruise.umple/test/cruise/umple/docs/DocumenterTest.java
@@ -120,10 +120,8 @@ DISABLED BECAUSE OF MAJOR CHANGES WHEN GENERATING USER MANUAL
     
     Assert.assertEquals(true,(new File("example/myTitle.html")).exists());
     Assert.assertEquals(true,(new File("example/myTitle3.html")).exists());
-    Assert.assertEquals(2,documenter.numberOfMessages());
-    AssertHelper.assertPathEquals("Created: example\\myTitle.html",documenter.getMessage(0));
-    AssertHelper.assertPathEquals("Created: example\\myTitle3.html",documenter.getMessage(1));
-    
+    Assert.assertEquals(1,documenter.numberOfMessages());
+    AssertHelper.assertPathEquals("Created 2 manual pages, in 1 groups, including example\\myTitle3.html",documenter.getMessage(0));
   }
   
   @Test


### PR DESCRIPTION
Previously there was a line emitted by the build for every single manual page created. This will simply create a summary line counting the number of pages, and giving the name of the last one. The objective is to shorten the build transcript so people notice the warnings that are currently being unheeded
