### PR TITLE
Add CORS support to UmpleOnline's compiler

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -23,6 +23,9 @@
 
 require_once("compiler_config.php");
 
+// Allow CORS so that any site may use the Umple compiler.
+header("Access-Control-Allow-Origin: *");
+
 if (isset($_REQUEST["save"]))
 {
   if(isset($_REQUEST["svgContent"]))


### PR DESCRIPTION
Only one change here - the compiler will return a header allowing any origin to access /scripts/compiler.php in UmpleOnline. This means that others can write applications (that aren't UmpleOnline) that will interface with the compiler.

More specifically, any instance of Orion will be able to access the compiler using the plugin I'm developing.
