### PR TITLE
Deactivating UmpleToTemplate Jet targets. This prevents people from overwriting the generated code and makes clear that the UmpleToTemplate is no longer active.

### DIFF
--- a/UmpleToCpp/ReadMe.txt
+++ b/UmpleToCpp/ReadMe.txt
@@ -1,4 +1,4 @@
-
+THIS IS DEPRECATED AND WILL BE DELETED SHORTLY
 
 This project is currently under development, the goal of this project to generate C++ code from Umple.
 

--- a/UmpleToTemplate/README.md
+++ b/UmpleToTemplate/README.md
@@ -1,0 +1,9 @@
+#Common templates
+
+This directory is intended to contain templates that are common among the various UmpleTo*
+directories.
+
+As of the time of writing there are no common templates as we are in the process of moving away from Jet
+to UmpleTL. Any common UmpleTL templates should be put in the UmpleTLTemplates directory if they are
+ever created. Any jet templates will be removed.
+

--- a/build/build.codegen.xml
+++ b/build/build.codegen.xml
@@ -2,7 +2,10 @@
 <project basedir=".." default="build" name="UmpleCodegen" >
 	
   <!-- Move the generic Jet templates into each project -->
+  <!-- THIS IS NO LONGER BEING DONE AS JET IS NOW DEPRECATED AND WILL BE DELETED -->
   <target name="prepare">	
+    <echo>THIS ANT TARGET IS NO LONGER ACTIVE as jet is deprecated</echo>
+    <!--
     <copy todir="UmpleToJava/templates" overwrite="true">
       <fileset dir="UmpleToTemplate/templates" excludes="*.svn" />
     </copy>
@@ -12,30 +15,13 @@
     <copy todir="UmpleToRuby/templates" overwrite="true">
       <fileset dir="UmpleToTemplate/templates" excludes="*.svn" />
     </copy>
-    <copy todir="UmpleToCpp/templates" overwrite="true">
-      <fileset dir="UmpleToTemplate/templates" excludes="*.svn" />
-    </copy>
+    -->
   </target>
   
   <!-- Translate the *.jet and *.jumpjet files into Java source code -->
-  <!-- JET CANNOT EASILY BE COMPILED FROM COMMAND LINE -->
+  <!-- DEPRECATED - TO DELETE - JET CANNOT EASILY BE COMPILED FROM COMMAND LINE -->
   <target name="generate">
   </target>
-
-  <!-- <target name="promote">
-    <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/java" overwrite="true">
-      <fileset dir="UmpleToJava/src/cruise/umple/compiler/java" excludes="*.svn" />
-    </copy>
-    <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/php" overwrite="true">
-      <fileset dir="UmpleToPhp/src/cruise/umple/compiler/php" excludes="*.svn" />
-    </copy>
-    <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/ruby" overwrite="true">
-      <fileset dir="UmpleToRuby/src/cruise/umple/compiler/ruby" excludes="*.svn" />
-    </copy>
-    <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/cpp" overwrite="true">
-      <fileset dir="UmpleToCpp/src/cruise/umple/compiler/cpp" excludes="*.svn" />
-    </copy>
-  </target> -->
 
   <target name="build" >
     <antcall target="prepare" />

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -109,6 +109,9 @@
 		<arg value="InsertDebugCodeScript.rb" />
 	</exec>
 	-->
+	  <echo>Copying of common templates no longer active</echo>
+	  <!-- DEPRECATED Templates in Jet not being used any more. We may reinstate
+	       UmplTL common templates later 
     <copy todir="UmpleToJava/templates" overwrite="true">
       <fileset dir="UmpleToTemplate/templates" excludes=".git*" />
     </copy>
@@ -118,9 +121,10 @@
     <copy todir="UmpleToRuby/templates" overwrite="true">
       <fileset dir="UmpleToTemplate/templates" excludes=".git*" />
     </copy>
-    <copy todir="UmpleToCpp/templates" overwrite="true">
+      -->
+    <!-- OLD CPP Deprecated <copy todir="UmpleToCpp/templates" overwrite="true">
       <fileset dir="UmpleToTemplate/templates" excludes=".git*" />
-    </copy>
+    </copy> -->
   </target>
 
   <!-- Unzip JDT libraries into the jar construction folder -->
@@ -160,6 +164,7 @@
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/ruby" overwrite="true">
       <fileset dir="UmpleToRuby/src-gen-UmpleTL/cruise/umple/compiler/ruby" excludes=".git* UmpleToRuby.java" />
     </copy>
+    <!-- OLD CPP DEPRECATED -->
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/cpp" overwrite="true">
       <fileset dir="UmpleToCpp/src/cruise/umple/compiler/cpp" excludes=".git*" />
     </copy>


### PR DESCRIPTION
The main purpose of this is to deactivate the build target that moves the Jet code around. Some prep for removal of the old cpp is also done.
