### PR TITLE
Fixed append in JavaSpecGenerator

### DIFF
--- a/UmpleToJava/src/cruise/umple/compiler/java/JavaSpecGenerator.java
+++ b/UmpleToJava/src/cruise/umple/compiler/java/JavaSpecGenerator.java
@@ -2609,6 +2609,14 @@ public class JavaSpecGenerator
   // i.e. format("Hello {0} {1}", "andrew","forward");
   private void append(StringBuffer buffer, String input, Object... variables)
   {
+    buffer.append(StringFormatter.format(input,variables));
+  }
+
+  // This method will have the JET stuff inserted into it.
+  // Will not be called anywhere, but will ensure the rest of the file works
+  // as expected
+  private void genHere()
+  {
     final StringBuffer stringBuffer = new StringBuffer();
     stringBuffer.append(TEXT_1);
     
@@ -4683,6 +4691,22 @@ public class JavaSpecGenerator
    /* Method Gen skipped due to special specialization syntax */
 
         // TODO!!
+      }
+      else if (includeFile == "association_SetOptionalNToMany.jet")
+      {
+        
+    
+   /* Method Gen skipped due to special specialization syntax */
+
+        // TODO?
+      }
+      else if (includeFile == "specializationSkip.jet")
+      {
+        
+    
+   /* Method Gen skipped due to special specialization syntax */
+
+        // TODO?
       }
       else if (includeFile != null)
       {

--- a/UmpleToJava/templates/association_set_specialization_reqSuperCode.jet
+++ b/UmpleToJava/templates/association_set_specialization_reqSuperCode.jet
@@ -412,6 +412,14 @@
       {
         %><%@ include file="specializationSkip.jet"%><%    // TODO!!
       }
+      else if (includeFile == "association_SetOptionalNToMany.jet")
+      {
+        %><%@ include file="specializationSkip.jet"%><%    // TODO?
+      }
+      else if (includeFile == "specializationSkip.jet")
+      {
+        %><%@ include file="specializationSkip.jet"%><%    // TODO?
+      }
       else if (includeFile != null)
       {
         appendln(stringBuffer,"You forgot to include {0}",includeFile);

--- a/UmpleToJava/templates/spec_generator.skeleton
+++ b/UmpleToJava/templates/spec_generator.skeleton
@@ -30,4 +30,10 @@ public class CLASS
     buffer.append(StringFormatter.format(input,variables));
   }
 
+  // This method will have the JET stuff inserted into it.
+  // Will not be called anywhere, but will ensure the rest of the file works
+  // as expected
+  private void genHere() {
+  
+  }
 }

--- a/cruise.umple/src-gen-jet/cruise/umple/compiler/java/JavaSpecGenerator.java
+++ b/cruise.umple/src-gen-jet/cruise/umple/compiler/java/JavaSpecGenerator.java
@@ -2609,6 +2609,14 @@ public class JavaSpecGenerator
   // i.e. format("Hello {0} {1}", "andrew","forward");
   private void append(StringBuffer buffer, String input, Object... variables)
   {
+    buffer.append(StringFormatter.format(input,variables));
+  }
+
+  // This method will have the JET stuff inserted into it.
+  // Will not be called anywhere, but will ensure the rest of the file works
+  // as expected
+  private void genHere()
+  {
     final StringBuffer stringBuffer = new StringBuffer();
     stringBuffer.append(TEXT_1);
     
@@ -4683,6 +4691,22 @@ public class JavaSpecGenerator
    /* Method Gen skipped due to special specialization syntax */
 
         // TODO!!
+      }
+      else if (includeFile == "association_SetOptionalNToMany.jet")
+      {
+        
+    
+   /* Method Gen skipped due to special specialization syntax */
+
+        // TODO?
+      }
+      else if (includeFile == "specializationSkip.jet")
+      {
+        
+    
+   /* Method Gen skipped due to special specialization syntax */
+
+        // TODO?
       }
       else if (includeFile != null)
       {


### PR DESCRIPTION
The general idea of the fix (in `JavaSpecGenerator.jet`) will also be applied to the Umple templates change.

Still passes all of the tests for the JavaSpecGenerator because they just checked to see if the code would compile.
