### PR TITLE
Add support for Appveyor and auto-env detection (#633, #724)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Umple Modelling Language
 
-[![Build Status](https://travis-ci.org/umple/umple.svg?branch=master)](https://travis-ci.org/umple/umple)
+[![Unix Build Status](https://travis-ci.org/umple/umple.svg?branch=master)](https://travis-ci.org/umple/umple) [![Windows Build status](https://ci.appveyor.com/api/projects/status/uwvrjpm6uis69es2/branch/master?svg=true)](https://ci.appveyor.com/project/Nava2/umple/branch/master)
 
 ##Introduction
 
@@ -25,7 +25,7 @@ More details can be found as follows
   * Live diagram of the metamodel: http://metamodel.umple.org
   * Architecture: http://architecture.umple.org
 
-Umple is continuously tested and build at the University of Ottawa using CruiseControl; see http://cc.umple.org . It is also built on Travis CI (https://travis-ci.org/).
+Umple is continuously tested and build at the University of Ottawa using CruiseControl; see http://cc.umple.org . It is also built on Travis CI (https://travis-ci.org/) and Appveyor (https://appveyor.com/).
  
 ###Project setup
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+version: 1.23.0-build-{build}
+
+clone_depth: 5
+
+cache:
+
+- '%HOME%\.ivy2'
+- '%HOME%\.m2'
+- '%HOME%\.ant\lib\'
+- '%APPVEYOR_BUILD_FOLDER%\dist\libs'
+- C:\tools\php
+- C:\ProgramData\chocolatey\lib\ant
+
+init:
+
+- ps: gem update --system
+- ps: cinst ant 2>&1 | Out-Null
+- ps: cinst php --version=5.6.17 2>&1 | Out-Null
+
+install:
+
+- ps: $env:Path="C:\Ruby21\bin;C:/tools/ruby22/bin;$($env:Path);C:\tools\php;C:\ProgramData\chocolatey\lib\ant"
+
+- ps: ant -version
+- ps: pushd build
+
+- cmd: ant bootstrap
+- cmd: ant deps-resolve-all
+
+- ps: popd
+
+- ps: php.exe --version
+- ps: ruby.exe -v
+- cmd: java.exe -version # using ps causes it to fail because it prints to sterr
+- ps: ant -version
+- ps: rake.bat -V
+
+build_script:
+
+- ps: cd build
+
+- cmd: ant first-build
+- cmd: ant -f build.umple.xml -Dfirst.build=false
+
+test_script:
+
+- cmd: ant -f build.testbed.xml -Dfirst.build=false
+

--- a/build/_appveyor.xml
+++ b/build/_appveyor.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project basedir=".." name="TravisProperties">
+
+  <!-- 
+    run by the appveyor VM, should work as-is on your machine, but be careful
+    as your code will be run against the "latest" Umple-d Umple.
+   -->
+  <property name="haltonfailure" value="true"/>    
+  <property name="shouldPackageUmpleOnline" value="false"/>
+  <property name="shouldDeploy" value="false"/>
+  <property name="showJunitSummary" value="true"/>
+  <property name="showJunitOutput" value="false"/> 
+
+  <property name="ivyRetrieveLogLevel" value="default" />
+  <property name="ivyResolveLogLevel" value="default" />
+  <property name="junit" value="*Test"/> 
+  <property name="rake_cmd" value="rake.bat"/>  
+
+  <property name="online" value="true" />
+   
+  <import file="_versionNew.xml" />
+
+
+</project>

--- a/build/_template.xml
+++ b/build/_template.xml
@@ -7,11 +7,56 @@
 
   <condition property="is.osx"><os family="mac" /></condition>
 
-  <property name="myenv" value="cc" />
+  <!-- Environment Detection: -->
+  <!-- Check different environment settings, eventually we will match to `wlocal` or `local` if no
+       special environment is detected. This may be overwritten with the `-Dmyenv` variable at 
+       runtime -->
+  <local name="env" />
+  <property environment="env"/>
+
+  <condition property="myenv" value="travis">
+    <and>
+      <isset property="env.CI" />
+      <isset property="env.TRAVIS" />
+    </and>
+  </condition>
+
+  <condition property="myenv" value="appveyor">
+    <and>
+      <isset property="env.CI" />
+      <isset property="env.APPVEYOR" />
+    </and>
+  </condition>
+
+  <local name="computer.hostname" />
+  <exec executable="hostname" outputproperty="computer.hostname"/>
+
+  <condition property="myenv" value="cc">
+    <and> <!-- Check for CC on cruise -->
+      <os family="unix" />
+      <equals arg1="${computer.hostname}" arg2="cruise" />
+    </and>
+  </condition>
+
+  <condition property="myenv" value="local">
+    <os family="unix" />
+  </condition>
+
+  <condition property="myenv" value="wlocal">
+    <os family="windows" />
+  </condition>
+
+  <echo message="Using myenv=${myenv}" />
+  <!-- /end Environment Detection -->
+
+
   <import file="_${myenv}.xml" />
   
   <property name="dist.dir"                     value="${basedir}/dist" />
   <property name="dist.libs.dir"                value="${dist.dir}/libs" />
+
+  <!-- Note: dist.dir and dist.libs.dir must be defined before importing this file. -->
+  <import file="build.deps.xml" />
 
   <!-- Macro that will build up jar properties: creates two, 
   1. dist.umple.@{name}.jar      -> most recent built jar
@@ -72,9 +117,6 @@
       <!-- 
         We ping three different sources that we know of to check if they are available. If they are not available
         then we know that the build is offline (as far as we are concerned).
-
-        Unfortunately, the <isreachable> tag from <condition> seems to return false negatives, thus doing an OS 
-        specific approach was required. This is handled in the custom <isreachable> macro defined above. 
       -->
       <parallel>
         <isreachable property="access.maven" 
@@ -106,8 +148,6 @@
       </if>
     </sequential>
   </macrodef>
-
-  <import file="build.deps.xml" />
 
   <!-- ```````````````````````````
     Clean up and initialize any potential byproduct

--- a/build/build.deps.xml
+++ b/build/build.deps.xml
@@ -191,6 +191,8 @@
       <pathelement location="${umple.stable.jar}"/>
     </path>
 
+    <echo>umple.stable.jar=${umple.stable.jar}</echo>
+
     <taskdef name="umplec" classname="cruise.umple.util.UmplecAntTask" classpathref="umple.last.classpath" />
   </target>
 

--- a/cruise.umple/src/Builder_Code.ump
+++ b/cruise.umple/src/Builder_Code.ump
@@ -7,6 +7,9 @@ class Command
 {
   depend  java.util.regex.*;  
   depend  java.lang.reflect.*;
+
+  const String NL = System.lineSeparator();
+
   String[] history;
   String[] messages;
   String[] attributes;
@@ -192,6 +195,8 @@ class Builder {
   depend org.apache.tools.ant.*;
   depend java.util.*;
   depend java.util.stream.*;
+
+  const String NL = System.lineSeparator();
   
   public URL compile(String directory, String jarname, String projectName, String javaTarget)
   {
@@ -243,7 +248,7 @@ class Builder {
   {
     // build string parameters:
 
-    final String exec = "ant" + (System.getProperty("os.name").toLowerCase().contains("windows") ? ".bat" : "");
+    final String exec = "ant";
     final String buildFilePath = (new File(buildFilename)).getAbsolutePath();
     String optionStr = "";
     if (options != null) {
@@ -274,17 +279,19 @@ class Builder {
           
           String line;
           while ((line = out.readLine()) != null) {
-            outSB.append(line + "\n");
+            outSB.append(line);
+            outSB.append(NL);
           }
 
           final StringBuilder errSB = new StringBuilder();
           while ((line = err.readLine()) != null) {
-            errSB.append(line + "\n");
+            errSB.append(line);
+            errSB.append(NL);
           }
 
           System.out.println("== Ant Task failed ==");
-          System.out.println("System.out => \n" + outSB);
-          System.err.println("System.err => \n" + errSB);
+          System.out.println("System.out => " + NL + outSB);
+          System.err.println("System.err => " + NL + errSB);
         }
         
       return false;
@@ -315,22 +322,22 @@ class Builder {
   {
     
     String antScript = "" +
-      "<project name=\"runtime-compiler\" default=\"go\" basedir=\".\">\n" +
-      "  <target name=\"clean\">\n" +
-      "    <delete file=\""+ jarname +"\" failonerror=\"false\" />\n" +
-      "    <delete failonerror=\"false\">\n" +
-      "        <fileset dir=\".\" includes=\"**/*.class\"/>\n" +
-      "      </delete>\n" +
-      "  </target>\n" +
-      "  <target name=\"compile\">\n" +
-      "    <javac debug=\"true\" debuglevel=\"source,lines,vars\" includeAntRuntime=\"false\" destdir=\".\" srcdir=\".\" target=\""+ javaTarget +"\">\n" +
-      "      <exclude name=\"**/.svn\"/>\n" +
-      "    </javac>\n" +
-      "  </target>\n" +
-      "  <target name=\"jar\">\n" +
-      "    <jar destfile=\""+ jarname +"\" basedir=\".\" excludes=\"**/.svn\" />\n" +
-      "  </target>\n" +
-      "  <target name=\"go\" depends=\"clean,compile,jar\" /> \n" +       
+      "<project name=\"runtime-compiler\" default=\"go\" basedir=\".\">" + NL +
+      "  <target name=\"clean\">" + NL +
+      "    <delete file=\""+ jarname +"\" failonerror=\"false\" />" + NL +
+      "    <delete failonerror=\"false\">" + NL +
+      "        <fileset dir=\".\" includes=\"**/*.class\"/>" + NL +
+      "      </delete>" + NL +
+      "  </target>" + NL +
+      "  <target name=\"compile\">" + NL +
+      "    <javac debug=\"true\" debuglevel=\"source,lines,vars\" includeAntRuntime=\"false\" destdir=\".\" srcdir=\".\" target=\""+ javaTarget +"\">" + NL +
+      "      <exclude name=\"**/.svn\"/>" + NL +
+      "    </javac>" + NL +
+      "  </target>" + NL +
+      "  <target name=\"jar\">" + NL +
+      "    <jar destfile=\""+ jarname +"\" basedir=\".\" excludes=\"**/.svn\" />" + NL +
+      "  </target>" + NL +
+      "  <target name=\"go\" depends=\"clean,compile,jar\" />" + NL +       
       "</project>";
     
     try {

--- a/cruise.umple/src/Compiler.ump
+++ b/cruise.umple/src/Compiler.ump
@@ -116,7 +116,7 @@ class CodeCompiler {
 
   private static void println(String output)
   {
-    console += output + "\n";
+    console += output + System.lineSeparator();
     System.out.println(output);
   }
 

--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -20,7 +20,8 @@ class DocumenterMain
      
     if (args.length < 2)
     {
-      println("Usage: java -jar umpledocs.jar <data_dir> <output_dir>\nExample: java -jar umple-docs.jar docs output");
+      println("Usage: java -jar umpledocs.jar <data_dir> <output_dir>" + System.lineSeparator() 
+              + "Example: java -jar umple-docs.jar docs output");
       return;
     }
      
@@ -41,7 +42,7 @@ class DocumenterMain
    
   private static void println(String output)
   {
-    console += output + "\n";
+    console += output + System.lineSeparator();
     System.out.println(output);
   }
 }

--- a/cruise.umple/src/Generator_CodeEcore_Model.ump
+++ b/cruise.umple/src/Generator_CodeEcore_Model.ump
@@ -198,7 +198,7 @@ class EcorePackage {
   emit getXmlHeader()(xmlHeader);
   
   String getCode(){
-    return getXmlHeader() + '\n' + super.getCode();
+    return getXmlHeader() + System.lineSeparator() + super.getCode();
   };
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/UmpleClassTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleClassTest.java
@@ -30,6 +30,8 @@ public class UmpleClassTest
   public void tearDown()
   {
     umpleClass = null;
+
+    SampleFileWriter.destroy("umpleClassTest.ump");
   }
   
   @Test

--- a/cruise.umple/test/cruise/umple/compiler/UmpleImportTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleImportTest.java
@@ -13,215 +13,196 @@ import org.junit.Test;
 import cruise.umple.util.SampleFileWriter;
 
 public class UmpleImportTest {
-	private static String pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler");
+    private static String pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler");
+    
+    private static String getAbsFile(final String name) {
+        return pathToInput + "/" + name;
+    }
 
-	@Before
-	public void setUp() throws Exception {
-	}
+    private static String loadScxmlFile(final String name) throws Exception {
+        assertTrue((new File(name)).exists());
 
-	@After
-	public void tearDown() throws Exception {
-	}
+        ScxmlImportHandler handler = new ScxmlImportHandler();
+        UmpleImportModel umple = handler.readDataFromXML(name);
+        return umple.generateUmple();
+    }
 
-	@Test
-	public void EcoreClassParsingTest() throws Exception {
+    private static String loadECoreFile(final String name) throws Exception {
+        assertTrue((new File(name)).exists());
 
-		String expectedText = loadUmpleFile("ECoreImport_ClassWithNamespace.ump");
-		String actualText = loadECoreFile("ECoreImport_ClassWithNamespace.ecore");
+        EcoreImportHandler handler = new EcoreImportHandler();
+        UmpleImportModel umple = handler.readDataFromXML(name);
+        return umple.generateUmple();
+    }
 
-		assertEquals(expectedText, actualText);
-	}
+    private static void assertImportFile(final UmpleImportType type, 
+            final String expectedPath, 
+            final String importFile) throws Exception {
+        final String realImportFile = getAbsFile(importFile);
+        String content;
+        if (type == UmpleImportType.ECORE) {
+            content = loadECoreFile(realImportFile);
+        } else if (type == UmpleImportType.SCXML) {
+            content = loadScxmlFile(realImportFile);
+        } else {
+            throw new IllegalArgumentException("Unknown UmpleImportType parameter = " + type);
+        }
 
-	@Test
-	public void EcoreInterfaceParsingTest() throws Exception {
+        final File expectedFile = new File(getAbsFile(expectedPath));
+        assertTrue(expectedFile.exists());
+        SampleFileWriter.assertFileContent(expectedFile, content);
+    }
 
-		String expectedText = loadUmpleFile("ECoreImport_InterfaceWithNamespace.ump");
-		String actualText = loadECoreFile("ECoreImport_InterfaceWithNamespace.ecore");
+    @Before
+    public void setUp() throws Exception {
+    }
 
-		assertEquals(expectedText, actualText);
-	}
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	@Test
-	public void EcoreClassAttributesParsingTest() throws Exception {
+    @Test
+    public void EcoreClassParsingTest() throws Exception {
+        assertImportFile(UmpleImportType.ECORE, 
+            "ECoreImport_ClassWithNamespace.ump", 
+            "ECoreImport_ClassWithNamespace.ecore");
+    }
 
-	  String expectedText = loadUmpleFile("ECoreImport_ClassAttributes.ump");
-		String actualText = loadECoreFile("ECoreImport_ClassAttributes.ecore");
+    @Test
+    public void EcoreInterfaceParsingTest() throws Exception {
+        assertImportFile(UmpleImportType.ECORE,
+            "ECoreImport_InterfaceWithNamespace.ump", 
+            "ECoreImport_InterfaceWithNamespace.ecore");
+    }
 
-		assertEquals(expectedText, actualText);
-	}
+    @Test
+    public void EcoreClassAttributesParsingTest() throws Exception {
 
-	@Test
-	public void EcoreClassAssociationParsingTest() throws Exception {
+        assertImportFile(UmpleImportType.ECORE,
+            "ECoreImport_ClassAttributes.ump", 
+            "ECoreImport_ClassAttributes.ecore");
+    }
 
-		String expectedText = loadUmpleFile("ECoreImport_Association.ump");
-		String actualText = loadECoreFile("ECoreImport_Association.ecore");
+    @Test
+    public void EcoreClassAssociationParsingTest() throws Exception {
 
-		assertEquals(expectedText, actualText);
-	}
+        assertImportFile(UmpleImportType.ECORE,
+            "ECoreImport_Association.ump", 
+            "ECoreImport_Association.ecore");
+    }
 
-	@Test
-	public void EcoreLargeScaleACGParsingTest() throws Exception {
+    @Test
+    public void EcoreLargeScaleACGParsingTest() throws Exception {
 
-		String expectedText = loadUmpleFile("ECoreImport_largeScale_ACG.ump");
-		String actualText = loadECoreFile("ECoreImport_largeScale_ACG.ecore");
+        assertImportFile(UmpleImportType.ECORE,
+            "ECoreImport_largeScale_ACG.ump", 
+            "ECoreImport_largeScale_ACG.ecore");
+    }
 
-		assertEquals(expectedText, actualText);
-	}
+    @Test
+    public void EcoreLargeScaleACMEParsingTest() throws Exception {
 
-	@Test
-	public void EcoreLargeScaleACMEParsingTest() throws Exception {
+        assertImportFile(UmpleImportType.ECORE,
+            "ECoreImport_largeScale_ACME.ump",
+            "ECoreImport_largeScale_ACME.ecore");
+    }
 
-		String expectedText = loadUmpleFile("ECoreImport_largeScale_ACME.ump");
-		String actualText = loadECoreFile("ECoreImport_largeScale_ACME.ecore");
+    @Test
+    public void ScxmlEmptyStateMachineTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_empty.ump",
+            "ScxmlImport_empty.scxml.txt");
+    }
 
-		assertEquals(expectedText, actualText);
-	}
+    @Test
+    public void ScxmlOneStateTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_one_state.ump",
+            "ScxmlImport_one_state.scxml.txt");
+    }
 
-	@Test
-	public void ScxmlEmptyStateMachineTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_empty.ump").trim();
-	  String actualText = loadScxmlFile("ScxmlImport_empty.scxml.txt").trim();
-	  assertEquals(expectedText, actualText);
-	}
+    @Test
+    public void ScxmlMultipleStatesTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_multiple_states.ump",
+            "ScxmlImport_multiple_states.scxml.txt");
+    }
 
-	@Test
-  public void ScxmlOneStateTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_one_state.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_one_state.scxml.txt").trim();
+    @Test
+    public void ScxmlOneNestedStateTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_one_nested_state.ump",
+            "ScxmlImport_one_nested_state.scxml.txt");
+    }
 
-    assertEquals(expectedText, actualText);
-  }
+    @Test
+    public void ScxmlMultipleNestedStatesTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_multiple_nested_states.ump",
+            "ScxmlImport_multiple_nested_states.scxml.txt");
+    }
 
-	@Test
-  public void ScxmlMultipleStatesTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_multiple_states.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_multiple_states.scxml.txt").trim();
+    @Test
+    public void ScxmlTransitionTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_transition.ump",
+            "ScxmlImport_transition.scxml.txt");
+    }
 
-    assertEquals(expectedText, actualText);
-  }
-
-	@Test
-  public void ScxmlOneNestedStateTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_one_nested_state.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_one_nested_state.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-  }
-
-	@Test
-  public void ScxmlMultipleNestedStatesTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_multiple_nested_states.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_multiple_nested_states.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-  }
-
-	@Test
-	public void ScxmlTransitionTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_transition.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_transition.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-	}
-
-	@Test
-  public void ScxmlTransitionWithGuardTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_transition_with_guard.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_transition_with_guard.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-  }
-	
-	@Test
-	public void ScxmlOnEntryEmptyTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_onentry_empty.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_onentry_empty.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-	}
-	
-	@Test
-	public void ScxmlOnEntryWithActionTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_onentry_with_action.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_onentry_with_action.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText); 
-	}
-	
-	@Test
-	public void ScxmlOnEntryWithMultilineActionTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_onentry_with_multiline_action.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_onentry_with_multiline_action.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-	}
-	
-	@Test
-	public void ScxmlOnEntryAndOnExitTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_onentry_and_onexit.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_onentry_and_onexit.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText);
-	}
-	
-	@Test 
-	public void ScxmlTransitionActionTest() throws Exception {
-	  String expectedText = loadUmpleFile("ScxmlImport_transition_action.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_transition_action.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText); 
-	}
-	
-	@Test 
-  public void ScxmlInitialStateTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_initial_state.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_initial_state.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText); 
-  }
-	
-	@Test 
-  public void ScxmlInitialNestedStateTest() throws Exception {
-    String expectedText = loadUmpleFile("ScxmlImport_initial_nested_state.ump").trim();
-    String actualText = loadScxmlFile("ScxmlImport_initial_nested_state.scxml.txt").trim();
-
-    assertEquals(expectedText, actualText); 
-  }
-
-	private static String loadScxmlFile(String name) throws Exception {
-	  String filename = getFullFilePath(name);
-	  assertEquals(true, (new File(filename)).exists());
-
-	  ScxmlImportHandler handler = new ScxmlImportHandler();
-	  UmpleImportModel umple = handler.readDataFromXML(filename);
-	  return umple.generateUmple();
-  }
-
-	private static String loadECoreFile(String name) throws Exception {
-		String filename = getFullFilePath(name);
-		assertEquals(true, (new File(filename)).exists());
-
-		EcoreImportHandler handler = new EcoreImportHandler();
-		UmpleImportModel umple = handler.readDataFromXML(filename);
-		return umple.generateUmple();
-	}
-
-	private static String loadUmpleFile(String name) throws IOException {
-
-		String filename = getFullFilePath(name);
-		StringBuilder builder = new StringBuilder();
-		FileReader reader = new FileReader(new File(filename));
-
-		int content;
-		while ((content = reader.read()) != -1) {
-			builder.append((char) content);
-		}
-		reader.close();
-		return builder.toString();
-	}
-
-	private static String getFullFilePath(String name) {
-		return pathToInput + "/"+ name;
-	}
+    @Test
+    public void ScxmlTransitionWithGuardTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_transition_with_guard.ump",
+            "ScxmlImport_transition_with_guard.scxml.txt");
+    }
+    
+    @Test
+    public void ScxmlOnEntryEmptyTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_onentry_empty.ump",
+            "ScxmlImport_onentry_empty.scxml.txt");
+    }
+    
+    @Test
+    public void ScxmlOnEntryWithActionTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_onentry_with_action.ump",
+            "ScxmlImport_onentry_with_action.scxml.txt"); 
+    }
+    
+    @Test
+    public void ScxmlOnEntryWithMultilineActionTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_onentry_with_multiline_action.ump",
+            "ScxmlImport_onentry_with_multiline_action.scxml.txt");
+    }
+    
+    @Test
+    public void ScxmlOnEntryAndOnExitTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_onentry_and_onexit.ump",
+            "ScxmlImport_onentry_and_onexit.scxml.txt");
+    }
+    
+    @Test 
+    public void ScxmlTransitionActionTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_transition_action.ump",
+            "ScxmlImport_transition_action.scxml.txt"); 
+    }
+    
+    @Test 
+    public void ScxmlInitialStateTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_initial_state.ump",
+            "ScxmlImport_initial_state.scxml.txt"); 
+    }
+    
+    @Test 
+    public void ScxmlInitialNestedStateTest() throws Exception {
+        assertImportFile(UmpleImportType.SCXML,
+            "ScxmlImport_initial_nested_state.ump",
+            "ScxmlImport_initial_nested_state.scxml.txt"); 
+    }
 
 }


### PR DESCRIPTION
- Add `_appveyor.xml` for setting up "template" on [appveyor](https://ci.appveyor.com/project/Nava2/umple).
- Add badge to README.md
- Removes reference to `ant.bat` in favour of `ant`
- Adds a debugging output for when it tries to load `<umplec>`
- Add comments for myenv decisions
- Fix accidental leftover test file
- Adds newline support for testing `UmpleImport*`

This pull request allows us to test against Windows via [Appveyor](https://ci.appveyor.com/project/Nava2/umple). I've already hooked up this repository and builds after this pull request will build against the system. I would like to hook up the system with Github so that PRs and commits are run against Appveyor before merging. This way, we do not have a discourse between supporting Windows and *NIX environments. 

I also added some easier instructions for Windows installation in the DevelopmentSetup wiki.

Closes #633 and closes #724.
