### PR TITLE
Reduce memory requirements for building Umple on Travis Linux closes #720

### DIFF
--- a/build/_template.xml
+++ b/build/_template.xml
@@ -182,6 +182,7 @@
     <deps-get-path conf="test" pathid="test.ivy.classpath" />
 
     <junit fork="yes" forkmode="perBatch" haltonfailure="${haltonfailure}" showoutput="${showJunitOutput}" printsummary="${showJunitSummary}" >
+      <jvmarg value="-Xmx500m"/>    
       <!-- <jmvarg value="-XstartOnFirstThread"/> -->
       <formatter type="xml" unless="${showJunitOutput}"/>
       <formatter usefile="false" type="brief" if="${showJunitOutput}"/>

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -72,12 +72,15 @@
 
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple/src/Master.ump"/>
+      <jvmarg value="-Xmx500m"/>
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
+      <jvmarg value="-Xmx500m"/>      
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
+      <jvmarg value="-Xmx500m"/>
     </java>
   </target>
 

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -262,6 +262,7 @@
           classpath="${dist.dir}/${dist.umple.docs.jar}">
       <arg value="build/reference"/>
       <arg value="${dist.path}/reference"/>
+      <jvmarg value="-Xmx500m"/>      
     </java>
     <copy todir="${dist.path}/reference/files">
       <fileset dir="build/reference/files"/>

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -72,15 +72,15 @@
 
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple/src/Master.ump"/>
-      <jvmarg value="-Xmx500m"/>
+      <jvmarg value="-Xmx150m"/>
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
-      <jvmarg value="-Xmx500m"/>      
+      <jvmarg value="-Xmx150m"/>      
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
-      <jvmarg value="-Xmx500m"/>
+      <jvmarg value="-Xmx150m"/>
     </java>
   </target>
 

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -55,12 +55,15 @@
 
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple/src/Master.ump"/>
+      <jvmarg value="-Xmx500m"/>
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
+      <jvmarg value="-Xmx500m"/>
     </java>
      <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
+      <jvmarg value="-Xmx500m"/>
     </java>
   </target>
 
@@ -72,15 +75,12 @@
 
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple/src/Master.ump"/>
-      <jvmarg value="-Xmx150m"/>
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
-      <jvmarg value="-Xmx150m"/>      
     </java>
     <java jar="${umple.stable.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
-      <jvmarg value="-Xmx150m"/>
     </java>
   </target>
 


### PR DESCRIPTION
On Travis Umple's resetUmpleSelf will now be limited to 500MB this causes a little more garbage collection (1% total time) when compiling Master.ump, but prevents travis from failing out on Linux. When doing a normal full build the umpleSelf ant task is used instead, which doesn't have this limit. 

Also the limit is applied to the documenter when building the manual and to template.test. These were failing out on travis on Linux.
