### PR TITLE
Partial fix to problems with parsing arithmetic expressions.

### DIFF
--- a/cruise.umple/src/NuSMVCoordinationUnit.ump
+++ b/cruise.umple/src/NuSMVCoordinationUnit.ump
@@ -197,16 +197,6 @@ class NuSMVCoordinator
 		}
   		return -1;
   	}
-	
-	/*private int getGuardIdentity( StateMachine sm, Guard gr) {
-  		int pos = 1;
-  		for(Guard guard : getAllGuards( sm ) ) {
-  			if(guard.equals(gr))
-  				return pos;
-  			pos++;
-  		}
-  		return -1;
-  	}*/
   	
   	private void generateSpecForStateReachability( StateMachine sm, ModuleBody body ) {
   		
@@ -328,10 +318,10 @@ class NuSMVCoordinator
 			for( State st : ( (StateMachine) obj).getStates() ) {
 				for( Transition trans : st.getNextTransition() )
 					results.add( trans );
-					if( st.hasNestedStateMachines() )
-						for( StateMachine smm : st.getNestedStateMachines() )
-							for( Transition transition : getAllTransitions( smm ) )
-								results.add( transition );
+				if( st.hasNestedStateMachines() )
+					for( StateMachine smm : st.getNestedStateMachines() )
+						for( Transition transition : getAllTransitions( smm ) )
+							results.add( transition );
 			}
 		}
 		else if( obj instanceof State ){
@@ -356,24 +346,6 @@ class NuSMVCoordinator
 			results += getObjectIdentity( root, element ) +" ";
 		System.out.println( results );
 	}
-  	
-  	//Generates a list of next transitions for a state and its substates (where possible).
-  	//That is transition that enables or activates a state
-  	/*private List<Transition> getAllTransitions( State st ) {
-		if( !st.hasNestedStateMachines() ) {
-			return st.getNextTransition();
-		}
-		else {	
-			List<Transition> allTransitions = new ArrayList<Transition>();
-			for( Transition tr : st.getNextTransition() )
-				allTransitions.add(tr);
-		
-			for( StateMachine sm : st.getNestedStateMachines() )
-				for( Transition transition : getAllTransitions( sm ) )
-					allTransitions.add( transition );
-		    return allTransitions;
-		}
-  	}*/
 	
 	private CaseStatement getCaseStatementForNullState( State st, StateMachine root ) {
 	
@@ -607,6 +579,7 @@ class NuSMVCoordinator
 			case "/=" : return true;
 			case ">>=" : return true;
 			case "<<=" : return true;
+			//case "^" : return true;
 			default : return false;
 		}		
 	}

--- a/cruise.umple/src/StateMachine.ump
+++ b/cruise.umple/src/StateMachine.ump
@@ -29,12 +29,14 @@ class StateMachine
   
   * nestedStateMachines -- 0..1 State parentState;
   
-  key { parentState, name } 
+  key { parentState, name }
   
   before setUmpleClass { if (aUmpleClass != null && aUmpleClass.isImmutable()) { return false; } }
   before setUmpleTrait { if (aUmpleTrait != null && aUmpleTrait.isImmutable()) { return false; } }
   //before getContainsHistoryState { if ("H".equals(name)) { containsHistoryState = true; } }
   //before getContainsDeepHistoryState { if ("HStar".equals(name)) { containsDeepHistoryState = true; } }
+
+ 
   
   Boolean queued = false;
   Boolean pooled = false;
@@ -317,7 +319,7 @@ class Guard
 			case "/=" : return true;
 			case ">>=" : return true;
 			case "<<=" : return true;
-			//case "!" : return true;
+			//case "^" : return true;
 			default : return false;
 		}		
 	}

--- a/cruise.umple/src/StateMachine_Code.ump
+++ b/cruise.umple/src/StateMachine_Code.ump
@@ -128,13 +128,26 @@ class StateMachine
       {
         for (Transition t : state.getTransitions())
         {
-          allTransitions.add(t);
+					//preventing duplicated transitions (Issue #760) - Temporary solution to facilitate analyzable output by nuXmv code generator...
+					if( !has(allTransitions, t) )
+          	allTransitions.add(t);
         }
       }
     }
     return allTransitions;
   }
-  
+  //introduced to prevent duplicated transition - Issue #760
+  private <E> boolean has( List<E> objectList, E whatToFind ) {
+  	boolean yes = false;
+  	for(E st : objectList) {
+  		if( st.equals(whatToFind) ) {
+  			yes = true;
+  			break;
+  		}
+  	}
+  	return yes;
+	}
+
   //Issue 519
   public boolean deleteState(State aState)
   {

--- a/cruise.umple/src/umple_constraints.grammar
+++ b/cruise.umple/src/umple_constraints.grammar
@@ -25,12 +25,12 @@ negativeConstraint : ( ! | not ) ( [[constraintName]] | [[constraint]] )
 constraintBody : OPEN_ROUND_BRACKET [[constraint]] CLOSE_ROUND_BRACKET
 linkingOp- : ( [=andOp:and|&&|&] | [!orOp:OPEN_ROUND_BRACKETor|\Q||\ECLOSE_ROUND_BRACKET] ) [[linkingOpBody]]
 linkingOpBody : [[constraint]]
-constraintExpr- : [[statemachineExpr]] | [[stringExpr]] | [[boolExpr]] | [[numExpr]] | [[associationExpr]]  | [[genExpr]] | [[loneBoolean]] | { [!fakeContraint:[^\n]+] } 
+constraintExpr- : [[statemachineExpr]] | [[stringExpr]] | [[boolExpr]] | [[numExpr]] | [[associationExpr]]  | [[genExpr]] | [[loneBoolean]] | { [!fakeContraint:[^\n]+] }
 
 loneBoolean : [[constraintVariable]]
 
-//must be a boolean
-boolExpr :  [[constraintVariable]] [[equalityOperator]] [[boolLiteral]] | [[boolLiteral]] [[equalityOperator]]  [[constraintVariable]] | [[boolLiteral]]
+//must be a boolean //fixing is here!!!
+boolExpr :  [[constraintVariable]] [[equalityOperator]] [[boolLiteral]] | [[boolLiteral]] [[equalityOperator]] [[constraintVariable]] | [[boolLiteral]] 
 boolLiteral : [=literal:true|false]
 
 //must be string
@@ -53,9 +53,9 @@ numberExpression3- : ( [[arithmeticCall]] | [[numberLiteral]] ) [[equalityOperat
 numberExpression4- : ( [[arithmeticCall]] | [[numberLiteral]] ) [[equalityOperator]]    ( [[arithmeticCall]] | [[numberLiteral]] )
 numberLiteral- : [!number:[0-9]+([\\.][0-9]+)?]
 numberName- : [[numberLiteral]] | [[constraintVariable]]
-arithmeticCall : [[lowArithmeticOperatorCall]] | [[highArithmeticOperatorCall]]
-lowArithmeticOperatorCall- : ( [[highArithmeticOperatorCall]] | [[arithmeticResolve]] )? [=operator:+|-] ( [[arithmeticCall]] | [[arithmeticResolve]] ) 
-highArithmeticOperatorCall- : [[arithmeticResolve]] [=operator:*|/|^] ( [[highArithmeticOperatorCall]] | [[arithmeticResolve]] ) 
+arithmeticCall : OPEN_ROUND_BRACKET ( [[lowArithmeticOperatorCall]] | [[highArithmeticOperatorCall]] ) CLOSE_ROUND_BRACKET
+lowArithmeticOperatorCall- : ( [[highArithmeticOperatorCall]] | [[arithmeticResolve]] )? [=operator:+|-|>>|<<] ( [[arithmeticCall]] | [[arithmeticResolve]] ) 
+highArithmeticOperatorCall- : [[arithmeticResolve]] [=operator:*|/|^|%] ( [[highArithmeticOperatorCall]] | [[arithmeticResolve]] ) 
 arithmeticResolve- : -( [[arithmeticCall]] -) | [[numberName]]
 
 equalityOperator- :  [=equalsOp:==|equals] | [=notequalsOp:!=|/=|=!|=/=]

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.nusmv.txt
@@ -33,10 +33,26 @@ MODULE State ( _stateDrive )
      t9 := event = ev_reachSecondSpeed & _stateDrive.state = StateDrive_first & g1;
      t10 := event = ev_reachThirdSpeed & _stateDrive.state = StateDrive_second & g2;
      t11 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g3;
-     t12 := event = ev_dropBelowThirdSpeed & _stateDrive.state = StateDrive_third;
+     t12 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g4;
+     t13 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g5;
+     t14 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g6;
+     t15 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g7;
+     t16 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g8;
+     t17 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g9;
+     t18 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g10;
+     t19 := event = ev_dropBelowSecondSpeed & _stateDrive.state = StateDrive_second & g11;
+     t20 := event = ev_dropBelowThirdSpeed & _stateDrive.state = StateDrive_third;
      g1 := driveSelected;
      g2 := !driveSelected;
      g3 := ((a > b) | (driveSelected & ((b < a) | (c >= b))));
+     g4 := ((a + c) > b);
+     g5 := (a - c) > b;
+     g6 := (a - c) > (b + 2);
+     g7 := (a - c) > (b * 2);
+     g8 := ((a - c) > (b * 2)) & driveSelected;
+     g9 := ((a - c) > (b * 2)) | ((a - c) > (b * 2));
+     g10 := ((a - c) > (b * 2)) | ((a - c) > (b^2));
+     g11 := ((a - c) > (b * 2)) | driveSelected;
 
    -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
    ASSIGN
@@ -44,7 +60,7 @@ MODULE State ( _stateDrive )
      next( state ) := case
        t5 | t6 : State_neutral;
        t1 : State_reverse;
-       t3 | t11 | t8 | t12 | t2 | t7 | t4 | t9 | t10 : State_drive;
+       t3 | t11 | t13 | t15 | t17 | t19 | t8 | t20 | t2 | t7 | t12 | t14 | t16 | t18 | t4 | t9 | t10 : State_drive;
        TRUE : state;
      esac;
 
@@ -79,8 +95,8 @@ MODULE StateDrive ( _state )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t7 | _state.t3 | _state.t11 : StateDrive_first;
-       _state.t4 | _state.t9 | _state.t8 | _state.t12 : StateDrive_second;
+       _state.t7 | _state.t12 | _state.t14 | _state.t16 | _state.t18 | _state.t3 | _state.t11 | _state.t13 | _state.t15 | _state.t17 | _state.t19 : StateDrive_first;
+       _state.t4 | _state.t9 | _state.t8 | _state.t20 : StateDrive_second;
        _state.t10 : StateDrive_third;
        _state.t1 | _state.t5 | _state.t2 | _state.t6 : null;
        _state.state = State_drive : StateDrive_first;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.ump
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.ump
@@ -33,6 +33,16 @@ class CarTransmission {
       second {
         reachThirdSpeed [!driveSelected] -> third;
         dropBelowSecondSpeed [ ((a > b) || (driveSelected && (!(b >= a) && (c < b)) ))] -> first;
+        dropBelowSecondSpeed [ ( (a + c) > b) ] -> first;
+        dropBelowSecondSpeed [ (a - c) > b] -> first;
+        dropBelowSecondSpeed [ (a - c) > (b + 2)] -> first;
+        dropBelowSecondSpeed [ (a - c) > (b * 2)] -> first;
+        dropBelowSecondSpeed [ ((a - c) > (b * 2)) && driveSelected] -> first;
+        dropBelowSecondSpeed [ ((a - c) > (b * 2)) || ((a - c) > (b * 2))] -> first;
+        dropBelowSecondSpeed [ ((a - c) > (b * 2)) || ((a - c) > (b ^ 2))] -> first;
+        dropBelowSecondSpeed [ ((a - c) > (b * 2)) || driveSelected] -> first; //when a = driveSelected
+        dropBelowSecondSpeed [ ((a - c) > (b * 2)) != ((a - c) > (b ^ 2))] -> first;
+        //dropBelowSecondSpeed [ ((a - c) > (b * 2)) == ((a - c) > (b ^ 2))] -> first;
       }
       
       third {


### PR DESCRIPTION
This contribution fixes the problems associated with guards with arithmetic expressions. The solution is partial as more test cases are required to finalize the issue (#734). An implementation to prevent duplicates in the list containing all transitions of any given state machine.
