### PR TITLE
Update README.md to use a table for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 #Umple Modelling Language
 
-* Travis CI `Mac` and `Linux` build status [![Build Status](https://travis-ci.org/umple/umple.svg?branch=master)](https://travis-ci.org/umple/umple)
+### Build Status
 
-* AppVeyor `windows` build status: [![Windows Build status](https://ci.appveyor.com/api/projects/status/gf9oqwtwgy4c45q6/branch/master?svg=true)](https://ci.appveyor.com/project/umple/umple/branch/master)   
-
+OS         | Linux  | OSX    | Windows  
+:--------- | ------ | ------ | -------- 
+**Status** | [![Travis-CI Build Status](https://travis-ci.org/umple/umple.svg?branch=master)](https://travis-ci.org/umple/umple) | [![Travis-CI Build Status](https://travis-ci.org/umple/umple.svg?branch=master)](https://travis-ci.org/umple/umple) | [![Windows Build status](https://ci.appveyor.com/api/projects/status/gf9oqwtwgy4c45q6/branch/master?svg=true)](https://ci.appveyor.com/project/umple/umple/branch/master) 
 
 
 ##Introduction


### PR DESCRIPTION
This uses a table for the build status rather than the original list. 

Minor, but looks nicer. :triangular_ruler: 

I forgot to tag the commit with `[skip ci]`, but waiting for CI is not necessary. This was followup for #742. 
