### PR TITLE
Warning 1009 no longer appears when interface lists subclass method 

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1355,7 +1355,7 @@ class UmpleInternalParser
     {
       for (Method aMethod : parentInterface.getMethods())
       {
-        boolean shouldAddMethod = verifyIfMethodIsConstructorOrGetSet(uClass, aMethod);
+        boolean shouldAddMethod = verifyIfMethodIsConstructorOrGetSet(uClass, aMethod, true);
         if (!(uClass.hasImplementedMethodIncludingWithinParentClasses(aMethod))
         && !(uClass.hasMethodInTraits(aMethod)) && !(uClass.isIsAbstract()) && shouldAddMethod)
         {
@@ -1375,7 +1375,7 @@ class UmpleInternalParser
    * 
    * @return True if the method is a constructor, getter/setter, false otherwise.
    */
-  private boolean verifyIfMethodIsConstructorOrGetSet(UmpleClass uClass, Method aMethod)
+  private boolean verifyIfMethodIsConstructorOrGetSet(UmpleClass uClass, Method aMethod, boolean checkingInInterface)
   {
     String methodName = aMethod.getName();
 
@@ -1390,7 +1390,9 @@ class UmpleInternalParser
         Attribute attr = uClass.getAttribute(possibleAttributeName);
         if (attr != null && !"internal".equals(attr.getModifier()))
         {
-          getParseResult().addErrorMessage(new ErrorMessage(1009, aMethod.getPosition(), methodName, attr.getName()));	
+          if(!checkingInInterface) {
+            getParseResult().addErrorMessage(new ErrorMessage(1009, aMethod.getPosition(), methodName, attr.getName(),uClass.getName()));
+          }
           return false;
         }
       }
@@ -2237,7 +2239,7 @@ class UmpleInternalParser
       UmpleClass uClass = (UmpleClass) uElement;
       
       // Add Getter/Setter/Constructor to Class
-      boolean shouldAddMethod = verifyIfMethodIsConstructorOrGetSet(uClass, aMethod);
+      boolean shouldAddMethod = verifyIfMethodIsConstructorOrGetSet(uClass, aMethod, false);
      
       //Issue 559
       if(uClass.hasMethod(aMethod))

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -165,7 +165,7 @@
 1006: 3, "http://cruise.eecs.uottawa.ca/umple/W1006StateMachineNotParsed.html", State machine syntax could not be processed. It has been considered as Extra Code ;
 1007: 3, "http://cruise.eecs.uottawa.ca/umple/W1007ElementNotParsed.html", Attribute or Association syntax could not be processed. It has been considered as Extra Code ;
 1008: 3, "http://cruise.eecs.uottawa.ca/umple/W1008MethodNotParsed.html", Method syntax could not be processed. It has been considered as Extra Code ;
-1009: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' has a name conflict with automatic generated getter/setter methods for attribute '{1}'. The user definition is being disconsidered. Please use a different name ;
+1009: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' has a name conflict with automatic generated getter/setter methods for attribute '{1}' in class '{2}'. Please use a different method name ;
 1010: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Constraint syntax, {0}, could not be processed. It has been considered as Extra Code ;
 1011: 3, "http://cruise.eecs.uottawa.ca/umple/W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
 1012: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' cannot be found. Injection was ignored. ;


### PR DESCRIPTION
This warning had been cluttering up the build for a long time. This helps fix #515 
