### PR TITLE
Add Issue/PR templates for Github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,45 @@
+
+## Checklist
+
+Before reporting an issue, please check the following:
+
+* [ ] The issue does not exist already
+* [ ] Using Java 8
+* [ ] The issue exists in the current `master` branch
+
+## Brief Description
+
+Brief, one or two sentences explaining the problem. 
+
+## Steps to Reproduce
+
+This is a **minimum** test case to validate the problem. Do not post large amounts of irrelevant code. If using a large code sample, feel free to use a [gist](https://gist.github.com/) or [UmpleOnline](http://cruise.eecs.uottawa.ca/umpleonline/).
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+## Expected Result
+
+The expected action
+
+## Actual Result
+
+The erroneous action
+
+## Build/Test Log (if applicable)
+
+Please copy your log output and paste it into a [gist](https://gist.github.com/) and link to it here. 
+
+## System configuration
+
+* Operating System: Linux, OSX, Windows, All
+* Java version: Run `java -version`
+* Most recent commit ID: Run `git status`, the number will be reported.
+
+## Misc Information
+
+
+Please use Github's markdown formatting for easier reading. [Github Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
+
+Add any relevant label's for this issue. If you are planning on fixing this issue, or know who will, please assign it. Do **not** blindly assign an issue, leave it unassigned instead.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,8 +9,7 @@ Brief, one or two sentences explaining the problem.
 This is a **minimum** test case to validate the problem. 
 
 1. Step 1
-2. Step 2
-3. Step 3
+2. ...
 
 If using a large code sample, feel free to use a [gist](https://gist.github.com/) or [UmpleOnline](http://cruise.eecs.uottawa.ca/umpleonline/).
 
@@ -26,4 +25,6 @@ Please include your build log output. If long, please paste it into a [gist](htt
 
 ## Labelling and Assigning
 
-Add any relevant label's for this issue. If you are planning on fixing this issue, or know who will, please assign it. Do **not** blindly assign an issue unless you are confident who will be fixing the issue.
+Add any relevant label's for this issue, such as 'associations', 'Component-UmpleOnline', etc. as well as Priority- and Diffic- label.
+
+If you are planning on fixing this issue, or know who will, please assign it. Do **not** blindly assign an issue unless you are confident who will be fixing the issue.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,44 +1,29 @@
-This is a *guide*, please remove unecessary sections as relevant. 
-
-## Checklist
-
-Before reporting an issue, please check the following:
-
-* [ ] The issue does not exist already
-* [ ] Using Java 8
-* [ ] The issue exists in the current `master` branch
+This is a *guide*, please remove this preamble and other irrelevant sections. Use [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for formatting. *Before writing*, please search to ensure the issue doesn't exist, and verify you are using the latest `master` branch and using Java 8.
 
 ## Brief Description
 
 Brief, one or two sentences explaining the problem. 
 
-## Steps to Reproduce
+## Minimum Steps to Reproduce
 
-This is a **minimum** test case to validate the problem. Do not post large amounts of irrelevant code. If using a large code sample, feel free to use a [gist](https://gist.github.com/) or [UmpleOnline](http://cruise.eecs.uottawa.ca/umpleonline/).
+This is a **minimum** test case to validate the problem. 
 
 1. Step 1
 2. Step 2
 3. Step 3
 
+If using a large code sample, feel free to use a [gist](https://gist.github.com/) or [UmpleOnline](http://cruise.eecs.uottawa.ca/umpleonline/).
+
 ## Expected Result
 
-The expected action
+Expected results.
 
 ## Actual Result
 
-The erroneous action
+Actual results
 
-## Build/Test Log (as applicable)
+Please include your build log output. If long, please paste it into a [gist](https://gist.github.com/) and link to it here. 
 
-Please copy your log output and paste it into a [gist](https://gist.github.com/) and link to it here. 
+## Labelling and Assigning
 
-## System configuration (as applicable)
-
-* Operating System: Linux, OSX, Windows, All
-* Most recent commit ID: Run `git status`, the number will be reported.
-
-## Misc Information
-
-Please use Github's markdown formatting for easier reading. [Github Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
-
-Add any relevant label's for this issue. If you are planning on fixing this issue, or know who will, please assign it. Do **not** blindly assign an issue, leave it unassigned instead.
+Add any relevant label's for this issue. If you are planning on fixing this issue, or know who will, please assign it. Do **not** blindly assign an issue unless you are confident who will be fixing the issue.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+This is a *guide*, please remove unecessary sections as relevant. 
 
 ## Checklist
 
@@ -27,18 +28,16 @@ The expected action
 
 The erroneous action
 
-## Build/Test Log (if applicable)
+## Build/Test Log (as applicable)
 
 Please copy your log output and paste it into a [gist](https://gist.github.com/) and link to it here. 
 
-## System configuration
+## System configuration (as applicable)
 
 * Operating System: Linux, OSX, Windows, All
-* Java version: Run `java -version`
 * Most recent commit ID: Run `git status`, the number will be reported.
 
 ## Misc Information
-
 
 Please use Github's markdown formatting for easier reading. [Github Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,16 @@
-Please read the [contribution guidelines](https://github.com/umple/umple/blob/master/CONTRIBUTING.md).
-
 **IMPORTANT**: By submitting a patch, you agree that your work will be licensed under the [license](https://github.com/umple/umple/blob/master/LICENSE.md) used by the project.
 
-If your pull request does not pass CI, it will **not** be merged (unless heavily justified). 
+If your pull request does not pass CI, it will **not** be merged (unless *heavily* justified). 
 
 ## Description
 
-Please provide a description of what this PR is meant to fix, and how it works (if it's not going to be very clear from the code). 
+Please provide a description of what this PR is meant to fix, and how it works (if it's not clear from the code changes). 
 
 ## Tests
 
-Please list all tests added or modified. All issues should have a test created to address the issue in the future (as relevant). 
+Please list all major test changes. All issues should have a test created to address the issue in the future (as relevant). 
 
-## Relevant Issues
+If closing issues, please write `Closes #ISSUE_NUMBER[, #ISSUE_NUMBER2, ...]`, to automatically close the equivalent issue.
 
-If closing issues, please write `Closes #ISSUE_NUMBER[, #ISSUE_NUMBER2, ...]`, this will automatically close issues.
+**Note:** This template is a guide, remove sections as applicable.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+Please read the [contribution guidelines](https://github.com/umple/umple/blob/master/CONTRIBUTING.md).
+
+**IMPORTANT**: By submitting a patch, you agree that your work will be licensed under the [license](https://github.com/umple/umple/blob/master/LICENSE.md) used by the project.
+
+If your pull request does not pass CI, it will **not** be merged (unless heavily justified). 
+
+## Description
+
+Please provide a description of what this PR is meant to fix, and how it works (if it's not going to be very clear from the code). 
+
+## Tests
+
+Please list all tests added or modified. All issues should have a test created to address the issue in the future (as relevant). 
+
+## Relevant Issues
+
+If closing issues, please write `Closes #ISSUE_NUMBER[, #ISSUE_NUMBER2, ...]`, this will automatically close issues.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Guidelines for bug reports:
    case.
 
 Please try to be as detailed as possible in your report. Include information about
-your Operating System and the version of the compiler you are usig. Please make sure you are using the latest version of Umple. Please provide steps to
+your Operating System and the version of the compiler you are using. Please make sure you are using the latest version of Umple. Please provide steps to
 reproduce the issue as well as the outcome you were expecting! All these details
 will help developers to fix any potential bugs.
 
@@ -206,7 +206,8 @@ in order to craft an excellent pull request:
 5. Make sure all the tests are still passing.
 
   ```sh
-  cd build ** ant -Dmyenv=local
+  cd build 
+  ant 
   ```
 
   This command will compile the code in your branch and use that


### PR DESCRIPTION
This takes advantage of the new [Issue/PR Templates](https://github.com/blog/2111-issue-and-pull-request-templates) that Github enabled. 

No CI required, only markdown changes.
