### PR TITLE
Fix `umpleself` to use the current jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,16 @@ before_install:
 
 env:
   global:
-    - ANT_FIRST='ant -f build.umple.xml -Dmyenv=travis'
-    - ANT_BUILD='ant -f build.umple.xml -Dmyenv=travis -Dfirst.build=false'
-    - ANT_TESTBED='ant -f build.testbed.xml -Dmyenv=travis -Dfirst.build=false'
+    - ANT_FIRST='ant -f build.umple.xml'
+    - ANT_BUILD='ant -f build.umple.xml -Dfirst.build=false'
+    - ANT_TESTBED='ant -f build.testbed.xml -Dfirst.build=false'
 
 script:
   - php --version ; ruby -v
   - cd build/
-  - ant -Dmyenv=travis bootstrap
+  - ant bootstrap
   # We resolve all of the dependencies before, this way the command will be unlikely to time out
-  - ant -Dmyenv=travis deps-resolve-all
+  - ant deps-resolve-all
 
   # Do a modified version of `first-build`
   - $ANT_FIRST clean init codegen rtcpp template.setVersion resetUmpleSelf

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -73,13 +73,13 @@
 
     <deps-load-path conf="core" pathid="core.ivy.classpath" />
 
-    <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple/src/Master.ump"/>
     </java>
-    <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umple.validator/src/Master.ump"/>
     </java>
-    <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+    <java jar="${dist.dir}/${dist.umple.jar}" fork="true" failonerror="true">
       <arg value="cruise.umplificator/src/Master.ump"/>
     </java>
   </target>


### PR DESCRIPTION
I think an overzealous refactoring happened which caused `resetUmpleSelf` to be equivalent to `umpleSelf`.

I can't test directly, but I'll let the CI handle that.

The tests fail, but I'm unaware if this is caused by my change or the issues in #740. 

Closes #739.
