### PR TITLE
Removed RuleBasedParser's dependency on UmpleModel

### DIFF
--- a/cruise.umple/src/Generator_CodeUmple.ump
+++ b/cruise.umple/src/Generator_CodeUmple.ump
@@ -567,7 +567,7 @@ class UmpleGenerator
       return;
     }
 
-    parser = new cruise.umple.parser.analysis.RuleBasedParser(getModel());
+    parser = new cruise.umple.parser.analysis.RuleBasedParser();
 
     // Populate the parser with Umple's grammar (see GrammarParsing_Code.ump)
     parser.addGrammarFile("/umple_core.grammar");

--- a/cruise.umple/src/GrammarParsing.ump
+++ b/cruise.umple/src/GrammarParsing.ump
@@ -31,8 +31,6 @@ class RuleBasedParser
 
   //List of umple grammar files which will dictate the rule graph that is contructed.
   String[] grammarFiles;
-  
-  UmpleModel model;
 }
 
 /*
@@ -124,8 +122,6 @@ class RuleBasedParserThread
 
   //The data package of the previous parse, so that things like keys and the filenames already parsed can be passed along
   ParserDataPackage data;
-  
-  UmpleModel model;
 }
 
 /*
@@ -206,9 +202,6 @@ class GrammarAnalyzer
   
   //if a balanced rule is created, it needs to know if the current context is nospaces or not
   noSpaces = false;
-
-  //umple model object that will become the meta model
-  UmpleModel model;
   
   Map<String,Analyzer> analyzerMap = new HashMap<String,Analyzer>();  
 

--- a/cruise.umple/src/GrammarParsing_Code.ump
+++ b/cruise.umple/src/GrammarParsing_Code.ump
@@ -130,7 +130,7 @@ class RuleBasedParser
         String currentLine = reader.readLine();
         if(analyzer==null)
         {
-          analyzer = new GrammarAnalyzer(getModel());
+          analyzer = new GrammarAnalyzer();
         }
 
         analyzer.getKeys().put("{}", new String[]{"{","}"});    
@@ -209,7 +209,6 @@ class RuleBasedParser
     }
     analyzer.init(file);
     analyzer.execute();
-    getModel().setAnalyzers(analyzer.getAnalyzerMap());
     setRootToken(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
@@ -223,7 +222,6 @@ class RuleBasedParser
     }
     analyzer.init(ruleName, input);
     analyzer.execute();
-    getModel().setAnalyzers(analyzer.getAnalyzerMap());
     setRootToken(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
@@ -380,7 +378,7 @@ class RuleBasedParser
         }
       }
     }
-    analyzer = new GrammarAnalyzer(getModel());
+    analyzer = new GrammarAnalyzer();
     analyzer.analyze(rootToken);
     analyzer.setupTerminals();
   }
@@ -502,7 +500,7 @@ class RuleBasedParserThread
     data.setParseResult(parseResult);
     data.init(token.getPosition());
     Token temp = new Token("ROOT","");
-    RuleBasedParser parser = new RuleBasedParser(getModel());
+    RuleBasedParser parser = new RuleBasedParser();
     parser.parse(root,temp,filename,data);
     Token answer = parser.getRootToken();
     synchronized(token)
@@ -542,7 +540,7 @@ class GrammarAnalyzer {
               rules.get("$ROOT$"),
               token,
               umpleFile.getPath() + File.separator+value,
-              data,getModel());
+              data);
             threads.add(thread);
             thread.start();
           }
@@ -585,7 +583,7 @@ class GrammarAnalyzer {
   public void execute()
   {
     setRootToken(new Token("ROOT",""));
-    RuleBasedParser parser = new RuleBasedParser(getModel());
+    RuleBasedParser parser = new RuleBasedParser();
     parser.parse(rules.get("$ROOT$"),getRootToken(), input,getData());
     setRootToken(parser.getRootToken());
     while(threads.size()>0)
@@ -629,7 +627,6 @@ class GrammarAnalyzer {
       Class cls = Class.forName(className);
       Analyzer a = (Analyzer) cls.newInstance();
       a.setName(name);
-      a.setModel(getModel());
       getAnalyzerMap().put(name,a);
       analyzerStack.push(a);
       wasMade = true;

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -28,6 +28,7 @@ class UmpleModel
   depend cruise.umple.analysis.*;
   depend cruise.umple.util.*;
   depend cruise.umple.compiler.exceptions.*;
+  depend cruise.umple.parser.analysis.*;
   depend java.util.zip.*; // new
   isA Runnable;
 

--- a/cruise.umple/src/UmpleAnalysis.ump
+++ b/cruise.umple/src/UmpleAnalysis.ump
@@ -15,7 +15,6 @@ class Analyzer
   depend java.lang.reflect.*;
   abstract;
   name = null;
-  UmpleModel model = null;
   0..* parent -- 0..* Analyzer children;
   void analyzeToken(Token token)
   {

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -44,12 +44,12 @@ class UmpleInternalParser
 
   public UmpleInternalParser()
   {
-    this("UmpleInternalParser", new UmpleModel(null), new RuleBasedParser(new UmpleModel(null)));
+    this("UmpleInternalParser", new UmpleModel(null), new RuleBasedParser());
   }
 
   public UmpleInternalParser(UmpleModel aModel)
   {
-    this("UmpleInternalParser", aModel, new RuleBasedParser(aModel));
+    this("UmpleInternalParser", aModel, new RuleBasedParser());
   }
 
   private void init()

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -232,9 +232,11 @@ class UmpleModel
   {
     boolean failed = false;
     String input;
-    cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(this);
+    RuleBasedParser parser = new RuleBasedParser();
     UmpleParser analyzer = new UmpleInternalParser("UmpleInternalParser",this,parser);
     ParseResult result = parser.parse(umpleFile);
+    
+    this.extractAnalyzersFromParser(parser);
 
     failed = !result.getWasSuccess();
     lastResult = result;
@@ -697,6 +699,16 @@ class UmpleModel
       } 
     }
     return null;
+  }
+  
+  /*
+   * Extracts Analyzers from a <code>RuleBasedParser</code>, assigning the
+   * analyzers to this model
+   *
+   * @param parser the <code>RuleBasedParser</code> to extract parsers from.
+   */
+  public void extractAnalyzersFromParser( RuleBasedParser parser ){
+    setAnalyzers(parser.getAnalyzer().getAnalyzerMap());
   }
 }
 

--- a/cruise.umple/src/sync/DeleteAction_Code.ump
+++ b/cruise.umple/src/sync/DeleteAction_Code.ump
@@ -21,7 +21,7 @@ class DeleteAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/DeleteAssociationAction_Code.ump
+++ b/cruise.umple/src/sync/DeleteAssociationAction_Code.ump
@@ -21,7 +21,7 @@ class DeleteAssociationAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/DeleteGeneralizationAction_Code.ump
+++ b/cruise.umple/src/sync/DeleteGeneralizationAction_Code.ump
@@ -21,7 +21,7 @@ class DeleteGeneralizationAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/EditAction_Code.ump
+++ b/cruise.umple/src/sync/EditAction_Code.ump
@@ -21,7 +21,7 @@ class EditAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/EditAssociationAction_Code.ump
+++ b/cruise.umple/src/sync/EditAssociationAction_Code.ump
@@ -21,7 +21,7 @@ class EditAssociationAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/NewAction_Code.ump
+++ b/cruise.umple/src/sync/NewAction_Code.ump
@@ -21,7 +21,7 @@ class NewAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/NewAssociationAction_Code.ump
+++ b/cruise.umple/src/sync/NewAssociationAction_Code.ump
@@ -36,7 +36,7 @@ class NewAssociationAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       
@@ -140,7 +140,7 @@ class NewAssociationAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/NewGeneralizationAction_Code.ump
+++ b/cruise.umple/src/sync/NewGeneralizationAction_Code.ump
@@ -21,7 +21,7 @@ class NewGeneralizationAction
       TextParser textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       UmpleParser umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/src/sync/UpdatePositioningAction_Code.ump
+++ b/cruise.umple/src/sync/UpdatePositioningAction_Code.ump
@@ -21,7 +21,7 @@ class UpdatePositioningAction
       textParser = new TextParser(getUmpleCode());
       UmpleFile umpleFile = new UmpleFile(new File(getFilename()));    
       UmpleModel umpleModel = new UmpleModel(umpleFile);
-      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser(umpleModel);
+      cruise.umple.parser.analysis.RuleBasedParser parser = new cruise.umple.parser.analysis.RuleBasedParser();
       umpleParser = new UmpleInternalParser("UmpleInternalParser", umpleModel, parser);
       ParseResult result = parser.parse(umpleFile);
       

--- a/cruise.umple/test/cruise/umple/compiler/FilterTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/FilterTest.java
@@ -375,7 +375,7 @@ public class FilterTest
     ErrorTypeSingleton.getInstance().reset();
     model = new UmpleModel(new UmpleFile(pathToInput,filename));
     model.setShouldGenerate(false);
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName,model,rbp);
     ParseResult result = rbp.parse(file);
     model.setLastResult(result);

--- a/cruise.umple/test/cruise/umple/compiler/ModelConstraintTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/ModelConstraintTest.java
@@ -52,9 +52,10 @@ public class ModelConstraintTest {
 		ErrorTypeSingleton.getInstance().reset();
 		model = new UmpleModel(new UmpleFile(pathToInput,filename));
 		model.setShouldGenerate(false);
-		RuleBasedParser rbp = new RuleBasedParser(model);
+		RuleBasedParser rbp = new RuleBasedParser();
 		parser = new UmpleInternalParser(umpleParserName,model,rbp);
 		ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
 		model.setLastResult(result);
 		boolean answer = result.getWasSuccess();
 		if (answer)

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserFilterTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserFilterTest.java
@@ -75,7 +75,7 @@ public class UmpleParserFilterTest
     model = new UmpleModel(new UmpleFile(pathToInput, filename));
     model.setShouldGenerate(false);
     boolean answer = true;
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName, model, rbp);
     ParseResult result = rbp.parse(file);
     answer = result.getWasSuccess();

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserStateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserStateMachineTest.java
@@ -2637,9 +2637,10 @@ public class UmpleParserStateMachineTest
     UmpleFile file = new UmpleFile(pathToInput, filename);
     model = new UmpleModel(new UmpleFile(pathToInput, filename));
     model.setShouldGenerate(false);
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName, model, rbp);
     ParseResult answer = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
     if (answer.getWasSuccess())
     {
       answer = parser.analyze(false);
@@ -2664,9 +2665,10 @@ public class UmpleParserStateMachineTest
     model = new UmpleModel(new UmpleFile(pathToInput, filename));
     model.setShouldGenerate(false);
     boolean answer = true;
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName, model, rbp);
     ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
     answer = result.getWasSuccess();
     if (answer)
     {
@@ -2701,9 +2703,10 @@ public class UmpleParserStateMachineTest
     model = new UmpleModel(new UmpleFile(pathToInput, filename));
     model.setShouldGenerate(false);
     boolean answer = true;
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName, model, rbp);
     ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
     answer = result.getWasSuccess();
     if (answer)
     {

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2560,9 +2560,10 @@ public class UmpleParserTest
     ErrorTypeSingleton.getInstance().reset();
     model = new UmpleModel(new UmpleFile(pathToInput,filename));
     model.setShouldGenerate(false);
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName,model,rbp);
     ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
     model.setLastResult(result);
     System.out.println(rbp.getRootToken());
     boolean answer = result.getWasSuccess();
@@ -2579,9 +2580,10 @@ public class UmpleParserTest
     UmpleFile file = new UmpleFile(pathToInput,filename);
     model = new UmpleModel(file);
     model.setShouldGenerate(false);
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName,model,rbp);
     ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
     model.setLastResult(result);
     boolean answer = result.getWasSuccess();
     if (answer)

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTracerTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTracerTest.java
@@ -1146,9 +1146,10 @@ public class UmpleParserTracerTest
 		ErrorTypeSingleton.getInstance().reset();
 		model = new UmpleModel(new UmpleFile(pathToInput,filename));
 		model.setShouldGenerate(false);
-		RuleBasedParser rbp = new RuleBasedParser(model);
+		RuleBasedParser rbp = new RuleBasedParser();
 		parser = new UmpleInternalParser(umpleParserName,model,rbp);
 		ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
 		model.setLastResult(result);
 
 		boolean answer = result.getWasSuccess();

--- a/cruise.umple/test/cruise/umple/compiler/UmpleUSEParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleUSEParserTest.java
@@ -129,7 +129,7 @@ public class UmpleUSEParserTest
     ErrorTypeSingleton.getInstance().reset();
     model = new UmpleModel(new UmpleFile(pathToInput,filename));
     model.setShouldGenerate(false);
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     parser = new UmpleInternalParser(umpleParserName,model,rbp);
     ParseResult result = rbp.parse(file);
     model.setLastResult(result);

--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -362,9 +362,10 @@ public class TemplateTest
     model.setShouldGenerate(false);
     if( aTracer != null )
     	model.setTracer(new TracerDirective(aTracer));
-    RuleBasedParser rbp = new RuleBasedParser(model);
+    RuleBasedParser rbp = new RuleBasedParser();
     UmpleParser parser = new UmpleInternalParser(umpleParserName, model, rbp);
     ParseResult result = rbp.parse(file);
+    model.extractAnalyzersFromParser(rbp);
     model.setLastResult(result);
 
     if (!result.getWasSuccess())

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestParseValidation.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestParseValidation.java
@@ -67,7 +67,7 @@ public class TestParseValidation {
 
 	public void assertParsing() {
 		initUmpleModel();
-		RuleBasedParser ruleParser = new RuleBasedParser(umpleModel);
+		RuleBasedParser ruleParser = new RuleBasedParser();
 		UmpleParser parser = new UmpleInternalParser(parserName, umpleModel, ruleParser);
 		ParseResult result = ruleParser.parse(umpleModel.getUmpleFile());
 		umpleModel.setLastResult(result);

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
@@ -95,7 +95,7 @@ public class TestResource {
 	}
 
 	private void parseModel() {
-		RuleBasedParser ruleParser = new RuleBasedParser(umpleModel);
+		RuleBasedParser ruleParser = new RuleBasedParser();
 		UmpleParser parser = new UmpleInternalParser(parserName, umpleModel, ruleParser);
 		ParseResult result = ruleParser.parse(umpleModel.getUmpleFile());
 		umpleModel.setLastResult(result);


### PR DESCRIPTION
This Pull Request removes `UmpleModel` from `RuleBasedParser`, `RuleBasedParserThread`, and `GrammarAnalyzer`. 

It changes how the analyzer is set up in the model from being done internally in the `RuleBasedParser`'s `parse(...)` methods, to be doing done after parsing by the model. This can be done in one of two ways, either `model.setAnalyzers( parser.getAnalyzer().getAnalyzerMap() )` or through a new method `model.extractAnalyzersFromParser( parser )`

Tests that were changed:
- All tests that constructed a `RuleBasedParser` directly were updated from `new RuleBasedParser( getModel() )` to `new RuleBasedParser()`
- `createUmpleSystem(...)` in `TemplateTest` was modified to reflect the above changes
