### PR TITLE
Removed Java tab and improved Php template

### DIFF
--- a/UmpleToJava/src/cruise/umple/compiler/java/JavaClassGenerator.java
+++ b/UmpleToJava/src/cruise/umple/compiler/java/JavaClassGenerator.java
@@ -2662,7 +2662,7 @@ public class JavaClassGenerator implements ILang
   protected final String TEXT_2642 = NL + "  " + NL + "  @Override" + NL + "  public void run ()" + NL + "  {" + NL + "    boolean status=false;" + NL + "    while (true) " + NL + "    {" + NL;
   protected final String TEXT_2643 = NL + "      " + NL + "      switch (m.type)" + NL + "      {";
   protected final String TEXT_2644 = " " + NL + "        default:" + NL + "      }" + NL + "      if(!status)" + NL + "      {" + NL + "        // Error message is written or  exception is raised" + NL + "      }" + NL + "    }" + NL + "  }";
-  protected final String TEXT_2645 = NL + NL + "  public String toString()" + NL + "  {" + NL + "\t  String outputString = \"\";";
+  protected final String TEXT_2645 = NL + NL + "  public String toString()" + NL + "  {" + NL + "    String outputString = \"\";";
   protected final String TEXT_2646 = NL + "  }";
   protected final String TEXT_2647 = "  " + NL + "  //------------------------" + NL + "  // DEVELOPER CODE - PROVIDED AS-IS" + NL + "  //------------------------" + NL + "  ";
   protected final String TEXT_2648 = NL + "  ";

--- a/UmpleToJava/templates/toString_declare.jet
+++ b/UmpleToJava/templates/toString_declare.jet
@@ -2,7 +2,7 @@
 
   public String toString()
   {
-	  String outputString = "";<%
+    String outputString = "";<%
 	  String customToStringPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before","toString"));
 	  String customToStringPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after","toString"));
 	  if (customToStringPrefixCode != null) 

--- a/UmpleToPhp/src/cruise/umple/compiler/php/PhpClassGenerator.java
+++ b/UmpleToPhp/src/cruise/umple/compiler/php/PhpClassGenerator.java
@@ -1291,7 +1291,7 @@ public class PhpClassGenerator implements ILang
   protected final String TEXT_1271 = "($";
   protected final String TEXT_1272 = ")" + NL + "  {" + NL + "    //" + NL + "    // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet" + NL + "    // This set file assumes the generation of a maximumNumberOfXXX method does not exist because " + NL + "    // it's not required (No upper bound)" + NL + "    //   " + NL + "" + NL + "    $wasSet = false;" + NL + "    " + NL + "    $";
   protected final String TEXT_1273 = " = $this->";
-  protected final String TEXT_1274 = ";" + NL + "\t" + NL + "    if ($";
+  protected final String TEXT_1274 = ";" + NL + "" + NL + "    if ($";
   protected final String TEXT_1275 = " == null)" + NL + "    {" + NL + "      if ($";
   protected final String TEXT_1276 = " != null)" + NL + "      {" + NL + "        if ($";
   protected final String TEXT_1277 = "->";
@@ -1320,7 +1320,7 @@ public class PhpClassGenerator implements ILang
   protected final String TEXT_1300 = " = $";
   protected final String TEXT_1301 = ";" + NL + "          $wasSet = true;" + NL + "        }" + NL + "      }" + NL + "    }" + NL + "    if ($wasSet)" + NL + "    {" + NL + "      $";
   protected final String TEXT_1302 = " = $";
-  protected final String TEXT_1303 = ";" + NL + "    }" + NL + "    return $wasSet;" + NL + "  }" + NL + "  ";
+  protected final String TEXT_1303 = ";" + NL + "    }" + NL + "    return $wasSet;" + NL + "  }" + NL;
   protected final String TEXT_1304 = NL + "//  public function ";
   protected final String TEXT_1305 = "($";
   protected final String TEXT_1306 = ")" + NL + "//  {" + NL + "//    //" + NL + "//    // The source of the code generation is association_SetOptionalOneToMN.jet" + NL + "//    // (this) set file assumes the generation of a maximumNumberOfXXX " + NL + "//    //   method ";

--- a/UmpleToPhp/templates/association_SetOptionalOneToMandatoryMany.jet
+++ b/UmpleToPhp/templates/association_SetOptionalOneToMandatoryMany.jet
@@ -10,7 +10,7 @@
     $wasSet = false;
     
     $<%=gen.translate("parameterExisting",av)%> = $this-><%=gen.translate("associationOne",av)%>;
-	
+
     if ($<%=gen.translate("parameterExisting",av)%> == null)
     {
       if ($<%=gen.translate("parameterOne",av)%> != null)
@@ -50,4 +50,4 @@
     }
     return $wasSet;
   }
-  
+

--- a/cruise.umple/src-gen-jet/cruise/umple/compiler/java/JavaClassGenerator.java
+++ b/cruise.umple/src-gen-jet/cruise/umple/compiler/java/JavaClassGenerator.java
@@ -2662,7 +2662,7 @@ public class JavaClassGenerator implements ILang
   protected final String TEXT_2642 = NL + "  " + NL + "  @Override" + NL + "  public void run ()" + NL + "  {" + NL + "    boolean status=false;" + NL + "    while (true) " + NL + "    {" + NL;
   protected final String TEXT_2643 = NL + "      " + NL + "      switch (m.type)" + NL + "      {";
   protected final String TEXT_2644 = " " + NL + "        default:" + NL + "      }" + NL + "      if(!status)" + NL + "      {" + NL + "        // Error message is written or  exception is raised" + NL + "      }" + NL + "    }" + NL + "  }";
-  protected final String TEXT_2645 = NL + NL + "  public String toString()" + NL + "  {" + NL + "\t  String outputString = \"\";";
+  protected final String TEXT_2645 = NL + NL + "  public String toString()" + NL + "  {" + NL + "    String outputString = \"\";";
   protected final String TEXT_2646 = NL + "  }";
   protected final String TEXT_2647 = "  " + NL + "  //------------------------" + NL + "  // DEVELOPER CODE - PROVIDED AS-IS" + NL + "  //------------------------" + NL + "  ";
   protected final String TEXT_2648 = NL + "  ";

--- a/cruise.umple/src-gen-jet/cruise/umple/compiler/php/PhpClassGenerator.java
+++ b/cruise.umple/src-gen-jet/cruise/umple/compiler/php/PhpClassGenerator.java
@@ -1291,7 +1291,7 @@ public class PhpClassGenerator implements ILang
   protected final String TEXT_1271 = "($";
   protected final String TEXT_1272 = ")" + NL + "  {" + NL + "    //" + NL + "    // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet" + NL + "    // This set file assumes the generation of a maximumNumberOfXXX method does not exist because " + NL + "    // it's not required (No upper bound)" + NL + "    //   " + NL + "" + NL + "    $wasSet = false;" + NL + "    " + NL + "    $";
   protected final String TEXT_1273 = " = $this->";
-  protected final String TEXT_1274 = ";" + NL + "\t" + NL + "    if ($";
+  protected final String TEXT_1274 = ";" + NL + "" + NL + "    if ($";
   protected final String TEXT_1275 = " == null)" + NL + "    {" + NL + "      if ($";
   protected final String TEXT_1276 = " != null)" + NL + "      {" + NL + "        if ($";
   protected final String TEXT_1277 = "->";
@@ -1320,7 +1320,7 @@ public class PhpClassGenerator implements ILang
   protected final String TEXT_1300 = " = $";
   protected final String TEXT_1301 = ";" + NL + "          $wasSet = true;" + NL + "        }" + NL + "      }" + NL + "    }" + NL + "    if ($wasSet)" + NL + "    {" + NL + "      $";
   protected final String TEXT_1302 = " = $";
-  protected final String TEXT_1303 = ";" + NL + "    }" + NL + "    return $wasSet;" + NL + "  }" + NL + "  ";
+  protected final String TEXT_1303 = ";" + NL + "    }" + NL + "    return $wasSet;" + NL + "  }" + NL;
   protected final String TEXT_1304 = NL + "//  public function ";
   protected final String TEXT_1305 = "($";
   protected final String TEXT_1306 = ")" + NL + "//  {" + NL + "//    //" + NL + "//    // The source of the code generation is association_SetOptionalOneToMN.jet" + NL + "//    // (this) set file assumes the generation of a maximumNumberOfXXX " + NL + "//    //   method ";

--- a/cruise.umple/test/cruise/umple/compiler/FLoatGenerator.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/FLoatGenerator.java.txt
@@ -123,7 +123,7 @@ public class FLoatGenerator
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "x" + ":" + getX()+ "," +
             "y" + ":" + getY()+ "," +

--- a/cruise.umple/test/cruise/umple/compiler/RangeX.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/RangeX.java.txt
@@ -60,7 +60,7 @@ public class RangeX
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "start" + ":" + getStart()+ "," +
             "end" + ":" + getEnd()+ "]"

--- a/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
@@ -205,7 +205,7 @@ public class RegularFlight
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "flightNumber" + ":" + getFlightNumber()+ "," +
             "flightNumber3" + ":" + getFlightNumber3()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Mentor.java.txt
@@ -164,7 +164,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "studentsPriority" + "=" + (getStudentsPriority() != null ? !getStudentsPriority().equals(this)  ? getStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null")

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Student.java.txt
@@ -164,7 +164,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentorsPriority" + "=" + (getMentorsPriority() != null ? !getMentorsPriority().equals(this)  ? getMentorsPriority().toString().replaceAll("  ","    ") : "this" : "null")

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Mentor.java.txt
@@ -164,7 +164,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "myStudentsPriority" + "=" + (getMyStudentsPriority() != null ? !getMyStudentsPriority().equals(this)  ? getMyStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null")

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Student.java.txt
@@ -164,7 +164,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "ProfsPriority" + "=" + (getProfsPriority() != null ? !getProfsPriority().equals(this)  ? getProfsPriority().toString().replaceAll("  ","    ") : "this" : "null")

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Mentor.java.txt
@@ -149,7 +149,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "studentsPriority" + "=" + (getStudentsPriority() != null ? !getStudentsPriority().equals(this)  ? getStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null")
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Student.java.txt
@@ -169,7 +169,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint1.java.txt
@@ -52,7 +52,7 @@ public class student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint3.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint3.java.txt
@@ -73,7 +73,7 @@ public class Client
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "minAge" + ":" + getMinAge()+ "," +
             "age" + ":" + getAge()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint4.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint4.java.txt
@@ -55,7 +55,7 @@ public class student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint5.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint5.java.txt
@@ -70,7 +70,7 @@ public class student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
             "weight" + ":" + getWeight()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint6.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint6.java.txt
@@ -70,7 +70,7 @@ public class student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
             "weight" + ":" + getWeight()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint7.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint7.java.txt
@@ -67,7 +67,7 @@ public class student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
             "weight" + ":" + getWeight()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint8.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint8.java.txt
@@ -67,7 +67,7 @@ public class student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
             "weight" + ":" + getWeight()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicPostcondition1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicPostcondition1.java.txt
@@ -59,7 +59,7 @@ public class Client
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "minAge" + ":" + getMinAge()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicPrecondition1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicPrecondition1.java.txt
@@ -59,7 +59,7 @@ public class Client
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "minAge" + ":" + getMinAge()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassInheritance.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassInheritance.java.txt
@@ -160,7 +160,7 @@ public class Teacher extends Person
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "position" + ":" + getPosition()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationAttributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationAttributes.java.txt
@@ -45,7 +45,7 @@ public class Token
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "p" + "=" + (getP() != null ? !getP().equals(this)  ? getP().toString().replaceAll("  ","    ") : "this" : "null")
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationClassTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationClassTest.java.txt
@@ -114,7 +114,7 @@ public class Registration
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "grade" + ":" + getGrade()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null") + System.getProperties().getProperty("line.separator") +

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeComments.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeComments.java.txt
@@ -55,7 +55,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "c" + ":" + getC()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeInlineComment.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeInlineComment.java.txt
@@ -48,7 +48,7 @@ public class Foo
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "bar" + ":" + getBar()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeMultilineComment.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeMultilineComment.java.txt
@@ -48,7 +48,7 @@ public class Foo
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
@@ -383,7 +383,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "x" + ":" + getX()+ "," +
             "str" + ":" + getStr()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_BuildOutputPath.ump.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_BuildOutputPath.ump.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_EmptyStringAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_EmptyStringAttr.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "grade" + ":" + getGrade()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes.java.txt
@@ -65,7 +65,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "capacity" + ":" + getCapacity()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes1.java.txt
@@ -50,7 +50,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes2.java.txt
@@ -82,7 +82,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "capacity" + ":" + getCapacity()+ "," +
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes3.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes3.java.txt
@@ -84,7 +84,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "capacity" + ":" + getCapacity()+ "," +
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import.java.txt
@@ -124,7 +124,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import2.java.txt
@@ -349,7 +349,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_IsA2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_IsA2.java.txt
@@ -48,7 +48,7 @@ public class SubMentor2 extends Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "subName" + ":" + getSubName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributeOnImmutableClass.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributeOnImmutableClass.java.txt
@@ -59,7 +59,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "studentNumber" + ":" + getStudentNumber()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributesOnSingleton.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributesOnSingleton.java.txt
@@ -89,7 +89,7 @@ public class Application
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "version" + ":" + getVersion()+ "]" + System.getProperties().getProperty("line.separator") +

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_ListAttributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_ListAttributes.java.txt
@@ -77,7 +77,7 @@ public class Token
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_MultipleAttributeComments.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_MultipleAttributeComments.java.txt
@@ -104,7 +104,7 @@ public class Foo
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "testAttribute1" + ":" + getTestAttribute1()+ "," +
             "testAttribute2" + ":" + getTestAttribute2()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
@@ -222,7 +222,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_underscore.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_underscore.java.txt
@@ -173,7 +173,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionWildCardTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionWildCardTest.java.txt
@@ -62,7 +62,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "firstName" + ":" + getFirstName()+ "," +
             "lastName" + ":" + getLastName()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/DateConstraint1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/DateConstraint1.java.txt
@@ -71,7 +71,7 @@ public class X
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "d" + "=" + (getD() != null ? !getD().equals(this)  ? getD().toString().replaceAll("  ","    ") : "this" : "null") + System.getProperties().getProperty("line.separator") +
             "  " + "e" + "=" + (getE() != null ? !getE().equals(this)  ? getE().toString().replaceAll("  ","    ") : "this" : "null")

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_AlreadyImmutable.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_AlreadyImmutable.java.txt
@@ -138,7 +138,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "stringId" + ":" + getStringId()+ "," +
             "booleanId" + ":" + getBooleanId()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
@@ -254,7 +254,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "stringId" + ":" + getStringId()+ "," +
             "booleanId" + ":" + getBooleanId()+ "," +

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMNTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMNTest.java.txt
@@ -117,7 +117,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMStarTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMStarTest.java.txt
@@ -112,7 +112,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalManyTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalManyTest.java.txt
@@ -112,7 +112,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalNTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalNTest.java.txt
@@ -122,7 +122,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOneTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOneTest.java.txt
@@ -66,7 +66,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalNTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalNTest.java.txt
@@ -117,7 +117,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalOneTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalOneTest.java.txt
@@ -66,7 +66,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalTests_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalTests_Unaware.java.txt
@@ -37,7 +37,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association.java.txt
@@ -238,7 +238,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association2.java.txt
@@ -238,7 +238,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MN.java.txt
@@ -228,7 +228,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MStar.java.txt
@@ -238,7 +238,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_MN.java.txt
@@ -211,7 +211,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_N.java.txt
@@ -238,7 +238,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_MN.java.txt
@@ -186,7 +186,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_OptionalN.java.txt
@@ -190,7 +190,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association.java.txt
@@ -228,7 +228,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association2.java.txt
@@ -228,7 +228,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_MStar.java.txt
@@ -186,7 +186,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_OptionalN.java.txt
@@ -221,7 +221,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_MN.java.txt
@@ -176,7 +176,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_Many.java.txt
@@ -236,7 +236,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_MStar.java.txt
@@ -176,7 +176,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_Many.java.txt
@@ -226,7 +226,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association.java.txt
@@ -169,7 +169,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association2.java.txt
@@ -169,7 +169,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_Many.java.txt
@@ -209,7 +209,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_N.java.txt
@@ -176,7 +176,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_Many.java.txt
@@ -220,7 +220,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_OptionalN.java.txt
@@ -169,7 +169,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_MStar.java.txt
@@ -211,7 +211,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_N.java.txt
@@ -228,7 +228,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association.java.txt
@@ -211,7 +211,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association2.java.txt
@@ -211,7 +211,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_N.java.txt
@@ -186,7 +186,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_OptionalN.java.txt
@@ -163,7 +163,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_MN.java.txt
@@ -93,7 +93,7 @@ public class Pupil
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_One.java.txt
@@ -194,7 +194,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_Many.java.txt
@@ -92,7 +92,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_One.java.txt
@@ -178,7 +178,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_Many.java.txt
@@ -81,7 +81,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_One.java.txt
@@ -158,7 +158,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_N.java.txt
@@ -93,7 +93,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_One.java.txt
@@ -167,7 +167,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association.java.txt
@@ -87,7 +87,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "id" + ":" + getId()+ "]" + System.getProperties().getProperty("line.separator") +

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association2.java.txt
@@ -87,7 +87,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_One.java.txt
@@ -175,7 +175,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_OptionalN.java.txt
@@ -93,7 +93,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Driver.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Driver.java.txt
@@ -93,7 +93,7 @@ public class MyDriver
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mySubordinate = "+(getMySubordinate()!=null?Integer.toHexString(System.identityHashCode(getMySubordinate())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Subordinate.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Subordinate.java.txt
@@ -93,7 +93,7 @@ public class MySubordinate
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "myDriver = "+(getMyDriver()!=null?Integer.toHexString(System.identityHashCode(getMyDriver())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association.java.txt
@@ -179,7 +179,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association2.java.txt
@@ -179,7 +179,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_MN.java.txt
@@ -73,7 +73,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_One.java.txt
@@ -236,7 +236,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_Many.java.txt
@@ -123,7 +123,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_One.java.txt
@@ -227,7 +227,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_Many.java.txt
@@ -83,7 +83,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_One.java.txt
@@ -156,7 +156,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_Many.java.txt
@@ -64,7 +64,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_One.java.txt
@@ -158,7 +158,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_N.java.txt
@@ -88,7 +88,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_One.java.txt
@@ -166,7 +166,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OneSymmetric.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OneSymmetric.java.txt
@@ -87,7 +87,7 @@ public class OneSymmetric
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +

--- a/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneAsymmetric.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneAsymmetric.java.txt
@@ -146,7 +146,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneSymmetric.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneSymmetric.java.txt
@@ -97,7 +97,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "superMentor = "+(getSuperMentor()!=null?Integer.toHexString(System.identityHashCode(getSuperMentor())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_One.java.txt
@@ -156,7 +156,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_Singleton.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_Singleton.java.txt
@@ -92,7 +92,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/StudentImmutableNotLazyTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/StudentImmutableNotLazyTest.java.txt
@@ -57,7 +57,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "," +
             "number2" + ":" + getNumber2()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Aware.java.txt
@@ -183,7 +183,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Aware.java.txt
@@ -175,7 +175,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Aware.java.txt
@@ -139,7 +139,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Aware.java.txt
@@ -126,7 +126,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Aware.java.txt
@@ -70,7 +70,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Aware.java.txt
@@ -171,7 +171,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Aware.java.txt
@@ -69,7 +69,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Unaware.java.txt
@@ -45,7 +45,7 @@ public class Student
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/implementation/java/javaRubyPHPConstraint.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/javaRubyPHPConstraint.java.txt
@@ -71,7 +71,7 @@ public class Range
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "start" + ":" + getStart()+ "," +
             "end" + ":" + getEnd()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/java/phpJavaRubyConstraint.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/phpJavaRubyConstraint.java.txt
@@ -71,7 +71,7 @@ public class Range
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "start" + ":" + getStart()+ "," +
             "end" + ":" + getEnd()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/php/OptionalOneToMStarTest_Many.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/OptionalOneToMStarTest_Many.php.txt
@@ -63,7 +63,7 @@ class Student
     $wasSet = false;
     
     $existingMentor = $this->mentor;
-	
+
     if ($existingMentor == null)
     {
       if ($aMentor != null)
@@ -103,7 +103,7 @@ class Student
     }
     return $wasSet;
   }
-  
+
   public function equals($compareTo)
   {
     return $this == $compareTo;

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CodeBlock_and_Expression/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CodeBlock_and_Expression/Java/TemplateTest.java.txt
@@ -84,7 +84,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CommentBlock/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CommentBlock/Java/TemplateTest.java.txt
@@ -79,7 +79,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_referToSharedTemplateDefinition/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_referToSharedTemplateDefinition/Java/TemplateTest.java.txt
@@ -80,7 +80,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_many_templateDefinitions/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_many_templateDefinitions/Java/TemplateTest.java.txt
@@ -80,7 +80,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_parameters/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_parameters/Java/TemplateTest.java.txt
@@ -80,7 +80,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_ExactSpace_methods/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_ExactSpace_methods/Java/TemplateTest.java.txt
@@ -100,7 +100,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Expressions/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Expressions/Java/TemplateTest.java.txt
@@ -113,7 +113,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "string1" + ":" + getString1()+ "," +
             "string2" + ":" + getString2()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Nested_reference_templates/Java/ClassGenerator.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Nested_reference_templates/Java/ClassGenerator.java.txt
@@ -113,7 +113,7 @@ public class ClassGenerator
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/HelperTemplate.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/HelperTemplate.java.txt
@@ -103,7 +103,7 @@ public class HelperTemplate
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/TemplateTest.java.txt
@@ -78,7 +78,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_complex_Generation/Java/HtmlNode.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_complex_Generation/Java/HtmlNode.java.txt
@@ -310,7 +310,7 @@ public class HtmlNode
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "tag" + ":" + getTag()+ "," +
             "content" + ":" + getContent()+ "]"

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleCodeBlock/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleCodeBlock/Java/TemplateTest.java.txt
@@ -77,7 +77,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleTest/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleTest/Java/TemplateTest.java.txt
@@ -76,7 +76,7 @@ public class TemplateTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+ "]"
      + outputString;
   }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/activeObject.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/activeObject.java.txt
@@ -300,7 +300,7 @@ public class Lamp
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "log" + ":" + getLog()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments.java.txt
@@ -143,7 +143,7 @@ public class LightFixture
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments_1.java.txt
@@ -143,7 +143,7 @@ public class LightFixture
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardSpacing.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardSpacing.java.txt
@@ -93,7 +93,7 @@ public class Garage
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "entranceClear" + ":" + getEntranceClear()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEvent.java.txt
@@ -94,7 +94,7 @@ public class LightFixture
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEventWithDefaultNoGuard.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEventWithDefaultNoGuard.java.txt
@@ -96,7 +96,7 @@ public class LightFixture
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/oneGuard.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/oneGuard.java.txt
@@ -88,7 +88,7 @@ public class LightFixture
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents.java.txt
@@ -324,7 +324,7 @@ public class Mentor implements Runnable
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
@@ -276,7 +276,7 @@ public class LightFixture implements Runnable
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents.java.txt
@@ -297,7 +297,7 @@ public class Mentor implements Runnable
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
@@ -248,7 +248,7 @@ public class LightFixture implements Runnable
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
@@ -249,7 +249,7 @@ public class LightFixture implements Runnable
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "brightness" + ":" + getBrightness()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testMultipleQSMs.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testMultipleQSMs.java.txt
@@ -350,7 +350,7 @@ public class X implements Runnable
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "ev" + ":" + getEv()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/timedEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/timedEvent.java.txt
@@ -197,7 +197,7 @@ public class Mentor
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceBiAssocManyToManyRoleCondition.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceBiAssocManyToManyRoleCondition.java.txt
@@ -190,7 +190,7 @@ public class Company
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceBigStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceBigStateMachine.java.txt
@@ -519,7 +519,7 @@ public class StateMachineTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceCaseAttrStm.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceCaseAttrStm.java.txt
@@ -202,7 +202,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "id" + ":" + getId()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbEvent.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbPostfix.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbPostfix.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbState.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbState.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeAfter.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeAfter.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeOccurences.java.txt
@@ -73,7 +73,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributePeriod.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributePeriod.java.txt
@@ -107,7 +107,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord1.java.txt
@@ -79,7 +79,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord2.java.txt
@@ -77,7 +77,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord3.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord3.java.txt
@@ -64,7 +64,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeUntil.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeUntil.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeOccurences.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord1.java.txt
@@ -59,7 +59,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord2.java.txt
@@ -59,7 +59,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceStateExitWhere.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceStateExitWhere.java.txt
@@ -105,7 +105,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceStateRecordAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceStateRecordAttr.java.txt
@@ -101,7 +101,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceStateRecordAttr2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceStateRecordAttr2.java.txt
@@ -116,7 +116,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceTransitionRecordAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceTransitionRecordAttr.java.txt
@@ -102,7 +102,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceBiAssocManyToManyRoleCondition.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceBiAssocManyToManyRoleCondition.java.txt
@@ -190,7 +190,7 @@ public class Company
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceBigStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceBigStateMachine.java.txt
@@ -519,7 +519,7 @@ public class StateMachineTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceCaseAttrStm.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceCaseAttrStm.java.txt
@@ -202,7 +202,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "id" + ":" + getId()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbEvent.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbPostfix.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbPostfix.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbState.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbState.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeAfter.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeAfter.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeOccurences.java.txt
@@ -73,7 +73,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributePeriod.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributePeriod.java.txt
@@ -107,7 +107,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord1.java.txt
@@ -79,7 +79,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord2.java.txt
@@ -77,7 +77,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord3.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord3.java.txt
@@ -64,7 +64,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeUntil.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeUntil.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeOccurences.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord1.java.txt
@@ -59,7 +59,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord2.java.txt
@@ -59,7 +59,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateEntryWhere.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateEntryWhere.java.txt
@@ -105,7 +105,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateExitWhere.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateExitWhere.java.txt
@@ -105,7 +105,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateRecordAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateRecordAttr.java.txt
@@ -101,7 +101,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateRecordAttr2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceStateRecordAttr2.java.txt
@@ -116,7 +116,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceTransitionRecordAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceTransitionRecordAttr.java.txt
@@ -102,7 +102,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceBiAssocManyToManyRoleCondition.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceBiAssocManyToManyRoleCondition.java.txt
@@ -190,7 +190,7 @@ public class Company
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceBigStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceBigStateMachine.java.txt
@@ -519,7 +519,7 @@ public class StateMachineTest
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceCaseAttrStm.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceCaseAttrStm.java.txt
@@ -202,7 +202,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "id" + ":" + getId()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbEvent.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbPostfix.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbPostfix.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbState.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbState.java.txt
@@ -100,7 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"
      + outputString;

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeAfter.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeAfter.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeOccurences.java.txt
@@ -73,7 +73,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributePeriod.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributePeriod.java.txt
@@ -107,7 +107,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord1.java.txt
@@ -79,7 +79,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord2.java.txt
@@ -77,7 +77,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord3.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord3.java.txt
@@ -64,7 +64,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeUntil.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeUntil.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeOccurences.java.txt
@@ -75,7 +75,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord1.java.txt
@@ -59,7 +59,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord2.java.txt
@@ -59,7 +59,7 @@ public class Tracer
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateEntryWhere.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateEntryWhere.java.txt
@@ -105,7 +105,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateExitWhere.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateExitWhere.java.txt
@@ -105,7 +105,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateRecordAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateRecordAttr.java.txt
@@ -101,7 +101,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateRecordAttr2.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceStateRecordAttr2.java.txt
@@ -116,7 +116,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "," +

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceTransitionRecordAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceTransitionRecordAttr.java.txt
@@ -102,7 +102,7 @@ public class Light
 
   public String toString()
   {
-	  String outputString = "";
+    String outputString = "";
 	  
     return super.toString() + "["+
             "v" + ":" + getV()+ "]"


### PR DESCRIPTION
## Description

This is a small pull request to set up the repository for starting to allow using the php Umple template instead of JET.

Had to change one template to allow Umple and JET to produce the same output for php.

Outlined in Issue #708, but does not fix much of the spacing issues in Java, to make it easier for everyone still working on Java templates. Further, similar, changes will need to be performed on Java before Umple templates for Java will be able to pass.
## Tests

Changed one Php test, to not expect a tab, and removed unnecessary spaces between two functions.
Also changed all Java tests that included `String outputString = "";` in their `toString()` function to not use a tab.
