### PR TITLE
Added Umple templates for Java, build defaulting to JET

### DIFF
--- a/UmpleToJava/.gitignore
+++ b/UmpleToJava/.gitignore
@@ -1,0 +1,2 @@
+UmpleToJava.java
+src-gen-UmpleTL/

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -1,0 +1,264 @@
+use UmpleNotice.ump;
+use association_Get_All.ump;
+use association_Set_All.ump;
+use attribute_Get_All.ump;
+use attribute_IsBoolean_All.ump;
+use attribute_Set_All.ump;
+use class_MethodDeclaration.ump;
+use constructor_Declare_All.ump;
+use delete_All.ump;
+use equals.ump;
+use import_packages.ump;
+use members_AllAssociations.ump;
+use members_AllAttributes.ump;
+use members_AllDoActivities.ump;
+use members_AllHelpers.ump;
+use members_AllStateMachines.ump;
+use members_AllStatics.ump;
+use queued_state_machine_inner_class.ump;
+use queued_state_machine_queuedEvent.ump;
+use queued_state_machine_removalThread_run.ump;
+use state_machine_Events_All.ump;
+use state_machine_Get_All.ump;
+use state_machine_Set_All.ump;
+use state_machine_doActivity_All.ump;
+use state_machine_timedEvent_All.ump;
+use toString_declare.ump;
+use trace.ump;
+use uncaught_exception.ump;
+
+
+namespace cruise.umple.compiler.java;
+
+external interface ILang{}
+
+class JavaClassGenerator {
+    depend cruise.umple.compiler.*;
+    depend cruise.umple.util.*;
+    depend java.util.*;
+    depend cruise.umple.parser.Position;
+
+    isA ILang;
+
+    // Add a newline to the end of the input
+    private void appendln(StringBuilder buffer, String input, Object... variables)
+    {
+        append(buffer, input + "\n", variables);
+    }
+
+    // This method will be used to append formatted strings
+    // i.e. format("Hello {0} {1}", "andrew","forward");
+    private void append(StringBuilder buffer, String input, Object... variables)
+    {
+        buffer.append(StringFormatter.format(input,variables));
+    }
+
+    emit getCode(UmpleModel model, UmpleElement uElement)(JavaClassGenerator);
+
+
+    JavaClassGenerator <<!<</*JavaClassGenerator*/>><<@ UmpleToJava.UmpleNotice >>
+<<#
+  UmpleClass uClass = (UmpleClass) uElement;
+  globalUmpleClass = uClass;  
+  GeneratedClass gClass = uClass.getGeneratedClass();
+  JavaGenerator gen = new JavaGenerator();
+  gen.setModel(model);
+  GeneratorHelper.generator = gen;
+
+  HashMap<String,String> codeInjectionMap = new HashMap<String,String>();
+  for (CodeInjection inject : uClass.getCodeInjections())
+  {
+    String operation = StringFormatter.toUnderscore(inject.getOperation());
+    String key = inject.getType() + ":" + operation;
+    String newCodeToInject = "";
+    String injectCode = inject.getConstraintTree()==null?inject.getCode():inject.getConstraintCode(gen);
+    if (codeInjectionMap.containsKey(key))
+    {
+      newCodeToInject = StringFormatter.format("{0}\n    {1}",codeInjectionMap.get(key),injectCode);
+    }
+    else
+    {
+      newCodeToInject = injectCode;
+    }
+    codeInjectionMap.put(key,newCodeToInject);
+  }
+
+  boolean isFirst = true;
+#>>
+
+<<=gen.translate("packageDefinition",uClass)>><<@ UmpleToJava.import_packages >>
+
+
+<<# if (uClass.numberOfComments() > 0) { append(realSb, "\n{0}", Comment.format("Javadoc",uClass.getComments())); } #>>
+<<# for (Position p : uClass.getPositions()) { #>>
+<<# uClass.setSourceFilename( p.getFilename() ); #>>
+// line <<= p.getLineNumber() >> "<<= uClass.getRelativePath("Java") >>"
+<<# } #>>
+public <<# if (uClass.getIsAbstract()) { append(realSb, "{0} ", "abstract"); } #>>class <<=uClass.getName()>><<= gen.translate("isA",uClass) >><<#
+
+for (StateMachine smq : uClass.getStateMachines())
+  {
+    if (smq.isQueued())
+    {
+      append(realSb," implements Runnable");
+      break;
+    }
+    else if(smq.isPooled())
+    {
+      append(realSb," implements Runnable");
+      break;
+    }
+  }
+
+#>>
+{
+  <<#getMemberCode(realSb, model,uClass,gClass,gen,isFirst);
+  getConstructorCode(realSb, model,uClass,gClass,gen,isFirst, false);
+  getAttributeCode(realSb, model,uClass,gClass,gen,isFirst,false);
+  getStateMachine1Code(realSb, model,uClass,gClass,gen,isFirst,false);
+  getAssociationCode(realSb, model,uClass,gClass,gen,isFirst,false);
+  getEqualsCode(realSb, model,uClass,gClass,gen,isFirst);
+  getStateMachine2Code(realSb, model,uClass,gClass,gen,isFirst);
+  getDeleteCode(realSb, model,uClass,gClass,gen,isFirst,false);
+  getExtraMethodsCode(realSb, model,uClass,gClass,gen,isFirst);
+  getAllExtraCode(realSb, model,uClass,gClass,gen,isFirst);
+  return realSb;
+    } 
+    private String getMemberCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst)
+  {#>><<@ UmpleToJava.members_AllStatics >><<@ UmpleToJava.members_AllAttributes >><<@ UmpleToJava.members_AllStateMachines >><<@ UmpleToJava.members_AllDoActivities >><<@ UmpleToJava.members_AllAssociations >><<@ UmpleToJava.members_AllHelpers >>
+  <<#return realSb.toString();
+    }
+  private UmpleClass globalUmpleClass = null;
+  public Map<String,UncaughtException> uncaughtExceptions = new HashMap<String,UncaughtException>();
+  
+    private String getConstructorCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst, boolean isFake)
+  {
+    Integer baseJavaLine = realSb.toString().split("\\n").length;
+    boolean reqSuperCode, reqCommonCode;
+    AssociationVariable relatedAssociation;
+    Association relatedAssoc;#>>
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+<<@ UmpleToJava.constructor_Declare_All >>
+  <<#return realSb.toString();
+    } 
+    private String getAttributeCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst, boolean isFake)
+  { 
+    String umpleSourceFile = "";
+    Integer baseJavaLine = realSb.toString().split("\\n").length;#>>
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+<<@ UmpleToJava.attribute_Set_All >><<@ UmpleToJava.attribute_Get_All >><<@ UmpleToJava.attribute_IsBoolean_All >>
+  <<#return realSb.toString();
+    } 
+    private String getStateMachine1Code(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst, boolean isFake)
+  {
+    Integer baseJavaLine = realSb.toString().split("\\n").length;#>><<@ UmpleToJava.state_machine_Get_All >><<@ UmpleToJava.state_machine_Events_All >><<@ UmpleToJava.state_machine_Set_All >><<#
+    return realSb.toString(); 
+  } 
+  private String getAssociationCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst, boolean isFake)
+  {
+    String umpleSourceFile = "";
+    Integer baseJavaLine = realSb.toString().split("\\n").length+3;#>><<@ UmpleToJava.association_Get_All >><<@ UmpleToJava.association_Set_All >>
+  <<#return realSb.toString();
+    } 
+    
+    private String getEqualsCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst)
+  {#>>
+<<# if (uClass.getKey().isProvided()) { #>><<@ UmpleToJava.equals >>
+<<# } #>>
+  <<#return realSb.toString();
+    } 
+    private String getStateMachine2Code(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst)
+  {#>><<@ UmpleToJava.state_machine_doActivity_All >><<@ UmpleToJava.state_machine_timedEvent_All >>
+  <<#return realSb.toString();
+    } 
+    private String getDeleteCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst, boolean isFake)
+  {
+    Integer baseJavaLine = realSb.toString().split("\\n").length+1; #>><<@ UmpleToJava.delete_All >>
+    <<# for (StateMachine smq : uClass.getStateMachines())
+     {
+       if (smq.isPooled())
+       {#>><<@ UmpleToJava.queued_state_machine_inner_class >><<@ UmpleToJava.queued_state_machine_queuedEvent >><<@ UmpleToJava.queued_state_machine_removalThread_run >>
+       <<# break;
+       }       
+       if (smq.isQueued())
+       {#>><<@ UmpleToJava.queued_state_machine_inner_class >><<@ UmpleToJava.queued_state_machine_queuedEvent >><<@ UmpleToJava.queued_state_machine_removalThread_run >>
+       <<# break;
+       }
+     }#>>
+  <<#return realSb.toString();
+    } 
+    private String getExtraMethodsCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst)
+  {#>>
+<<# if (uClass.hasMethods()) { #>><<@ UmpleToJava.class_MethodDeclaration >>
+<<# } #>><<# 
+   boolean matchFound = false;
+   UmpleClass parent = uClass.getExtendsClass(); 
+   if(uClass.getExtraCode() != null)
+   {
+     matchFound = java.util.regex.Pattern.compile(".*((public)|(protected)|(private))\\s+(String)\\s+(toString)\\s*\\(\\s*\\).*", java.util.regex.Pattern.DOTALL).matcher(uClass.getExtraCode()).matches();
+   }
+   if(parent!=null && parent.getExtraCode() != null)
+   {
+     matchFound = java.util.regex.Pattern.compile(".*((public)|(protected)|(private))\\s+(String)\\s+(toString)\\s*\\(\\s*\\).*", java.util.regex.Pattern.DOTALL).matcher(parent.getExtraCode()).matches();
+   }
+   if(!matchFound)
+   for(Method meth: uClass.getMethods())
+   {
+     if("toString".equals(meth.getName()))
+     {
+       matchFound = true;
+       break;
+     }
+   }
+   if(!matchFound && parent!=null)
+   for(Method meth: parent.getMethods())
+   {
+     if("toString".equals(meth.getName()))
+     {
+       matchFound = true;
+       break;
+     }
+   }
+   if (uClass.getAttributes().size()>0 && !matchFound){ #>><<@ UmpleToJava.toString_declare >>
+<<# } #>>
+  <<#return realSb.toString();
+    } 
+    private String getAllExtraCode(StringBuilder realSb, UmpleModel model,UmpleClass uClass, GeneratedClass gClass, JavaGenerator gen, boolean isFirst)
+  {#>>
+<<# 
+  boolean isMainClass = false;
+  if (uClass.getExtraCode() != null && uClass.getExtraCode().length() > 0) { #>>  
+  //------------------------
+  // DEVELOPER CODE - PROVIDED AS-IS
+  //------------------------
+  
+  <<=uClass.getExtraCode()>>
+  
+
+<<# } #>><<@ UmpleToJava.trace >><<#if(uClass!=mainMainClass){#>>
+}<<#}
+  return realSb.toString();
+}
+#>><<@ UmpleToJava.uncaught_exception >><<#
+
+
+
+/* This function is meant purely to properly end the emit code in Umple
+   Should never be called
+   Only purpose is to make sure the 'if (numSpaces > 0)' part of the template
+   Doesn't cause errors */
+private StringBuilder endTemplate()
+{
+  GeneratorHelper.generator = null;
+  int numSpaces = 0;
+  StringBuilder newCode = null;
+  StringBuilder sb = null;
+  String spaces = "";
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/JavaInterfaceGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaInterfaceGenerator.ump
@@ -1,0 +1,58 @@
+use UmpleNotice.ump;
+use import_packages_interface.ump;
+use interface_AbstractMethodDeclaration.ump;
+use interface_constantDeclaration.ump;
+
+
+namespace cruise.umple.compiler.java;
+
+external interface ILang{}
+
+class JavaInterfaceGenerator {
+    depend cruise.umple.compiler.*;
+    depend cruise.umple.util.*;
+    depend java.util.*;
+
+    isA ILang;
+
+    // Add a newline to the end of the input
+    private void appendln(StringBuilder buffer, String input, Object... variables)
+    {
+        append(buffer, input + "\n", variables);
+    }
+
+    // This method will be used to append formatted strings
+    // i.e. format("Hello {0} {1}", "andrew","forward");
+    private void append(StringBuilder buffer, String input, Object... variables)
+    {
+        buffer.append(StringFormatter.format(input,variables));
+    }
+
+    emit getCode(UmpleModel model, UmpleElement uElement)(JavaInterfaceGenerator);
+
+
+    JavaInterfaceGenerator <<!<</*JavaInterfaceGenerator*/>><<@ UmpleToJava.UmpleNotice >>
+<<#
+  UmpleInterface uInterface = (UmpleInterface) uElement;
+  //GeneratedInterface gInterface = uInterface.getGeneratedInterface();
+  JavaGenerator gen = new JavaGenerator();
+  gen.setModel(model);
+
+  String extraCode = "";
+  if (uInterface.getExtraCode() != null)
+  {
+    extraCode = uInterface.getExtraCode();
+  }
+
+#>>
+<<=gen.translate("packageDefinition",uInterface)>><<@ UmpleToJava.import_packages_interface >>
+
+public interface <<=uInterface.getName()>><<= gen.translate("isA",uInterface) >>
+{
+  <<=extraCode>>
+<<# if (uInterface.hasConstants()) { #>><<@ UmpleToJava.interface_constantDeclaration >>
+<<# } #>>
+ <<# if (uInterface.hasMethods()) { #>><<@ UmpleToJava.interface_AbstractMethodDeclaration >>
+<<# } #>>
+}!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/JavaSpecGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaSpecGenerator.ump
@@ -1,0 +1,104 @@
+use UmpleNotice.ump;
+use association_set_specialization_reqCommonCode.ump;
+use association_set_specialization_reqSuperCode.ump;
+
+
+namespace cruise.umple.compiler.java;
+
+external interface ILang{}
+
+class JavaSpecGenerator {
+    depend cruise.umple.compiler.*;
+    depend cruise.umple.util.*;
+    depend java.util.*;
+
+    isA ILang;
+
+    // Add a newline to the end of the input
+    private void appendln(StringBuilder buffer, String input, Object... variables)
+    {
+        append(buffer, input + "\n", variables);
+    }
+
+    // This method will be used to append formatted strings
+    // i.e. format("Hello {0} {1}", "andrew","forward");
+    private void append(StringBuilder buffer, String input, Object... variables)
+    {
+        buffer.append(StringFormatter.format(input,variables));
+    }
+
+    emit getCode(UmpleModel model, UmpleElement uElement)(JavaSpecGenerator);
+
+
+    JavaSpecGenerator <<!<</*JavaSpecGenerator*/>><<@ UmpleToJava.UmpleNotice >>
+<<#
+    return realSb;
+	} // end append
+	
+  public void getAssociationCode_specialization_reqSuperCode(JavaGenerator gen, String includeFile, String includeFile2, String includeFile3, StringBuilder realSb, AssociationVariable av, AssociationVariable relatedAssociation,
+  		String customSetPrefixCode, String customSetPostfixCode, String customAddPrefixCode, String customAddPostfixCode, String customRemovePrefixCode, String customRemovePostfixCode,
+  		String customSetManyPrefixCode, String customSetManyPostfixCode, List<TraceItem> traceItemAssocRemoves, List<TraceItem> traceItemAssocAdds, UmpleClass uClass, boolean sortMethodAdded, String umpleSourceFile,
+  		Map<String,UncaughtException> uncaughtExceptions, UmpleClass globalUmpleClass, boolean addNewLine, boolean mulChangedToOne, boolean relMulChangedToOne, boolean mulChangedToN, boolean reqSetCode, boolean relReqCommonCode, boolean relReqSetCode, String scName) 
+  	{ 
+  	this.uncaughtExceptions = uncaughtExceptions;
+  	this.globalUmpleClass = globalUmpleClass;
+  #>><<@ UmpleToJava.association_set_specialization_reqSuperCode >><<#
+     }// end super code
+     
+  public void getAssociationCode_specialization_reqCommonCode(JavaGenerator gen, String includeFile, String includeFile2, String includeFile3, StringBuilder realSb, AssociationVariable av, AssociationVariable relatedAssociation,
+  		String customSetPrefixCode, String customSetPostfixCode, String customAddPrefixCode, String customAddPostfixCode, String customRemovePrefixCode, String customRemovePostfixCode,
+  		String customSetManyPrefixCode, String customSetManyPostfixCode, List<TraceItem> traceItemAssocRemoves, List<TraceItem> traceItemAssocAdds, UmpleClass uClass, boolean sortMethodAdded, String umpleSourceFile,
+  		Map<String,UncaughtException> uncaughtExceptions, UmpleClass globalUmpleClass, boolean addNewLine, boolean mulChangedToOne, boolean relMulChangedToOne, boolean mulChangedToN, boolean reqSetCode, boolean relReqCommonCode, boolean relReqSetCode, String scName) 
+  	{
+  	 this.uncaughtExceptions = uncaughtExceptions;
+  	 this.globalUmpleClass = globalUmpleClass;
+  #>><<@ UmpleToJava.association_set_specialization_reqCommonCode >><<# 
+    } // end common code
+    
+    java.util.regex.Pattern lineNumberPattern = java.util.regex.Pattern.compile("// line ([0|1|2|3|4|5|6|7|8|9]*) (.*)");
+private void addUncaughtExceptionVariables(int javaline, String code, String methodname)
+{
+  String[] lines = code.split("\\n");
+  java.util.regex.Matcher matcher = lineNumberPattern.matcher(lines[0]);
+  if(matcher.matches())
+  {
+    if(!uncaughtExceptions.containsKey(methodname))
+    {
+      uncaughtExceptions.put(methodname,new UncaughtException(globalUmpleClass.getName(), methodname));
+    }
+    uncaughtExceptions.get(methodname).addUncaughtFileName(matcher.group(2));
+    uncaughtExceptions.get(methodname).addUncaughtUmpleLine(Integer.parseInt(matcher.group(1))-1);
+    uncaughtExceptions.get(methodname).addUncaughtJavaLine(javaline+1);
+    uncaughtExceptions.get(methodname).addUncaughtLength(lines.length);
+  }  
+}
+private void addUncaughtExceptionVariables(String methodname, String filename, int umpleline, int javaline, int length)
+{
+  if(!uncaughtExceptions.containsKey(methodname))
+  {
+    uncaughtExceptions.put(methodname,new UncaughtException(globalUmpleClass.getName(), methodname));
+  }
+  
+  uncaughtExceptions.get(methodname).addUncaughtFileName(filename);
+  uncaughtExceptions.get(methodname).addUncaughtUmpleLine(umpleline-1);
+  uncaughtExceptions.get(methodname).addUncaughtJavaLine(javaline+1);
+  uncaughtExceptions.get(methodname).addUncaughtLength(length);
+}
+
+private Map<String,UncaughtException> uncaughtExceptions;
+private UmpleClass globalUmpleClass;
+
+/* This function is meant purely to properly end the emit code in Umple
+   Should never be called
+   Only purpose is to make sure the 'if (numSpaces > 0)' part of the template
+   Doesn't cause errors */
+private StringBuilder endTemplate()
+{
+  GeneratorHelper.generator = null;
+  int numSpaces = 0;
+  StringBuilder newCode = null;
+  StringBuilder sb = null;
+  String spaces = "";
+
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/Master.ump
+++ b/UmpleToJava/UmpleTLTemplates/Master.ump
@@ -1,0 +1,17 @@
+/*
+
+Copyright: All contributers to the Umple Project
+
+This file is made available subject to the open source license found at:
+http://umple.org/license
+
+This is the Umple php template master files that calls all major php template files.
+By compiling this file, Umple will regenerate all Php generator files
+
+*/
+
+generate Java "../src-gen-UmpleTL";
+
+use JavaClassGenerator.ump;
+use JavaInterfaceGenerator.ump;
+use JavaSpecGenerator.ump;

--- a/UmpleToJava/UmpleTLTemplates/UmpleNotice.ump
+++ b/UmpleToJava/UmpleTLTemplates/UmpleNotice.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    UmpleNotice <<!<</*UmpleNotice*/>>/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    association_AddImmutableUnidirectionalMany <<!<</*association_AddImmutableUnidirectionalMany*/>>
+  private boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<= gen.translate("attributeCanSet",av) >> = false;
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()")+"\n":"")
+>>    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    wasAdded = true;
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()")+"\n":"")
+>>    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+  !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany_relatedSpecialization.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    association_AddImmutableUnidirectionalMany_relatedSpecialization <<!<</*association_AddImmutableUnidirectionalMany_relatedSpecialization*/>>
+  private boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<= gen.translate("attributeCanSet",av) >> = false;
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()")+"\n":"")
+>>    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    wasAdded = true;
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()")+"\n":"")
+>>    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+  !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions.ump
@@ -1,0 +1,47 @@
+class UmpleToJava {
+    association_AddIndexControlFunctions <<!<</*association_AddIndexControlFunctions*/>>
+  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  {  
+    boolean wasAdded = false;
+    if(<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > <<=gen.translate("numberOfMethod",av)>>()) { index = <<=gen.translate("numberOfMethod",av)>>() - 1; }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("associationMany",av)>>.add(index, <<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    }
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("addOrMoveAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  {
+    boolean wasAdded = false;
+    if(<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > <<=gen.translate("numberOfMethod",av)>>()) { index = <<=gen.translate("numberOfMethod",av)>>() - 1; }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("associationMany",av)>>.add(index, <<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    } 
+    else 
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("parameterOne",av)>>, index);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    return wasAdded;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_relatedSpecialization.ump
@@ -1,0 +1,47 @@
+class UmpleToJava {
+    association_AddIndexControlFunctions_relatedSpecialization <<!<</*association_AddIndexControlFunctions_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  {  
+    boolean wasAdded = false;
+    if(<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > <<=gen.translate("numberOfMethod",av)>>()) { index = <<=gen.translate("numberOfMethod",av)>>() - 1; }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("associationMany",av)>>.add(index, <<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    }
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("addOrMoveAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  {
+    boolean wasAdded = false;
+    if(<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > <<=gen.translate("numberOfMethod",av)>>()) { index = <<=gen.translate("numberOfMethod",av)>>() - 1; }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("associationMany",av)>>.add(index, <<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    } 
+    else 
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("parameterOne",av)>>, index);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    return wasAdded;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_specialization.ump
@@ -1,0 +1,39 @@
+class UmpleToJava {
+    association_AddIndexControlFunctions_specialization <<!<</*association_AddIndexControlFunctions_specialization*/>>
+  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  {  
+    boolean wasAdded = false;
+    if(<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > <<=gen.translate("numberOfMethod",av)>>()) { index = <<=gen.translate("numberOfMethod",av)>>() - 1; }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = super.<<=gen.translate("addAtMethod",av)>>(<<=gen.translate("parameterOne",av)>>, int index);
+    }
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("addOrMoveAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  {
+    boolean wasAdded = false;
+    if(<<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>().contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > <<=gen.translate("numberOfMethod",av)>>()) { index = <<=gen.translate("numberOfMethod",av)>>() - 1; }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index);
+    } 
+    else 
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("parameterOne",av)>>, index);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    return wasAdded;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToMany.ump
@@ -1,0 +1,44 @@
+class UmpleToJava {
+    association_AddMNToMany <<!<</*association_AddMNToMany*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    int oldIndex = <<=gen.translate("associationMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.remove(oldIndex);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) == -1)
+    {
+      wasRemoved = true;
+    }
+    else
+    {
+      wasRemoved = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!wasRemoved)
+      {
+        <<=gen.translate("associationMany",av)>>.add(oldIndex,<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_relatedSpecialization.ump
@@ -1,0 +1,44 @@
+class UmpleToJava {
+    association_AddMNToMany_relatedSpecialization <<!<</*association_AddMNToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    int oldIndex = <<=gen.translate("associationMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.remove(oldIndex);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) == -1)
+    {
+      wasRemoved = true;
+    }
+    else
+    {
+      wasRemoved = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!wasRemoved)
+      {
+        <<=gen.translate("associationMany",av)>>.add(oldIndex,<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_specialization.ump
@@ -1,0 +1,27 @@
+class UmpleToJava {
+    association_AddMNToMany_specialization <<!<</*association_AddMNToMany_specialization*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+
+    
+<<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne.ump
@@ -1,0 +1,86 @@
+class UmpleToJava {
+    association_AddMNToOnlyOne <<!<</*association_AddMNToOnlyOne*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      return null;
+    }
+    else
+    {
+      return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+    }
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>> && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    //<<=gen.relatedTranslate("associationOne",av)>> already at minimum (<<=av.getMultiplicity().getLowerBound()>>)
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_relatedSpecialization.ump
@@ -1,0 +1,86 @@
+class UmpleToJava {
+    association_AddMNToOnlyOne_relatedSpecialization <<!<</*association_AddMNToOnlyOne_relatedSpecialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      return null;
+    }
+    else
+    {
+      return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+    }
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>> && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>()))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    //<<=gen.relatedTranslate("associationOne",av)>> already at minimum (<<=av.getMultiplicity().getLowerBound()>>)
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_specialization.ump
@@ -1,0 +1,79 @@
+class UmpleToJava {
+    association_AddMNToOnlyOne_specialization <<!<</*association_AddMNToOnlyOne_specialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      return null;
+    }
+    else
+    {
+      return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+    }
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+<<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>_One<<=gen.relatedTranslate("type",av)>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>> && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>(); <<# } #>>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    //<<=gen.relatedTranslate("associationOne",av)>> already at minimum (<<=av.getMultiplicity().getLowerBound()>>)
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    
+    wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne.ump
@@ -1,0 +1,59 @@
+class UmpleToJava {
+    association_AddMNToOptionalOne <<!<</*association_AddMNToOptionalOne*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+<<# if (!av.isStar()) { #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) {addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+<<# } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> != null && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+    else if (<<=gen.relatedTranslate("parameterExisting",av)>> != null)
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>,this);
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>) && <<=gen.translate("numberOfMethod",av)>>() > <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>,null);
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,59 @@
+class UmpleToJava {
+    association_AddMNToOptionalOne_relatedSpecialization <<!<</*association_AddMNToOptionalOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+<<# if (!av.isStar()) { #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) {addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+<<# } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> != null && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+    else if (<<=gen.relatedTranslate("parameterExisting",av)>> != null)
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>,this);
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>) && <<=gen.translate("numberOfMethod",av)>>() > <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>,null);
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_specialization.ump
@@ -1,0 +1,57 @@
+class UmpleToJava {
+    association_AddMNToOptionalOne_specialization <<!<</*association_AddMNToOptionalOne_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+<<# if (!av.isStar()) { #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) {addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+<<# } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> != null && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() > <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany.ump
@@ -1,0 +1,46 @@
+class UmpleToJava {
+    association_AddMStarToMany <<!<</*association_AddMStarToMany*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    int oldIndex = <<=gen.translate("associationMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.remove(oldIndex);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) == -1)
+    {
+      wasRemoved = true;
+    }
+    else
+    {
+      wasRemoved = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!wasRemoved)
+      {
+        <<=gen.translate("associationMany",av)>>.add(oldIndex,<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_relatedSpecialization.ump
@@ -1,0 +1,46 @@
+class UmpleToJava {
+    association_AddMStarToMany_relatedSpecialization <<!<</*association_AddMStarToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    int oldIndex = <<=gen.translate("associationMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.remove(oldIndex);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) == -1)
+    {
+      wasRemoved = true;
+    }
+    else
+    {
+      wasRemoved = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!wasRemoved)
+      {
+        <<=gen.translate("associationMany",av)>>.add(oldIndex,<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_specialization.ump
@@ -1,0 +1,28 @@
+class UmpleToJava {
+    association_AddMStarToMany_specialization <<!<</*association_AddMStarToMany_specialization*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+
+    
+<<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne.ump
@@ -1,0 +1,74 @@
+class UmpleToJava {
+    association_AddMandatoryManyToOne <<!<</*association_AddMandatoryManyToOne*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> = new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    return <<=gen.translate("parameterNew",av)>>;
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>> && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      return wasAdded;
+    }
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    //<<=gen.relatedTranslate("associationOne",av)>> already at minimum (<<=av.getMultiplicity().getLowerBound()>>)
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_relatedSpecialization.ump
@@ -1,0 +1,74 @@
+class UmpleToJava {
+    association_AddMandatoryManyToOne_relatedSpecialization <<!<</*association_AddMandatoryManyToOne_relatedSpecialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> = new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    return <<=gen.translate("parameterNew",av)>>;
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>> && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      return wasAdded;
+    }
+<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>()))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    //<<=gen.relatedTranslate("associationOne",av)>> already at minimum (<<=av.getMultiplicity().getLowerBound()>>)
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_specialization.ump
@@ -1,0 +1,56 @@
+class UmpleToJava {
+    association_AddMandatoryManyToOne_specialization <<!<</*association_AddMandatoryManyToOne_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+<<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);
+
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>> && <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      return wasAdded;
+    }
+
+    wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>(); <<# } #>>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    //<<=gen.relatedTranslate("associationOne",av)>> already at minimum (<<=av.getMultiplicity().getLowerBound()>>)
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod.ump
@@ -1,0 +1,39 @@
+class UmpleToJava {
+    association_AddManyToManyMethod <<!<</*association_AddManyToManyMethod*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+<<# if (!av.getMultiplicity().isUpperBoundMany()) { #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+
+<<# } #>><<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) != -1)
+    {
+      wasAdded = true;
+    }
+    else
+    {
+      wasAdded = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      if (!wasAdded)
+      {
+        <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_relatedSpecialization.ump
@@ -1,0 +1,39 @@
+class UmpleToJava {
+    association_AddManyToManyMethod_relatedSpecialization <<!<</*association_AddManyToManyMethod_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+<<# if (!av.getMultiplicity().isUpperBoundMany()) { #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+
+<<# } #>><<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) != -1)
+    {
+      wasAdded = true;
+    }
+    else
+    {
+      wasAdded = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      if (!wasAdded)
+      {
+        <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_specialization.ump
@@ -1,0 +1,28 @@
+class UmpleToJava {
+    association_AddManyToManyMethod_specialization <<!<</*association_AddManyToManyMethod_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null && av.getMultiplicity().getUpperBound() == 1) { #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("associationOne",av)>> = <<=gen.translate("getMethod",av)>>(<<#if (mulChangedToOne) { #>>0 <<# } #>>);
+    <<# } else if (customAddPrefixCode != null) { #>>
+   List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>(); 
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+<<# if (!av.getMultiplicity().isUpperBoundMany()) { #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+<<# } #>>
+    wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+
+    
+<<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOne.ump
@@ -1,0 +1,53 @@
+class UmpleToJava {
+    association_AddManyToOne <<!<</*association_AddManyToOne*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (!this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_relatedSpecialization.ump
@@ -1,0 +1,53 @@
+class UmpleToJava {
+    association_AddManyToOne_relatedSpecialization <<!<</*association_AddManyToOne_relatedSpecialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (!this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>()))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_specialization.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    association_AddManyToOne_specialization <<!<</*association_AddManyToOne_specialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    // need to keep this because of the type differences between sub & super classes
+    return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne.ump
@@ -1,0 +1,52 @@
+class UmpleToJava {
+    association_AddManyToOptionalOne <<!<</*association_AddManyToOptionalOne*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> == null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else if (!this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+      wasRemoved = true;<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,57 @@
+class UmpleToJava {
+    association_AddManyToOptionalOne_relatedSpecialization <<!<</*association_AddManyToOptionalOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> == null)
+    {
+      <<# if (!relReqSetCode) { #>>
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+      <<# } else { #>>
+      <<=gen.translate("parameterOne",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      <<# } #>>
+    }
+    else if (!this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("parameterOne",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+      wasRemoved = true;<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_specialization.ump
@@ -1,0 +1,62 @@
+class UmpleToJava {
+    association_AddManyToOptionalOne_specialization <<!<</*association_AddManyToOptionalOne_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>_<<# if (relatedAssociation.getMultiplicity().getUpperBound() != 1) { #>><<=gen.relatedTranslate("type",av)>><<# } else { #>>One<<=gen.relatedTranslate("type",av)>><<# } #>>();<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> == null)
+    {
+      <<# if (!relReqSetCode) { #>>
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+      <<# } else { #>>
+      <<=gen.translate("parameterOne",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      <<# } #>>
+    }
+    else if (!this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)a
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>(); <<# } #>>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+      wasRemoved = true;<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne.ump
@@ -1,0 +1,63 @@
+class UmpleToJava {
+    association_AddOptionalNToOne <<!<</*association_AddOptionalNToOne*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      return null;
+    }
+    else
+    {
+      return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+    }
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (!this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_relatedSpecialization.ump
@@ -1,0 +1,63 @@
+class UmpleToJava {
+    association_AddOptionalNToOne_relatedSpecialization <<!<</*association_AddOptionalNToOne_relatedSpecialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      return null;
+    }
+    else
+    {
+      return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+    }
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();
+    boolean <<=gen.relatedTranslate("parameterIsNew",av)>> = <<=gen.relatedTranslate("parameterExisting",av)>> != null && !this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterIsNew",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    //Unable to remove <<=gen.translate("parameterOne",av)>>, as it must always have a <<=gen.relatedTranslate("associationOne",av)>>
+    if (!this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>()))
+    {
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_specialization.ump
@@ -1,0 +1,35 @@
+class UmpleToJava {
+    association_AddOptionalNToOne_specialization <<!<</*association_AddOptionalNToOne_specialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  {
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      return null;
+    }
+    else
+    {
+      return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
+    }
+  }
+
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne.ump
@@ -1,0 +1,59 @@
+class UmpleToJava {
+    association_AddOptionalNToOptionalOne <<!<</*association_AddOptionalNToOptionalOne*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> == null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else if (!this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,59 @@
+class UmpleToJava {
+    association_AddOptionalNToOptionalOne_relatedSpecialization <<!<</*association_AddOptionalNToOptionalOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>();<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> == null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    else if (!this.equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    }
+    else
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("parameterOne",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_specialization.ump
@@ -1,0 +1,23 @@
+class UmpleToJava {
+    association_AddOptionalNToOptionalOne_specialization <<!<</*association_AddOptionalNToOptionalOne_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "      ")); } #>>
+      return wasAdded;
+    }
+
+    wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN.ump
@@ -1,0 +1,51 @@
+class UmpleToJava {
+    association_AddUnidirectionalMN <<!<</*association_AddUnidirectionalMN*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() < <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_relatedSpecialization.ump
@@ -1,0 +1,51 @@
+class UmpleToJava {
+    association_AddUnidirectionalMN_relatedSpecialization <<!<</*association_AddUnidirectionalMN_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() < <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_specialization.ump
@@ -1,0 +1,46 @@
+class UmpleToJava {
+    association_AddUnidirectionalMN_specialization <<!<</*association_AddUnidirectionalMN_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() < <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar.ump
@@ -1,0 +1,49 @@
+class UmpleToJava {
+    association_AddUnidirectionalMStar <<!<</*association_AddUnidirectionalMStar*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>><<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar_relatedSpecialization.ump
@@ -1,0 +1,49 @@
+class UmpleToJava {
+    association_AddUnidirectionalMStar_relatedSpecialization <<!<</*association_AddUnidirectionalMStar_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>><<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    if (<<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+
+    <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasRemoved = true;
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany.ump
@@ -1,0 +1,38 @@
+class UmpleToJava {
+    association_AddUnidirectionalMany <<!<</*association_AddUnidirectionalMany*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>><<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_relatedSpecialization.ump
@@ -1,0 +1,38 @@
+class UmpleToJava {
+    association_AddUnidirectionalMany_relatedSpecialization <<!<</*association_AddUnidirectionalMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>><<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    wasAdded = true;
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_specialization.ump
@@ -1,0 +1,24 @@
+class UmpleToJava {
+    association_AddUnidirectionalMany_specialization <<!<</*association_AddUnidirectionalMany_specialization*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("getMethod",av)>>().contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = super.<<=gen.translate("removeMethod",av)>>(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN.ump
@@ -1,0 +1,41 @@
+class UmpleToJava {
+    association_AddUnidirectionalOptionalN <<!<</*association_AddUnidirectionalOptionalN*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() < <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+<<= umpleSourceFile >>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_relatedSpecialization.ump
@@ -1,0 +1,41 @@
+class UmpleToJava {
+    association_AddUnidirectionalOptionalN_relatedSpecialization <<!<</*association_AddUnidirectionalOptionalN_relatedSpecialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() < <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = true;
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+<<= umpleSourceFile >>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<= 
+(traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasRemoved = true;
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>>
+    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_specialization.ump
@@ -1,0 +1,24 @@
+class UmpleToJava {
+    association_AddUnidirectionalOptionalN_specialization <<!<</*association_AddUnidirectionalOptionalN_specialization*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("associationMany",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>();
+    <<# } #>>
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("numberOfMethod",av)>>() < <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPre()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+      wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
+(traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+>>
+    }
+    <<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>
+    return wasAdded;
+  }
+<<= umpleSourceFile >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany.ump
@@ -1,0 +1,59 @@
+class UmpleToJava {
+    association_GetMany <<!<</*association_GetMany*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>(int index)
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPre()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationMany",av)+".get(index)"):"")
+>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("associationMany",av)>>.get(index);<<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPost()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("parameterOne",av)):"")
+>>
+    <<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    return <<=gen.translate("parameterOne",av)>>;
+  }
+
+  
+<<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  public List<<<=gen.translate("type",av)>>> <<=gen.translate("getManyMethod",av)>>()
+  {
+    <<# if (customGetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPrefixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPrefixCode, "    ")); } #>>
+    List<<<=gen.translate("type",av)>>> <<=gen.translate("parameterMany",av)>> = Collections.unmodifiableList(<<=gen.translate("associationMany",av)>>);
+    <<# if (customGetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPostfixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPostfixCode, "    ")); } #>>
+    return <<=gen.translate("parameterMany",av)>>;
+  }
+
+  public int <<=gen.translate("numberOfMethod",av)>>()
+  {
+    <<# if (customNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customNumberOfPrefixCode,gen.translate("numberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customNumberOfPrefixCode, "    ")); } #>>
+    int number = <<=gen.translate("associationMany",av)>>.size();
+    <<# if (customNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customNumberOfPostfixCode,gen.translate("numberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customNumberOfPostfixCode, "    ")); } #>>
+    return number;
+  }
+
+  public boolean <<=gen.translate("hasManyMethod",av)>>()
+  {
+    <<# if (customHasManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasManyPrefixCode,gen.translate("hasManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasManyPrefixCode, "    ")); } #>>
+    boolean has = <<=gen.translate("associationMany",av)>>.size() > 0;
+    <<# if (customHasManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasManyPostfixCode,gen.translate("hasManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasManyPostfixCode, "    ")); } #>>
+    return has;
+  }
+
+  public int <<=gen.translate("indexOfMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    <<# if (customIndexOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIndexOfPrefixCode,gen.translate("indexOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIndexOfPrefixCode, "    ")); } #>>
+    int index = <<=gen.translate("associationMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);
+    <<# if (customIndexOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIndexOfPostfixCode,gen.translate("indexOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIndexOfPostfixCode, "    ")); } #>>
+    return index;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany_clear.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany_clear.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    association_GetMany_clear <<!<</*association_GetMany_clear*/>>
+  protected void clear_<<=gen.translate("associationMany",av)>>()
+  {
+    <<=gen.translate("associationMany",av)>>.clear();
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany_relatedSpecialization.ump
@@ -1,0 +1,32 @@
+class UmpleToJava {
+    association_GetMany_relatedSpecialization <<!<</*association_GetMany_relatedSpecialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>(int index)
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPre()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationMany",av)+".get(index)"):"")
+>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = (<<=gen.translate("type",av)>>)<<=gen.translate("associationMany",av)>>.get(index);<<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPost()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("parameterOne",av)):"")
+>>
+    <<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    return <<=gen.translate("parameterOne",av)>>;
+  }
+
+  
+<<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  /* required for Java 7. */
+  @SuppressWarnings("unchecked")
+  public List<<<=gen.translate("type",av)>>> <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customGetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPrefixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPrefixCode, "    ")); } #>>
+    <<#String scgName = relatedAssoc.getEnd(av.getRelevantEnd()).getSuperClassName();#>>
+    List<? extends <<=scgName>>> <<=gen.translate("parameterMany",av)>> = Collections.unmodifiableList(<<=gen.translate("associationMany",av)>>);
+    <<# if (customGetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPostfixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPostfixCode, "    ")); } #>>
+    return (List<<<=gen.translate("type",av)>>>)<<=gen.translate("parameterMany",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany_specialization.ump
@@ -1,0 +1,32 @@
+class UmpleToJava {
+    association_GetMany_specialization <<!<</*association_GetMany_specialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>(int index)
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPre()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationMany",av)+".get(index)"):"")
+>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = (<<=gen.translate("type",av)>>)super.<<=gen.translate("getMethod",av)>>(index);<<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPost()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("parameterOne",av)):"")
+>>
+    <<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    return <<=gen.translate("parameterOne",av)>>;
+  }
+
+  
+<<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  /* required for Java 7. */
+  @SuppressWarnings("unchecked")
+  public List<<<=gen.translate("type",av)>>> <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customGetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPrefixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPrefixCode, "    ")); } #>>
+    <<#String scgName = relatedAssoc.getEnd(av.getRelevantEnd()).getSuperClassName();#>>
+    List<? extends <<=scgName>>> <<=gen.translate("parameterMany",av)>> = super.<<=gen.translate("getManyMethod",av)>>();
+    <<# if (customGetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPostfixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPostfixCode, "    ")); } #>>
+    return (List<<<=gen.translate("type",av)>>>)<<=gen.translate("parameterMany",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne.ump
@@ -1,0 +1,32 @@
+class UmpleToJava {
+    association_GetOne <<!<</*association_GetOne*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+<<# if (customGetPostfixCode == null) { #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationOne",av)):"")
+>>
+    return <<=gen.translate("associationOne",av)>>;
+<<# } else { #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPre()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationOne",av)):"")
+>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("associationOne",av)>>;<<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPost()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("parameterOne",av)):"")
+>>
+    <<# addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); #>>
+    return <<=gen.translate("parameterOne",av)>>;
+<<# } #>>
+  }<<# 
+  if(av.getMultiplicity().getLowerBound() == 0) {
+  #>>
+
+  public boolean <<=gen.translate("hasMethod",av)>>()
+  {
+    boolean has = <<=gen.translate("associationOne",av)>> != null;
+    return has;
+  }
+<<# } #>>
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne_clear.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne_clear.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    association_GetOne_clear <<!<</*association_GetOne_clear*/>>
+  protected void clear_<<=gen.translate("associationOne",av)>>()
+  {
+    <<=gen.translate("associationOne",av)>> = null;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne_relatedSpecialization.ump
@@ -1,0 +1,23 @@
+class UmpleToJava {
+    association_GetOne_relatedSpecialization <<!<</*association_GetOne_relatedSpecialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+<<# if (customGetPostfixCode == null) { #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationOne",av)):"")
+>>
+    return (<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# if (mulChangedToOne) { #>>.get(0)<<# } #>>;
+<<# } else { #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPre()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationOne",av)):"")
+>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = (<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# if (mulChangedToOne) {#>>.get(0)<<# } #>>;<<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPost()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("parameterOne",av)):"")
+>>
+    <<# addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); #>>
+    return <<=gen.translate("parameterOne",av)>>;
+<<# } #>>
+  } 
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne_specialization.ump
@@ -1,0 +1,28 @@
+class UmpleToJava {
+    association_GetOne_specialization <<!<</*association_GetOne_specialization*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()
+  {
+    <<# if (customGetPrefixCode != null && mulChangedToOne) { #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("associationOne",av)>> = <<#if (relReqSuperCode) { #>>(<<=gen.translate("type",av)>>)<<# } #>>super.<<=gen.translate("getMethod",av)>>(0);%>
+    <<# } else if (customGetPrefixCode != null) { #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("associationOne",av)>> = <<#if (relReqSuperCode) { #>>(<<=gen.translate("type",av)>>)<<# } #>>super.<<=gen.translate("getMethod",av)>>();%>
+    <<# } #>>
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+<<# if (customGetPostfixCode == null) { #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationOne",av)):"")
+>>
+    return <<#if (relReqSuperCode) { #>>(<<=gen.translate("type",av)>>)<<# } #>>super.<<=gen.translate("getMethod",av)>>(<<#if (mulChangedToOne) { #>>0<<# } #>>);
+<<# } else { #>><<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPre()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("associationOne",av)):"")
+>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = (<<=gen.translate("type",av)>>)super.<<=gen.translate("getMethod",av)>>(<<#if (mulChangedToOne)#>>0);<<# for( TraceItem traceItem : traceItems ) #>><<= 
+(traceItem!=null&&traceItem.getIsPost()?"\n"+traceItem.trace(gen, av,"as_g", uClass,gen.translate("parameterOne",av)):"")
+>>
+    <<# addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); #>>
+    return <<=gen.translate("parameterOne",av)>>;
+<<# } #>>
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_GetPrivate.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetPrivate.ump
@@ -1,0 +1,17 @@
+class UmpleToJava {
+    association_GetPrivate <<!<</*association_GetPrivate*/>>
+  private void <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterOne",av)>>)
+  {
+    try
+    {
+      java.lang.reflect.Field mentorField = <<=gen.translate("parameterOne",av)>>.getClass().getDeclaredField("<<=gen.relatedTranslate("associationOne",av)>>");
+      mentorField.setAccessible(true);
+      mentorField.set(<<=gen.translate("parameterOne",av)>>, <<=gen.relatedTranslate("parameterOne",av)>>);
+    }
+    catch (Exception e)
+    {
+      throw new RuntimeException("Issue internally setting <<=gen.relatedTranslate("parameterOne",av)>> to <<=gen.translate("parameterOne",av)>>", e);
+    }
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_Get_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_Get_All.ump
@@ -1,0 +1,93 @@
+use association_GetMany.ump;
+use association_GetMany_clear.ump;
+use association_GetMany_relatedSpecialization.ump;
+use association_GetMany_specialization.ump;
+use association_GetOne.ump;
+use association_GetOne_clear.ump;
+use association_GetOne_relatedSpecialization.ump;
+use association_GetOne_specialization.ump;
+use specializationCode_Get.ump;
+
+
+class UmpleToJava {
+    association_Get_All <<!<</*association_Get_All*/>><<#
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  for (AssociationVariable av : uClass.getAssociationVariables()) 
+  {
+    #>><<@ UmpleToJava.specializationCode_Get >><<# 
+
+    if (!av.getIsNavigable())
+    {
+      continue;
+    }
+
+    gen.setParameterConstraintName(av.getName());
+
+    List<TraceItem> traceItems = av.getTraced("getMethod", uClass);
+
+    String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+    String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getMethod",av)));
+
+    String customGetDefaultPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getDefaultMethod",av)));
+    String customGetDefaultPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getDefaultMethod",av)));
+
+    String customGetManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getManyMethod",av)));
+    String customGetManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getManyMethod",av)));
+
+    String customNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("numberOfMethod",av)));
+    String customNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("numberOfMethod",av)));
+
+    String customHasManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("hasManyMethod",av)));
+    String customHasManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("hasManyMethod",av)));
+
+    String customIndexOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("indexOfMethod",av)));
+    String customIndexOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("indexOfMethod",av)));
+
+    boolean hasCodeInjections = customGetPrefixCode != null || customGetPostfixCode != null;
+  
+    if (av.isOne())
+    {
+      if (reqSuperCode)
+      {
+        #>><<@ UmpleToJava.association_GetOne_specialization >><<#
+      }
+      else if (reqCommonCode)
+      {
+        #>><<@ UmpleToJava.association_GetOne_relatedSpecialization >><<#
+      }
+      else
+      {
+        #>><<@ UmpleToJava.association_GetOne >><<#
+        if (relatedAssoc != null && relatedAssoc.getIsSpecialized())
+        {
+          #>><<@ UmpleToJava.association_GetOne_clear >><<#
+        }
+      }
+    }
+    else if (av.isMany())
+    {
+      if (reqSuperCode)
+      {
+        #>><<@ UmpleToJava.association_GetMany_specialization >><<#
+      }
+      else if (reqCommonCode)
+      {
+        #>><<@ UmpleToJava.association_GetMany_relatedSpecialization >><<#
+      }
+      else
+      {
+        #>><<@ UmpleToJava.association_GetMany >><<#
+        if (relatedAssoc != null && relatedAssoc.getIsSpecialized())
+        {
+          #>><<@ UmpleToJava.association_GetMany_clear >><<#
+        }
+      }
+    }
+    else
+    {
+      #>>UNABLE TO UNDERSAND association variable (see association_Get_All.jet)<<#
+    }
+ }
+ gen.setParameterConstraintName("");
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    association_IsNumberOfValidMethod <<!<</*association_IsNumberOfValidMethod*/>>
+  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>()
+  {
+    <<# if (customIsNumberOfValidPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPrefixCode,gen.translate("isNumberOfValidMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPrefixCode, "    ")); } #>>
+<<# if (av.getMultiplicity().isUpperBoundMany()) { #>>
+    boolean isValid = <<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("minimumNumberOfMethod",av)>>();
+<<# } else { #>>
+    boolean isValid = <<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("minimumNumberOfMethod",av)>>() && <<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("maximumNumberOfMethod",av)>>();
+<<# } #>>
+    <<# if (customIsNumberOfValidPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPostfixCode,gen.translate("isNumberOfValidMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPostfixCode, "    ")); } #>>
+    return isValid;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_relatedSpecialization.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    association_IsNumberOfValidMethod_relatedSpecialization <<!<</*association_IsNumberOfValidMethod_relatedSpecialization*/>>
+  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customIsNumberOfValidPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPrefixCode,gen.translate("isNumberOfValidMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPrefixCode, "    ")); } #>>
+<<# if (av.getMultiplicity().isUpperBoundMany()) { #>>
+    boolean isValid = <<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>();
+<<# } else { #>>
+    boolean isValid = <<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>() && <<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>();
+<<# } #>>
+    <<# if (customIsNumberOfValidPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPostfixCode,gen.translate("isNumberOfValidMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPostfixCode, "    ")); } #>>
+    return isValid;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_specialization.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    association_IsNumberOfValidMethod_specialization <<!<</*association_IsNumberOfValidMethod_specialization*/>>
+  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customIsNumberOfValidPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPrefixCode,gen.translate("isNumberOfValidMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPrefixCode, "    ")); } #>>
+<<# if (av.getMultiplicity().isUpperBoundMany()) { #>>
+    boolean isValid = <<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>();
+<<# } else { #>>
+    boolean isValid = <<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>() && <<=gen.translate("numberOfMethod",av)>>() <= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>();
+<<# } #>>
+    <<# if (customIsNumberOfValidPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPostfixCode,gen.translate("isNumberOfValidMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPostfixCode, "    ")); } #>>
+    return isValid;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod.ump
@@ -1,0 +1,25 @@
+class UmpleToJava {
+    association_MaximumNumberOfMethod <<!<</*association_MaximumNumberOfMethod*/>><<#
+    String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+
+    String customMaximumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("maximumNumberOfMethod",av)));
+    String customMaximumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("maximumNumberOfMethod",av)));
+    
+    #>>
+<<# if (customMaximumNumberOfPrefixCode == null && customMaximumNumberOfPostfixCode == null) { #>>
+  public static int <<=gen.translate("maximumNumberOfMethod",av)>>()
+  {
+    return <<=av.getMultiplicity().getUpperBound()>>;
+  }
+<<# } else { #>><<=umpleSourceFile>>
+  public static int <<=gen.translate("maximumNumberOfMethod",av)>>()
+  {
+    <<# if (customMaximumNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMaximumNumberOfPrefixCode,gen.translate("maximumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMaximumNumberOfPrefixCode, "    ")); } #>>
+    int maximum = <<=av.getMultiplicity().getUpperBound()>>;
+    <<# if (customMaximumNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMaximumNumberOfPostfixCode,gen.translate("maximumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMaximumNumberOfPostfixCode, "    ")); } #>>
+    return maximum;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_relatedSpecialization.ump
@@ -1,0 +1,25 @@
+class UmpleToJava {
+    association_MaximumNumberOfMethod_relatedSpecialization <<!<</*association_MaximumNumberOfMethod_relatedSpecialization*/>><<#
+    String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+
+    String customMaximumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("maximumNumberOfMethod",av)));
+    String customMaximumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("maximumNumberOfMethod",av)));
+    
+    #>>
+<<# if (customMaximumNumberOfPrefixCode == null && customMaximumNumberOfPostfixCode == null) { #>>
+  public static int <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    return <<=av.getMultiplicity().getUpperBound()>>;
+  }
+<<# } else { #>><<=umpleSourceFile>>
+  public static int <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customMaximumNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMaximumNumberOfPrefixCode,gen.translate("maximumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMaximumNumberOfPrefixCode, "    ")); } #>>
+    int maximum = <<=av.getMultiplicity().getUpperBound()>>;
+    <<# if (customMaximumNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMaximumNumberOfPostfixCode,gen.translate("maximumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMaximumNumberOfPostfixCode, "    ")); } #>>
+    return maximum;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_specialization.ump
@@ -1,0 +1,25 @@
+class UmpleToJava {
+    association_MaximumNumberOfMethod_specialization <<!<</*association_MaximumNumberOfMethod_specialization*/>><<#
+    String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+
+    String customMaximumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("maximumNumberOfMethod",av)));
+    String customMaximumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("maximumNumberOfMethod",av)));
+    
+    #>>
+<<# if (customMaximumNumberOfPrefixCode == null && customMaximumNumberOfPostfixCode == null) { #>>
+  public static int <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    return <<=av.getMultiplicity().getUpperBound()>>;
+  }
+<<# } else { #>><<=umpleSourceFile>>
+  public static int <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customMaximumNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMaximumNumberOfPrefixCode,gen.translate("maximumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMaximumNumberOfPrefixCode, "    ")); } #>>
+    int maximum = <<=av.getMultiplicity().getUpperBound()>>;
+    <<# if (customMaximumNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMaximumNumberOfPostfixCode,gen.translate("maximumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMaximumNumberOfPostfixCode, "    ")); } #>>
+    return maximum;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod.ump
@@ -1,0 +1,22 @@
+class UmpleToJava {
+    association_MinimumNumberOfMethod <<!<</*association_MinimumNumberOfMethod*/>><<#
+    String customMinimumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("minimumNumberOfMethod",av)));
+    String customMinimumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("minimumNumberOfMethod",av)));
+    #>>
+<<# if (customMinimumNumberOfPrefixCode == null && customMinimumNumberOfPostfixCode == null) { #>>
+  public static int <<=gen.translate("minimumNumberOfMethod",av)>>()
+  {
+    return <<=av.getMultiplicity().getLowerBound()>>;
+  }
+<<# } else { #>>
+  public static int <<=gen.translate("minimumNumberOfMethod",av)>>()
+  {
+    <<# if (customMinimumNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMinimumNumberOfPrefixCode,gen.translate("minimumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMinimumNumberOfPrefixCode, "    ")); } #>>
+    int minimum = <<=av.getMultiplicity().getLowerBound()>>;
+    <<# if (customMinimumNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMinimumNumberOfPostfixCode,gen.translate("minimumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMinimumNumberOfPostfixCode, "    ")); } #>>
+    return minimum;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_relatedSpecialization.ump
@@ -1,0 +1,22 @@
+class UmpleToJava {
+    association_MinimumNumberOfMethod_relatedSpecialization <<!<</*association_MinimumNumberOfMethod_relatedSpecialization*/>><<#
+    String customMinimumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("minimumNumberOfMethod",av)));
+    String customMinimumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("minimumNumberOfMethod",av)));
+    #>>
+<<# if (customMinimumNumberOfPrefixCode == null && customMinimumNumberOfPostfixCode == null) { #>>
+  public static int <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    return <<=av.getMultiplicity().getLowerBound()>>;
+  }
+<<# } else { #>>
+  public static int <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customMinimumNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMinimumNumberOfPrefixCode,gen.translate("minimumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMinimumNumberOfPrefixCode, "    ")); } #>>
+    int minimum = <<=av.getMultiplicity().getLowerBound()>>;
+    <<# if (customMinimumNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMinimumNumberOfPostfixCode,gen.translate("minimumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMinimumNumberOfPostfixCode, "    ")); } #>>
+    return minimum;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_specialization.ump
@@ -1,0 +1,22 @@
+class UmpleToJava {
+    association_MinimumNumberOfMethod_specialization <<!<</*association_MinimumNumberOfMethod_specialization*/>><<#
+    String customMinimumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("minimumNumberOfMethod",av)));
+    String customMinimumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("minimumNumberOfMethod",av)));
+    #>>
+<<# if (customMinimumNumberOfPrefixCode == null && customMinimumNumberOfPostfixCode == null) { #>>
+  public static int <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    return <<=av.getMultiplicity().getLowerBound()>>;
+  }
+<<# } else { #>>
+  public static int <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customMinimumNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMinimumNumberOfPrefixCode,gen.translate("minimumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMinimumNumberOfPrefixCode, "    ")); } #>>
+    int minimum = <<=av.getMultiplicity().getLowerBound()>>;
+    <<# if (customMinimumNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customMinimumNumberOfPostfixCode,gen.translate("minimumNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customMinimumNumberOfPostfixCode, "    ")); } #>>
+    return minimum;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_RemoveMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RemoveMany.ump
@@ -1,0 +1,37 @@
+class UmpleToJava {
+    association_RemoveMany <<!<</*association_RemoveMany*/>>
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<=
+    (traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+    >>
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    if (!<<=gen.translate("associationMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av));
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "      ")); } #>>
+      return wasRemoved;
+    }
+
+    int oldIndex = <<=gen.translate("associationMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);
+    <<=gen.translate("associationMany",av)>>.remove(oldIndex);
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("indexOfMethod",av)>>(this) == -1)
+    {
+      wasRemoved = true;
+    }
+    else
+    {
+      wasRemoved = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!wasRemoved)
+      {
+        <<=gen.translate("associationMany",av)>>.add(oldIndex,<<=gen.translate("parameterOne",av)>>);
+      }
+    }
+    <<# if (customRemovePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); } #>><<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<=
+    (traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPost()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")
+    >>
+    return wasRemoved;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod.ump
@@ -1,0 +1,22 @@
+class UmpleToJava {
+    association_RequiredNumberOfMethod <<!<</*association_RequiredNumberOfMethod*/>><<#
+    String customRequiredNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("requiredNumberOfMethod",av)));
+    String customRequiredNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("requiredNumberOfMethod",av)));
+#>>
+<<# if (customRequiredNumberOfPrefixCode == null && customRequiredNumberOfPostfixCode == null) { #>><<= umpleSourceFile >>
+  public static int <<=gen.translate("requiredNumberOfMethod",av)>>()
+  {
+    return <<=av.getMultiplicity().getLowerBound()>>;
+  }
+<<# } else { #>>
+  public static int <<=gen.translate("requiredNumberOfMethod",av)>>()
+  {
+    <<# if (customRequiredNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRequiredNumberOfPrefixCode,gen.translate("requiredNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRequiredNumberOfPrefixCode, "    ")); } #>>
+    int required = <<=av.getMultiplicity().getLowerBound()>>;
+    <<# if (customRequiredNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRequiredNumberOfPostfixCode,gen.translate("requiredNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRequiredNumberOfPostfixCode, "    ")); } #>>
+    return required;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_relatedSpecialization.ump
@@ -1,0 +1,22 @@
+class UmpleToJava {
+    association_RequiredNumberOfMethod_relatedSpecialization <<!<</*association_RequiredNumberOfMethod_relatedSpecialization*/>><<#
+    String customRequiredNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("requiredNumberOfMethod",av)));
+    String customRequiredNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("requiredNumberOfMethod",av)));
+#>>
+<<# if (customRequiredNumberOfPrefixCode == null && customRequiredNumberOfPostfixCode == null) { #>><<= umpleSourceFile >>
+  public static int <<=gen.translate("requiredNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    return <<=av.getMultiplicity().getLowerBound()>>;
+  }
+<<# } else { #>>
+  public static int <<=gen.translate("requiredNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customRequiredNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRequiredNumberOfPrefixCode,gen.translate("requiredNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRequiredNumberOfPrefixCode, "    ")); } #>>
+    int required = <<=av.getMultiplicity().getLowerBound()>>;
+    <<# if (customRequiredNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRequiredNumberOfPostfixCode,gen.translate("requiredNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRequiredNumberOfPostfixCode, "    ")); } #>>
+    return required;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_specialization.ump
@@ -1,0 +1,22 @@
+class UmpleToJava {
+    association_RequiredNumberOfMethod_specialization <<!<</*association_RequiredNumberOfMethod_specialization*/>><<#
+    String customRequiredNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("requiredNumberOfMethod",av)));
+    String customRequiredNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("requiredNumberOfMethod",av)));
+#>>
+<<# if (customRequiredNumberOfPrefixCode == null && customRequiredNumberOfPostfixCode == null) { #>><<= umpleSourceFile >>
+  public static int <<=gen.translate("requiredNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    return <<=av.getMultiplicity().getLowerBound()>>;
+  }
+<<# } else { #>>
+  public static int <<=gen.translate("requiredNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()
+  {
+    <<# if (customRequiredNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRequiredNumberOfPrefixCode,gen.translate("requiredNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRequiredNumberOfPrefixCode, "    ")); } #>>
+    int required = <<=av.getMultiplicity().getLowerBound()>>;
+    <<# if (customRequiredNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRequiredNumberOfPostfixCode,gen.translate("requiredNumberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRequiredNumberOfPostfixCode, "    ")); } #>>
+    return required;
+  }
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToMany.ump
@@ -1,0 +1,50 @@
+class UmpleToJava {
+    association_SetMNToMany <<!<</*association_SetMNToMany*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>() || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterOldMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("associationMany",av)>>);
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> : <<=gen.translate("parameterVerifiedMany",av)>>)
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterNew",av)>>);
+      if (<<=gen.translate("parameterOldMany",av)>>.contains(<<=gen.translate("parameterNew",av)>>))
+      {
+        <<=gen.translate("parameterOldMany",av)>>.remove(<<=gen.translate("parameterNew",av)>>);
+      }
+      else
+      {
+        <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      }
+    }
+
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> : <<=gen.translate("parameterOldMany",av)>>)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_relatedSpecialization.ump
@@ -1,0 +1,50 @@
+class UmpleToJava {
+    association_SetMNToMany_relatedSpecialization <<!<</*association_SetMNToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>() || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterOldMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>());
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> : <<=gen.translate("parameterVerifiedMany",av)>>)
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterNew",av)>>);
+      if (<<=gen.translate("parameterOldMany",av)>>.contains(<<=gen.translate("parameterNew",av)>>))
+      {
+        <<=gen.translate("parameterOldMany",av)>>.remove(<<=gen.translate("parameterNew",av)>>);
+      }
+      else
+      {
+        <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      }
+    }
+
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> : <<=gen.translate("parameterOldMany",av)>>)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_specialization.ump
@@ -1,0 +1,41 @@
+class UmpleToJava {
+    association_SetMNToMany_specialization <<!<</*association_SetMNToMany_specialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>() || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    
+<<# if ( !reqSetCode ) { #>>
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationMany",av)>>();
+    for ( <<=gen.translate("type",av)>> orphan : <<=gen.translate("parameterMany",av)>>)
+    {
+      <<=gen.translate("addMethod",av)>>(orphan);
+    }
+    wasSet = true;
+    <<# } #>>
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne.ump
@@ -1,0 +1,72 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetMNToOptionalOne <<!<</*association_SetMNToOptionalOne*/>><<#
+  String existingToNewMap = StringFormatter.format("{0}ToNew{1}", relatedAssociation.getName(), av.getUpperCaseName());
+  String orCheckMaxBound = av.isStar() ? "" : StringFormatter.format(" || {0}.length > {1}()", gen.translate("parameterMany",av), gen.translate("maximumNumberOfMethod",av));
+#>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterMany",av)>>.length < <<=gen.translate("minimumNumberOfMethod",av)>>()<<=orCheckMaxBound>>)
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCheckNewMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    HashMap<<<=gen.relatedTranslate("type",av)>>,Integer> <<=existingToNewMap>> = new HashMap<<<=gen.relatedTranslate("type",av)>>,Integer>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterCheckNewMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      else if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null && !this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+      {
+        <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+        if (!<<=existingToNewMap>>.containsKey(<<=gen.relatedTranslate("parameterExisting",av)>>))
+        {
+          <<=existingToNewMap>>.put(<<=gen.relatedTranslate("parameterExisting",av)>>, new Integer(<<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>()));
+        }
+        Integer currentCount = <<=existingToNewMap>>.get(<<=gen.relatedTranslate("parameterExisting",av)>>);
+        int nextCount = currentCount - 1;
+        if (nextCount < <<=av.getMultiplicity().getLowerBound()>>)
+        {
+          <<# if (customSetManyPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "          ")); } #>>
+          return wasSet;
+        }
+        <<=existingToNewMap>>.put(<<=gen.relatedTranslate("parameterExisting",av)>>, new Integer(nextCount));
+      }
+      <<=gen.translate("parameterCheckNewMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    <<=gen.translate("associationMany",av)>>.removeAll(<<=gen.translate("parameterCheckNewMany",av)>>);
+
+    for (<<=gen.translate("type",av)>> orphan : <<=gen.translate("associationMany",av)>>)
+    {
+      <<=gen.relatedTranslate("setMethod",av)>>(orphan, null);
+    }
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null)
+      {
+        <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>().<<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      }
+      <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>, this);
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+<<@ UmpleToJava.association_GetPrivate >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,72 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetMNToOptionalOne_relatedSpecialization <<!<</*association_SetMNToOptionalOne_relatedSpecialization*/>><<#
+  String existingToNewMap = StringFormatter.format("{0}ToNew{1}", relatedAssociation.getName(), av.getUpperCaseName());
+  String orCheckMaxBound = av.isStar() ? "" : StringFormatter.format(" || {0}.length > {1}{2}{3}()", gen.translate("parameterMany",av), gen.translate("maximumNumberOfMethod",av), "_", gen.translate("type",av));
+#>>
+  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterMany",av)>>.length < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()<<=orCheckMaxBound>>)
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCheckNewMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    HashMap<<<=gen.relatedTranslate("type",av)>>,Integer> <<=existingToNewMap>> = new HashMap<<<=gen.relatedTranslate("type",av)>>,Integer>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterCheckNewMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      else if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>(<<# if (relMulChangedToOne) { #>>0<<# } #>>) != null && !this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>(<<# if (relMulChangedToOne) { #>>0<<# } #>>)))
+      {
+        <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>(<<# if (relMulChangedToOne) { #>>0<<# } #>>);
+        if (!<<=existingToNewMap>>.containsKey(<<=gen.relatedTranslate("parameterExisting",av)>>))
+        {
+          <<=existingToNewMap>>.put(<<=gen.relatedTranslate("parameterExisting",av)>>, new Integer(<<=gen.relatedTranslate("parameterExisting",av)>>.<<=gen.translate("numberOfMethod",av)>>()));
+        }
+        Integer currentCount = <<=existingToNewMap>>.get(<<=gen.relatedTranslate("parameterExisting",av)>>);
+        int nextCount = currentCount - 1;
+        if (nextCount < <<=av.getMultiplicity().getLowerBound()>>)
+        {
+          <<# if (customSetManyPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "          ")); } #>>
+          return wasSet;
+        }
+        <<=existingToNewMap>>.put(<<=gen.relatedTranslate("parameterExisting",av)>>, new Integer(nextCount));
+      }
+      <<=gen.translate("parameterCheckNewMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    <<=gen.translate("associationMany",av)>>.removeAll(<<=gen.translate("parameterCheckNewMany",av)>>);
+
+    for (<<=gen.translate("type",av)>> orphan : <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(orphan, null);
+    }
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>(<<# if (relMulChangedToOne) { #>>0<<# } #>>) != null)
+      {
+        <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>(<<# if (relMulChangedToOne) { #>>0<<# } #>>).<<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+      }
+      <<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(<<=gen.translate("parameterOne",av)>>, this);
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+<<@ UmpleToJava.association_GetPrivate >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_specialization.ump
@@ -1,0 +1,37 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetMNToOptionalOne_specialization <<!<</*association_SetMNToOptionalOne_specialization*/>><<#
+  String existingToNewMap = StringFormatter.format("{0}ToNew{1}", relatedAssociation.getName(), av.getUpperCaseName());
+  String orCheckMaxBound = av.isStar() ? "" : StringFormatter.format(" || {0}.length > {1}{2}{3}()", gen.translate("parameterMany",av), gen.translate("maximumNumberOfMethod",av), "_", gen.translate("type",av));
+#>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterMany",av)>>.length < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>()<<=orCheckMaxBound>>)
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    
+<<# if ( !reqSetCode ) { #>>
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationMany",av)>>();
+    for ( <<=gen.translate("type",av)>> orphan : <<=gen.translate("parameterMany",av)>> )
+    {
+      <<=gen.translate("addMethod",av)>>(orphan);
+    }
+    wasSet = true;
+    <<# } #>>
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+<<@ UmpleToJava.association_GetPrivate >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany.ump
@@ -1,0 +1,50 @@
+class UmpleToJava {
+    association_SetMStarToMany <<!<</*association_SetMStarToMany*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterOldMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("associationMany",av)>>);
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> : <<=gen.translate("parameterVerifiedMany",av)>>)
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterNew",av)>>);
+      if (<<=gen.translate("parameterOldMany",av)>>.contains(<<=gen.translate("parameterNew",av)>>))
+      {
+        <<=gen.translate("parameterOldMany",av)>>.remove(<<=gen.translate("parameterNew",av)>>);
+      }
+      else
+      {
+        <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      }
+    }
+
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> : <<=gen.translate("parameterOldMany",av)>>)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_relatedSpecialization.ump
@@ -1,0 +1,50 @@
+class UmpleToJava {
+    association_SetMStarToMany_relatedSpecialization <<!<</*association_SetMStarToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterOldMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>());
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> : <<=gen.translate("parameterVerifiedMany",av)>>)
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterNew",av)>>);
+      if (<<=gen.translate("parameterOldMany",av)>>.contains(<<=gen.translate("parameterNew",av)>>))
+      {
+        <<=gen.translate("parameterOldMany",av)>>.remove(<<=gen.translate("parameterNew",av)>>);
+      }
+      else
+      {
+        <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      }
+    }
+
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> : <<=gen.translate("parameterOldMany",av)>>)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_specialization.ump
@@ -1,0 +1,41 @@
+class UmpleToJava {
+    association_SetMStarToMany_specialization <<!<</*association_SetMStarToMany_specialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    
+<<# if ( !reqSetCode ) { #>>
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationMany",av)>>();
+    for ( <<=gen.translate("type",av)>> orphan : <<=gen.translate("parameterMany",av)>> )
+    {
+      <<=gen.translate("addMethod",av)>>(orphan);
+    }
+    wasSet = true;
+    <<# } #>>
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne.ump
@@ -1,0 +1,54 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetNToOptionalOne <<!<</*association_SetNToOptionalOne*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCheckNewMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterCheckNewMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av));
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      else if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null && !this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      <<=gen.translate("parameterCheckNewMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterCheckNewMany",av)>>.size() != <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.removeAll(<<=gen.translate("parameterCheckNewMany",av)>>);
+    
+    for (<<=gen.translate("type",av)>> orphan : <<=gen.translate("associationMany",av)>>)
+    {
+      <<=gen.relatedTranslate("setMethod",av)>>(orphan, null);
+    }
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>, this);
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+<<@ UmpleToJava.association_GetPrivate >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,54 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetNToOptionalOne_relatedSpecialization <<!<</*association_SetNToOptionalOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCheckNewMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterCheckNewMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av));
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      else if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>() != null && !this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (relMulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>><<# } #>>()))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      <<=gen.translate("parameterCheckNewMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterCheckNewMany",av)>>.size() != <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.removeAll(<<=gen.translate("parameterCheckNewMany",av)>>);
+    
+    for (<<=gen.translate("type",av)>> orphan : <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(orphan, null);
+    }
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      <<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(<<=gen.translate("parameterOne",av)>>, this);
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+<<@ UmpleToJava.association_GetPrivate >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_specialization.ump
@@ -1,0 +1,52 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetNToOptionalOne_specialization <<!<</*association_SetNToOptionalOne_specialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCheckNewMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterCheckNewMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av));
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      else if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null && !this.equals(<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+      {
+        <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+      <<=gen.translate("parameterCheckNewMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterCheckNewMany",av)>>.size() != <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    
+<<# if ( !reqSetCode ) { #>>
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationMany",av)>>();
+    for ( <<=gen.translate("type",av)>> orphan : <<=gen.translate("parameterMany",av)>> )
+    {
+      <<=gen.translate("addMethod",av)>>(orphan);
+    }
+    wasSet = true;
+    <<# } #>>
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+<<@ UmpleToJava.association_GetPrivate >>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN.ump
@@ -1,0 +1,44 @@
+class UmpleToJava {
+    association_SetOneToAtMostN <<!<</*association_SetOneToAtMostN*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    //<<=gen.translate("associationOne",av)>> already at maximum (<<=relatedAssociation.getMultiplicity().getUpperBound()>>)
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      boolean didRemove = <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!didRemove)
+      {
+        <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+        <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+        return wasSet;
+      }
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_relatedSpecialization.ump
@@ -1,0 +1,54 @@
+class UmpleToJava {
+    association_SetOneToAtMostN_relatedSpecialization <<!<</*association_SetOneToAtMostN_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    //<<=gen.translate("associationOne",av)>> already at maximum (<<=relatedAssociation.getMultiplicity().getUpperBound()>>)
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<# if (!mulChangedToOne) { #>>
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    <<# } else { #>>
+    <<=gen.translate("associationOne",av)>>.clear();
+    <<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      boolean didRemove = <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!didRemove)
+      {
+          <<# if (!mulChangedToOne) { #>>
+        <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+        <<# } else { #>>
+        <<=gen.translate("associationOne",av)>>.clear();
+        <<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterExisting",av)>>);
+        <<# } #>>
+        <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+        return wasSet;
+      }
+    }
+    <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_specialization.ump
@@ -1,0 +1,36 @@
+class UmpleToJava {
+    association_SetOneToAtMostN_specialization <<!<</*association_SetOneToAtMostN_specialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    //<<=gen.translate("associationOne",av)>> already at maximum (<<=relatedAssociation.getMultiplicity().getUpperBound()>>)
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    
+<<# if ( !reqSetCode ) { #>>
+    wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationOne",av)>>();
+    wasSet = <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany.ump
@@ -1,0 +1,43 @@
+class UmpleToJava {
+    association_SetOneToMandatoryMany <<!<</*association_SetOneToMandatoryMany*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av));
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    if (<<=gen.translate("associationOne",av)>> != null && <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      boolean didRemove = <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!didRemove)
+      {
+        <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+        <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+        return wasSet;
+      }
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_relatedSpecialization.ump
@@ -1,0 +1,57 @@
+class UmpleToJava {
+    association_SetOneToMandatoryMany_relatedSpecialization <<!<</*association_SetOneToMandatoryMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av));
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    if (<<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>() != null && <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>().<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<# if (!mulChangedToOne) { #>>
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    <<# } else { #>>
+    <<=gen.translate("associationOne",av)>>.clear();
+    <<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      boolean didRemove = <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!didRemove)
+      {
+          <<# if (!mulChangedToOne) { #>>
+        <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+        <<# } else { #>>
+        <<=gen.translate("associationOne",av)>>.clear();
+        <<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterExisting",av)>>);
+        <<# } #>>
+        <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+        return wasSet;
+      }
+    }
+    <<# if (!mulChangedToOne) { #>>
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    <<# } else { #>>
+    <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>().<<=gen.relatedTranslate("addMethod",av)>>(this);
+    <<# } #>>
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_specialization.ump
@@ -1,0 +1,35 @@
+class UmpleToJava {
+    association_SetOneToMandatoryMany_specialization <<!<</*association_SetOneToMandatoryMany_specialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av));
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null && <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    
+<<# if ( !reqSetCode ) { #>>
+    wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationOne",av)>>();
+    wasSet = <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMany.ump
@@ -1,0 +1,28 @@
+class UmpleToJava {
+    association_SetOneToMany <<!<</*association_SetOneToMany*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass.ump
@@ -1,0 +1,35 @@
+class UmpleToJava {
+    association_SetOneToManyAssociationClass <<!<</*association_SetOneToManyAssociationClass*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    if (!<<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+    {
+      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+      wasSet = false;
+    }
+    else
+    {
+      wasSet = true;
+    }
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass_relatedSpecialization.ump
@@ -1,0 +1,35 @@
+class UmpleToJava {
+    association_SetOneToManyAssociationClass_relatedSpecialization <<!<</*association_SetOneToManyAssociationClass_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    if (!<<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+    {
+      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+      wasSet = false;
+    }
+    else
+    {
+      wasSet = true;
+    }
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_relatedSpecialization.ump
@@ -1,0 +1,28 @@
+class UmpleToJava {
+    association_SetOneToMany_relatedSpecialization <<!<</*association_SetOneToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_specialization.ump
@@ -1,0 +1,29 @@
+class UmpleToJava {
+    association_SetOneToMany_specialization <<!<</*association_SetOneToMany_specialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<=gen.translate("type",av)>> <<=gen.translate("associationOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN.ump
@@ -1,0 +1,44 @@
+class UmpleToJava {
+    association_SetOneToOptionalN <<!<</*association_SetOneToOptionalN*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    //<<=gen.translate("associationOne",av)>> already at maximum (<<=relatedAssociation.getMultiplicity().getUpperBound()>>)
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av));
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      boolean didRemove = <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!didRemove)
+      {
+        <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+        <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN_relatedSpecialization.ump
@@ -1,0 +1,44 @@
+class UmpleToJava {
+    association_SetOneToOptionalN_relatedSpecialization <<!<</*association_SetOneToOptionalN_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    //Must provide <<=gen.translate("associationOne",av)>> to <<=gen.relatedTranslate("associationOne",av)>>
+    if (<<=gen.translate("parameterOne",av)>> == null)
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    //<<=gen.translate("associationOne",av)>> already at maximum (<<=relatedAssociation.getMultiplicity().getUpperBound()>>)
+    if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av));
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      boolean didRemove = <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      if (!didRemove)
+      {
+        <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+        <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+        append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "        ")); } #>>
+        return wasSet;
+      }
+    }
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne.ump
@@ -1,0 +1,40 @@
+class UmpleToJava {
+    association_SetOneToOptionalOne <<!<</*association_SetOneToOptionalOne*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> == null)
+    {
+      //Unable to <<=gen.translate("setMethod",av)>> to null, as <<=gen.relatedTranslate("associationOne",av)>> must always be associated to a <<=gen.translate("associationOne",av)>>
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> != null && !equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      //Unable to <<=gen.translate("setMethod",av)>>, the current <<=gen.translate("associationOne",av)>> already has a <<=gen.relatedTranslate("associationOne",av)>>, which would be orphaned if it were re-assigned
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterNew",av)>>;
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+
+    if (<<=gen.translate("parameterOld",av)>> != null)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,47 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetOneToOptionalOne_relatedSpecialization <<!<</*association_SetOneToOptionalOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> == null)
+    {
+      //Unable to <<=gen.translate("setMethod",av)>> to null, as <<=gen.relatedTranslate("associationOne",av)>> must always be associated to a <<=gen.translate("associationOne",av)>>
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>>()<<# } else if (relMulChangedToOne) { #>>(0)<<# } #>>;
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> != null && !equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      //Unable to <<=gen.translate("setMethod",av)>>, the current <<=gen.translate("associationOne",av)>> already has a <<=gen.relatedTranslate("associationOne",av)>>, which would be orphaned if it were re-assigned
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<# if (!mulChangedToOne) { #>><<=gen.translate("parameterNew",av)>><<# } else { #>>new ArrayList<<<=scName>>>()<<# } #>>;
+    <<# if (mulChangedToOne) { #>><<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterNew",av)>>);<<# } #>>
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(this);
+
+    if (<<=gen.translate("parameterOld",av)>> != null)
+    {
+      <<=gen.translate("parameterOld",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+
+
+<<# if (mulChangedToOne) { #>><<@ UmpleToJava.association_GetPrivate >>
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_specialization.ump
@@ -1,0 +1,40 @@
+class UmpleToJava {
+    association_SetOneToOptionalOne_specialization <<!<</*association_SetOneToOptionalOne_specialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> == null)
+    {
+      //Unable to <<=gen.translate("setMethod",av)>> to null, as <<=gen.relatedTranslate("associationOne",av)>> must always be associated to a <<=gen.translate("associationOne",av)>>
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+    if (<<=gen.relatedTranslate("parameterExisting",av)>> != null && !equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      //Unable to <<=gen.translate("setMethod",av)>>, the current <<=gen.translate("associationOne",av)>> already has a <<=gen.relatedTranslate("associationOne",av)>>, which would be orphaned if it were re-assigned
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterNew",av)>>;
+    <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+
+    if (<<=gen.translate("parameterOld",av)>> != null)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany.ump
@@ -1,0 +1,50 @@
+class UmpleToJava {
+    association_SetOptionalNToMany <<!<</*association_SetOptionalNToMany*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterOldMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("associationMany",av)>>);
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> : <<=gen.translate("parameterVerifiedMany",av)>>)
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterNew",av)>>);
+      if (<<=gen.translate("parameterOldMany",av)>>.contains(<<=gen.translate("parameterNew",av)>>))
+      {
+        <<=gen.translate("parameterOldMany",av)>>.remove(<<=gen.translate("parameterNew",av)>>);
+      }
+      else
+      {
+        <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      }
+    }
+
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> : <<=gen.translate("parameterOldMany",av)>>)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_relatedSpecialization.ump
@@ -1,0 +1,50 @@
+class UmpleToJava {
+    association_SetOptionalNToMany_relatedSpecialization <<!<</*association_SetOptionalNToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterOldMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>());
+    <<=gen.translate("associationMany",av)>>.clear();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> : <<=gen.translate("parameterVerifiedMany",av)>>)
+    {
+      <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterNew",av)>>);
+      if (<<=gen.translate("parameterOldMany",av)>>.contains(<<=gen.translate("parameterNew",av)>>))
+      {
+        <<=gen.translate("parameterOldMany",av)>>.remove(<<=gen.translate("parameterNew",av)>>);
+      }
+      else
+      {
+        <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+      }
+    }
+
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOld",av)>> : <<=gen.translate("parameterOldMany",av)>>)
+    {
+      <<=gen.translate("parameterOld",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_specialization.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    association_SetOptionalNToMany_specialization <<!<</*association_SetOptionalNToMany_specialization*/>>
+  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMN.ump
@@ -1,0 +1,57 @@
+class UmpleToJava {
+    association_SetOptionalOneToMandatoryMN <<!<</*association_SetOptionalOneToMandatoryMN*/>>
+//  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+//  {
+//    //
+//    // The source of the code generation is association_SetOptionalOneToMN.jet
+//    // (this) set file assumes the generation of a maximumNumberOfXXX 
+//    //   method <<=gen.relatedTranslate("maximumNumberOfMethod",av)>>
+//    // Currently this will not compile due to Issue351 - the template code is fine.
+//    //
+//
+//    boolean wasSet = false;
+//    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+//  
+//    if (<<=gen.translate("parameterExisting",av)>> == null)
+//    {  
+//      if (<<=gen.translate("parameterOne",av)>> != null)
+//      { 
+//        if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+//          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+//          wasSet = true;
+//        }
+//      }
+//    }
+//    else
+//    {
+//      if (<<=gen.translate("parameterExisting",av)>> != null)
+//      {
+//        if (<<=gen.translate("parameterOne",av)>> == null)
+//        {
+//          if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>> < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>)
+//            <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+//            <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>  // <<=gen.translate("parameterOne",av)>> == null;
+//            wasSet = true;
+//        }
+//      }
+//      else
+//      {
+//        if (   <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>> < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>()
+//            && <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>> > <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>()
+//           )
+//          <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+//          <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+//          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+//          wasSet = true;
+//        }
+//      }
+//    }
+//    
+//    if (wasSet)
+//    {
+//      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+//    }
+//    
+//    return wasSet;
+//  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMN_relatedSpecialization.ump
@@ -1,0 +1,57 @@
+class UmpleToJava {
+    association_SetOptionalOneToMandatoryMN_relatedSpecialization <<!<</*association_SetOptionalOneToMandatoryMN_relatedSpecialization*/>>
+//  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+//  {
+//    //
+//    // The source of the code generation is association_SetOptionalOneToMN.jet
+//    // (this) set file assumes the generation of a maximumNumberOfXXX 
+//    //   method <<=gen.relatedTranslate("maximumNumberOfMethod",av)>>
+//    // Currently this will not compile due to Issue351 - the template code is fine.
+//    //
+//
+//    boolean wasSet = false;
+//    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+//  
+//    if (<<=gen.translate("parameterExisting",av)>> == null)
+//    {  
+//      if (<<=gen.translate("parameterOne",av)>> != null)
+//      { 
+//        if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+//          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+//          wasSet = true;
+//        }
+//      }
+//    }
+//    else
+//    {
+//      if (<<=gen.translate("parameterExisting",av)>> != null)
+//      {
+//        if (<<=gen.translate("parameterOne",av)>> == null)
+//        {
+//          if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>> < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>)
+//            <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+//            <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>  // <<=gen.translate("parameterOne",av)>> == null;
+//            wasSet = true;
+//        }
+//      }
+//      else
+//      {
+//        if (   <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>> < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>()
+//            && <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>> > <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>()
+//           )
+//          <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+//          <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+//          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+//          wasSet = true;
+//        }
+//      }
+//    }
+//    
+//    if (wasSet)
+//    {
+//      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+//    }
+//    
+//    return wasSet;
+//  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany.ump
@@ -1,0 +1,53 @@
+class UmpleToJava {
+    association_SetOptionalOneToMandatoryMany <<!<</*association_SetOptionalOneToMandatoryMany*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    //
+    // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet
+    // This set file assumes the generation of a maximumNumberOfXXX method does not exist because 
+    // it's not required (No upper bound)
+    //   
+    boolean wasSet = false;
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+
+    if (<<=gen.translate("parameterExisting",av)>> == null)
+    {
+      if (<<=gen.translate("parameterOne",av)>> != null)
+      {
+        if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+        {
+          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+          wasSet = true;
+        }
+      }
+    } 
+    else if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      if (<<=gen.translate("parameterOne",av)>> == null)
+      {
+        if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>() < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>())
+        {
+          <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;  // <<=gen.translate("parameterOne",av)>> == null
+          wasSet = true;
+        }
+      } 
+      else
+      {
+        if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>() < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>())
+        {
+          <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+          <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+          wasSet = true;
+        }
+      }
+    }
+    if (wasSet)
+    {
+      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+    }
+    return wasSet;
+  }
+  !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_relatedSpecialization.ump
@@ -1,0 +1,53 @@
+class UmpleToJava {
+    association_SetOptionalOneToMandatoryMany_relatedSpecialization <<!<</*association_SetOptionalOneToMandatoryMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    //
+    // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet
+    // This set file assumes the generation of a maximumNumberOfXXX method does not exist because 
+    // it's not required (No upper bound)
+    //   
+    boolean wasSet = false;
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+
+    if (<<=gen.translate("parameterExisting",av)>> == null)
+    {
+      if (<<=gen.translate("parameterOne",av)>> != null)
+      {
+        if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+        {
+          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+          wasSet = true;
+        }
+      }
+    } 
+    else if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      if (<<=gen.translate("parameterOne",av)>> == null)
+      {
+        if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>() < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>())
+        {
+          <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;  // <<=gen.translate("parameterOne",av)>> == null
+          wasSet = true;
+        }
+      } 
+      else
+      {
+        if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>() < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>())
+        {
+          <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+          <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+          <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("parameterOne",av)>>;
+          wasSet = true;
+        }
+      }
+    }
+    if (wasSet)
+    {
+      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterExisting",av)>>;
+    }
+    return wasSet;
+  }
+  !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_specialization.ump
@@ -1,0 +1,58 @@
+class UmpleToJava {
+    association_SetOptionalOneToMandatoryMany_specialization <<!<</*association_SetOptionalOneToMandatoryMany_specialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    //
+    // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet
+    // This set file assumes the generation of a maximumNumberOfXXX method does not exist because 
+    // it's not required (No upper bound)
+    //   
+    boolean wasSet = false;
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+
+    if (<<=gen.translate("parameterExisting",av)>> == null)
+    {
+      if (<<=gen.translate("parameterOne",av)>> != null)
+      {
+        if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this))
+        {
+          <<# if (!reqSetCode) { #>>
+          wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+          <<# } else { #>>
+          super.clear_<<=gen.translate("associationOne",av)>>();
+          wasSet = <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+          <<# } #>>
+        }
+      }
+    } 
+    else if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      if (<<=gen.translate("parameterOne",av)>> == null)
+      {
+        if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>() < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>())
+        {
+          <<# if ( !reqSetCode ) { #>>
+          wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+          <<# } else { #>>
+          super.clear_<<=gen.translate("associationOne",av)>>();
+          wasSet = <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+          <<# } #>>
+        }
+      } 
+      else
+      {
+        if (<<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>() < <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>())
+        {
+          <<# if (!reqSetCode) { #>>
+          wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+          <<# } else { #>>
+          super.clear_<<=gen.translate("associationOne",av)>>();
+          wasSet = <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+          <<# } #>>
+        }
+      }
+    }
+    return wasSet;
+  }
+  !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany.ump
@@ -1,0 +1,24 @@
+class UmpleToJava {
+    association_SetOptionalOneToMany <<!<</*association_SetOptionalOneToMany*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    if (<<=gen.translate("parameterOne",av)>> != null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany_relatedSpecialization.ump
@@ -1,0 +1,29 @@
+class UmpleToJava {
+    association_SetOptionalOneToMany_relatedSpecialization <<!<</*association_SetOptionalOneToMany_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<# if (!mulChangedToOne) { #>>
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    <<# } else { #>>
+    <<=gen.translate("associationOne",av)>>.clear();
+    <<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    if (<<=gen.translate("parameterOne",av)>> != null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne.ump
@@ -1,0 +1,37 @@
+class UmpleToJava {
+    association_SetOptionalOneToOne <<!<</*association_SetOptionalOneToOne*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationOne",av)>> != null && !<<=gen.translate("associationOne",av)>>.equals(<<=gen.translate("parameterNew",av)>>) && equals(<<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      //Unable to <<=gen.translate("setMethod",av)>>, as existing <<=gen.translate("associationOne",av)>> would become an orphan
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterNew",av)>>;
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterOld",av)>> = <<=gen.translate("parameterNew",av)>> != null ? <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() : null;
+
+    if (!this.equals(<<=gen.relatedTranslate("parameterOld",av)>>))
+    {
+      if (<<=gen.relatedTranslate("parameterOld",av)>> != null)
+      {
+        <<=gen.relatedTranslate("parameterOld",av)>>.<<=gen.translate("associationOne",av)>> = null;
+      }
+      if (<<=gen.translate("associationOne",av)>> != null)
+      {
+        <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+      }
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne_relatedSpecialization.ump
@@ -1,0 +1,38 @@
+class UmpleToJava {
+    association_SetOptionalOneToOne_relatedSpecialization <<!<</*association_SetOptionalOneToOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("associationOne",av)>> != null && !<<=gen.translate("associationOne",av)>>.equals(<<=gen.translate("parameterNew",av)>>) && equals(<<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>()))
+    {
+      //Unable to <<=gen.translate("setMethod",av)>>, as existing <<=gen.translate("associationOne",av)>> would become an orphan
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationOne",av)>> = <<# if (!mulChangedToOne) { #>><<=gen.translate("parameterNew",av)>><<# } else { #>>new ArrayList<<<=scName>>>()<<# } #>>;
+    <<# if (!mulChangedToOne) { #>><<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterNew",av)>>);<<# } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterOld",av)>> = <<=gen.translate("parameterNew",av)>> != null ? <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() : null;
+
+    if (!this.equals(<<=gen.relatedTranslate("parameterOld",av)>>))
+    {
+      if (<<=gen.relatedTranslate("parameterOld",av)>> != null)
+      {
+        <<=gen.relatedTranslate("parameterOld",av)>>.clear_<<=gen.translate("associationOne",av)>>();
+      }
+      if (<<=gen.translate("associationOne",av)>> != null)
+      {
+        <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(this);
+      }
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    association_SetOptionalOneToOptionalN <<!<</*association_SetOptionalOneToOptionalN*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> != null && <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    if (<<=gen.translate("parameterOne",av)>> != null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_relatedSpecialization.ump
@@ -1,0 +1,36 @@
+class UmpleToJava {
+    association_SetOptionalOneToOptionalN_relatedSpecialization <<!<</*association_SetOptionalOneToOptionalN_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> != null && <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+    <<# if (!mulChangedToOne) { #>>
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    <<# } else { #>>
+    <<=gen.translate("associationOne",av)>>.clear();
+    <<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    if (<<=gen.translate("parameterExisting",av)>> != null && !<<=gen.translate("parameterExisting",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }
+    if (<<=gen.translate("parameterOne",av)>> != null)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("addMethod",av)>>(this);
+    }
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_specialization.ump
@@ -1,0 +1,27 @@
+class UmpleToJava {
+    association_SetOptionalOneToOptionalN_specialization <<!<</*association_SetOptionalOneToOptionalN_specialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterOne",av)>> != null && <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() >= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("maximumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+    {
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    
+<<# if (!reqSetCode) { #>>
+    wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# } else { #>>
+    super.clear_<<=gen.translate("associationOne",av)>>();
+    wasSet = <<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    <<# } #>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne.ump
@@ -1,0 +1,43 @@
+class UmpleToJava {
+    association_SetOptionalOneToOptionalOne <<!<</*association_SetOptionalOneToOptionalOne*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> == null)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+      <<=gen.translate("associationOne",av)>> = null;
+      
+      if (<<=gen.translate("parameterExisting",av)>> != null && <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null)
+      {
+        <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+      }
+      wasSet = true;
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterCurrent",av)>> = <<=gen.translate("getMethod",av)>>();
+    if (<<=gen.translate("parameterCurrent",av)>> != null && !<<=gen.translate("parameterCurrent",av)>>.equals(<<=gen.translate("parameterNew",av)>>))
+    {
+      <<=gen.translate("parameterCurrent",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }
+
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterNew",av)>>;
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>>();
+
+    if (!equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(this);
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,59 @@
+use association_GetPrivate.ump;
+
+
+class UmpleToJava {
+    association_SetOptionalOneToOptionalOne_relatedSpecialization <<!<</*association_SetOptionalOneToOptionalOne_relatedSpecialization*/>>
+  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> == null)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<# if (mulChangedToOne) { #>><<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()<<# } else {#>>(<<=gen.translate("type",av)>>)<<=gen.translate("associationOne",av)>><<# } #>>;
+      clear_<<=gen.translate("associationOne",av)>>();
+      
+      if (<<=gen.translate("parameterExisting",av)>> != null && <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null)
+      {
+        <<=gen.translate("parameterExisting",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+      }
+      wasSet = true;
+      <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterCurrent",av)>> = <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>();
+    if (<<=gen.translate("parameterCurrent",av)>> != null && !<<=gen.translate("parameterCurrent",av)>>.equals(<<=gen.translate("parameterNew",av)>>))
+    {
+      <<=gen.translate("parameterCurrent",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+    }
+
+    <<=gen.translate("associationOne",av)>> = <<# if (!mulChangedToOne) { #>><<=gen.translate("parameterNew",av)>><<# } else { #>>new ArrayList<<<=scName>>>()<<# } #>>;
+    <<# if (mulChangedToOne) { #>><<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterNew",av)>>);<<# } #>>
+    <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterExisting",av)>> = <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.relatedTranslate("type",av)>>()<<# } else if (relMulChangedToOne) { #>>(0)<<# } else { #>>()<<# } #>>;
+
+    if (!equals(<<=gen.relatedTranslate("parameterExisting",av)>>))
+    {
+      <<# if (mulChangedToOne) { #>> 
+      for (<<=scName>> orphan : <<=gen.translate("associationOne",av)>>)
+      {
+        <<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>((<<=gen.translate("type",av)>>)orphan,this);
+      }      
+      <<# } else if (relMulChangedToOne) { #>>
+        <<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(<<=gen.translate("parameterNew",av)>>,this);
+      <<# } else { #>>
+      <<=gen.translate("parameterNew",av)>>.<<=gen.relatedTranslate("setMethod",av)>><<# if (relReqCommonCode) { #>>_<<=gen.relatedTranslate("type",av)>><<# } #>>(this);
+      <<# } #>>
+    }
+    wasSet = true;<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<=
+    (traceItemAssocAdd!=null&&traceItemAssocAdd.getIsPost()?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,"1"):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+
+
+<<# if (mulChangedToOne || relMulChangedToOne) { #>><<@ UmpleToJava.association_GetPrivate >>
+<<# } #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalMN <<!<</*association_SetUnidirectionalMN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>() || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_relatedSpecialization.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalMN_relatedSpecialization <<!<</*association_SetUnidirectionalMN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>() || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_specialization.ump
@@ -1,0 +1,41 @@
+class UmpleToJava {
+    association_SetUnidirectionalMN_specialization <<!<</*association_SetUnidirectionalMN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>() || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+    
+    
+<<# if (!reqSetCode) { #>>
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# } else { #>>
+    clear_<<=gen.translate("associationOne",av)>>();
+    for ( <<=gen.translate("type",av)>> orphan : <<=gen.translate("parameterMany",av)>> )
+    {
+      <<=gen.translate("addMethod",av)>>(orphan);
+    }
+    wasSet = true;
+    <<# } #>>
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalMStar <<!<</*association_SetUnidirectionalMStar*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_relatedSpecialization.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalMStar_relatedSpecialization <<!<</*association_SetUnidirectionalMStar_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_specialization.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    association_SetUnidirectionalMStar_specialization <<!<</*association_SetUnidirectionalMStar_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() < <<=gen.translate("minimumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalMany <<!<</*association_SetUnidirectionalMany*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length)
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_relatedSpecialization.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalMany_relatedSpecialization <<!<</*association_SetUnidirectionalMany_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length)
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_specialization.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    association_SetUnidirectionalMany_specialization <<!<</*association_SetUnidirectionalMany_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length)
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalN <<!<</*association_SetUnidirectionalN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("requiredNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_relatedSpecialization.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalN_relatedSpecialization <<!<</*association_SetUnidirectionalN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("requiredNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_specialization.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    association_SetUnidirectionalN_specialization <<!<</*association_SetUnidirectionalN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("requiredNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    association_SetUnidirectionalOne <<!<</*association_SetUnidirectionalOne*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> != null)
+    {
+      <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterNew",av)>>;
+      wasSet = true;
+    }
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne_relatedSpecialization.ump
@@ -1,0 +1,19 @@
+class UmpleToJava {
+    association_SetUnidirectionalOne_relatedSpecialization <<!<</*association_SetUnidirectionalOne_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    if (<<=gen.translate("parameterNew",av)>> != null)
+    {
+      <<=gen.translate("associationOne",av)>> = <<# if (!mulChangedToOne) { #>><<=gen.translate("parameterNew",av)>><<# } else { #>>new ArrayList<<<=scName>>>()<<# } #>>;
+      <<# if (!mulChangedToOne) { #>><<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterNew",av)>>);<<# } #>>
+      wasSet = true;
+    }
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalOptionalN <<!<</*association_SetUnidirectionalOptionalN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_relatedSpecialization.ump
@@ -1,0 +1,33 @@
+class UmpleToJava {
+    association_SetUnidirectionalOptionalN_relatedSpecialization <<!<</*association_SetUnidirectionalOptionalN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    <<=gen.translate("associationMany",av)>>.clear();
+    <<=gen.translate("associationMany",av)>>.addAll(<<=gen.translate("parameterVerifiedMany",av)>>);
+    wasSet = true;
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_specialization.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    association_SetUnidirectionalOptionalN_specialization <<!<</*association_SetUnidirectionalOptionalN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPrefixCode, "    ")); } #>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterVerifiedMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    for (<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterMany",av)>>)
+    {
+      if (<<=gen.translate("parameterVerifiedMany",av)>>.contains(<<=gen.translate("parameterOne",av)>>))
+      {
+        continue;
+      }
+      <<=gen.translate("parameterVerifiedMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    }
+
+    if (<<=gen.translate("parameterVerifiedMany",av)>>.size() != <<=gen.translate("parameterMany",av)>>.length || <<=gen.translate("parameterVerifiedMany",av)>>.size() > <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "      ")); } #>>
+      return wasSet;
+    }
+
+    wasSet = super.<<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterMany",av)>>);
+    <<# if (customSetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPostfixCode,gen.translate("setManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetManyPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+    association_SetUnidirectionalOptionalOne <<!<</*association_SetUnidirectionalOptionalOne*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterNew",av)>>;
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne_relatedSpecialization.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    association_SetUnidirectionalOptionalOne_relatedSpecialization <<!<</*association_SetUnidirectionalOptionalOne_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<=gen.translate("associationOne",av)>> = <<# if (!mulChangedToOne) { #>><<=gen.translate("parameterNew",av)>><<# } else { #>>new ArrayList<<<=scName>>>()<<# } #>>;
+    <<# if (mulChangedToOne) { #>><<=gen.translate("associationOne",av)>>.add(<<=gen.translate("parameterNew",av)>>);<<# } #>>
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_Set_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_Set_All.ump
@@ -1,0 +1,578 @@
+use association_AddIndexControlFunctions.ump;
+use association_AddMNToMany.ump;
+use association_AddMNToOnlyOne.ump;
+use association_AddMNToOptionalOne.ump;
+use association_AddMStarToMany.ump;
+use association_AddMandatoryManyToOne.ump;
+use association_AddManyToManyMethod.ump;
+use association_AddManyToOne.ump;
+use association_AddManyToOptionalOne.ump;
+use association_AddOptionalNToOne.ump;
+use association_AddOptionalNToOptionalOne.ump;
+use association_AddUnidirectionalMN.ump;
+use association_AddUnidirectionalMStar.ump;
+use association_AddUnidirectionalMany.ump;
+use association_AddUnidirectionalOptionalN.ump;
+use association_IsNumberOfValidMethod.ump;
+use association_MaximumNumberOfMethod.ump;
+use association_MinimumNumberOfMethod.ump;
+use association_RemoveMany.ump;
+use association_RequiredNumberOfMethod.ump;
+use association_SetMNToMany.ump;
+use association_SetMNToOptionalOne.ump;
+use association_SetMStarToMany.ump;
+use association_SetNToOptionalOne.ump;
+use association_SetOneToAtMostN.ump;
+use association_SetOneToMandatoryMany.ump;
+use association_SetOneToMany.ump;
+use association_SetOneToManyAssociationClass.ump;
+use association_SetOneToOptionalOne.ump;
+use association_SetOptionalNToMany.ump;
+use association_SetOptionalOneToMandatoryMN.ump;
+use association_SetOptionalOneToMandatoryMany.ump;
+use association_SetOptionalOneToMany.ump;
+use association_SetOptionalOneToOne.ump;
+use association_SetOptionalOneToOptionalN.ump;
+use association_SetOptionalOneToOptionalOne.ump;
+use association_SetUnidirectionalMN.ump;
+use association_SetUnidirectionalMStar.ump;
+use association_SetUnidirectionalMany.ump;
+use association_SetUnidirectionalN.ump;
+use association_SetUnidirectionalOne.ump;
+use association_SetUnidirectionalOptionalN.ump;
+use association_SetUnidirectionalOptionalOne.ump;
+use association_Sort.ump;
+use specializationCode_Set.ump;
+
+
+class UmpleToJava {
+    association_Set_All <<!<</*association_Set_All*/>><<#
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  
+  boolean sortMethodAdded = false; //To ensure that only one sort method is created per class
+  for (AssociationVariable av : uClass.getAssociationVariables())
+  {
+  
+    gen.setParameterConstraintName(av.getName());
+
+    #>><<@ UmpleToJava.specializationCode_Set >><<#
+
+    if (!av.getIsNavigable())
+    { 
+      continue;
+    } 
+    
+    //TraceItem traceItem = av.getTraced("associationAdd", uClass);
+    List<TraceItem> traceItemAssocAdds = av.getTraced("associationAdd", uClass);
+    List<TraceItem> traceItemAssocRemoves = av.getTraced("associationRemove", uClass);
+
+    String customSetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("setMethod",av)));
+    String customSetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("setMethod",av)));
+
+    String customSetManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("setManyMethod",av)));
+    String customSetManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("setManyMethod",av)));
+
+    String customAddPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("addMethod",av)));
+    String customAddPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("addMethod",av)));
+
+    String customRemovePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("removeMethod",av)));
+    String customRemovePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("removeMethod",av)));
+
+    String customIsNumberOfValidPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("isNumberOfValidMethod",av)));
+    String customIsNumberOfValidPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("isNumberOfValidMethod",av)));
+    
+    String includeFileOne = null;
+    String includeFileTwo = null;
+    
+    boolean hasIsNumberOfValidMethod = false;
+    boolean hasAddManyToManyTemplateMethod = false;
+    boolean hasMaximumNumberOfMethod = av.isMany() && !av.isStar();
+    boolean hasMinimumNumberOfMethod = av.isMany();
+    boolean hasRequiredNumberOfMethod = av.isN();
+    boolean hasRemoveManyTemplateMethod = false;
+    String includeFile = null;
+    String includeFile2 = null;
+    String includeFile3 = null;
+
+    boolean addNewLine = false;
+    
+    
+    if (reqSuperCode) {
+    	  JavaSpecGenerator ng = new JavaSpecGenerator();
+          ng.getAssociationCode_specialization_reqSuperCode(gen, includeFile, includeFile2, includeFile3, realSb, av, relatedAssociation, 
+          				 customSetPrefixCode,  customSetPostfixCode,  customAddPrefixCode,  customAddPostfixCode,  customRemovePrefixCode,  customRemovePostfixCode,
+  						 customSetManyPrefixCode,  customSetManyPostfixCode, traceItemAssocRemoves, traceItemAssocAdds, uClass, sortMethodAdded, umpleSourceFile, 
+  						 this.uncaughtExceptions, globalUmpleClass, addNewLine, mulChangedToOne, relMulChangedToOne, mulChangedToN, reqSetCode, relReqCommonCode, relReqSetCode, scName);
+    		
+    }
+
+    else if (reqCommonCode) {
+    	  JavaSpecGenerator ng = new JavaSpecGenerator();
+          ng.getAssociationCode_specialization_reqCommonCode(gen, includeFile, includeFile2, includeFile3, realSb, av, relatedAssociation,
+          				 customSetPrefixCode,  customSetPostfixCode,  customAddPrefixCode,  customAddPostfixCode,  customRemovePrefixCode,  customRemovePostfixCode,
+  						 customSetManyPrefixCode,  customSetManyPostfixCode, traceItemAssocRemoves, traceItemAssocAdds, uClass, sortMethodAdded, umpleSourceFile, 
+  						 this.uncaughtExceptions, globalUmpleClass, addNewLine, mulChangedToOne, relMulChangedToOne, mulChangedToN, reqSetCode, relReqCommonCode, relReqSetCode, scName);
+          
+    } 
+    
+	else {
+
+      if (!relatedAssociation.getIsNavigable())
+      {
+        if (av.isOptionalOne())
+        {
+          includeFile = "association_SetUnidirectionalOptionalOne.jet";
+        }
+        else if (av.isOnlyOne())
+        {
+          includeFile = "association_SetUnidirectionalOne.jet";
+        }
+        else if (av.isMStar())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalMStar.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalMStar.jet";
+        }
+        else if (av.isMN())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalMN.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalMN.jet";
+        }
+        else if (av.isN())
+        {
+          includeFile = "association_SetUnidirectionalN.jet";
+        }
+        else if (av.isOptionalN())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalOptionalN.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalOptionalN.jet";
+        }
+        else if (av.isImmutable() && av.isMany())
+        {
+          includeFile = "association_SetUnidirectionalMany.jet";
+        }
+        else if (av.isMany())
+        {
+          includeFile = "association_AddUnidirectionalMany.jet";
+        }
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+      {
+        //ignore
+      }  
+      else if (av.isN() && relatedAssociation.isOptionalOne())
+      { 
+        includeFile = "association_SetNToOptionalOne.jet";
+      }
+      else if (av.isMN() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddMNToOptionalOne.jet";
+        includeFile2 = "association_SetMNToOptionalOne.jet";
+      }
+      else if (av.isMandatoryMany() && av.isStar() && relatedAssociation.isMany())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMStarToMany.jet";
+        includeFile2 = "association_SetMStarToMany.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isMandatoryMany())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany.jet";
+        includeFile2 = "association_SetMNToMany.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isOptionalN())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany.jet";
+      }
+      else if ((av.isMN() || av.isN()) && !relatedAssociation.isOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany.jet";
+        includeFile2 = "association_SetMNToMany.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_SetOptionalOneToOptionalOne.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOne())
+      {
+        includeFile = "association_SetOptionalOneToOne.jet";
+      }
+      else if (av.isOne() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_SetOneToOptionalOne.jet";
+      }
+      else if (av.isMandatoryMany() && av.isStar() && relatedAssociation.isOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        includeFile = "association_AddMandatoryManyToOne.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isOnlyOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        includeFile = "association_AddMNToOnlyOne.jet";
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOnlyOne())
+      {
+        includeFile = "association_AddOptionalNToOne.jet";
+      }
+      else if (av.isOptionalN() && (relatedAssociation.isMN() || relatedAssociation.isOptionalN()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOptionalMany())
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+        includeFile = "association_SetOptionalNToMany.jet";
+      }
+      else if (av.isMany() && relatedAssociation.isOnlyOne())
+      {
+        includeFile = "association_AddManyToOne.jet";
+      }
+      else if (av.isOptionalN() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isMany() && (relatedAssociation.isMN() || relatedAssociation.isN() || relatedAssociation.isMany()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddOptionalNToOptionalOne.jet";
+      }
+      else if (av.isMany() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddManyToOptionalOne.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMandatoryMany() && relatedAssociation.isStar())
+      {
+        includeFile = "association_SetOneToMandatoryMany.jet";
+      }
+      else if (av.isOnlyOne() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+      {
+        includeFile = "association_SetOneToAtMostN.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isOptionalN())
+      {
+        includeFile = "association_SetOneToAtMostN.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMany() && !(av.isMandatory() && !av.isOne()) && !(uClass instanceof AssociationClass))
+      {
+        includeFile = "association_SetOneToMany.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMany() && !(av.isMandatory() && !av.isOne()) && (uClass instanceof AssociationClass))
+      {
+        includeFile = "association_SetOneToManyAssociationClass.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalN())
+      {
+        includeFile = "association_SetOptionalOneToOptionalN.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalMany())
+      {
+        includeFile = "association_SetOptionalOneToMany.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isMandatoryMany())
+      {
+        // Insert code to include code here
+        if (relatedAssociation.isUpperBounded())
+        {
+          //
+          // This program cannot currently include SetOptionalOneToMandatoryMN.jet because of Issue351 where add/remove methods do not generate
+          //
+          // includeFile = "association_SetOptionalOneToMandatoryMN.jet";
+        } 
+        else
+        {
+          //
+          // We can include association_SetOptionalOneToMandatoryMany.jet
+          // 
+          includeFile = "association_SetOptionalOneToMandatoryMany.jet";
+        } 
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isMandatory())
+      {
+        //ignore
+      }
+
+      else
+      {
+        #>>//FIXME - FOUND UNKNOWN ASSOCIATION RELATIONSHIP <<=av>> : <<=relatedAssociation>><<#
+      }
+      
+      if(av.isSorted())
+      {
+        includeFile3 = "association_Sort.jet";
+      }
+      else if(av.isMany() && !av.isImmutable() && !av.isN())
+      {
+        includeFile3 = "association_AddIndexControlFunctions.jet";
+      }
+
+      addNewLine = false;
+      if (hasIsNumberOfValidMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_IsNumberOfValidMethod >><<#
+      }
+      
+      if (hasRequiredNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_RequiredNumberOfMethod >><<#
+      }
+
+      if (hasMinimumNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_MinimumNumberOfMethod >><<#
+      }
+      
+      if (hasMaximumNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_MaximumNumberOfMethod >><<#
+      }
+      
+      if (hasAddManyToManyTemplateMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<@ UmpleToJava.association_AddManyToManyMethod >><<#
+      }
+      
+      if (hasRemoveManyTemplateMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<@ UmpleToJava.association_RemoveMany >><<#
+      }
+    
+ // } // end else for non-specializated associations  
+
+    // current cutoff point
+
+  
+    if (addNewLine) { appendln(realSb,""); }
+    addNewLine = true;
+
+////// TODOOOOO
+
+
+
+  
+      #>><<#
+      // How do you dynamically include a file in JET?!?
+      
+      if (includeFile == "association_SetUnidirectionalOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOptionalOne >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOne >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOne >><<#
+      }
+      else if (includeFile == "association_SetOneToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToOptionalOne >><<#
+      }
+      else if (includeFile == "association_AddMandatoryManyToOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMandatoryManyToOne >><<#
+      }
+      else if (includeFile == "association_AddMNToOnlyOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToOnlyOne >><<#
+      }
+      else if (includeFile == "association_AddOptionalNToOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddOptionalNToOne >><<#
+      }
+      else if (includeFile == "association_SetOptionalNToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalNToMany >><<#
+      }
+      else if (includeFile == "association_AddManyToOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddManyToOne >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOptionalOne >><<#
+      }
+      else if (includeFile == "association_AddMNToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToMany >><<#
+      }
+      else if (includeFile == "association_AddMStarToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMStarToMany >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOptionalN.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOptionalN >><<#
+      }
+      else if (includeFile == "association_SetOneToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToMany >><<#
+      }
+      else if (includeFile == "association_SetOneToManyAssociationClass.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToManyAssociationClass >><<#
+      }
+      else if (includeFile == "association_SetOneToAtMostN.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToAtMostN >><<#
+      }
+      else if (includeFile == "association_SetOneToMandatoryMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToMandatoryMany >><<#
+      }
+      else if (includeFile == "association_AddManyToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddManyToOptionalOne >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMany >><<#
+      }
+      else if (includeFile == "association_AddOptionalNToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddOptionalNToOptionalOne >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMN.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMN >><<#
+      }
+      else if (includeFile == "association_AddMNToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToOptionalOne >><<#
+      }
+      else if (includeFile == "association_SetNToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetNToOptionalOne >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMany.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMany >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalOptionalN.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalOptionalN >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMStar.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMStar >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalN.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalN >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMany >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMandatoryMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMandatoryMany >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMandatoryMN.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMandatoryMN >><<#
+      }
+      else if (includeFile != null)
+      {
+        appendln(realSb,"You forgot to include {0}",includeFile);
+      }
+      
+      #>><<#
+      if (includeFile2 == "association_SetMNToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMNToMany >><<#
+      }
+      else if (includeFile2 == "association_SetMStarToMany.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMStarToMany >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalMN.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMN >><<#
+      }
+      else if (includeFile2 == "association_SetMNToOptionalOne.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMNToOptionalOne >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalOptionalN.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOptionalN >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalMStar.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMStar >><<#
+      }
+      else if (includeFile2 != null)
+      {
+        appendln(realSb,"You forgot to include {0}",includeFile2);
+      }
+      
+      if(includeFile3 == "association_Sort.jet" && !sortMethodAdded)
+      {
+        #>><<@ UmpleToJava.association_Sort >><<#
+        sortMethodAdded = true; //after the sort method has been added, this boolean stops it from being added again
+      }
+      else if(includeFile3 == "association_AddIndexControlFunctions.jet")
+      {
+        #>><<@ UmpleToJava.association_AddIndexControlFunctions >><<#
+      }
+
+    }
+  
+  }
+  gen.setParameterConstraintName("");
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_Sort.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_Sort.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    association_Sort <<!<</*association_Sort*/>>
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqCommonCode.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqCommonCode.ump
@@ -1,0 +1,504 @@
+use association_AddIndexControlFunctions_relatedSpecialization.ump;
+use association_AddMNToMany_relatedSpecialization.ump;
+use association_AddMNToOnlyOne_relatedSpecialization.ump;
+use association_AddMNToOptionalOne_relatedSpecialization.ump;
+use association_AddMStarToMany_relatedSpecialization.ump;
+use association_AddMandatoryManyToOne_relatedSpecialization.ump;
+use association_AddManyToManyMethod_relatedSpecialization.ump;
+use association_AddManyToOne_relatedSpecialization.ump;
+use association_AddManyToOptionalOne_relatedSpecialization.ump;
+use association_AddOptionalNToOne_relatedSpecialization.ump;
+use association_AddOptionalNToOptionalOne_relatedSpecialization.ump;
+use association_AddUnidirectionalMN_relatedSpecialization.ump;
+use association_AddUnidirectionalMStar_relatedSpecialization.ump;
+use association_AddUnidirectionalMany_relatedSpecialization.ump;
+use association_AddUnidirectionalOptionalN_relatedSpecialization.ump;
+use association_IsNumberOfValidMethod_relatedSpecialization.ump;
+use association_MaximumNumberOfMethod_relatedSpecialization.ump;
+use association_MinimumNumberOfMethod_relatedSpecialization.ump;
+use association_RemoveMany.ump;
+use association_RequiredNumberOfMethod_relatedSpecialization.ump;
+use association_SetMNToMany_relatedSpecialization.ump;
+use association_SetMNToOptionalOne_relatedSpecialization.ump;
+use association_SetMStarToMany_relatedSpecialization.ump;
+use association_SetNToOptionalOne_relatedSpecialization.ump;
+use association_SetOneToAtMostN_relatedSpecialization.ump;
+use association_SetOneToMandatoryMany_relatedSpecialization.ump;
+use association_SetOneToManyAssociationClass_relatedSpecialization.ump;
+use association_SetOneToMany_relatedSpecialization.ump;
+use association_SetOneToOptionalOne_relatedSpecialization.ump;
+use association_SetOptionalNToMany_relatedSpecialization.ump;
+use association_SetOptionalOneToMandatoryMN_relatedSpecialization.ump;
+use association_SetOptionalOneToMandatoryMany_relatedSpecialization.ump;
+use association_SetOptionalOneToMany_relatedSpecialization.ump;
+use association_SetOptionalOneToOne_relatedSpecialization.ump;
+use association_SetOptionalOneToOptionalN_relatedSpecialization.ump;
+use association_SetOptionalOneToOptionalOne_relatedSpecialization.ump;
+use association_SetUnidirectionalMN_relatedSpecialization.ump;
+use association_SetUnidirectionalMStar_relatedSpecialization.ump;
+use association_SetUnidirectionalMany_relatedSpecialization.ump;
+use association_SetUnidirectionalN_relatedSpecialization.ump;
+use association_SetUnidirectionalOne_relatedSpecialization.ump;
+use association_SetUnidirectionalOptionalN_relatedSpecialization.ump;
+use association_SetUnidirectionalOptionalOne_relatedSpecialization.ump;
+use association_Sort.ump;
+
+
+class UmpleToJava {
+    association_set_specialization_reqCommonCode <<!<</*association_set_specialization_reqCommonCode*/>><<#
+
+    String customIsNumberOfValidPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("isNumberOfValidMethod",av)));
+    String customIsNumberOfValidPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("isNumberOfValidMethod",av)));
+    
+    String includeFileOne = null;
+    String includeFileTwo = null;
+    
+    boolean hasIsNumberOfValidMethod = false;
+    boolean hasAddManyToManyTemplateMethod = false;
+    boolean hasMaximumNumberOfMethod = av.isMany() && !av.isStar();
+    boolean hasMinimumNumberOfMethod = av.isMany();
+    boolean hasRequiredNumberOfMethod = av.isN();
+    boolean hasRemoveManyTemplateMethod = false;
+    
+      if (!relatedAssociation.getIsNavigable())
+      {
+        if (av.isOptionalOne())
+        {
+          includeFile = "association_SetUnidirectionalOptionalOne_relatedSpecialization.jet";
+        }
+        else if (av.isOnlyOne())
+        {
+          includeFile = "association_SetUnidirectionalOne_relatedSpecialization.jet";
+        }
+        else if (av.isMStar())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalMStar_relatedSpecialization.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalMStar_relatedSpecialization.jet";
+        }
+        else if (av.isMN())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalMN_relatedSpecialization.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalMN_relatedSpecialization.jet";
+        }
+        else if (av.isN())
+        {
+          includeFile = "association_SetUnidirectionalN_relatedSpecialization.jet";
+        }
+        else if (av.isOptionalN())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalOptionalN_relatedSpecialization.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalOptionalN_relatedSpecialization.jet";
+        }
+        else if (av.isImmutable() && av.isMany())
+        {
+          includeFile = "association_SetUnidirectionalMany_relatedSpecialization.jet";
+        }
+        else if (av.isMany())
+        {
+          includeFile = "association_AddUnidirectionalMany_relatedSpecialization.jet";
+        }
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+      {
+        //ignore
+      }  
+      else if (av.isN() && relatedAssociation.isOptionalOne())
+      { 
+        includeFile = "association_SetNToOptionalOne_relatedSpecialization.jet";
+      }
+      else if (av.isMN() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddMNToOptionalOne_relatedSpecialization.jet";
+        includeFile2 = "association_SetMNToOptionalOne_relatedSpecialization.jet";
+      }
+      else if (av.isMandatoryMany() && av.isStar() && relatedAssociation.isMany())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMStarToMany_relatedSpecialization.jet";
+        includeFile2 = "association_SetMStarToMany_relatedSpecialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isMandatoryMany())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany_relatedSpecialization.jet";
+        includeFile2 = "association_SetMNToMany_relatedSpecialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isOptionalN())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany_relatedSpecialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && !relatedAssociation.isOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany_relatedSpecialization.jet";
+        includeFile2 = "association_SetMNToMany_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_SetOptionalOneToOptionalOne_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOne())
+      {
+        includeFile = "association_SetOptionalOneToOne_relatedSpecialization.jet";
+      }
+      else if (av.isOne() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_SetOneToOptionalOne_relatedSpecialization.jet";
+      }
+      else if (av.isMandatoryMany() && av.isStar() && relatedAssociation.isOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        includeFile = "association_AddMandatoryManyToOne_relatedSpecialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isOnlyOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        includeFile = "association_AddMNToOnlyOne_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOnlyOne())
+      {
+        includeFile = "association_AddOptionalNToOne_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalN() && (relatedAssociation.isMN() || relatedAssociation.isOptionalN()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOptionalMany())
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+        includeFile = "association_SetOptionalNToMany_relatedSpecialization.jet";
+      }
+      else if (av.isMany() && relatedAssociation.isOnlyOne())
+      {
+        includeFile = "association_AddManyToOne_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalN() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isMany() && (relatedAssociation.isMN() || relatedAssociation.isN() || relatedAssociation.isMany()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddOptionalNToOptionalOne_relatedSpecialization.jet";
+      }
+      else if (av.isMany() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddManyToOptionalOne_relatedSpecialization.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMandatoryMany() && relatedAssociation.isStar())
+      {
+        includeFile = "association_SetOneToMandatoryMany_relatedSpecialization.jet";
+      }
+      else if (av.isOnlyOne() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+      {
+        includeFile = "association_SetOneToAtMostN_relatedSpecialization.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isOptionalN())
+      {
+        includeFile = "association_SetOneToAtMostN_relatedSpecialization.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMany() && !(av.isMandatory() && !av.isOne()) && !(uClass instanceof AssociationClass))
+      {
+        includeFile = "association_SetOneToMany_relatedSpecialization.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMany() && !(av.isMandatory() && !av.isOne()) && (uClass instanceof AssociationClass))
+      {
+        includeFile = "association_SetOneToManyAssociationClass_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalN())
+      {
+        includeFile = "association_SetOptionalOneToOptionalN_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalMany())
+      {
+        includeFile = "association_SetOptionalOneToMany_relatedSpecialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isMandatoryMany())
+      {
+        // Insert code to include code here
+        if (relatedAssociation.isUpperBounded())
+        {
+          //
+          // This program cannot currently include SetOptionalOneToMandatoryMN.jet because of Issue351 where add/remove methods do not generate
+          //
+          // includeFile = "association_SetOptionalOneToMandatoryMN.jet";
+        } 
+        else
+        {
+          //
+          // We can include association_SetOptionalOneToMandatoryMany.jet
+          // 
+          includeFile = "association_SetOptionalOneToMandatoryMany_relatedSpecialization.jet";
+        } 
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isMandatory())
+      {
+        //ignore
+      }
+
+      else
+      {
+        #>>//FIXME - FOUND UNKNOWN ASSOCIATION RELATIONSHIP <<=av>> : <<=relatedAssociation>><<#
+      }
+      
+      if(av.isSorted())
+      {
+        includeFile3 = "association_Sort.jet";
+      }
+      else if(av.isMany() && !av.isImmutable() && !av.isN())
+      {
+        includeFile3 = "association_AddIndexControlFunctions_relatedSpecialization.jet";
+      }
+
+      addNewLine = false;
+      if (hasIsNumberOfValidMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_IsNumberOfValidMethod_relatedSpecialization >><<#
+      }
+      
+      if (hasRequiredNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_RequiredNumberOfMethod_relatedSpecialization >><<#
+      }
+
+      if (hasMinimumNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_MinimumNumberOfMethod_relatedSpecialization >><<#
+      }
+      
+      if (hasMaximumNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_MaximumNumberOfMethod_relatedSpecialization >><<#
+      }
+      
+      if (hasAddManyToManyTemplateMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<@ UmpleToJava.association_AddManyToManyMethod_relatedSpecialization >><<#
+      }
+      
+      if (hasRemoveManyTemplateMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<@ UmpleToJava.association_RemoveMany >><<#
+      }      
+
+ 	  
+    if (addNewLine) { appendln(realSb,""); }
+    addNewLine = true;
+	
+      if (includeFile == "association_SetUnidirectionalOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOneToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddMandatoryManyToOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMandatoryManyToOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddMNToOnlyOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToOnlyOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddOptionalNToOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddOptionalNToOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalNToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalNToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddManyToOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddManyToOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddMNToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddMStarToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMStarToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOptionalN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOptionalN_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOneToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOneToManyAssociationClass_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToManyAssociationClass_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOneToAtMostN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToAtMostN_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOneToMandatoryMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToMandatoryMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddManyToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddManyToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddOptionalNToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddOptionalNToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMN_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddMNToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetNToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetNToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalOptionalN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalOptionalN_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMStar_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMStar_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalN_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMandatoryMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMandatoryMany_relatedSpecialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMandatoryMN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMandatoryMN_relatedSpecialization >><<#
+      }
+      else if (includeFile != null)
+      {
+        appendln(realSb,"You forgot to include {0}",includeFile);
+      }
+      
+      #>><<#
+      if (includeFile2 == "association_SetMNToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMNToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile2 == "association_SetMStarToMany_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMStarToMany_relatedSpecialization >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalMN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMN_relatedSpecialization >><<#
+      }
+      else if (includeFile2 == "association_SetMNToOptionalOne_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMNToOptionalOne_relatedSpecialization >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalOptionalN_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOptionalN_relatedSpecialization >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalMStar_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMStar_relatedSpecialization >><<#
+      }
+      else if (includeFile2 != null)
+      {
+        appendln(realSb,"You forgot to include {0}",includeFile2);
+      }
+      
+      if(includeFile3 == "association_Sort.jet" && !sortMethodAdded)
+      {
+        #>><<@ UmpleToJava.association_Sort >><<#
+        sortMethodAdded = true; //after the sort method has been added, this boolean stops it from being added again
+      }
+      else if(includeFile3 == "association_AddIndexControlFunctions_relatedSpecialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddIndexControlFunctions_relatedSpecialization >><<#
+      }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqSuperCode.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqSuperCode.ump
@@ -1,0 +1,505 @@
+use association_AddIndexControlFunctions_specialization.ump;
+use association_AddMNToMany_specialization.ump;
+use association_AddMNToOnlyOne_specialization.ump;
+use association_AddMNToOptionalOne_specialization.ump;
+use association_AddMStarToMany_specialization.ump;
+use association_AddMandatoryManyToOne_specialization.ump;
+use association_AddManyToManyMethod_specialization.ump;
+use association_AddManyToOne_specialization.ump;
+use association_AddManyToOptionalOne_specialization.ump;
+use association_AddOptionalNToOne_specialization.ump;
+use association_AddOptionalNToOptionalOne_specialization.ump;
+use association_AddUnidirectionalMN_specialization.ump;
+use association_AddUnidirectionalMany_specialization.ump;
+use association_AddUnidirectionalOptionalN_specialization.ump;
+use association_IsNumberOfValidMethod_specialization.ump;
+use association_MaximumNumberOfMethod_specialization.ump;
+use association_MinimumNumberOfMethod_specialization.ump;
+use association_RequiredNumberOfMethod_specialization.ump;
+use association_SetMNToMany_specialization.ump;
+use association_SetMNToOptionalOne_specialization.ump;
+use association_SetMStarToMany_specialization.ump;
+use association_SetNToOptionalOne_specialization.ump;
+use association_SetOneToAtMostN_specialization.ump;
+use association_SetOneToMandatoryMany_specialization.ump;
+use association_SetOneToMany_specialization.ump;
+use association_SetOptionalNToMany_specialization.ump;
+use association_SetOptionalOneToMandatoryMany_specialization.ump;
+use association_SetOptionalOneToOptionalN_specialization.ump;
+use association_SetUnidirectionalMN_specialization.ump;
+use association_SetUnidirectionalMStar_specialization.ump;
+use association_SetUnidirectionalMany_specialization.ump;
+use association_SetUnidirectionalN_specialization.ump;
+use association_SetUnidirectionalOptionalN_specialization.ump;
+use association_Sort.ump;
+use specializationSkip.ump;
+
+
+class UmpleToJava {
+    association_set_specialization_reqSuperCode <<!<</*association_set_specialization_reqSuperCode*/>><<#
+	String customIsNumberOfValidPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("isNumberOfValidMethod",av)));
+    String customIsNumberOfValidPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("isNumberOfValidMethod",av)));
+    
+    String includeFileOne = null;
+    String includeFileTwo = null;
+    
+    boolean hasIsNumberOfValidMethod = false;
+    boolean hasAddManyToManyTemplateMethod = false;
+    boolean hasMaximumNumberOfMethod = av.isMany() && !av.isStar();
+    boolean hasMinimumNumberOfMethod = av.isMany();
+    boolean hasRequiredNumberOfMethod = av.isN();
+    boolean hasRemoveManyTemplateMethod = false;
+    
+	  if (!relatedAssociation.getIsNavigable())
+      {
+        if (av.isOptionalOne())
+        {
+          includeFile = "specializationSkip.jet";
+        }
+        else if (av.isOnlyOne())
+        {
+          includeFile = "specializationSkip.jet";
+        }
+        else if (av.isMStar())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "specializationSkip.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalMStar_specialization.jet";
+        }
+        else if (av.isMN())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalMN_specialization.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalMN_specialization.jet";
+        }
+        else if (av.isN())
+        {
+          includeFile = "association_SetUnidirectionalN_specialization.jet";
+        }
+        else if (av.isOptionalN())
+        {
+          if (!av.isImmutable())
+          {
+            includeFile = "association_AddUnidirectionalOptionalN_specialization.jet";
+          }
+          includeFile2 = "association_SetUnidirectionalOptionalN_specialization.jet";
+        }
+        else if (av.isImmutable() && av.isMany())
+        {
+          includeFile = "association_SetUnidirectionalMany_specialization.jet";
+        }
+        else if (av.isMany())
+        {
+          includeFile = "association_AddUnidirectionalMany_specialization.jet";
+        }
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+      {
+        //ignore
+      }  
+      else if (av.isN() && relatedAssociation.isOptionalOne())
+      { 
+        includeFile = "association_SetNToOptionalOne_specialization.jet";
+      }
+      else if (av.isMN() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddMNToOptionalOne_specialization.jet";
+        includeFile2 = "association_SetMNToOptionalOne_specialization.jet";
+      }
+      else if (av.isMandatoryMany() && av.isStar() && relatedAssociation.isMany())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMStarToMany_specialization.jet";
+        includeFile2 = "association_SetMStarToMany_specialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isMandatoryMany())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany_specialization.jet";
+        includeFile2 = "association_SetMNToMany_specialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isOptionalN())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany_specialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && !relatedAssociation.isOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        hasAddManyToManyTemplateMethod = true;
+        includeFile = "association_AddMNToMany_specialization.jet";
+        includeFile2 = "association_SetMNToMany_specialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOne())
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isOne() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isMandatoryMany() && av.isStar() && relatedAssociation.isOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        includeFile = "association_AddMandatoryManyToOne_specialization.jet";
+      }
+      else if ((av.isMN() || av.isN()) && relatedAssociation.isOnlyOne())
+      {
+        hasIsNumberOfValidMethod = true;
+        includeFile = "association_AddMNToOnlyOne_specialization.jet";
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOnlyOne())
+      {
+        includeFile = "association_AddOptionalNToOne_specialization.jet";
+      }
+      else if (av.isOptionalN() && (relatedAssociation.isMN() || relatedAssociation.isOptionalN()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOptionalMany())
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+        includeFile = "association_SetOptionalNToMany.jet";
+      }
+      else if (av.isMany() && relatedAssociation.isOnlyOne())
+      {
+        includeFile = "association_AddManyToOne_specialization.jet";
+      }
+      else if (av.isOptionalN() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isMany() && (relatedAssociation.isMN() || relatedAssociation.isN() || relatedAssociation.isMany()))
+      {
+        hasAddManyToManyTemplateMethod = true;
+        if (!av.isImmutable())
+        {
+          hasRemoveManyTemplateMethod = true;
+        }
+      }
+      else if (av.isOptionalN() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "association_AddOptionalNToOptionalOne_specialization.jet";
+      }
+      else if (av.isMany() && relatedAssociation.isOptionalOne())
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMandatoryMany() && relatedAssociation.isStar())
+      {
+        includeFile = "association_SetOneToMandatoryMany_specialization.jet";
+      }
+      else if (av.isOnlyOne() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+      {
+        includeFile = "association_SetOneToAtMostN_specialization.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isOptionalN())
+      {
+        includeFile = "association_SetOneToAtMostN_specialization.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMany() && !(av.isMandatory() && !av.isOne()) && !(uClass instanceof AssociationClass))
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isOnlyOne() && relatedAssociation.isMany() && !(av.isMandatory() && !av.isOne()) && (uClass instanceof AssociationClass))
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalN())
+      {
+        includeFile = "association_SetOptionalOneToOptionalN_specialization.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isOptionalMany())
+      {
+        includeFile = "specializationSkip.jet";
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isMandatoryMany())
+      {
+        // Insert code to include code here
+        if (relatedAssociation.isUpperBounded())
+        {
+          //
+          // This program cannot currently include SetOptionalOneToMandatoryMN.jet because of Issue351 where add/remove methods do not generate
+          //
+          //          PLEASE NOTE
+          // If Issue351 is resolved, remember to change the specialization
+          // code as well -- do not just include this here.
+          //
+          // includeFile = "association_SetOptionalOneToMandatoryMN.jet";
+        } 
+        else
+        {
+          //
+          // We can include association_SetOptionalOneToMandatoryMany.jet
+          // 
+          includeFile = "association_SetOptionalOneToMandatoryMany_specialization.jet";
+        } 
+      }
+      else if (av.isOptionalOne() && relatedAssociation.isMandatory())
+      {
+        //ignore
+      }
+
+      else
+      {
+        #>>//FIXME - FOUND UNKNOWN ASSOCIATION RELATIONSHIP <<=av>> : <<=relatedAssociation>><<#
+      }
+      
+      if(av.isSorted())
+      {
+        includeFile3 = "association_Sort.jet";
+      }
+      else if(av.isMany() && !av.isImmutable() && !av.isN())
+      {
+        includeFile3 = "association_AddIndexControlFunctions_specialization.jet";
+      }
+
+      addNewLine = false;
+      if (hasIsNumberOfValidMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_IsNumberOfValidMethod_specialization >><<#
+      }
+      
+      if (hasRequiredNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_RequiredNumberOfMethod_specialization >><<#
+      }
+
+      if (hasMinimumNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_MinimumNumberOfMethod_specialization >><<#
+      }
+      
+      if (hasMaximumNumberOfMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<#
+        #>><<@ UmpleToJava.association_MaximumNumberOfMethod_specialization >><<#
+      }
+      
+      if (hasAddManyToManyTemplateMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<@ UmpleToJava.association_AddManyToManyMethod_specialization >><<#
+      }
+      
+      if (hasRemoveManyTemplateMethod)
+      {
+        if (addNewLine) { appendln(realSb,""); }
+        addNewLine = true;
+        #>><<@ UmpleToJava.specializationSkip >><<#
+      }
+	    
+    if (addNewLine) { appendln(realSb,""); }
+    addNewLine = true;	
+	
+      if (includeFile == "association_SetUnidirectionalOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_SetUnidirectionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_SetOptionalOneToOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_SetOneToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_AddMandatoryManyToOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMandatoryManyToOne_specialization >><<#
+      }
+      else if (includeFile == "association_AddMNToOnlyOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToOnlyOne_specialization >><<#
+      }
+      else if (includeFile == "association_AddOptionalNToOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddOptionalNToOne_specialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalNToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalNToMany_specialization >><<#
+      }
+      else if (includeFile == "association_AddManyToOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddManyToOne_specialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_AddMNToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToMany_specialization >><<#
+      }
+      else if (includeFile == "association_AddMStarToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMStarToMany_specialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToOptionalN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToOptionalN_specialization >><<#
+      }
+      else if (includeFile == "association_SetOneToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToMany_specialization >><<#
+      }
+      else if (includeFile == "association_SetOneToManyAssociationClass_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_SetOneToAtMostN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToAtMostN_specialization >><<#
+      }
+      else if (includeFile == "association_SetOneToMandatoryMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOneToMandatoryMany_specialization >><<#
+      }
+      else if (includeFile == "association_AddManyToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddManyToOptionalOne_specialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_AddOptionalNToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddOptionalNToOptionalOne_specialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMN_specialization >><<#
+      }
+      else if (includeFile == "association_AddMNToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddMNToOptionalOne_specialization >><<#
+      }
+      else if (includeFile == "association_SetNToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetNToOptionalOne_specialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalMany_specialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalOptionalN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_AddUnidirectionalOptionalN_specialization >><<#
+      }
+      else if (includeFile == "association_AddUnidirectionalMStar_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_SetUnidirectionalN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalN_specialization >><<#
+      }
+      else if (includeFile == "association_SetUnidirectionalMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMany_specialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMandatoryMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetOptionalOneToMandatoryMany_specialization >><<#
+      }
+      else if (includeFile == "association_SetOptionalOneToMandatoryMN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO!!
+      }
+      else if (includeFile == "association_SetOptionalNToMany.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO?
+      }
+      else if (includeFile == "specializationSkip.jet")
+      {
+        #>><<@ UmpleToJava.specializationSkip >><<#    // TODO?
+      }
+      else if (includeFile != null)
+      {
+        appendln(realSb,"You forgot to include {0}",includeFile);
+      }
+      
+      #>><<#
+      if (includeFile2 == "association_SetMNToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMNToMany_specialization >><<#
+      }
+      else if (includeFile2 == "association_SetMStarToMany_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMStarToMany_specialization >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalMN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMN_specialization >><<#
+      }
+      else if (includeFile2 == "association_SetMNToOptionalOne_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetMNToOptionalOne_specialization >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalOptionalN_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalOptionalN_specialization >><<#
+      }
+      else if (includeFile2 == "association_SetUnidirectionalMStar_specialization.jet")
+      {
+        #>><<@ UmpleToJava.association_SetUnidirectionalMStar_specialization >><<#
+      }
+      else if (includeFile2 != null)
+      {
+        appendln(realSb,"You forgot to include {0}",includeFile2);
+      }
+      
+      if(includeFile3 == "association_Sort.jet" && !sortMethodAdded)
+      {
+        #>><<@ UmpleToJava.association_Sort >><<#
+        sortMethodAdded = true; //after the sort method has been added, this boolean stops it from being added again
+      }
+      else if(includeFile3 == "association_AddIndexControlFunctions.jet")
+      {
+        #>><<@ UmpleToJava.association_AddIndexControlFunctions_specialization >><<#
+      }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_Get.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Get.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    attribute_Get <<!<</*attribute_Get*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+    return <<=gen.translate("attributeOne",av)>>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetCodeInjection.ump
@@ -1,0 +1,14 @@
+class UmpleToJava {
+    attribute_GetCodeInjection <<!<</*attribute_GetCodeInjection*/>>
+  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("type",av) >> <<= gen.translate("parameterOne",av) >> = <<=gen.translate("attributeOne",av)>>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>    return <<= gen.translate("parameterOne",av) >>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDefaulted.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDefaulted.ump
@@ -1,0 +1,11 @@
+class UmpleToJava {
+    attribute_GetDefaulted <<!<</*attribute_GetDefaulted*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
+  {
+    <<# if (customGetDefaultPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetDefaultPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+    return <<= gen.translate("parameterValue",av) >>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDefaultedCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDefaultedCodeInjection.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+    attribute_GetDefaultedCodeInjection <<!<</*attribute_GetDefaultedCodeInjection*/>>
+  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
+  {
+    <<# if (customGetDefaultPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getDefaultMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetDefaultPrefixCode, "    ")); } #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<= gen.translate("parameterValue",av) >>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetDefaultPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetDefaultPostfixCode,gen.translate("getDefaultMethod",av));
+      append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetDefaultPostfixCode, "    ")); } #>>    return <<=gen.translate("parameterOne",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDerived.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDerived.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    attribute_GetDerived <<!<</*attribute_GetDerived*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  {
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+    return <<= gen.translate("parameterValue",av) >>;<<#addUncaughtExceptionVariables(gen.translate("getMethod",av),av.getPosition().getFilename(),av.getPosition().getLineNumber(),realSb.toString().split("\\n").length-1,1);#>>
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDerivedCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDerivedCodeInjection.ump
@@ -1,0 +1,14 @@
+class UmpleToJava {
+    attribute_GetDerivedCodeInjection <<!<</*attribute_GetDerivedCodeInjection*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("type",av) >> <<= gen.translate("parameterOne",av) >> = <<= gen.translate("parameterValue",av) >>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>    return <<= gen.translate("parameterOne",av) >>;<<#addUncaughtExceptionVariables(gen.translate("getMethod",av),av.getPosition().getFilename(),av.getPosition().getLineNumber(),realSb.toString().split("\\n").length-1,1);#>>
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetMany.ump
@@ -1,0 +1,63 @@
+class UmpleToJava {
+    attribute_GetMany <<!<</*attribute_GetMany*/>>
+  public <<=gen.translate("typeMany",av)>> <<=gen.translate("getMethod",av)>>(int index)
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("attributeMany",av)>>.get(index);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>    return <<=gen.translate("parameterOne",av)>>;
+  }
+
+  public <<=gen.translate("typeMany",av)>>[] <<=gen.translate("getManyMethod",av)>>()
+  {
+    <<# if (customGetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPrefixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetManyPrefixCode, "    ")); } #>>
+    <<= gen.translate("typeMany",av)>>[] <<=gen.translate("parameterMany",av)>> = <<=gen.translate("attributeMany",av)>>.toArray(new <<=gen.translate("typeMany",av)>>[<<=gen.translate("attributeMany",av)>>.size()]);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_ga", uClass):"")>>
+
+
+<<# if (customGetManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetManyPostfixCode,gen.translate("getManyMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetManyPostfixCode, "    ")); } #>>    return <<=gen.translate("parameterMany",av)>>;
+  }
+
+  public int <<=gen.translate("numberOfMethod",av)>>()
+  {
+    <<# if (customNumberOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customNumberOfPrefixCode,gen.translate("numberOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customNumberOfPrefixCode, "    ")); } #>>
+    int number = <<=gen.translate("attributeMany",av)>>.size();
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_n", uClass, "number"):"")>>
+
+
+<<# if (customNumberOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customNumberOfPostfixCode,gen.translate("numberOfMethod",av));
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customNumberOfPostfixCode, "    ")); } #>>    return number;
+  }
+
+  public boolean <<=gen.translate("hasManyMethod",av)>>()
+  {
+    <<# if (customHasManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasManyPrefixCode,gen.translate("hasManyMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasManyPrefixCode, "    ")); } #>>
+    boolean has = <<=gen.translate("attributeMany",av)>>.size() > 0;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_h", uClass):"")>>
+
+
+<<# if (customHasManyPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasManyPostfixCode,gen.translate("hasManyMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customHasManyPostfixCode, "    ")); }#>>    return has;
+  }
+
+  public int <<=gen.translate("indexOfMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    <<# if (customIndexOfPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIndexOfPrefixCode,gen.translate("indexOfMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customIndexOfPrefixCode, "    ")); } #>>
+    int index = <<=gen.translate("attributeMany",av)>>.indexOf(<<=gen.translate("parameterOne",av)>>);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_i", uClass, gen.translate("parameterOne",av), "index"):"")>>
+
+
+<<# if (customIndexOfPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIndexOfPostfixCode,gen.translate("indexOfMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customIndexOfPostfixCode, "    ")); } #>>    return index;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetUnique.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetUnique.ump
@@ -1,0 +1,11 @@
+class UmpleToJava {
+    attribute_GetUnique <<!<</*attribute_GetUnique*/>>
+  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  {
+    <<# if (customGetUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePrefixCode,gen.translate("getUniqueMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetUniquePrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+    return <<=gen.translate("uniqueMap",av)>>.get(<<=gen.translate("parameterOne",av)>>);
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetUniqueCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetUniqueCodeInjection.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+    attribute_GetUniqueCodeInjection <<!<</*attribute_GetUniqueCodeInjection*/>>
+  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  {
+    <<# if (customGetUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePrefixCode,gen.translate("getUniqueMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetUniquePrefixCode, "    ")); } #>>
+    <<=av.getUmpleClass().getName()>> <<=gen.translate("parameterGetUnique",av)>> = <<=gen.translate("uniqueMap",av)>>.get(<<=gen.translate("parameterOne",av)>>);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetUniquePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePostfixCode,gen.translate("getUniqueMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetUniquePostfixCode, "    ")); } #>>    return <<=gen.translate("parameterGetUnique",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_Get_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Get_All.ump
@@ -1,0 +1,132 @@
+use attribute_Get.ump;
+use attribute_GetCodeInjection.ump;
+use attribute_GetDefaulted.ump;
+use attribute_GetDefaultedCodeInjection.ump;
+use attribute_GetDerived.ump;
+use attribute_GetDerivedCodeInjection.ump;
+use attribute_GetMany.ump;
+use attribute_GetUnique.ump;
+use attribute_GetUniqueCodeInjection.ump;
+use attribute_HasUnique.ump;
+use attribute_HasUniqueCodeInjection.ump;
+
+
+class UmpleToJava {
+    attribute_Get_All <<!<</*attribute_Get_All*/>><<#
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  for (Attribute av : uClass.getAttributes()) 
+  {
+    if (av.getIsAutounique() || av.isConstant() || "internal".equals(av.getModifier()))
+    {
+      continue;
+    }
+    
+    gen.setParameterConstraintName(av.getName());
+
+    List<TraceItem> traceItems = av.getTraced("getMethod", uClass);
+    
+    String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+    String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getMethod",av)));
+
+    String customGetDefaultPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getDefaultMethod",av)));
+    String customGetDefaultPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getDefaultMethod",av)));
+
+    String customGetManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getManyMethod",av)));
+    String customGetManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getManyMethod",av)));
+
+    String customNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("numberOfMethod",av)));
+    String customNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("numberOfMethod",av)));
+
+    String customHasManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("hasManyMethod",av)));
+    String customHasManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("hasManyMethod",av)));
+
+    String customIndexOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("indexOfMethod",av)));
+    String customIndexOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("indexOfMethod",av)));
+        
+    String customHasUniquePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("hasUniqueMethod",av)));
+    String customHasUniquePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("hasUniqueMethod",av)));
+    
+    String customGetUniquePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getUniqueMethod",av)));
+    String customGetUniquePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getUniqueMethod",av)));
+
+    if (av.getIsList())
+    {
+      #>><<@ UmpleToJava.attribute_GetMany >><<#
+    }
+    else 
+    {
+
+      if (av.getIsDerived() && customGetPostfixCode != null)
+      {
+        #>><<@ UmpleToJava.attribute_GetDerivedCodeInjection >><<#
+      }
+      else if (av.getIsDerived())
+      {
+        #>><<@ UmpleToJava.attribute_GetDerived >><<#
+      }
+      else if (customGetPostfixCode != null)
+      {
+        #>><<@ UmpleToJava.attribute_GetCodeInjection >><<#
+      }
+      else
+      {
+        #>><<@ UmpleToJava.attribute_Get >><<#
+      }
+      
+      appendln(realSb, "");
+      
+      if (av.getModifier().equals("defaulted") && customGetDefaultPostfixCode != null)
+      {
+        #>><<@ UmpleToJava.attribute_GetDefaultedCodeInjection >><<#
+      }
+      else if (av.getModifier().equals("defaulted"))
+      {
+        #>><<@ UmpleToJava.attribute_GetDefaulted >><<#
+      }
+      
+      if (av.getIsUnique())
+      {
+        if (customGetUniquePostfixCode != null)
+        {
+          #>><<@ UmpleToJava.attribute_GetUniqueCodeInjection >><<#
+        } 
+        else 
+        {
+          #>><<@ UmpleToJava.attribute_GetUnique >><<#
+        }
+        if (customHasUniquePostfixCode != null)
+        {
+          #>><<@ UmpleToJava.attribute_HasUniqueCodeInjection >><<#
+        }
+        else
+        {
+          #>><<@ UmpleToJava.attribute_HasUnique >><<#
+        }
+      }
+    }
+  }
+
+  for (Attribute av : uClass.getAttributes()) 
+  {
+  
+    if (av.getIsAutounique())
+    {
+      String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+      String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getMethod",av)));
+      
+      List<TraceItem> traceItems = av.getTraced("getMethod", uClass);
+      
+      if (customGetPostfixCode != null)
+      {
+        #>><<@ UmpleToJava.attribute_GetCodeInjection >><<#
+      }
+      else
+      {
+        #>><<@ UmpleToJava.attribute_Get >><<#
+      }
+      appendln(realSb, "");
+    }
+  }
+  gen.setParameterConstraintName("");
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_HasUnique.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_HasUnique.ump
@@ -1,0 +1,11 @@
+class UmpleToJava {
+    attribute_HasUnique <<!<</*attribute_HasUnique*/>>
+  public static boolean <<=gen.translate("hasUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  {
+    <<# if (customHasUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasUniquePrefixCode,gen.translate("hasUniqueMethod",av));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasUniquePrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+    return <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("parameterOne",av)>>) != null;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_HasUniqueCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_HasUniqueCodeInjection.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+    attribute_HasUniqueCodeInjection <<!<</*attribute_HasUniqueCodeInjection*/>>
+  public static boolean <<=gen.translate("hasUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  {
+    <<# if (customHasUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasUniquePrefixCode,gen.translate("hasUniqueMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasUniquePrefixCode, "    ")); } #>>
+    boolean <<=gen.translate("parameterHasUnique",av)>> = <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("parameterOne",av)>>) != null;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customHasUniquePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasUniquePostfixCode,gen.translate("hasUniqueMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customHasUniquePostfixCode, "    ")); } #>>    return <<=gen.translate("parameterHasUnique",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBoolean.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBoolean.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    attribute_IsBoolean <<!<</*attribute_IsBoolean*/>>
+  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_i", uClass, gen.translate("parameterOne",av), "index"):"")>>
+    return <<=gen.translate("attributeOne",av)>>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjection.ump
@@ -1,0 +1,14 @@
+class UmpleToJava {
+    attribute_IsBooleanCodeInjection <<!<</*attribute_IsBooleanCodeInjection*/>>
+  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("type",av) >> <<= gen.translate("parameterOne",av) >> = <<= gen.translate("attributeOne",av) >>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_i", uClass, gen.translate("parameterOne",av), "index"):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("isMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>    return <<= gen.translate("parameterOne",av) >>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjectionDerived.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjectionDerived.ump
@@ -1,0 +1,14 @@
+class UmpleToJava {
+    attribute_IsBooleanCodeInjectionDerived <<!<</*attribute_IsBooleanCodeInjectionDerived*/>>
+  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("type",av) >> <<= gen.translate("parameterOne",av) >> = <<= gen.translate("parameterValue",av) >>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_i", uClass, gen.translate("parameterOne",av), "index"):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("isMethod",av));   
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); }#>>    return <<= gen.translate("parameterOne",av) >>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanDerived.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanDerived.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    attribute_IsBooleanDerived <<!<</*attribute_IsBooleanDerived*/>>
+  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_i", uClass, gen.translate("parameterOne",av), "index"):"")>>
+    return <<=gen.translate("parameterValue",av)>>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBoolean_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBoolean_All.ump
@@ -1,0 +1,45 @@
+use attribute_IsBoolean.ump;
+use attribute_IsBooleanCodeInjection.ump;
+use attribute_IsBooleanCodeInjectionDerived.ump;
+use attribute_IsBooleanDerived.ump;
+
+
+class UmpleToJava {
+    attribute_IsBoolean_All <<!<</*attribute_IsBoolean_All*/>><<#
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  for (Attribute av : uClass.getAttributes()) 
+  {
+    if (!av.getType().equals("Boolean") || av.getIsAutounique() || av.isConstant() || "internal".equals(av.getModifier()))
+    {
+      continue;
+    }
+  
+    gen.setParameterConstraintName(av.getName());
+
+    List<TraceItem> traceItems = av.getTraced("getMethod", uClass);
+
+    String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("isMethod",av)));
+    String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("isMethod",av)));
+    
+    if (av.getIsDerived() && customGetPostfixCode != null)
+    {
+      #>><<@ UmpleToJava.attribute_IsBooleanCodeInjectionDerived >><<#
+    }
+    else if (av.getIsDerived())
+    {
+      #>><<@ UmpleToJava.attribute_IsBooleanDerived >><<#
+    }
+    else if (customGetPostfixCode != null)
+    {
+      #>><<@ UmpleToJava.attribute_IsBooleanCodeInjection >><<#
+    }
+    else
+    {
+      #>><<@ UmpleToJava.attribute_IsBoolean >><<#
+    }
+      
+    appendln(realSb, "");
+  }
+  gen.setParameterConstraintName("");
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_Set.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set.ump
@@ -1,0 +1,17 @@
+class UmpleToJava {
+    attribute_Set <<!<</*attribute_Set*/>>
+  public boolean <<= gen.translate("setMethod",av) >>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_s", uClass,gen.translate("parameterOne",av)):"")>>
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av) >>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_s", uClass):"")>>
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    attribute_SetDefaulted <<!<</*attribute_SetDefaulted*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_s", uClass,gen.translate("parameterOne",av)):"")>>
+    <<= gen.translate("attributeOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_s", uClass):"")>>
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+
+  public boolean <<=gen.translate("resetMethod",av)>>()
+  {
+    boolean wasReset = false;
+    <<# if (customResetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customResetPrefixCode,gen.translate("resetMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customResetPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_t", uClass,gen.translate("parameterOne",av)):"")>>
+    <<= gen.translate("attributeOne",av)>> = <<=gen.translate("getDefaultMethod",av)>>();
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_t", uClass):"")>>
+    wasReset = true;
+    <<# if (customResetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customResetPostfixCode,gen.translate("resetMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customResetPostfixCode, "    ")); } #>>
+    return wasReset;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted_subclass.ump
@@ -1,0 +1,17 @@
+class UmpleToJava {
+    attribute_SetDefaulted_subclass <<!<</*attribute_SetDefaulted_subclass*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { 
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+      <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_s", uClass,gen.translate("parameterOne",av)):"")>>
+      wasSet = super.<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_s", uClass):"")>>
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetImmutable.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetImmutable.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    attribute_SetImmutable <<!<</*attribute_SetImmutable*/>>
+  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<= gen.translate("attributeCanSet",av) >> = false;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_s", uClass,gen.translate("parameterOne",av)):"")>>
+    <<= gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_s", uClass):"")>>
+    wasSet = true;
+    <<# if (customSetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetMany.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    attribute_SetMany <<!<</*attribute_SetMany*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_a", uClass,gen.translate("parameterOne",av)):"")>>
+    wasAdded = <<=gen.translate("attributeMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_a", uClass):"")>>
+
+
+<<# if (customAddPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customAddPostfixCode, "    ")); } #>>    return wasAdded;
+  }
+
+  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasRemoved = false;
+    <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customRemovePrefixCode, "    ")); } #>>
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_r", uClass,gen.translate("parameterOne",av)):"")>>
+    wasRemoved = <<=gen.translate("attributeMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_r", uClass):"")>>
+
+
+<<# if (customRemovePostfixCode != null) {addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePostfixCode,gen.translate("removeMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customRemovePostfixCode, "    ")); }#>>    return wasRemoved;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetMany_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetMany_subclass.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    attribute_SetMany_subclass <<!<</*attribute_SetMany_subclass*/>>
+  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasAdded = false;
+    <<# if (customAddPrefixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
+      <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_a", uClass,gen.translate("parameterOne",av)):"")>>
+      wasAdded = super.<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+      <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_a", uClass):"")>>
+    <<# if (customAddPostfixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPostfixCode,gen.translate("addMethod",av)); 
+      append(realSb, "{0}\n",GeneratorHelper.doIndent(customAddPostfixCode, "    "));
+    } #>>
+    return wasAdded;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_Set_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set_All.ump
@@ -1,0 +1,102 @@
+use attribute_Set.ump;
+use attribute_SetDefaulted.ump;
+use attribute_SetDefaulted_subclass.ump;
+use attribute_SetImmutable.ump;
+use attribute_SetMany.ump;
+use attribute_SetMany_subclass.ump;
+use attribute_Set_subclass.ump;
+
+
+class UmpleToJava {
+    attribute_Set_All <<!<</*attribute_Set_All*/>><<#
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  for (Attribute av : uClass.getAttributes())
+  {
+    if (av.isConstant() || av.getIsAutounique() || "internal".equals(av.getModifier()) || av.getIsDerived())
+    {
+      continue;
+    }
+
+    gen.setParameterConstraintName(av.getName());    
+    
+    List<TraceItem> traceItems = av.getTraced("setMethod", uClass);
+    
+
+    String customSetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("setMethod",av)));
+    String customSetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("setMethod",av)));
+
+    String customResetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("resetMethod",av)));
+    String customResetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("resetMethod",av)));
+
+    String customAddPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("addMethod",av)));
+    String customAddPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("addMethod",av)));
+  
+    String customRemovePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("removeMethod",av)));
+    String customRemovePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("removeMethod",av)));
+    
+    if (av.isImmutable())
+    {
+      if (av.getIsLazy())
+      {
+        #>><<@ UmpleToJava.attribute_SetImmutable >><<#
+      }
+    }
+    else if (av.getModifier().equals("defaulted"))
+    {
+      #>><<@ UmpleToJava.attribute_SetDefaulted >><<#
+    }
+    else if (av.getIsList())
+    {
+      #>><<@ UmpleToJava.attribute_SetMany >><<#
+    }
+    else
+    {
+      #>><<@ UmpleToJava.attribute_Set >><<#
+    }
+  }
+
+  if(uClass.getExtendsClass()!=null)
+  {
+    for(Attribute av:uClass.getExtendsClass().getAttributes())
+    {
+      if (av.isConstant() || av.getIsAutounique() || "internal".equals(av.getModifier()) || av.getIsDerived())
+      {
+        continue;
+      }
+
+      List<TraceItem> traceItems = av.getTraced("setMethod", uClass);
+
+      gen.setParameterConstraintName(av.getName());
+
+      String customSetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("setMethod",av)));
+      String customSetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("setMethod",av)));
+
+//      String customResetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("resetMethod",av)));
+//      String customResetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("resetMethod",av)));
+      
+      String customAddPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("addMethod",av)));
+      String customAddPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("addMethod",av)));
+
+//      String customRemovePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("removeMethod",av)));
+//      String customRemovePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("removeMethod",av)));
+
+      if(customSetPrefixCode!=null||customSetPostfixCode!=null)
+      {
+        if (av.getModifier().equals("defaulted"))
+        {
+          #>><<@ UmpleToJava.attribute_SetDefaulted_subclass >><<#
+        }
+        else if (av.getIsList())
+        {
+          #>><<@ UmpleToJava.attribute_SetMany_subclass >><<#
+        }
+        else if(!av.isImmutable()||av.getIsLazy())//if(customSetPrefixCode!=null&&customSetPostfixCode!=null&&customSetPrefixCode.matches("[\\s]*if.*\\n[\\s]*.*"))
+        {
+          #>><<@ UmpleToJava.attribute_Set_subclass >><<#
+        }
+      }    
+    }
+  }
+  gen.setParameterConstraintName("");
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_Set_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set_subclass.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    attribute_Set_subclass <<!<</*attribute_Set_subclass*/>>
+  public boolean <<= gen.translate("setMethod",av) >>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasSet = false;
+    <<# if (customSetPrefixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+      <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_s", uClass,gen.translate("parameterOne",av)):"")>>
+      wasSet = super.<<= gen.translate("setMethod",av) >>(<<=gen.translate("parameterOne",av)>>);
+      <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_s", uClass):"")>>
+    <<# if (customSetPostfixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+    return wasSet;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -1,0 +1,297 @@
+class UmpleToJava {
+    class_MethodDeclaration <<!<</*class_MethodDeclaration*/>><<#
+    if (uClass.hasMethods())
+    {
+      for (Method aMethod : uClass.getMethods()) 
+      {
+        List<TraceItem> traceItems= aMethod.getTraced("method",uClass);
+        
+        if(!aMethod.getExistsInLanguage("Java"))
+          continue;
+        
+          
+        Position p = aMethod.getCodePosition();
+        String positionHeader = "";        
+        
+        if (p != null) {
+//        use annotations instead
+        uClass.setSourceFilename( p.getFilename() );
+        positionHeader = "  // line " + p.getLineNumber() + " \"" + uClass.getRelativePath("Java") + "\"\n";
+//        positionHeader = "\n  @umplesourcefile(line={"+p.getLineNumber()+"},file={\""+p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/","")+ "\"},javaline={"+(javaline+4)+"},length={"+(aMethod.getIsImplemented()?2: aMethod.getMethodBody().getExtraCode().split("\\n").length+2)+"})";          
+        }
+        else 
+        {
+          p = aMethod.getPosition();
+//          positionHeader = "\n  @umplesourcefile(line={"+p.getLineNumber()+"},file={\""+p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/","")+ "\"},javaline={"+(javaline+3)+"},length={"+(aMethod.getIsImplemented()?2: aMethod.getMethodBody().getExtraCode().split("\\n").length+2)+"})";
+        }
+        String methodModifier = aMethod.getModifier().equals("") ? "public" : aMethod.getModifier();
+        String methodImplementationModifier = aMethod.getIsAbstract() ? " abstract" : "";
+        String methodName = aMethod.getName();
+        String methodType = aMethod.getType();
+        String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName()));
+        String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName()));
+        String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        
+        String customPostconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Postcondition"));
+        customPostconditionCode = customPostconditionCode==null?"":customPostconditionCode;
+
+        String methodBody = aMethod.getIsImplemented() ? "      return " + gen.translate(methodType) + ";" : aMethod.getMethodBody().getExtraCode();
+        String properMethodBody = "    " + methodBody; 
+        String override =  aMethod.getIsImplemented() ? "  @Override\n" : "";
+        String paramName="";
+        String paramType="";
+        String aSingleParameter="";
+        String isList="";
+        String finalParams = "";        
+        String finalParamsWithoutTypes = "";
+        if(methodName.equals("main")&&methodType.equals("void")&&methodModifier.contains("public")&&methodModifier.contains("static"))
+        {
+          String exceptionHandlerPackage = "";
+          if(mainMainClass!=null)
+          {
+            exceptionHandlerPackage = mainMainClass.getPackageName()+"."+mainMainClass.getName()+".";
+          }
+          else
+          {
+            mainMainClass = uClass;
+          }
+          properMethodBody = "    Thread.currentThread().setUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+
+                             "    Thread.setDefaultUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+properMethodBody;
+          uClass.setHasMainMethod(true);
+        }
+        StringBuilder parameters = new StringBuilder();
+        StringBuilder parametersWithoutTypes = new StringBuilder();
+        if (aMethod.hasMethodParameters())
+        {
+          for (MethodParameter aMethodParam : aMethod.getMethodParameters()) 
+          {
+            paramName = aMethodParam.getName();
+            paramType = aMethodParam.getType();
+            isList = aMethodParam.getIsList() ? " [] " : " ";
+            aSingleParameter = paramType + isList + paramName;
+            parameters.append(aSingleParameter + ", ");
+            parametersWithoutTypes.append(aMethodParam.getName() + ", ");
+          }
+          
+          finalParams = parameters.toString().substring(0, parameters.toString().length()-2);
+          finalParamsWithoutTypes = parametersWithoutTypes.toString().substring(0, parametersWithoutTypes.toString().length()-2);
+        }
+        
+        if (aMethod.numberOfComments() > 0) { append(realSb, "\n\n  {0}", Comment.format("Method Javadoc",aMethod.getComments())); }
+        
+        append(realSb,"\n");
+        int javaline = realSb.toString().split("\\n").length+(aMethod.numberOfComments() > 0?0:1);
+
+        StringBuilder methodExceptionsBuilder = new StringBuilder();
+        if(aMethod.getExceptions()!=null&&aMethod.numberOfExceptions()>0)
+        {
+          methodExceptionsBuilder.append(" throws ");
+          String exceptioncomma = "";
+          for(String methodException:aMethod.getExceptions())
+          {
+            if(!"".equals(methodException))
+            {
+              methodExceptionsBuilder.append(exceptioncomma);
+              methodExceptionsBuilder.append(methodException);
+              exceptioncomma = ",";
+            }
+          }
+        }
+        String methodExceptions = methodExceptionsBuilder.toString();
+
+        if(!"".equals(customPostconditionCode))
+        {
+          StringBuilder lineNumbers = new StringBuilder();
+          StringBuilder javaLineNumbers = new StringBuilder();
+          StringBuilder filenames = new StringBuilder();
+          StringBuilder lengths = new StringBuilder();
+          String comma = "";
+          if(p!=null)
+          {
+            int previousConditionsFound = 0;
+            for(Postcondition condition:uClass.getPostconditions())
+            {
+              if(condition.getMethod().equals(aMethod)&&condition.getPosition()!=null)
+              {
+                lineNumbers.append(comma+(condition.getPosition().getLineNumber()));
+                filenames.append(comma+condition.getPosition().getFilename());
+                javaLineNumbers.append(comma+(javaline+7+3*previousConditionsFound));
+                lengths.append(comma+"1");
+                comma = ",";
+                previousConditionsFound++;
+              }
+            }
+          }
+          if(!"".equals(lineNumbers.toString())){
+            String positionEndHeader = "\n";
+          }
+                    
+          append(realSb,positionHeader);
+          append(realSb,override);
+          append(realSb, "{5}  {0}{1} {2} {3}({4}){6}", methodModifier, methodImplementationModifier, methodType, methodName, finalParams, positionHeader, methodExceptions);
+        
+          appendln(realSb, "{");
+          if(!"".equals(methodType)&&!"void".equals(methodType))
+          {
+            append(realSb, "    {0} result = {1}_Original({2});\n", methodType, methodName, finalParamsWithoutTypes);
+          }
+          else
+          {
+            append(realSb, "    {0}_Original({1});\n", methodName, finalParamsWithoutTypes);
+          }
+          appendln(realSb, GeneratorHelper.doIndent(customPostconditionCode, "    "));
+          if(!"".equals(methodType)&&!"void".equals(methodType))
+          {
+            append(realSb, "    return result;\n");
+            javaline++;
+          }          
+          appendln(realSb, "  }");
+          
+          javaline+= 5+customPostconditionCode.split("\\n").length;
+          append(realSb, "\n  {0}{1} {2} {3}_Original({4}){5}", methodModifier, methodImplementationModifier, methodType, methodName, finalParams, methodExceptions);
+        }
+        else
+        {
+          append(realSb,override);
+          append(realSb, "{5}  {0}{1} {2} {3}({4}){6}", methodModifier, methodImplementationModifier, methodType, methodName, finalParams, positionHeader, methodExceptions);
+        }
+        if(aMethod.getIsAbstract())
+        {
+          append(realSb, ";");
+        }
+        else
+        {
+          appendln(realSb, "{");
+          for( TraceItem traceItem : traceItems )append(realSb, (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, aMethod,"me_e", uClass):""));
+          if (customPreconditionCode != null) { append(realSb, "\n{0}\n",GeneratorHelper.doIndent(customPreconditionCode, "    "));}
+          if (customBeforeInjectionCode != null) { append(realSb, "{0}\n",GeneratorHelper.doIndent(customBeforeInjectionCode, "    "));}
+          
+          addUncaughtExceptionVariables(methodName,p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/",""),p.getLineNumber(),javaline,realSb.toString().split("\\n").length+1-javaline);
+          String traceCode = "";
+          if(properMethodBody.contains("return"))
+          {
+            for( TraceItem traceItem : traceItems )traceCode += (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, aMethod,"me_x", uClass):"");
+              properMethodBody = properMethodBody.replaceAll("return", traceCode + "return");
+
+            if(customAfterInjectionCode != null) {
+              // Do some pre-processing to handle returns not being on a new line. Doing this allows us to maintain suitable indentation.
+              String[] properMethodLines = properMethodBody.split("\\n");
+              String fixedProperMethodBody = "";
+              for(int i = 0; i < properMethodLines.length; i++) {
+                if(properMethodLines[i].contains("return") && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
+                  String[] splitLines = properMethodLines[i].split("return", 2); 
+                  // Determine indentation of return by adding indentation amount to previous line
+                  String returnIndent = "";
+                  int j = 0;
+                  while(splitLines[0].charAt(j) == ' ') {
+                    returnIndent += " ";
+                    j++;
+                  }
+
+                  fixedProperMethodBody += returnIndent + splitLines[0].trim() + "\n";
+
+                  String[] returnLines = splitLines[1].split(";");
+                  if(returnLines.length > 1 && returnLines[1].trim().length() > 0) {
+                    fixedProperMethodBody += returnIndent + "  return " + returnLines[0].trim() + ";\n" + returnIndent + returnLines[1].trim() + "\n"; 
+                  } else {
+                    fixedProperMethodBody += returnIndent + "  return " + splitLines[1].trim() + "\n"; 
+                  }
+                } else {
+                  fixedProperMethodBody += properMethodLines[i] + "\n";
+                }
+              }
+
+              properMethodBody = fixedProperMethodBody;
+
+              String properMethodIndent = "";
+              int indentIndex = 0;
+              while(indentIndex < properMethodBody.length() && properMethodBody.charAt(indentIndex) == ' ') {
+                properMethodIndent += " ";
+                indentIndex++;
+              }
+
+              // inject the after injection code after every return, while appropriate indentation
+              for(int i = -1; (i = properMethodBody.indexOf("return", i + 1)) != -1; ) {
+                // determine the indentation of the return
+                String indent = "";
+                while(i >= 1 && properMethodBody.charAt(--i) == ' ') {
+                  indent += " ";
+                }
+
+                // Need to determine if block has braces surrounding it. To do this, take the previous
+                // lines of code and apply some regex to remove all of the comments.
+                String[] previousLinesOfCode = properMethodBody.substring(0, i+1).replaceAll("\\/\\*([\\S\\s]+?)\\*\\/", "").replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//.*$", "").split("\\n");
+                int commentLineCount = properMethodBody.substring(0, i+1).split("\\n").length - previousLinesOfCode.length;
+
+                // set previousLine to be the first non-empty line
+                int previousLine = -1; 
+                for(int j = previousLinesOfCode.length - 1; j >= 0; j--) {
+                  if(previousLinesOfCode[j].trim().length() > 0) {
+                    previousLine = j;
+                    break;
+                  }
+                }
+
+                String previousLineStr = previousLinesOfCode[previousLine].trim();
+
+                // Need to subtract the number of lines of comments between the return and the previous line of code
+                while(!properMethodBody.split("\\n")[previousLine + commentLineCount].trim().equals(previousLineStr)) {
+                  commentLineCount--;
+                }
+              
+                // If we need to, insert braces, otherwise continue as normal
+                String indentedCustomAfterInjectionCode = GeneratorHelper.doIndent("\n" + customAfterInjectionCode, indent);
+                String braceIndent = "";
+                String brace = "";
+                String braceNewLine = "";
+                if(previousLine != -1 && (previousLineStr.charAt(previousLineStr.length()-1) == ')' || (previousLineStr.length() >= 4 && previousLineStr.substring(previousLineStr.length()-4).equals("else")))) {
+                  String[] methodLines = properMethodBody.split("\\n");
+                  previousLine += commentLineCount;
+
+                  // determine how indented the brace is
+                  int j = 0;
+                  while(j < methodLines[previousLine].length() && methodLines[previousLine].charAt(j) == ' ') {
+                    braceIndent += " ";
+                    j++;
+                  }
+
+                  methodLines[previousLine] = braceIndent + methodLines[previousLine].trim() + " {"; 
+
+                  // Set properMethodBody to be String.join(methodLines, "\\n")
+                  String newProperMethodBody = "";
+                  for(int k = 0; k < methodLines.length; k++) {
+                    newProperMethodBody += methodLines[k];
+                    if(k != methodLines.length - 1) {
+                      newProperMethodBody += "\n";
+                    }
+                  }
+                  properMethodBody = newProperMethodBody;
+
+                  brace = "}";
+                  braceNewLine = "\n";
+                }
+
+                i += indent.length() + 1;
+                String[] returnAndRest = properMethodBody.substring(i).split(";", 2);
+                properMethodBody = properMethodIndent + properMethodBody.substring(0, i).trim() + indentedCustomAfterInjectionCode + "\n" + indent + returnAndRest[0].trim() + ";" + braceNewLine + braceIndent + brace + returnAndRest[1]; 
+                i += indentedCustomAfterInjectionCode.length() + braceIndent.length() + 7;
+              }
+
+              // if the last line isn't a return, insert the injection at the very end
+              String[] lines = properMethodBody.split("\\n");
+              if(!lines[lines.length-1].contains("return")) {
+                properMethodBody += GeneratorHelper.doIndent("\n" + customAfterInjectionCode, "    ");
+              }
+            }
+          }
+          appendln(realSb, properMethodBody);
+          if(!properMethodBody.contains("return"))
+          {
+            for( TraceItem traceItem : traceItems )append(realSb, (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, aMethod,"me_x", uClass):""));
+            if (customAfterInjectionCode != null) { append(realSb, "{0}\n",GeneratorHelper.doIndent(customAfterInjectionCode, "    "));}
+          }
+          appendln(realSb, "  }");
+        }
+      }
+    }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignDefault.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignDefault.ump
@@ -1,0 +1,42 @@
+use constructor_AssociationAssignMandatoryMany.ump;
+use constructor_AssociationAssignOne.ump;
+
+
+class UmpleToJava {
+    constructor_AssociationAssignDefault <<!<</*constructor_AssociationAssignDefault*/>><<#
+  if (!av.getIsNavigable())
+  {
+    continue;
+  }
+
+  // if it's a specialization, skip the association code for the av
+  if ( reqSuperCode || reqCommonCode )
+  {
+    continue;
+  }
+
+  if (av.isOnlyOne())
+  {
+    #>><<@ UmpleToJava.constructor_AssociationAssignOne >><<#
+  }
+  else if (av.isOptionalMany())
+  {
+    appendln(realSb,"");
+    append(realSb, "    {0} = new ArrayList<{1}>();", gen.translate("associationMany",av), gen.getType(av));
+  }
+  else if (av.isMandatoryMany())
+  {
+    #>><<@ UmpleToJava.constructor_AssociationAssignMandatoryMany >><<#
+  }
+  else if (av.getMultiplicity().getLowerBound() > 0)
+  {
+    #>><<=gen.translate("associationMany",av)>> = new ArrayList<<<=gen.getType(av)>>>();
+    <<=gen.translate("associationMany",av)>>.add(<<=gen.translate("parameterOne",av)>>);<<#
+  }
+  else
+  {
+    continue;
+  }
+  hasBody = true;
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignImmutableOptionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignImmutableOptionalMany.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    constructor_AssociationAssignImmutableOptionalMany <<!<</*constructor_AssociationAssignImmutableOptionalMany*/>>
+    <<=gen.translate("associationMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    boolean <<=gen.translate("didAddMany",av)>> = <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterAll",av)>>);
+    if (!<<=gen.translate("didAddMany",av)>>)
+    {
+      throw new RuntimeException("Unable to create <<=gen.relatedTranslate("type",av)>>, must not have duplicate <<=gen.translate("associationMany",av)>>.");
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignImmutableOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignImmutableOptionalN.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    constructor_AssociationAssignImmutableOptionalN <<!<</*constructor_AssociationAssignImmutableOptionalN*/>><<# String requiredNumber = StringFormatter.format("{0}", av.getMultiplicity().getUpperBound()); #>>
+    <<=gen.translate("associationMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    boolean <<=gen.translate("didAddMany",av)>> = <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterAll",av)>>);
+    if (!<<=gen.translate("didAddMany",av)>>)
+    {
+      throw new RuntimeException("Unable to create <<=gen.relatedTranslate("type",av)>>, must have <<=requiredNumber>> or fewer <<=gen.translate("associationMany",av)>>, no duplicates.");
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignImmutableOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignImmutableOptionalOne.ump
@@ -1,0 +1,5 @@
+class UmpleToJava {
+    constructor_AssociationAssignImmutableOptionalOne <<!<</*constructor_AssociationAssignImmutableOptionalOne*/>><<#   
+    append(realSb, "\n    {0}({1});", gen.translate("setMethod",av), gen.translate("parameterOne",av));
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignMandatoryMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignMandatoryMany.ump
@@ -1,0 +1,24 @@
+class UmpleToJava {
+    constructor_AssociationAssignMandatoryMany <<!<</*constructor_AssociationAssignMandatoryMany*/>><<#
+  String requiredNumber = "";
+  if (av.isN())
+  {
+    requiredNumber += av.getMultiplicity().getLowerBound();
+  }
+  else if (av.isStar())
+  {
+    requiredNumber = StringFormatter.format("at least {0}", av.getMultiplicity().getLowerBound());
+  }
+  else
+  {
+    requiredNumber = StringFormatter.format("{0} to {1}", av.getMultiplicity().getLowerBound(), av.getMultiplicity().getUpperBound());
+  }
+  
+#>>
+    <<=gen.translate("associationMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();
+    boolean <<=gen.translate("didAddMany",av)>> = <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("parameterAll",av)>>);
+    if (!<<=gen.translate("didAddMany",av)>>)
+    {
+      throw new RuntimeException("Unable to create <<=gen.relatedTranslate("type",av)>>, must have <<=requiredNumber>> <<=gen.translate("associationMany",av)>>");
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignOne.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    constructor_AssociationAssignOne <<!<</*constructor_AssociationAssignOne*/>>
+    boolean <<=gen.translate("didAdd",av)>> = <<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>);
+    if (!<<=gen.translate("didAdd",av)>>)
+    {
+      throw new RuntimeException("Unable to create <<=gen.relatedTranslate("associationOne",av)>> due to <<=gen.translate("associationOne",av)>>");
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignOneToOne.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    constructor_AssociationAssignOneToOne <<!<</*constructor_AssociationAssignOneToOne*/>>
+    if (<<=gen.translate("parameterOne",av)>> == null || <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("getMethod",av)>>() != null)
+    {
+      throw new RuntimeException("Unable to create <<=gen.relatedTranslate("type",av)>> due to <<=gen.translate("parameterOne",av)>>");
+    }
+    <<=gen.translate("associationOne",av)>> = <<=gen.translate("parameterOne",av)>>;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignOptionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignOptionalMany.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    constructor_AssociationAssignOptionalMany <<!<</*constructor_AssociationAssignOptionalMany*/>>
+    <<=gen.translate("associationMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignUndirectionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationAssignUndirectionalOne.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    constructor_AssociationAssignUndirectionalOne <<!<</*constructor_AssociationAssignUndirectionalOne*/>>
+    if (!<<=gen.translate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>))
+    {
+      throw new RuntimeException("Unable to create <<=gen.relatedTranslate("type",av)>> due to <<=gen.translate("parameterOne",av)>>");
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AssociationCreateOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AssociationCreateOneToOne.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    constructor_AssociationCreateOneToOne <<!<</*constructor_AssociationCreateOneToOne*/>>
+    <<=gen.translate("associationOne",av)>> = new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsForMandatory",relatedAssociation)>>);!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssign.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssign.ump
@@ -1,0 +1,6 @@
+class UmpleToJava {
+    constructor_AttributeAssign <<!<</*constructor_AttributeAssign*/>><<#
+  String parameterLookup = av.getValue() == null || av.getModifier().equals("fixml") ? "parameterOne" : "parameterValue";
+#>>
+    <<=gen.translate("attributeOne",av)>> = <<=gen.translate(parameterLookup,av)>>;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignAutounique.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignAutounique.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    constructor_AttributeAssignAutounique <<!<</*constructor_AttributeAssignAutounique*/>>
+    <<=gen.translate("attributeOne",av)>> = <<=gen.translate("parameterNext",av)>>++;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignDefaulted.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignDefaulted.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    constructor_AttributeAssignDefaulted <<!<</*constructor_AttributeAssignDefaulted*/>>
+    <<=gen.translate("resetMethod",av)>>();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignImmutable.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignImmutable.ump
@@ -1,0 +1,6 @@
+class UmpleToJava {
+    constructor_AttributeAssignImmutable <<!<</*constructor_AttributeAssignImmutable*/>><<#
+  String parameterLookup = av.getValue() == null ? "parameterOne" : "parameterValue";
+#>>
+    <<=gen.translate("attributeOne",av)>> = <<=gen.translate(parameterLookup,av)>>;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignLazy.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignLazy.ump
@@ -1,0 +1,39 @@
+class UmpleToJava {
+    constructor_AttributeAssignLazy <<!<</*constructor_AttributeAssignLazy*/>><<#
+  String parameterLookup = null; // av.getValue() == null ? "parameterOne" : "parameterValue";
+  String defaultValue = null;
+  
+ 
+  if(av.getValue() == null)
+  {
+     // Try to assign a null value or 0 value if we recognize
+     // one of Umple's built in data types. (http://cruise.site.uottawa.ca/umple/UmpleBuiltinDataTypes.html)
+
+     if(av.getType().equals("String") || av.getType().equals("Date") || av.getType().equals("Time"))
+     {
+  	   defaultValue = "null";
+     }
+     else if(av.getType().equals("Double") || av.getType().equals("Integer"))
+     {
+       defaultValue = "0";
+     }
+     else if(av.getType().equals("Float"))
+     {
+  	   defaultValue = "0.0f";
+     }
+     else if(av.getType().equals("Boolean"))
+     {
+  	   defaultValue = "false";
+     }
+   }
+   else
+   {
+       defaultValue = gen.translate("parameterValue",av);
+   }
+  
+  // Only assign a value if we could find a default
+  if(defaultValue != null)
+  { #>>
+    <<=gen.translate("attributeOne",av)>> = <<=defaultValue >>;
+<<#} #>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignList.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignList.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    constructor_AttributeAssignList <<!<</*constructor_AttributeAssignList*/>>
+    <<=gen.translate("attributeMany",av)>> = new ArrayList<<<=gen.translate("typeMany",av)>>>();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignUnique.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeAssignUnique.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    constructor_AttributeAssignUnique <<!<</*constructor_AttributeAssignUnique*/>>
+    if (!<<=gen.translate("setMethod", av)>>(<<=gen.translate("parameterOne", av)>>))
+    {
+      throw new RuntimeException("Cannot create due to duplicate <<=av.getName()>>");
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_AttributeUnassignedImmutable.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_AttributeUnassignedImmutable.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    constructor_AttributeUnassignedImmutable <<!<</*constructor_AttributeUnassignedImmutable*/>>
+    <<=gen.translate("attributeCanSet",av)>> = true;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_DeclareDefault.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_DeclareDefault.ump
@@ -1,0 +1,370 @@
+use constructor_AssociationAssignDefault.ump;
+use constructor_AssociationAssignImmutableOptionalMany.ump;
+use constructor_AssociationAssignImmutableOptionalN.ump;
+use constructor_AssociationAssignImmutableOptionalOne.ump;
+use constructor_AssociationAssignMandatoryMany.ump;
+use constructor_AssociationAssignOneToOne.ump;
+use constructor_AssociationAssignOptionalMany.ump;
+use constructor_AssociationAssignUndirectionalOne.ump;
+use constructor_AttributeAssign.ump;
+use constructor_AttributeAssignAutounique.ump;
+use constructor_AttributeAssignDefaulted.ump;
+use constructor_AttributeAssignImmutable.ump;
+use constructor_AttributeAssignLazy.ump;
+use constructor_AttributeAssignList.ump;
+use constructor_AttributeAssignUnique.ump;
+use constructor_AttributeUnassignedImmutable.ump;
+use constructor_NestedStateMachineAssignDefault.ump;
+use constructor_Singleton.ump;
+use constructor_StateMachineAssignDefault.ump;
+use specializationCode_Constructor.ump;
+
+
+class UmpleToJava {
+    constructor_DeclareDefault <<!<</*constructor_DeclareDefault*/>><<#
+
+  String customConstructorPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before","constructor"));
+  String customConstructorPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after","constructor"));
+
+  String accessibility = uClass.getIsSingleton() ? "private" : "public";
+  append(realSb,"\n  {0} {1}({2})",new Object[] {accessibility, uClass.getName(), gClass.getLookup("constructorSignature")});
+
+  String extraNote = null;
+  
+  appendln(realSb, "");
+  
+  boolean hasBody = false;
+
+  append(realSb, "  {");
+  if (!uClass.isRoot() && !"interface".equals(uClass.getExtendsClass().getModifier()))
+  {
+    appendln(realSb, "");
+    append(realSb, "    super({0});", gClass.getParentClass().getLookup("constructorSignature_caller"));
+    hasBody = true;
+  }
+  
+  if (customConstructorPrefixCode != null)
+  {
+    addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customConstructorPrefixCode,uClass.getName());
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customConstructorPrefixCode, "    "));
+    hasBody = true;
+  }
+
+  if (uClass.getKey().isProvided())
+  {
+    hasBody = true;
+    appendln(realSb, "");
+    append(realSb, "    cachedHashCode = -1;");
+  }
+  
+  for(String memberId : uClass.getKey().getMembers())
+  {
+    Attribute av = uClass.getAttribute(memberId);
+    AssociationVariable as = uClass.getAssociationVariable(memberId);
+    if (av != null  && !av.isImmutable())
+    {
+      hasBody = true;
+      appendln(realSb, "");
+      append(realSb, "    {0} = true;", gen.translate("attributeCanSet",av));
+    }
+    else if (as != null)
+    {
+      hasBody = true;
+      appendln(realSb, "");
+      append(realSb, "    {0} = true;", gen.translate("associationCanSet",as));
+    }
+  } 
+  
+  for (Attribute av : uClass.getAttributes())
+  {
+    if (av.getIsAutounique() || av.getIsUnique() || av.isConstant() || "theInstance".equals(gen.translate("attributeOne",av)) || av.getIsDerived())
+    {
+      continue;
+    }
+    
+    List<TraceItem> traceItems= av.getTraced("constructor",uClass);
+    
+    if (av.getIsList())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignList >><<#
+    }
+    else if ("defaulted".equals(av.getModifier()))
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignDefaulted >><<# 
+    }
+    else if (av.isImmutable() && av.getIsLazy())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeUnassignedImmutable >><<#
+    }
+    else if (av.isImmutable())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignImmutable >><<# 
+    }
+    else
+    {
+      hasBody = true;
+      if(!av.getIsLazy()){
+         #>><<@ UmpleToJava.constructor_AttributeAssign >><<#
+      }
+      else
+      {
+         #>><<@ UmpleToJava.constructor_AttributeAssignLazy >><<#
+      }
+    }
+    
+    if(!traceItems.isEmpty())
+    {
+#>>
+    ( new Thread()
+    {
+      Thread thread;
+      {
+        thread = Thread.currentThread();
+      }
+      public void run()
+      {
+        while( thread.isAlive() )
+        {
+          <<# for( TraceItem traceItem : traceItems ) #>><<= traceItem.trace(gen,av,"at_p",uClass) >>
+          try
+          {
+            Thread.sleep(<<# for( TraceItem traceItem : traceItems ) #>><<= traceItem.getPeriodClause() >>);
+          }
+          catch (InterruptedException e)
+          {
+            e.printStackTrace();
+          }
+        }
+      }
+    }
+    ).start();<<#
+    }
+  }
+
+  for (Attribute av : uClass.getAttributes())
+  {
+    if (av.getIsAutounique())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignAutounique >><<#
+    }
+    else if (av.getIsUnique())
+    {
+   	  hasBody = true;
+   	  #>><<@ UmpleToJava.constructor_AttributeAssignUnique >><<#
+    }
+  }
+  
+  for (AssociationVariable av : uClass.getAssociationVariables())
+  {
+
+    #>><<@ UmpleToJava.specializationCode_Constructor >><<#
+
+    if (!av.getIsNavigable() || !av.isImmutable())
+    {
+      continue;
+    }
+    append(realSb, "\n    {0} = true;", gen.translate("associationCanSet",av));
+  }
+  boolean doneOnce=false;
+  String firstSorted = "";
+  for (AssociationVariable av : uClass.getAssociationVariables()) 
+  {
+
+    #>><<@ UmpleToJava.specializationCode_Constructor >><<#
+
+  	if (av.isOnlyOne() && av.getRelatedAssociation().isMany() && av.getRelatedAssociation().isSorted() && av.getIsNavigable())
+  	{
+  		if("".equals(firstSorted))
+  		{
+  			firstSorted = gen.translate("attributeOne",av) + "=" + gen.translate("parameterOne",av) + ";";
+  		}
+  		else
+  		{
+  			if(!doneOnce)
+  			{
+  				append(realSb,"\n    {0}\n    {1}\n    {2}","// Direct set of variable needed to ensure consistency","// for multiple sorted associations",firstSorted);
+  				doneOnce = true;
+  			}	
+  			append(realSb,"\n    {0}={1};", gen.translate("attributeOne",av),gen.translate("parameterOne",av));
+    	}
+  	}
+  }
+  for (AssociationVariable av : uClass.getAssociationVariables()) 
+  {
+    #>><<@ UmpleToJava.specializationCode_Constructor >><<#
+    
+    if (!av.getIsNavigable())
+    {
+      continue;
+    }
+    
+    if (!relatedAssociation.getIsNavigable())
+    {
+      if (av.isOnlyOne())
+      {
+        hasBody = true;
+        #>><<@ UmpleToJava.constructor_AssociationAssignUndirectionalOne >><<#
+      }
+      else if (av.isOptionalOne() && av.isImmutable())
+      {
+        hasBody = true;
+        #>><<@ UmpleToJava.constructor_AssociationAssignImmutableOptionalOne >><<#
+      }
+      else if (av.isMandatoryMany())
+      {
+        hasBody = true;
+        #>><<@ UmpleToJava.constructor_AssociationAssignMandatoryMany >><<#
+      }
+      else if (av.isOptionalN() && av.isImmutable())
+      {
+        hasBody = true;
+        #>><<@ UmpleToJava.constructor_AssociationAssignImmutableOptionalN >><<#
+      }
+      else if (av.isMany() && av.isImmutable())
+      {
+      	hasBody = true;
+        #>><<@ UmpleToJava.constructor_AssociationAssignImmutableOptionalMany >><<#
+      }
+      else if (av.isMany())
+      {
+        hasBody = true;
+        #>><<@ UmpleToJava.constructor_AssociationAssignOptionalMany >><<#
+      }
+      continue;
+    }
+    
+    if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AssociationAssignOneToOne >><<#
+    }
+    else if ((av.isMN() || av.isN()) && (relatedAssociation.isMandatory() || relatedAssociation.isOptionalN()))
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AssociationAssignOptionalMany >><<#
+    }
+    else
+    {
+      #>><<@ UmpleToJava.constructor_AssociationAssignDefault >><<#
+    }
+  }
+  
+  boolean foundQueued=false;
+  boolean foundPooled=false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    State state = sm.getStartState();
+    if (state == null)
+    {
+      continue;
+    }
+    hasBody = true;
+    for (StateMachine nestedSm : sm.getNestedStateMachines())
+    {
+      #>><<@ UmpleToJava.constructor_NestedStateMachineAssignDefault >><<#
+    }
+    #>><<@ UmpleToJava.constructor_StateMachineAssignDefault >><<#
+    if (sm.isQueued())
+    {
+      foundQueued = true;
+    }
+    if (sm.isPooled())
+    {
+      foundPooled = true;
+    }
+  }
+  if(foundQueued == true)
+  {
+    append(realSb,"\n    queue = new MessageQueue();");
+    append(realSb,"\n    removal=new Thread(this);");
+    append(realSb,"\n    //start the thread of {0}", uClass.getName());
+    append(realSb,"\n    removal.start();");
+  }
+  if(foundPooled == true)
+  {
+    append(realSb,"\n    pool = new MessagePool();");
+    append(realSb,"\n    removal=new Thread(this);");
+    append(realSb,"\n    //start the thread of {0}", uClass.getName());
+    append(realSb,"\n    removal.start();");
+  }
+  
+  if (customConstructorPostfixCode != null)
+  {
+    addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customConstructorPostfixCode,uClass.getName());
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customConstructorPostfixCode, "    "));
+    hasBody = true;
+  }
+
+  if (hasBody)
+  {
+    appendln(realSb, "");
+    append(realSb, "  }");
+  }
+  else
+  {
+    append(realSb, "}");
+  }
+  
+  // fixml attribute (create empty constructor)
+  boolean fixmlAttr = false;
+  boolean emptyConstructor = false;
+  
+  for (Attribute av : uClass.getAttributes())
+	  if ("fixml".equals(av.getModifier()))
+	  {
+		  fixmlAttr = true;
+		  break;
+	  }
+
+  for( CodeInjection ci  : uClass.getCodeInjections())
+	  if( ci.getOperation().equals("emptyConstructor"))
+	  {
+		  emptyConstructor = true;
+		  break;
+	  }
+
+  for (Attribute av : uClass.getAttributes())
+  {
+	  if ("fixml".equals(av.getModifier()))
+	  {
+		  accessibility = uClass.getIsSingleton() ? "private" : "public";
+		  appendln(realSb,"");
+		  appendln(realSb,"");
+		  appendln(realSb,"  {0} {1}()",new Object[] {accessibility, uClass.getName()});
+		  appendln(realSb,"  {");
+		  for (Attribute a : uClass.getAttributes())
+			  if ("fixml".equals(a.getModifier()) && a.getValue() != null )
+				  append(realSb, "    {0} = {1};\n", a.getName(),a.getValue());
+		  for( CodeInjection ci  : uClass.getCodeInjections())
+			  if( ci.getOperation().equals("emptyConstructor"))
+				  appendln(realSb,"    {0}",ci.getCode());
+		  appendln(realSb,"  }");
+		  break;
+	  }
+  }
+
+  if( fixmlAttr == false && emptyConstructor == true )
+  {
+	  accessibility = uClass.getIsSingleton() ? "private" : "public";
+	  appendln(realSb,"");
+	  appendln(realSb,"");
+	  appendln(realSb,"  {0} {1}()",new Object[] {accessibility, uClass.getName()});
+	  appendln(realSb,"  {");
+	  for( CodeInjection ci  : uClass.getCodeInjections())
+		  if( ci.getOperation().equals("emptyConstructor"))
+			  appendln(realSb,"    {0}",ci.getCode());
+	  appendln(realSb,"  }");
+  }
+
+  if (uClass.getIsSingleton())
+  {
+    appendln(realSb, "");
+    #>><<@ UmpleToJava.constructor_Singleton >><<#
+  }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_DeclareOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_DeclareOneToOne.ump
@@ -1,0 +1,112 @@
+use constructor_AssociationAssignDefault.ump;
+use constructor_AssociationAssignOptionalMany.ump;
+use constructor_AssociationCreateOneToOne.ump;
+use constructor_AttributeAssign.ump;
+use constructor_AttributeAssignAutounique.ump;
+use constructor_AttributeAssignDefaulted.ump;
+use constructor_AttributeAssignLazy.ump;
+use constructor_AttributeAssignList.ump;
+use specializationCode_Constructor.ump;
+
+
+class UmpleToJava {
+    constructor_DeclareOneToOne <<!<</*constructor_DeclareOneToOne*/>><<#
+  
+  String signature = gClass.getLookup("constructorSignature_mandatory");
+  hasBody = false;
+#>>
+
+  public <<=uClass.getName()>>(<<=gen.translate("constructorMandatory",uClass)>>)
+  {
+<<#
+  if (!uClass.isRoot())
+  {
+    appendln(realSb, "");
+    append(realSb, "    super({0});", gClass.getParentClass().getLookup("constructorSignature_caller"));
+    hasBody = true;
+  }
+  
+  if (customConstructorPrefixCode != null) 
+  {
+    addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customConstructorPrefixCode,uClass.getName());
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customConstructorPrefixCode, "    "));
+    hasBody = true;
+  }
+  
+  for (Attribute av : uClass.getAttributes())
+  {
+    if (av.getIsAutounique() || av.isConstant() || "theInstance".equals(gen.translate("attributeOne",av)))
+    {
+      continue;
+    }
+  
+    if (av.getIsList())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignList >><<#
+    }
+    else if (av.getModifier().equals("defaulted"))
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignDefaulted >><<# 
+    }
+    else if (av.getIsLazy())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignLazy >><<#
+    }
+    else
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssign >><<#
+    }
+  }
+
+  for (Attribute av : uClass.getAttributes())
+  {
+    if (av.getIsAutounique())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignAutounique >><<#
+    }
+  }
+  
+  for (AssociationVariable av : uClass.getAssociationVariables()) 
+  {
+    #>><<@ UmpleToJava.specializationCode_Constructor >><<#
+    
+    if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AssociationCreateOneToOne >><<#
+    }
+    else if ((av.isMN() || av.isN()) && (relatedAssociation.isMandatory() || relatedAssociation.isOptionalN()))
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AssociationAssignOptionalMany >><<#
+    }
+    else
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AssociationAssignDefault >><<#
+    }
+  }
+  
+  if (customConstructorPostfixCode != null) 
+  {
+    addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customConstructorPostfixCode,uClass.getName());
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customConstructorPostfixCode, "    "));
+    hasBody = true;
+  }
+  
+  if (hasBody)
+  {
+    appendln(realSb, "");
+    append(realSb, "  }");
+  }
+  else
+  {
+    append(realSb, "}");
+  }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_Declare_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_Declare_All.ump
@@ -1,0 +1,28 @@
+use constructor_DeclareDefault.ump;
+use constructor_DeclareOneToOne.ump;
+use specializationCode_Constructor.ump;
+
+
+class UmpleToJava {
+    constructor_Declare_All <<!<</*constructor_Declare_All*/>><<#
+  boolean isOneToOne = false;
+
+  for (AssociationVariable av : uClass.getAssociationVariables()) 
+  {
+
+   #>><<@ UmpleToJava.specializationCode_Constructor >><<#
+
+    if (av.isOnlyOne() && relatedAssociation.isOnlyOne() && av.getIsNavigable() && relatedAssociation.getIsNavigable())
+    {
+      isOneToOne = true;
+      break;
+    }
+  }
+  #>><<@ UmpleToJava.constructor_DeclareDefault >><<#
+  if (isOneToOne)
+  {
+    #>><<@ UmpleToJava.constructor_DeclareOneToOne >><<#
+  }
+
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_NestedStateMachineAssignDefault.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_NestedStateMachineAssignDefault.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    constructor_NestedStateMachineAssignDefault <<!<</*constructor_NestedStateMachineAssignDefault*/>>
+    <<=gen.translate("setMethod",nestedSm)>>(<<=gen.translate("type",nestedSm)>>.<<=gen.translate("stateNull",nestedSm)>>);
+    <<#if (nestedSm.getContainsDeepHistoryState()){#>>
+    <<=gen.translate("stateMachineOne",nestedSm)>>HStar = <<=gen.translate("type",nestedSm)>>.<<=nestedSm.getState(1).getName()>>;<<#}#>>
+    <<#if (nestedSm.getContainsHistoryState()){#>>
+    <<=gen.translate("stateMachineOne",nestedSm)>>H = <<=gen.translate("type",nestedSm)>>.<<=nestedSm.getState(1).getName()>>;<<#}#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_Singleton.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_Singleton.ump
@@ -1,0 +1,11 @@
+class UmpleToJava {
+    constructor_Singleton <<!<</*constructor_Singleton*/>>
+  public static <<=uClass.getName()>> getInstance()
+  {
+    if(theInstance == null)
+    {
+      theInstance = new <<=uClass.getName()>>();
+    }
+    return theInstance;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/constructor_StateMachineAssignDefault.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_StateMachineAssignDefault.ump
@@ -1,0 +1,13 @@
+class UmpleToJava {
+    constructor_StateMachineAssignDefault <<!<</*constructor_StateMachineAssignDefault*/>>
+    <<=gen.translate("setMethod",sm)>>(<<=gen.translate("type",sm)>>.<<=gen.translate("stateOne",state)>>);
+<<#
+    for (StateMachine smq : uClass.getStateMachines())
+    {
+      if (smq.isQueued() || smq.isPooled())
+      {
+        //nothing to do
+      }
+    }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_All.ump
@@ -1,0 +1,381 @@
+use delete_MandatoryFromOptionalOne.ump;
+use delete_MandatoryFromOptionalOne_specialization.ump;
+use delete_ManyFromMN.ump;
+use delete_ManyFromMN_specialization.ump;
+use delete_ManyFromMN_specialization_relCommon.ump;
+use delete_ManyFromMany.ump;
+use delete_ManyFromMany_specialization.ump;
+use delete_ManyFromOne.ump;
+use delete_ManyFromOne_specialization.ump;
+use delete_ManyFromOptionalOne.ump;
+use delete_ManyFromOptionalOne_specialization.ump;
+use delete_ManyFromX_comp.ump;
+use delete_ManyFromX_comp_specialization.ump;
+use delete_OneFromMany.ump;
+use delete_OneFromMany_specialization.ump;
+use delete_OneFromOne.ump;
+use delete_OneFromOne_specialization.ump;
+use delete_OneFromOptionalOne.ump;
+use delete_OneFromOptionalOne_specialization.ump;
+use delete_OptionalOneFromMN.ump;
+use delete_OptionalOneFromMN_comp.ump;
+use delete_OptionalOneFromMN_comp_specialization.ump;
+use delete_OptionalOneFromMN_specialization.ump;
+use delete_OptionalOneFromMany.ump;
+use delete_OptionalOneFromMany_comp.ump;
+use delete_OptionalOneFromMany_comp_specialization.ump;
+use delete_OptionalOneFromMany_specialization.ump;
+use delete_OptionalOneFromN.ump;
+use delete_OptionalOneFromN_comp.ump;
+use delete_OptionalOneFromN_comp_specialization.ump;
+use delete_OptionalOneFromN_specialization.ump;
+use delete_OptionalOneFromOne.ump;
+use delete_OptionalOneFromOne_comp.ump;
+use delete_OptionalOneFromOne_comp_specialization.ump;
+use delete_OptionalOneFromOne_specialization.ump;
+use delete_OptionalOneFromOptionalOne.ump;
+use delete_OptionalOneFromOptionalOne_specialization.ump;
+use delete_UndirectionalMany.ump;
+use delete_UndirectionalMany_specialization.ump;
+use delete_UndirectionalOne.ump;
+use delete_UndirectionalOne_specialization.ump;
+use specializationCode_Delete.ump;
+use specializationSkip.ump;
+
+
+class UmpleToJava {
+    delete_All <<!<</*delete_All*/>><<#
+  String customDeletePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before","delete"));
+  String customDeletePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after","delete"));
+
+  appendln(realSb,"\n  public void delete()");
+  append(realSb,"  {");
+
+  boolean hasSomethingToDelete = false;  
+
+  if (customDeletePrefixCode != null) 
+  {
+    addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customDeletePrefixCode,"delete");
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customDeletePrefixCode, "    "));
+    hasSomethingToDelete = true;
+  }
+
+  for (AssociationVariable av : uClass.getAssociationVariables()) 
+  {
+    #>><<@ UmpleToJava.specializationCode_Delete >><<#
+    
+    if (!av.getIsNavigable() || av.isImmutable())
+    {
+      continue;
+    }
+    
+    if ( reqCommonCode )      /* Same Class Specialization Case */
+    {
+      #>><<@ UmpleToJava.specializationSkip >><<#
+    }
+    else if (reqSuperCode)    /* Subclass Case */
+    {
+      if (!relatedAssociation.getIsNavigable())
+      {
+        if (av.isOne())
+        {
+          hasSomethingToDelete = true;
+          #>><<@ UmpleToJava.delete_UndirectionalOne_specialization >><<#
+        }
+        else if (av.isMany())
+        {
+          hasSomethingToDelete = true;
+          #>><<@ UmpleToJava.delete_UndirectionalMany_specialization >><<#
+        }
+        continue;
+      }
+      
+     
+      if (relatedAssociation.getIsComposition()) {
+      	if ((relatedAssociation.isOnlyOne() || relatedAssociation.isOptionalOne()) && av.isOnlyOne()) {
+      		#>><<@ UmpleToJava.delete_OneFromOne_specialization >><<#
+      	}
+      	else if ((relatedAssociation.isOnlyOne() || relatedAssociation.isOptionalOne()) && av.isOptionalOne()) {
+      		#>><<@ UmpleToJava.delete_OptionalOneFromOne_comp_specialization >><<#
+      	}
+      	else if ((relatedAssociation.isOnlyOne() || relatedAssociation.isOptionalOne()) && av.isMany()) {
+      		#>><<@ UmpleToJava.delete_ManyFromX_comp_specialization >><<#
+      	}
+      	
+      	else if (relatedAssociation.isMany() && av.isOnlyOne()) {
+      		#>><<@ UmpleToJava.delete_OneFromOne_specialization >><<#
+      	}
+      	else if (relatedAssociation.isMany() && av.isOptionalOne()) {
+      	    #>><<@ UmpleToJava.delete_OptionalOneFromOne_specialization >><<#
+      	}
+      	else if (relatedAssociation.isMany() && av.isMany()) {
+      	    #>><<@ UmpleToJava.delete_ManyFromX_comp_specialization >><<#
+      	}
+      	else {
+      		continue;
+      	}
+      	
+      	
+      }
+      
+      else if (av.getIsComposition() && (av.isMany() && relatedAssociation.isOnlyOne())) { 
+      	// normally this is the same for compositions, except for ManyToOne, the
+      	// list has to be cleared on the Many end (here, the ones are successfully deleted, 
+      	// but they are not removed from the list)
+    		// this functionality is not present for compositions, since, in the case
+    		// of deleting one from many, this would be on the composition end, and OneFromOne would
+    		// be called so the object is actually deleted. 	
+    
+      	#>><<@ UmpleToJava.delete_ManyFromX_comp_specialization >><<#
+  	  
+      }
+      
+      else if (av.getIsComposition() && (av.isMany() && relatedAssociation.isOptionalOne() && !av.isMandatory())) { 
+      	
+      	#>><<@ UmpleToJava.delete_OptionalOneFromMany_comp_specialization >><<#
+  	  
+      }
+      
+      else if (av.getIsComposition() && (av.isOptionalOne() && relatedAssociation.getMultiplicity().getLowerBound() > 1  && !relatedAssociation.isMandatory())) { 
+      	
+      	#>><<@ UmpleToJava.delete_OptionalOneFromMN_comp_specialization >><<#
+  	  
+      }
+      
+      else if (av.getIsComposition() && (av.isOptionalOne() && relatedAssociation.getMultiplicity().getLowerBound() > 1  && relatedAssociation.isMandatory())) { 
+      	
+      	#>><<@ UmpleToJava.delete_OptionalOneFromN_comp_specialization >><<#
+  	  
+      }
+      
+      
+      else {
+      
+  	    if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OneFromOne_specialization >><<#
+  	    }
+  	    else if (av.isOptionalOne() && relatedAssociation.isOptionalOne())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OptionalOneFromOptionalOne_specialization >><<#
+  	    }
+  	    else if (av.isOnlyOne() && relatedAssociation.isOptionalOne())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OneFromOptionalOne_specialization >><<#
+  	    }
+  	    else if (av.isOptionalOne() && relatedAssociation.isOnlyOne())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OptionalOneFromOne_specialization >><<#
+  	    }
+  	    else if (av.isOptionalOne() && relatedAssociation.isOptionalMany())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OptionalOneFromMany_specialization >><<#
+  	    }
+  	    else if (av.isOptionalOne() && relatedAssociation.isN())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OptionalOneFromN_specialization >><<#
+  	    }
+  	    else if (av.isOptionalOne() && relatedAssociation.isMN())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OptionalOneFromMN_specialization >><<#
+  	    }
+  	    else if (av.isOne() && relatedAssociation.isMany())
+  	    {
+  	      #>><<@ UmpleToJava.delete_OneFromMany_specialization >><<#
+  	    }
+  	    else if (av.isMandatory() && relatedAssociation.isOptionalOne())
+  	    {
+          #>><<@ UmpleToJava.delete_MandatoryFromOptionalOne_specialization >><<#
+  	    }
+  	    else if (av.isMany() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+  	    {
+          if (relatedAssociation.getNeedsCommonCode())
+          {
+            #>><<@ UmpleToJava.delete_ManyFromMN_specialization_relCommon >><<#
+          }
+          else
+          {
+            #>><<@ UmpleToJava.delete_ManyFromMN_specialization >><<#
+  	      }
+        }
+  	    else if (av.isMany() && relatedAssociation.isMany())
+  	    {
+          #>><<@ UmpleToJava.delete_ManyFromMany_specialization >><<#
+  	    }
+  	    else if (av.isMany() && relatedAssociation.isOnlyOne()) 
+  	    {
+  	      #>><<@ UmpleToJava.delete_ManyFromOne_specialization >><<#
+  	    }
+  	    else if (av.isMany() && relatedAssociation.isOptionalOne())
+  	    {
+  	      #>><<@ UmpleToJava.delete_ManyFromOptionalOne_specialization >><<#
+  	    }
+  	    else
+  	    {
+  	      continue;
+  	    }
+  	  }
+	  }
+    else  /* Normal Case */
+    {
+      if (!relatedAssociation.getIsNavigable())
+      {
+        if (av.isOne())
+        {
+          hasSomethingToDelete = true;
+          #>><<@ UmpleToJava.delete_UndirectionalOne >><<#
+        }
+        else if (av.isMany())
+        {
+          hasSomethingToDelete = true;
+          #>><<@ UmpleToJava.delete_UndirectionalMany >><<#
+        }
+        continue;
+      }
+      
+     
+      if (relatedAssociation.getIsComposition()) {
+      	if ((relatedAssociation.isOnlyOne() || relatedAssociation.isOptionalOne()) && av.isOnlyOne()) {
+      		#>><<@ UmpleToJava.delete_OneFromOne >><<#
+      	}
+      	else if ((relatedAssociation.isOnlyOne() || relatedAssociation.isOptionalOne()) && av.isOptionalOne()) {
+      		#>><<@ UmpleToJava.delete_OptionalOneFromOne_comp >><<#
+      	}
+      	else if ((relatedAssociation.isOnlyOne() || relatedAssociation.isOptionalOne()) && av.isMany()) {
+      		#>><<@ UmpleToJava.delete_ManyFromX_comp >><<#
+      	}
+      	
+      	else if (relatedAssociation.isMany() && av.isOnlyOne()) {
+      		#>><<@ UmpleToJava.delete_OneFromOne >><<#
+      	}
+      	else if (relatedAssociation.isMany() && av.isOptionalOne()) {
+      	    #>><<@ UmpleToJava.delete_OptionalOneFromOne >><<#
+      	}
+      	else if (relatedAssociation.isMany() && av.isMany()) {
+      	    #>><<@ UmpleToJava.delete_ManyFromX_comp >><<#
+      	}
+      	else {
+      		continue;
+      	}
+      	
+      	
+      }
+      
+      else if (av.getIsComposition() && (av.isMany() && relatedAssociation.isOnlyOne())) { 
+        // normally this is the same for compositions, except for ManyToOne, the
+        // list has to be cleared on the Many end (here, the ones are successfully deleted, 
+        // but they are not removed from the list)
+        // this functionality is not present for compositions, since, in the case
+        // of deleting one from many, this would be on the composition end, and OneFromOne would
+        // be called so the object is actually deleted.   
+    
+        #>><<@ UmpleToJava.delete_ManyFromX_comp >><<#
+      
+      }
+      
+      else if (av.getIsComposition() && (av.isMany() && relatedAssociation.isOptionalOne() && !av.isMandatory())) { 
+        
+        #>><<@ UmpleToJava.delete_OptionalOneFromMany_comp >><<#
+      
+      }
+      
+      else if (av.getIsComposition() && (av.isOptionalOne() && relatedAssociation.getMultiplicity().getLowerBound() > 1  && !relatedAssociation.isMandatory())) { 
+        
+        #>><<@ UmpleToJava.delete_OptionalOneFromMN_comp >><<#
+      
+      }
+      
+      else if (av.getIsComposition() && (av.isOptionalOne() && relatedAssociation.getMultiplicity().getLowerBound() > 1  && relatedAssociation.isMandatory())) { 
+        
+        #>><<@ UmpleToJava.delete_OptionalOneFromN_comp >><<#
+      
+      }
+      else 
+      {
+        if (av.isOnlyOne() && relatedAssociation.isOnlyOne())
+        {
+          #>><<@ UmpleToJava.delete_OneFromOne >><<#
+        }
+        else if (av.isOptionalOne() && relatedAssociation.isOptionalOne())
+        {
+          #>><<@ UmpleToJava.delete_OptionalOneFromOptionalOne >><<#
+        }
+        else if (av.isOnlyOne() && relatedAssociation.isOptionalOne())
+        {
+          #>><<@ UmpleToJava.delete_OneFromOptionalOne >><<#
+        }
+        else if (av.isOptionalOne() && relatedAssociation.isOnlyOne())
+        {
+          #>><<@ UmpleToJava.delete_OptionalOneFromOne >><<#
+        }
+        else if (av.isOptionalOne() && relatedAssociation.isOptionalMany())
+        {
+          #>><<@ UmpleToJava.delete_OptionalOneFromMany >><<#
+        }
+        else if (av.isOptionalOne() && relatedAssociation.isN())
+        {
+          #>><<@ UmpleToJava.delete_OptionalOneFromN >><<#
+        }
+        else if (av.isOptionalOne() && relatedAssociation.isMN())
+        {
+          #>><<@ UmpleToJava.delete_OptionalOneFromMN >><<#
+        }
+        else if (av.isOne() && relatedAssociation.isMany())
+        {
+          #>><<@ UmpleToJava.delete_OneFromMany >><<#
+        }
+        else if (av.isMandatory() && relatedAssociation.isOptionalOne())
+        {
+          #>><<@ UmpleToJava.delete_MandatoryFromOptionalOne >><<#
+        }
+        else if (av.isMany() && (relatedAssociation.isMN() || relatedAssociation.isN()))
+        {
+          #>><<@ UmpleToJava.delete_ManyFromMN >><<#
+        }
+        else if (av.isMany() && relatedAssociation.isMany())
+        {
+          #>><<@ UmpleToJava.delete_ManyFromMany >><<#
+        }
+        else if (av.isMany() && relatedAssociation.isOnlyOne()) 
+        {
+          #>><<@ UmpleToJava.delete_ManyFromOne >><<#
+        }
+        else if (av.isMany() && relatedAssociation.isOptionalOne())
+        {
+          #>><<@ UmpleToJava.delete_ManyFromOptionalOne >><<#
+        }
+        else
+        {
+          continue;
+        }
+      }
+    }
+  	hasSomethingToDelete = true;
+  }
+  
+  if (!uClass.isRoot() && !"external".equals(uClass.getExtendsClass().getModifier()))
+  {
+    hasSomethingToDelete = true;
+    appendln(realSb,"");
+    append(realSb, "    super.delete();");
+  }
+
+  if (customDeletePostfixCode != null) 
+  {
+    addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customDeletePostfixCode,"delete");
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customDeletePostfixCode, "    "));
+    hasSomethingToDelete = true;
+  }
+
+  if (hasSomethingToDelete)
+  {
+    appendln(realSb, "");
+    appendln(realSb, "  }");
+  }
+  else
+  {
+    appendln(realSb, "}");
+  }
+
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_MandatoryFromOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_MandatoryFromOptionalOne.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    delete_MandatoryFromOptionalOne <<!<</*delete_MandatoryFromOptionalOne*/>>
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("associationMany",av)>>)
+    {
+      <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>,null);
+    }
+    <<=gen.translate("associationMany",av)>>.clear();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_MandatoryFromOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_MandatoryFromOptionalOne_specialization.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    delete_MandatoryFromOptionalOne_specialization <<!<</*delete_MandatoryFromOptionalOne_specialization*/>>
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>())
+    {
+      <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("parameterOne",av)>>,null);
+    }
+    clear_<<=gen.translate("associationMany",av)>>();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromMN.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_ManyFromMN <<!<</*delete_ManyFromMN*/>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCopyOfMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("associationMany",av)>>);
+    <<=gen.translate("associationMany",av)>>.clear();
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterCopyOfMany",av)>>)
+    {
+      if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>())
+      {
+        <<=gen.translate("parameterOne",av)>>.delete();
+      }
+      else
+      {
+        <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromMN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromMN_specialization.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_ManyFromMN_specialization <<!<</*delete_ManyFromMN_specialization*/>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCopyOfMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>());
+    clear_<<=gen.translate("associationMany",av)>>();
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterCopyOfMany",av)>>)
+    {
+      if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+      {
+        <<=gen.translate("parameterOne",av)>>.delete();
+      }
+      else
+      {
+        <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromMN_specialization_relCommon.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromMN_specialization_relCommon.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_ManyFromMN_specialization_relCommon <<!<</*delete_ManyFromMN_specialization_relCommon*/>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCopyOfMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("getManyMethod",av)>>());
+    clear_<<=gen.translate("associationMany",av)>>();
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterCopyOfMany",av)>>)
+    {
+      if (<<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=gen.translate("type",av)>>.<<=gen.relatedTranslate("minimumNumberOfMethod",av)>>_<<=gen.relatedTranslate("type",av)>>())
+      {
+        <<=gen.translate("parameterOne",av)>>.delete();
+      }
+      else
+      {
+        <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromMany.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_ManyFromMany <<!<</*delete_ManyFromMany*/>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCopyOfMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("associationMany",av)>>);
+    <<=gen.translate("associationMany",av)>>.clear();
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterCopyOfMany",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromMany_specialization.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_ManyFromMany_specialization <<!<</*delete_ManyFromMany_specialization*/>>
+    ArrayList<<<=gen.translate("type",av)>>> <<=gen.translate("parameterCopyOfMany",av)>> = new ArrayList<<<=gen.translate("type",av)>>>(<<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>());
+    clear_<<=gen.translate("associationMany",av)>>();
+    for(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> : <<=gen.translate("parameterCopyOfMany",av)>>)
+    {
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromOne.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    delete_ManyFromOne <<!<</*delete_ManyFromOne*/>>
+    for(int i=<<=gen.translate("associationMany",av)>>.size(); i > 0; i--)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("associationMany",av)>>.get(i - 1);
+      <<=gen.translate("parameterOne",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromOne_specialization.ump
@@ -1,0 +1,3 @@
+class UmpleToJava {
+    delete_ManyFromOne_specialization <<!<</*delete_ManyFromOne_specialization*/>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromOptionalOne.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_ManyFromOptionalOne <<!<</*delete_ManyFromOptionalOne*/>>
+    while( !<<=gen.translate("associationMany",av)>>.isEmpty() )
+    {
+      <<=gen.translate("associationMany",av)>>.get(0).<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromOptionalOne_specialization.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_ManyFromOptionalOne_specialization <<!<</*delete_ManyFromOptionalOne_specialization*/>>
+    for( <<=gen.translate("type",av)>> orphan : <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>() )
+    {
+      orphan.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromX_comp.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromX_comp.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    delete_ManyFromX_comp <<!<</*delete_ManyFromX_comp*/>>
+    while (<<=gen.translate("associationMany",av)>>.size() > 0)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("associationMany",av)>>.get(<<=gen.translate("associationMany",av)>>.size() - 1);
+      <<=gen.translate("parameterOne",av)>>.delete();
+      <<=gen.translate("associationMany",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+    }
+    !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_ManyFromX_comp_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_ManyFromX_comp_specialization.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    delete_ManyFromX_comp_specialization <<!<</*delete_ManyFromX_comp_specialization*/>>
+    while (<<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>().size() > 0)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>().get(<<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>().size() - 1);
+      <<=gen.translate("parameterOne",av)>>.delete();
+      <<=gen.translate("getManyMethod",av)>>_<<=gen.translate("type",av)>>().remove(<<=gen.translate("parameterOne",av)>>);
+    }
+    !>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OneFromMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OneFromMany.ump
@@ -1,0 +1,6 @@
+class UmpleToJava {
+    delete_OneFromMany <<!<</*delete_OneFromMany*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("associationOne",av)>>;
+    this.<<=gen.translate("associationOne",av)>> = null;
+    <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OneFromMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OneFromMany_specialization.ump
@@ -1,0 +1,6 @@
+class UmpleToJava {
+    delete_OneFromMany_specialization <<!<</*delete_OneFromMany_specialization*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>();
+    clear_<<=gen.translate("associationOne",av)>>();
+    <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OneFromOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OneFromOne.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OneFromOne <<!<</*delete_OneFromOne*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = null;
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OneFromOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OneFromOne_specialization.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    delete_OneFromOne_specialization <<!<</*delete_OneFromOne_specialization*/>>
+
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>();
+    super.clear_<<=gen.translate("associationOne", av)>>();
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OneFromOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OneFromOptionalOne.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OneFromOptionalOne <<!<</*delete_OneFromOptionalOne*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = null;
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OneFromOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OneFromOptionalOne_specialization.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OneFromOptionalOne_specialization <<!<</*delete_OneFromOptionalOne_specialization*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+    super.clear_<<=gen.translate("associationOne", av)>>();
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOne.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_OptionalOne <<!<</*delete_OptionalOne*/>>
+  public boolean <<=gen.translate("deleteMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasDeleted = false;
+    <<# if (customDeletePrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customDeletePrefixCode, "    ")); } #>>
+    if(<<=gen.translate("associationOne",av)>>.equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("associationOne",av)>> = null;
+      wasDeleted = true;
+    }
+    <<# if (customDeletePostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customDeletePostfixCode, "    ")); } #>>
+    return wasDeleted;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_OptionalOneFromMN <<!<</*delete_OptionalOneFromMN*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+      if (<<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=relatedAssociation.getMultiplicity().getLowerBound()>>)
+      {
+        <<=gen.translate("associationOne",av)>>.delete();
+      }
+      else
+      {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("associationOne",av)>>;
+        this.<<=gen.translate("associationOne",av)>> = null;
+        <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN_comp.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN_comp.ump
@@ -1,0 +1,19 @@
+class UmpleToJava {
+    delete_OptionalOneFromMN_comp <<!<</*delete_OptionalOneFromMN_comp*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+      if (<<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=relatedAssociation.getMultiplicity().getLowerBound()>>)
+      {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("associationOne",av)>>;
+        this.<<=gen.translate("associationOne",av)>> = null;
+        <<=gen.translate("removeParameterOne",av)>>.delete();
+      
+      }
+      else
+      {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("associationOne",av)>>;
+        this.<<=gen.translate("associationOne",av)>> = null;
+        <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN_comp_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN_comp_specialization.ump
@@ -1,0 +1,19 @@
+class UmpleToJava {
+    delete_OptionalOneFromMN_comp_specialization <<!<</*delete_OptionalOneFromMN_comp_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+      if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=relatedAssociation.getMultiplicity().getLowerBound()>>)
+      {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+        clear_<<=gen.translate("associationOne",av)>>();
+        <<=gen.translate("removeParameterOne",av)>>.delete();
+      
+      }
+      else
+      {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+        clear_<<=gen.translate("associationOne",av)>>();
+        <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMN_specialization.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_OptionalOneFromMN_specialization <<!<</*delete_OptionalOneFromMN_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+      if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().<<=gen.relatedTranslate("numberOfMethod",av)>>() <= <<=relatedAssociation.getMultiplicity().getLowerBound()>>)
+      {
+        <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().delete();
+      }
+      else
+      {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+        clear_<<=gen.translate("associationOne",av)>>();
+        <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+      }
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromMany <<!<</*delete_OptionalOneFromMany*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("associationOne",av)>>;
+      this.<<=gen.translate("associationOne",av)>> = null;
+      <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany_comp.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany_comp.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromMany_comp <<!<</*delete_OptionalOneFromMany_comp*/>>
+    while( !<<=gen.translate("associationOne",av)>>.isEmpty() )
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("associationOne",av)>>.get(0);
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+      <<=gen.translate("associationOne",av)>>.remove(<<=gen.translate("parameterOne",av)>>);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany_comp_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany_comp_specialization.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromMany_comp_specialization <<!<</*delete_OptionalOneFromMany_comp_specialization*/>>
+    while( !<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().isEmpty() )
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } else { #>>_<<=gen.translate("type",av)>><<# } #>>().get(0);
+      <<=gen.translate("parameterOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+      <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().remove(<<=gen.translate("parameterOne",av)>>);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromMany_specialization.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromMany_specialization <<!<</*delete_OptionalOneFromMany_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+      <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+      clear_<<=gen.translate("associationOne",av)>>();
+      <<=gen.translate("removeParameterOne",av)>>.<<=gen.relatedTranslate("removeMethod",av)>>(this);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_OptionalOneFromN <<!<</*delete_OptionalOneFromN*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+      <<=gen.translate("associationOne",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN_comp.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN_comp.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromN_comp <<!<</*delete_OptionalOneFromN_comp*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("associationOne",av)>>;
+        this.<<=gen.translate("associationOne",av)>> = null;
+        <<=gen.translate("removeParameterOne",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN_comp_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN_comp_specialization.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromN_comp_specialization <<!<</*delete_OptionalOneFromN_comp_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+        <<=gen.translate("type",av)>> <<=gen.translate("removeParameterOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+        clear_<<=gen.translate("associationOne",av)>>();
+        <<=gen.translate("removeParameterOne",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromN_specialization.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_OptionalOneFromN_specialization <<!<</*delete_OptionalOneFromN_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+      <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromOne <<!<</*delete_OptionalOneFromOne*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = null;
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne_comp.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne_comp.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    delete_OptionalOneFromOne_comp <<!<</*delete_OptionalOneFromOne_comp*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("associationOne",av)>>;
+    <<=gen.translate("associationOne",av)>> = null;
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.delete();
+      <<=gen.translate("parameterExisting",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne_comp_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne_comp_specialization.ump
@@ -1,0 +1,10 @@
+class UmpleToJava {
+    delete_OptionalOneFromOne_comp_specialization <<!<</*delete_OptionalOneFromOne_comp_specialization*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+    super.clear_<<=gen.translate("associationOne", av)>>();
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.delete();
+      <<=gen.translate("parameterExisting",av)>>.clear_<<=gen.relatedTranslate("associationOne",av)>>();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOne_specialization.ump
@@ -1,0 +1,9 @@
+class UmpleToJava {
+    delete_OptionalOneFromOne_specialization <<!<</*delete_OptionalOneFromOne_specialization*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+    super.clear_<<=gen.translate("associationOne", av)>>();
+    if (<<=gen.translate("parameterExisting",av)>> != null)
+    {
+      <<=gen.translate("parameterExisting",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOptionalOne.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_OptionalOneFromOptionalOne <<!<</*delete_OptionalOneFromOptionalOne*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+      <<=gen.translate("associationOne",av)>>.<<=gen.relatedTranslate("setMethod",av)>>(null);
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneFromOptionalOne_specialization.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_OptionalOneFromOptionalOne_specialization <<!<</*delete_OptionalOneFromOptionalOne_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+      <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().clear_<<=gen.relatedTranslate("associationOne",av)>>();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneToOne.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_OptionalOneToOne <<!<</*delete_OptionalOneToOne*/>>
+    if (<<=gen.translate("associationOne",av)>> != null)
+    {
+      <<=gen.translate("associationOne",av)>>.delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOneToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOneToOne_specialization.ump
@@ -1,0 +1,7 @@
+class UmpleToJava {
+    delete_OptionalOneToOne_specialization <<!<</*delete_OptionalOneToOne_specialization*/>>
+    if (<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() != null)
+    {
+      <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().delete();
+    }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_OptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_OptionalOne_specialization.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    delete_OptionalOne_specialization <<!<</*delete_OptionalOne_specialization*/>>
+  public boolean <<=gen.translate("deleteMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  {
+    boolean wasDeleted = false;
+    <<# if (customDeletePrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customDeletePrefixCode, "    ")); } #>>
+    if(<<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>().equals(<<=gen.translate("parameterOne",av)>>))
+    {
+      <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>() = null;
+      wasDeleted = true;
+    }
+    <<# if (customDeletePostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customDeletePostfixCode, "    ")); } #>>
+    return wasDeleted;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_UndirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_UndirectionalMany.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    delete_UndirectionalMany <<!<</*delete_UndirectionalMany*/>>
+    <<=gen.translate("associationMany",av)>>.clear();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_UndirectionalMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_UndirectionalMany_specialization.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    delete_UndirectionalMany_specialization <<!<</*delete_UndirectionalMany_specialization*/>>
+    clear_<<=gen.translate("associationMany",av)>>();!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_UndirectionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_UndirectionalOne.ump
@@ -1,0 +1,4 @@
+class UmpleToJava {
+    delete_UndirectionalOne <<!<</*delete_UndirectionalOne*/>>
+    <<=gen.translate("associationOne",av)>> = null;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/delete_UndirectionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_UndirectionalOne_specialization.ump
@@ -1,0 +1,5 @@
+class UmpleToJava {
+    delete_UndirectionalOne_specialization <<!<</*delete_UndirectionalOne_specialization*/>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterExisting",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();
+    <<=gen.translate("parameterExisting",av)>> = null;!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/equals.ump
+++ b/UmpleToJava/UmpleTLTemplates/equals.ump
@@ -1,0 +1,164 @@
+class UmpleToJava {
+    equals <<!<</*equals*/>><<#
+
+  StringBuilder checks = new StringBuilder();
+  StringBuilder hash = new StringBuilder();
+  StringBuilder canSet = new StringBuilder();
+  
+  for(String memberId : uClass.getKey().getMembers())
+  {
+    Attribute av = uClass.getAttribute(memberId);
+    AssociationVariable as = uClass.getAssociationVariable(memberId);
+    if (av != null)
+    {
+      String avString = av.getIsDerived()?(gen.translate("getMethod",av)+"()"):gen.translate("attributeOne",av);
+      if (!av.isImmutable() || av.getIsLazy()) canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("attributeCanSet",av)));
+      if (av.getIsList())
+      {
+        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",gen.translate("attributeMany",av)));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n\n"));
+        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",gen.translate("attributeMany",av)));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",av),gen.translate("attributeMany",av)));
+        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",av),gen.translate("attributeMany",av)));
+        checks.append(StringFormatter.format("      if (me == null && them != null)\n"));
+        checks.append(StringFormatter.format("      {\n"));
+        checks.append(StringFormatter.format("       return false;\n"));
+        checks.append(StringFormatter.format("      }\n"));
+        checks.append(StringFormatter.format("      else if (me != null && !me.equals(them))\n"));
+        checks.append(StringFormatter.format("      {\n"));
+        checks.append(StringFormatter.format("        return false;\n"));
+        checks.append(StringFormatter.format("      }\n"));
+        checks.append(StringFormatter.format("    }\n"));
+      }
+      else if ("Integer".equals(av.getType()) || "Boolean".equals(av.getType()) || "Double".equals(av.getType()))
+      {
+        checks.append(StringFormatter.format("    if ({0} != compareTo.{0})\n",avString));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n"));
+      }
+      else
+      {
+        checks.append(StringFormatter.format("    if ({0} == null && compareTo.{0} != null)\n",avString));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n"));
+        checks.append(StringFormatter.format("    else if ({0} != null && !{0}.equals(compareTo.{0}))\n",avString));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n"));
+      }
+      checks.append("\n");
+    }
+    else if (as != null)
+    {
+      String asString = gen.translate("attributeOne",as);
+      canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("associationCanSet",as)));
+      if (as.isMany())
+      {
+        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",gen.translate("associationMany",as)));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n\n"));
+        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",gen.translate("attributeMany",as)));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",as),gen.translate("associationMany",as)));
+        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",as),gen.translate("associationMany",as)));
+        checks.append(StringFormatter.format("      if (me == null && them != null)\n"));
+        checks.append(StringFormatter.format("      {\n"));
+        checks.append(StringFormatter.format("       return false;\n"));
+        checks.append(StringFormatter.format("      }\n"));
+        checks.append(StringFormatter.format("      else if (me != null && !me.equals(them))\n"));
+        checks.append(StringFormatter.format("      {\n"));
+        checks.append(StringFormatter.format("        return false;\n"));
+        checks.append(StringFormatter.format("      }\n"));
+        checks.append(StringFormatter.format("    }\n"));
+      }
+      else
+      {
+        checks.append(StringFormatter.format("    if ({0} == null && compareTo.{0} != null)\n",asString));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n"));
+        checks.append(StringFormatter.format("    else if ({0} != null && !{0}.equals(compareTo.{0}))\n",asString));
+        checks.append(StringFormatter.format("    {\n"));
+        checks.append(StringFormatter.format("      return false;\n"));
+        checks.append(StringFormatter.format("    }\n"));
+      }
+      checks.append("\n");
+    }
+    
+    if (av != null)
+    {
+      String avString = av.getIsDerived()?(gen.translate("getMethod",av)+"()"):gen.translate("attributeOne",av);
+      if ("Integer".equals(av.getType()) && !av.getIsList())
+      {
+        hash.append(StringFormatter.format("    cachedHashCode = cachedHashCode * 23 + {0};\n",avString));
+      }
+      else if ("Double".equals(av.getType()) && !av.getIsList())
+      {
+        hash.append(StringFormatter.format("    cachedHashCode = cachedHashCode * 23 + (new Double({0})).hashCode();\n",avString));
+      }
+      else if ("Boolean".equals(av.getType()) && !av.getIsList())
+      {
+        hash.append(StringFormatter.format("    cachedHashCode = cachedHashCode * 23 + ({0} ? 1 : 0);\n",avString));
+      }
+      else
+      {
+        String attributeType = av.getIsList() ? "attributeMany" : av.getIsDerived()?"getMethod":"attributeOne";
+        String typeString = gen.translate(attributeType,av)+(av.getIsDerived()?"()":"");
+        hash.append(StringFormatter.format("    if ({0} != null)\n",typeString));
+        hash.append(StringFormatter.format("    {\n"));
+        hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23 + {0}.hashCode();\n",typeString));
+        hash.append(StringFormatter.format("    }\n"));
+        hash.append(StringFormatter.format("    else\n"));
+        hash.append(StringFormatter.format("    {\n"));
+        hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23;\n"));
+        hash.append(StringFormatter.format("    }\n"));
+      }
+      hash.append("\n");
+    }
+    else if (as != null)
+    {
+      String attributeType = as.isOne() ? "attributeOne" : "attributeMany";
+      hash.append(StringFormatter.format("    if ({0} != null)\n",gen.translate(attributeType,as)));
+      hash.append(StringFormatter.format("    {\n"));
+      hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23 + {0}.hashCode();\n",gen.translate(attributeType,as)));
+      hash.append(StringFormatter.format("    }\n"));
+      hash.append(StringFormatter.format("    else\n"));
+      hash.append(StringFormatter.format("    {\n"));
+      hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23;\n"));
+      hash.append(StringFormatter.format("    }\n"));
+    }
+  }
+
+#>>
+  public boolean equals(Object obj)
+  {
+    if (obj == null) { return false; }
+    if (!getClass().equals(obj.getClass())) { return false; }
+
+    <<= uClass.getName() >> compareTo = (<<= uClass.getName() >>)obj;
+  
+    <<= checks.toString().trim() >>
+
+    return true;
+  }
+
+  public int hashCode()
+  {
+    if (cachedHashCode != -1)
+    {
+      return cachedHashCode;
+    }
+    cachedHashCode = 17;
+    <<= hash.toString().trim() >>
+
+    <<= canSet.toString().trim() >>
+    return cachedHashCode;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/import_packages.ump
+++ b/UmpleToJava/UmpleTLTemplates/import_packages.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+    import_packages <<!<</*import_packages*/>><<#
+  for (Depend depend : uClass.getDepends())
+  {
+    appendln(realSb, "");
+    append(realSb, "import {0};",depend.getName());
+  }
+  
+  for (String anImport : gClass.getMultiLookup("import"))
+  {
+    appendln(realSb, "");
+    append(realSb, "import {0};",anImport);
+  }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/import_packages_interface.ump
+++ b/UmpleToJava/UmpleTLTemplates/import_packages_interface.ump
@@ -1,0 +1,42 @@
+class UmpleToJava {
+    import_packages_interface <<!<</*import_packages_interface*/>><<#
+  for (Depend depend : uInterface.getDepends())
+  {
+    appendln(realSb, "");
+    append(realSb, "import {0};",depend.getName());
+  }
+
+  Boolean hasDate = false;
+  Boolean hasTime = false;
+  for(Constant aConstant : uInterface.getConstants())
+  {
+    if(aConstant.getType().equals("Time"))
+    {
+      hasTime = true;
+    }
+    else if(aConstant.getType().equals("Date"))
+    {
+      hasDate = true;
+    }
+  }
+
+  if(hasDate == true)
+  {
+    appendln(realSb, "");
+    append(realSb, "import java.sql.Date;");
+  }
+
+  if(hasTime == true)
+  {
+    appendln(realSb, "");
+    append(realSb, "import java.sql.Time;");
+  }
+  
+  // TODO: No test failed from removing this
+  // for (String anImport : gInterface.getMultiLookup("import"))
+  // {
+  //  appendln(realSb, "");
+  //  append(realSb, "import {0};",anImport);
+  // }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/interface_AbstractMethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/interface_AbstractMethodDeclaration.ump
@@ -1,0 +1,35 @@
+class UmpleToJava {
+    interface_AbstractMethodDeclaration <<!<</*interface_AbstractMethodDeclaration*/>><<#
+	 appendln(realSb, "");
+     appendln(realSb,"  // ABSTRACT METHODS ");
+    	for (Method aMethod : uInterface.getMethods()) 
+    	{
+    		String methodModifier = aMethod.getModifier().equals("") ? "public" : aMethod.getModifier();
+    		String methodName = aMethod.getName();
+    		String methodType = aMethod.getType();
+    		String paramName="";
+    		String paramType="";
+    		String aSingleParameter="";
+    		String isList="";
+    	    String parameters = "";
+    		if (aMethod.hasMethodParameters())
+    		{
+    			for (MethodParameter aMethodParam : aMethod.getMethodParameters()) 
+    			{
+    				paramName = aMethodParam.getName();
+    				paramType = aMethodParam.getType();
+        			isList = aMethodParam.getIsList() ? " [] " : " ";
+    				aSingleParameter = paramType + isList + paramName;
+        			parameters += aSingleParameter + ", ";
+    			}
+    			String finalParams = parameters.substring(0, parameters.length()-2);
+    			appendln(realSb, "");
+    			append(realSb, " {0} {1} {2}({3});", methodModifier, methodType, methodName, finalParams);	
+    		}
+    		else{
+    			appendln(realSb, "");
+    			append(realSb, " {0} {1} {2}();", methodModifier, methodType, methodName);
+    		}
+    	}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/interface_constantDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/interface_constantDeclaration.ump
@@ -1,0 +1,23 @@
+class UmpleToJava {
+    interface_constantDeclaration <<!<</*interface_constantDeclaration*/>><<#
+appendln(realSb, "");
+appendln(realSb,"  // CONSTANT MEMBERS  ");
+ for (Constant aConstant : uInterface.getConstants()) 
+ {
+ 	String constantName = aConstant.getName();
+ 	String constantModifier = "public static final";
+    String constantType =  gen.translateInterfaceType(aConstant.getType());
+ 	String constantValue =  gen.translateInterfaceValue(aConstant.getValue(), constantType);
+
+ 
+ if (!(constantValue.equals(""))){
+ 	appendln(realSb, "");
+ 	append(realSb, " {0} {1} {2} = {3};", constantModifier, constantType, constantName, constantValue);
+ }
+ else{
+ 	appendln(realSb, "");
+ 	append(realSb, " {0} {1} {2};", constantModifier, constantType, constantName);
+ }
+ }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/members_AllAssociations.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllAssociations.ump
@@ -1,0 +1,41 @@
+use specializationCode.ump;
+
+
+class UmpleToJava {
+    members_AllAssociations <<!<</*members_AllAssociations*/>><<#
+{
+  isFirst = true;
+  for (AssociationVariable av : uClass.getAssociationVariables())
+  {
+
+    #>><<@ UmpleToJava.specializationCode >><<#
+    if (!av.getIsNavigable())
+    {
+      continue;
+    }
+    
+    if (isFirst)
+    {
+      appendln(realSb, "");
+      appendln(realSb, "");
+            
+      append(realSb,"  //{0} Associations", uClass.getName());
+      isFirst = false;
+    }
+  
+    appendln(realSb, "");
+    
+    //if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Association Javadoc", av.getComments())); }
+    
+    if (av.isOne())
+    {
+      	append(realSb, "  private {0} {1};", gen.translate("type",av), gen.translate("attributeOne",av));
+    }
+    else
+    {    
+      	append(realSb, "  private List<{0}> {1};", gen.translate("typeMany",av), gen.translate("attributeMany",av));
+    }
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/members_AllAttributes.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllAttributes.ump
@@ -1,0 +1,105 @@
+class UmpleToJava {
+    members_AllAttributes <<!<</*members_AllAttributes*/>><<#
+{
+
+  appendln(realSb, "");
+  appendln(realSb, "");
+  appendln(realSb, "  //------------------------");
+  appendln(realSb, "  // MEMBER VARIABLES");
+  append(realSb, "  //------------------------");
+
+  isFirst = true;
+  for(Attribute av : uClass.getAttributes())
+  {
+    if (av.isConstant() || av.getIsAutounique() || av.getIsDerived())
+    {
+      continue;
+    }
+    if (isFirst)
+    {
+      appendln(realSb, "");
+      appendln(realSb, "");
+      append(realSb,"  //{0} Attributes", uClass.getName());
+      isFirst = false;
+    }
+    
+    String type = gen.translate("type",av);
+    String attribute = gen.translate("attributeOne",av);
+    if (av.getIsList())
+    {
+      attribute = gen.translate("attributeMany",av);
+      type = StringFormatter.format("List<{0}>",gen.translate("typeMany",av));
+    }
+
+    appendln(realSb, "");
+    
+    if("internal".equals(av.getModifier()))
+    {
+      if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); }
+    }
+    append(realSb, "  private {0} {1};", type, attribute);
+  }
+  
+  isFirst = true;
+  for(Attribute av : uClass.getAttributes())
+  {
+    if (!av.getIsAutounique())
+    {
+      continue;
+    }
+    if (isFirst)
+    {
+      appendln(realSb, "");
+      appendln(realSb, "");
+      append(realSb,"  //Autounique Attributes");
+      isFirst = false;
+    }
+    appendln(realSb, "");
+    if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); }
+    append(realSb, "  private int {0};", gen.translate("attributeOne",av));
+  }
+  
+  isFirst = true;
+  for( TraceDirective td : uClass.getTraceDirectives() )
+  {
+	  for( TraceCondition traceCond : td.getCondition() )
+	  {
+		  if (isFirst && (traceCond.getConditionType().equals("until") ||  traceCond.getConditionType().equals("after")))
+		  {
+			  appendln(realSb, "");
+			  append(realSb, "  //Trace Attributes");
+			  isFirst = false;
+		  }
+		  if(traceCond.getConditionType().equals("until") )
+		  {
+			  for( AttributeTraceItem traceAttr : td.getAttributeTraceItems() )
+			  {
+				  for( UmpleVariable attr : traceAttr.getUmpleVariables() )
+				  {
+					  String attrName = gen.translate("attribute",(Attribute)attr);
+					  attrName = attrName.substring(0,1).toUpperCase()+attrName.substring(1).toLowerCase();
+					  appendln(realSb, "");
+					  append(realSb, "  private boolean {0} = true;", "trace" + attrName + "Until");  
+				  }
+			  }  
+		  }
+		  if(traceCond.getConditionType().equals("after") )
+		  {
+			  for( AttributeTraceItem traceAttr : td.getAttributeTraceItems() )
+			  {
+				  for( UmpleVariable attr : traceAttr.getUmpleVariables() )
+				  {
+					  String attrName = gen.translate("attribute",(Attribute)attr);
+					  attrName = attrName.substring(0,1).toUpperCase()+attrName.substring(1).toLowerCase();
+					  appendln(realSb, "");
+					  append(realSb, "  private boolean {0} = false;", "trace" + attrName + "After");  
+				  }
+			  }
+		  }
+		  
+	  }
+	  
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/members_AllDoActivities.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllDoActivities.ump
@@ -1,0 +1,25 @@
+class UmpleToJava {
+    members_AllDoActivities <<!<</*members_AllDoActivities*/>><<#
+{
+  isFirst = true;
+  for(StateMachine sm : uClass.getAllStateMachines())
+  {
+    
+    for (State state : sm.getStates())
+    {
+      for (Activity activity : state.getActivities())
+      {
+        if (isFirst)
+        {
+          appendln(realSb, "");
+          appendln(realSb, "");
+          append(realSb,"  //{0} Do Activity Threads", uClass.getName());
+          isFirst = false;
+        }
+        append(realSb, "\n  Thread {0} = null;", gen.translate("doActivityThread",activity));
+      }
+    }
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/members_AllHelpers.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllHelpers.ump
@@ -1,0 +1,133 @@
+use specializationCode.ump;
+
+
+class UmpleToJava {
+    members_AllHelpers <<!<</*members_AllHelpers*/>><<#
+{
+
+  isFirst = true;
+  if (uClass.getKey().isProvided())
+  {
+    isFirst = false;
+    appendln(realSb, "");
+    appendln(realSb, "");
+    appendln(realSb,"  //Helper Variables");
+    append(realSb, "  private int cachedHashCode;");
+  }
+
+  for (Attribute av : uClass.getAttributes())
+  {
+    if (av.isImmutable() && av.isIsLazy())
+    {
+      if (isFirst)
+      {
+        isFirst = false;
+        appendln(realSb, "");
+        appendln(realSb, "");
+        appendln(realSb,"  //Helper Variables");
+      } 
+      else
+      {
+        appendln(realSb, "");
+      }
+      append(realSb, "  private boolean {0};", gen.translate("attributeCanSet",av));
+    }
+  }
+  
+  for (AssociationVariable av : uClass.getAssociationVariables())
+  {
+
+    #>><<@ UmpleToJava.specializationCode >><<#
+    if (!av.getIsNavigable())
+    {
+      continue;
+    }
+    if (av.isImmutable())
+    {
+      if (isFirst)
+      {
+        isFirst = false;
+        appendln(realSb, "");
+        appendln(realSb, "");
+        appendln(realSb,"  //Helper Variables");
+      } 
+      else
+      {
+        appendln(realSb, "");
+      }
+      append(realSb, "  private boolean {0};", gen.translate("associationCanSet",av));
+    }
+  }
+  
+  for(String memberId : uClass.getKey().getMembers())
+  {
+    Attribute av = uClass.getAttribute(memberId);
+    AssociationVariable as = uClass.getAssociationVariable(memberId);
+    if (av != null  && !av.isImmutable())
+    {
+      appendln(realSb, "");
+      append(realSb, "  private boolean {0};", gen.translate("attributeCanSet",av));
+    }
+    else if (as != null)
+    {
+      appendln(realSb, "");
+      append(realSb, "  private boolean {0};", gen.translate("associationCanSet",as));
+    }
+  }
+  
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    for (Event e : sm.getEvents())
+    {
+      if (!e.getIsTimer())
+      {
+        continue;
+      }
+    
+      if (isFirst)
+      {
+        isFirst = false;
+        appendln(realSb, "");
+        appendln(realSb, "");
+        appendln(realSb,"  //Helper Variables");
+      }
+      else
+      {
+        appendln(realSb, "");
+      }
+      append(realSb, "  private TimedEventHandler {0};", gen.translate("eventHandler",e));
+    }
+  }
+
+  for (StateMachine sm : uClass.getStateMachines())
+  {
+    if(!sm.getNestedStateMachines().isEmpty())
+    {
+      for (StateMachine nsm : sm.getNestedStateMachines())
+      {
+        for (Event event : nsm.getEvents())
+        {
+          if(!event.getIsTimer())
+          {
+            continue;
+          }
+         
+          if (isFirst)
+          {
+            isFirst = false;
+            appendln(realSb, "");
+            appendln(realSb, "");
+            appendln(realSb,"  //Helper Variables");
+          }
+          else
+          {
+            appendln(realSb, "");
+          }
+          append(realSb, "  private TimedEventHandler {0};", gen.translate("eventHandler", event));
+        }
+      }
+    }
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/members_AllStateMachines.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllStateMachines.ump
@@ -1,0 +1,118 @@
+class UmpleToJava {
+    members_AllStateMachines <<!<</*members_AllStateMachines*/>><<#
+{
+  isFirst = true;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    List<StateMachine> allNested = sm.getNestedStateMachines();
+
+    if (isFirst)
+    {
+      appendln(realSb, "");
+      appendln(realSb, "");
+      append(realSb,"  //{0} State Machines", uClass.getName());
+      isFirst = false;
+    }
+  
+    append(realSb, "\n  public enum {0} { {1} }", gen.translate("type", sm), gen.translate("listStates", sm));
+
+    for (StateMachine nestedSm : allNested)
+    {
+      append(realSb, "\n  public enum {0} { {1} }", gen.translate("type", nestedSm), 
+             gen.translate("listStates",nestedSm));
+    }
+    
+    append(realSb, "\n  private {0} {1};", gen.translate("type",sm), gen.translate("stateMachineOne", sm));
+    for (StateMachine nestedSm : allNested)
+    {
+      append(realSb, "\n  private {0} {1};", gen.translate("type",nestedSm), gen.translate("stateMachineOne", nestedSm));
+      if(nestedSm.getContainsHistoryState())
+      {
+        append(realSb, "\n  private {0} {1}H;", gen.translate("type",nestedSm), gen.translate("stateMachineOne", nestedSm));
+      }
+      if(nestedSm.getContainsDeepHistoryState())
+      {
+        append(realSb, "\n  private {0} {1}HStar;", gen.translate("type",nestedSm), gen.translate("stateMachineOne", nestedSm));
+      }
+    }  
+  }
+  
+  boolean foundQueued = false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    if(sm.isQueued())
+    {
+      foundQueued = true;
+    }
+  }
+  if(foundQueued == true)
+  {
+    append(realSb,"\n  ");
+    append(realSb,"\n  //enumeration type of messages accepted by {0}", uClass.getName());
+    append(realSb, "\n  protected enum MessageType { {0} }", gen.translate("listEventsForQSM",uClass));   
+  }
+
+  boolean foundQueuedSM = false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    if(sm.isQueued())
+    {
+       foundQueuedSM = true;
+    }
+  }
+  if(foundQueuedSM == true)
+  {
+    append(realSb,"\n  ");
+    append(realSb,"\n  MessageQueue queue;");
+    append(realSb,"\n  Thread removal;");
+  } 
+ 
+  boolean foundPooledSM = false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {  
+    if(sm.isPooled())
+    {
+      foundPooledSM = true;
+    }
+  }
+  if(foundPooledSM == true)
+  {
+    append(realSb,"\n  ");
+    append(realSb,"\n  MessagePool pool;");
+    append(realSb,"\n  Thread removal;");
+    append(realSb,"\n  ");
+    append(realSb,"\n  //enumeration type of messages accepted by {0}", uClass.getName());
+    append(realSb, "\n  protected enum MessageType { {0} }", gen.translate("listEventsForPooledSM",uClass));
+  } 
+
+  boolean foundPooled = false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    if (sm.isPooled()){
+      foundPooled = true;
+    }
+  }
+  if(foundPooled == true)
+  {
+    append(realSb,"\n");
+    append(realSb,"\n  // Map for a {0} pooled state machine that allows querying which events are possible in each map", uClass.getName());
+    append(realSb,"\n");
+    append(realSb,"\n  public static final Map<Object, HashSet<MessageType>> stateMessageMap = new HashMap<Object, HashSet<MessageType>>();");
+    append(realSb,"\n  static {");
+  }
+   
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    if(sm.isPooled())
+    {
+      append(realSb,"\n  {0}",gen.translate("listMessageTypesStates",sm));
+    }
+  }
+  
+  if(foundPooled == true)
+  {
+    append(realSb,"\n  }");
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/members_AllStatics.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllStatics.ump
@@ -1,0 +1,61 @@
+class UmpleToJava {
+    members_AllStatics <<!<</*members_AllStatics*/>><<#
+{
+  isFirst = true;
+  for(Attribute av : uClass.getAttributes())
+  {
+  
+    if (!av.isConstant() && !av.getIsAutounique() && !av.getIsUnique())
+    {
+      continue;
+    }
+
+    if (isFirst)
+    {
+      appendln(realSb, "");
+      appendln(realSb, "");
+      appendln(realSb, "  //------------------------");
+      appendln(realSb, "  // STATIC VARIABLES");
+      appendln(realSb, "  //------------------------");
+      isFirst = false;
+    }
+  
+    if (av.isConstant())
+    {
+      appendln(realSb, "");
+      if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); }
+      append(realSb, "  public static final {0} {1} = {2};", gen.getType(av), av.getName(), gen.translate("parameterValue",av));
+    }
+    else if (av.getIsAutounique())
+    {
+      String defaultValue = av.getValue() == null ? "1" : av.getValue();
+      appendln(realSb, "");
+      append(realSb, "  private static int next{0} = {1};", av.getUpperCaseName(), defaultValue);
+    }
+    else if (av.getIsUnique())
+    {
+      appendln(realSb, "");
+      append(realSb, "  private static Map<{0}, {1}> {2} = new HashMap<{0}, {1}>();",
+        av.getType(),
+        av.getUmpleClass().getName(),
+        gen.translate("uniqueMap", av));
+    }
+  }
+  
+  if (uClass.getIsSingleton())
+  {
+    if (isFirst)
+    {
+      appendln(realSb, "");
+      appendln(realSb, "");
+      appendln(realSb, "  //------------------------");
+      appendln(realSb, "  // STATIC VARIABLES");
+      appendln(realSb, "  //------------------------");
+      appendln(realSb, "");
+      isFirst = false;
+    }
+    append(realSb, "  private static {0} theInstance = null;", uClass.getName());
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_inner_class.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_inner_class.ump
@@ -1,0 +1,138 @@
+class UmpleToJava {
+    queued_state_machine_inner_class <<!<</*queued_state_machine_inner_class*/>><<#
+  appendln(realSb,"\n  protected class Message");
+  appendln(realSb,"  {");
+  appendln(realSb,"    MessageType type;"); 
+  appendln(realSb,"    ");  
+  appendln(realSb,"    //Message parameters");
+  appendln(realSb,"    Vector<Object> param;"); 
+  appendln(realSb,"    ");   
+  appendln(realSb,"    public Message(MessageType t, Vector<Object> p)");
+  appendln(realSb,"    {");
+  appendln(realSb,"      type = t; "); 
+  appendln(realSb,"      param = p;");
+  appendln(realSb,"    }");
+  appendln(realSb,"");
+  appendln(realSb,"    @Override");
+  appendln(realSb,"    public String toString()");
+  appendln(realSb,"    {");
+  appendln(realSb,"      return type + \",\" + param;");
+  appendln(realSb,"    }");
+  appendln(realSb,"  }");
+  appendln(realSb,"  ");  
+ 
+  if (smq.isQueued())
+  {
+    appendln(realSb,"  protected class MessageQueue {");
+    appendln(realSb,"    Queue<Message> messages = new LinkedList<Message>();");
+    appendln(realSb,"    ");   
+    appendln(realSb,"    public synchronized void put(Message m)");
+    appendln(realSb,"    {");
+    appendln(realSb,"      messages.add(m); "); 
+    appendln(realSb,"      notify();");
+    appendln(realSb,"    }");
+    appendln(realSb,"");  
+    appendln(realSb,"    public synchronized Message getNext()");
+    appendln(realSb,"    {");
+    appendln(realSb,"      try {");
+    appendln(realSb,"        while (messages.isEmpty()) "); 
+    appendln(realSb,"        {");
+    appendln(realSb,"          wait();");
+    appendln(realSb,"        }");
+    appendln(realSb,"      } catch (InterruptedException e) { e.printStackTrace(); } "); 
+    appendln(realSb,"");
+    appendln(realSb,"      //The element to be removed");
+    appendln(realSb,"      Message m = messages.remove(); "); 
+    appendln(realSb,"      return (m);");
+    appendln(realSb,"    }");
+    append(realSb,"  }");  
+  }
+  else if(smq.isPooled())
+  {
+    appendln(realSb,"  protected class MessagePool {");
+    appendln(realSb,"    Queue<Message> messages = new LinkedList<Message>();");
+    appendln(realSb,"    ");   
+    appendln(realSb,"    public synchronized void put(Message m)");
+    appendln(realSb,"    {");
+    appendln(realSb,"      messages.add(m); "); 
+    appendln(realSb,"      notify();");
+    appendln(realSb,"    }");
+    appendln(realSb,"");  
+    appendln(realSb,"    public synchronized Message getNext()");
+    appendln(realSb,"    {");
+    appendln(realSb,"      Message message=null;");
+    appendln(realSb,"");
+    appendln(realSb,"      try {");
+    appendln(realSb,"        message=getNextProcessableMessage();");
+    appendln(realSb,"        while (message==null)");
+    appendln(realSb,"        {");
+    appendln(realSb,"          wait();");
+    appendln(realSb,"          message=getNextProcessableMessage();");
+    appendln(realSb,"        }");
+    appendln(realSb,"      } catch (InterruptedException e) { e.printStackTrace(); }");
+    appendln(realSb,"");
+    appendln(realSb,"      // return the message");
+    appendln(realSb,"      return (message);");
+    appendln(realSb,"    }");
+    appendln(realSb,"");
+    appendln(realSb,"    public Message getNextProcessableMessage()");
+    appendln(realSb,"    {");
+    appendln(realSb,"      // Iterate through messages and remove the first message that matches one of the Messages list");
+    appendln(realSb,"      // otherwise return null");
+    appendln(realSb,"      for (Message msg: messages)");
+    appendln(realSb,"      {");
+    
+    for(StateMachine sm: uClass.getStateMachines())
+    {
+      if(sm.isPooled())
+      {
+        if(sm.getNestedStateMachines().isEmpty())
+        {
+          append(realSb,"        if(stateMessageMap.get(get");
+          append(realSb,"{0}", gen.translate("type",sm));
+          appendln(realSb,"()).contains(msg.type))");
+          appendln(realSb,"        {");
+          appendln(realSb,"          //The element to be removed");
+          appendln(realSb,"          messages.remove(msg);");
+          appendln(realSb,"          return (msg);");
+          appendln(realSb,"        }");
+        }
+        else if(!sm.getNestedStateMachines().isEmpty())
+        {
+          append(realSb,"        if(stateMessageMap.get(get");
+          append(realSb,"{0}", gen.translate("type",sm));
+          appendln(realSb,"()).contains(msg.type))");
+          appendln(realSb,"        {");
+          appendln(realSb,"          //The element to be removed");
+          appendln(realSb,"          messages.remove(msg);");
+          appendln(realSb,"          return (msg);");
+          appendln(realSb,"        }");
+          append(realSb,"        else");
+          int nsmSize = sm.getNestedStateMachines().size();
+          int nesCount = 0;
+          for(StateMachine nsm : sm.getNestedStateMachines())
+          {
+            nesCount++;
+            append(realSb," if(stateMessageMap.get(get");
+            append(realSb,"{0}", gen.translate("type",nsm));
+            appendln(realSb,"()).contains(msg.type))");
+            appendln(realSb,"        {");
+            appendln(realSb,"          //The element to be removed");
+            appendln(realSb,"          messages.remove(msg);");
+            appendln(realSb,"          return (msg);");
+            appendln(realSb,"        }");
+            if(nsmSize > nesCount)
+            {
+              append(realSb,"        else");
+            }
+          }
+        }
+      }
+    }
+    appendln(realSb,"      }");
+    appendln(realSb,"      return null;");
+    appendln(realSb,"    }");
+    append(realSb,"  }"); 
+  }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_queuedEvent.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_queuedEvent.ump
@@ -1,0 +1,204 @@
+class UmpleToJava {
+    queued_state_machine_queuedEvent <<!<</*queued_state_machine_queuedEvent*/>><<#
+  append(realSb,"\n");
+  append(realSb,"\n  //------------------------------");
+  append(realSb,"\n  //messages accepted ");
+  append(realSb,"\n  //------------------------------");
+  append(realSb,"\n");
+  
+  
+  String evName="";
+  boolean sameEvName=false;
+  List<String> evList=new ArrayList<String>();
+          
+  for (StateMachine sm : uClass.getStateMachines())
+  {
+    if(sm.isQueued() || sm.isPooled()) 
+    { 
+      for(Event event : sm.getEvents())
+      { 
+        for(int i=0; i<evList.size(); i++)
+        {
+          if(evList.get(i).equals(event.getName()))
+          {
+            sameEvName=true;
+          }
+        }
+             
+        if(sameEvName == false)
+        {
+          if(event.isAutoTransition() == false)
+          {
+            if(event.getIsTimer())
+            {
+               evList.add(event.getName());
+               append(realSb,"\n");
+               append(realSb,"  public boolean ");
+               append(realSb,"{0} ()",gen.translate("eventMethod",event));
+               append(realSb,"\n  {");
+               append(realSb,"\n    boolean wasAdded = false;");
+          
+               if(sm.isQueued())
+               {
+                 append(realSb,"\n    queue.put(new Message(MessageType.{0}",gen.translate("eventMethod",event));
+               }
+               if(sm.isPooled())
+               {
+                 append(realSb,"\n    pool.put(new Message(MessageType.{0}",gen.translate("eventMethod",event));
+               }
+               append(realSb,"_M, null));");
+       
+               append(realSb,"\n    wasAdded = true;");
+               append(realSb,"\n    return wasAdded;");
+               append(realSb,"\n  }");
+               append(realSb,"\n");
+               evName = event.getName();
+            }
+            if(!event.isUnspecified())
+            {
+              if( !evName.equals(event.getName()))
+              {
+                evList.add(event.getName());
+                append(realSb,"\n");
+                append(realSb,"  public void ");
+                append(realSb,"{0} ({1})",gen.translate("eventMethod",event), event.getArgs());
+                append(realSb,"\n  {");
+          
+                if (!event.getArgs().equals(""))
+                {
+                  append(realSb,"\n    Vector v = new Vector({0});", event.getParams().size());
+                  for ( int i=0; i < event.getParams().size(); i++)
+                  {
+                    append(realSb,"\n    v.add({0}, {1});",i, event.getParam(i).getName());
+                  }
+                  if(sm.isQueued())
+                  {
+                    append(realSb,"\n    queue.put(new Message(MessageType.{0}",gen.translate("eventMethod",event));
+                  }
+                  if(sm.isPooled())
+                  {
+                    append(realSb,"\n    pool.put(new Message(MessageType.{0}",gen.translate("eventMethod",event));
+                  }
+                  append(realSb,"_M, v));");
+                }
+                else
+                {
+                  if(sm.isQueued())
+                  {
+                    append(realSb,"\n    queue.put(new Message(MessageType.{0}",gen.translate("eventMethod",event));
+                  }
+                  if(sm.isPooled())
+                  {
+                    append(realSb,"\n    pool.put(new Message(MessageType.{0}",gen.translate("eventMethod",event));
+                  }
+                  append(realSb,"_M, null));");
+                }
+                append(realSb,"\n  }");
+                append(realSb,"\n");
+                evName = event.getName();
+              }
+            }
+          }
+        }
+        sameEvName = false;        
+      }
+
+
+      for (StateMachine nsm : sm.getNestedStateMachines())
+      {
+        for (Event e : nsm.getEvents())
+        {
+          for(int i=0; i<evList.size(); i++)
+          {
+            if(evList.get(i).equals(e.getName()))
+            {
+              sameEvName=true;
+            }
+          }
+        
+          if(sameEvName == false)
+          {
+            if(e.isAutoTransition() == false)
+            {
+              if(e.getIsTimer())
+              {
+                evList.add(e.getName());
+                append(realSb,"\n");
+                append(realSb,"  public boolean ");
+                append(realSb,"{0} ()",gen.translate("eventMethod",e));
+                append(realSb,"\n  {");
+                append(realSb,"\n    boolean wasAdded = false;");
+          
+                if(sm.isQueued())
+                {
+                  append(realSb,"\n    queue.put(new Message(MessageType.{0}",gen.translate("eventMethod",e));
+                }
+                if(sm.isPooled())
+                {
+                  append(realSb,"\n    pool.put(new Message(MessageType.{0}",gen.translate("eventMethod",e));
+                }
+                append(realSb,"_M, null));");
+       
+                append(realSb,"\n    wasAdded = true;");
+                append(realSb,"\n    return wasAdded;");
+                append(realSb,"\n  }");
+                append(realSb,"\n");
+                evName = e.getName();
+              }
+              if(!e.isUnspecified())
+              {
+                 if(e.getIsInternal() == false)
+                 {
+                   if( !evName.equals(e.getName()))
+                   {
+                     evList.add(e.getName());
+                     append(realSb,"\n");
+                     append(realSb,"  public void ");
+                     append(realSb,"{0} ({1})",gen.translate("eventMethod",e), e.getArgs());
+                     append(realSb,"\n  {");
+        
+                     if (!e.getArgs().equals(""))
+                     {
+                       evList.add(e.getName());
+                       append(realSb,"\n    Vector v = new Vector({0});", e.getParams().size());
+                       for ( int i=0; i < e.getParams().size(); i++)
+                       {
+                         append(realSb,"\n    v.add({0}, {1});",i, e.getParam(i).getName());
+                       }
+                       if(sm.isQueued())
+                       {
+                         append(realSb,"\n    queue.put(new Message(MessageType.{0}",gen.translate("eventMethod",e));
+                       }
+                       if(sm.isPooled())
+                       {
+                         append(realSb,"\n    pool.put(new Message(MessageType.{0}",gen.translate("eventMethod",e));
+                       } 
+                       append(realSb,"_M, v));"); 
+                     }
+                     else
+                     {
+                       if(sm.isQueued())
+                       {
+                         append(realSb,"\n    queue.put(new Message(MessageType.{0}",gen.translate("eventMethod",e));
+                       }
+                       if(sm.isPooled())
+                       {
+                         append(realSb,"\n    pool.put(new Message(MessageType.{0}",gen.translate("eventMethod",e));
+                       }
+                       append(realSb,"_M, null));");
+                     }
+                     append(realSb,"\n  }");
+                     append(realSb,"\n");
+                     evName = e.getName();
+                   }
+                 }
+               }
+             }
+           }
+           sameEvName=false;
+         }
+        }
+      }
+    }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_removalThread_run.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_removalThread_run.ump
@@ -1,0 +1,145 @@
+class UmpleToJava {
+    queued_state_machine_removalThread_run <<!<</*queued_state_machine_removalThread_run*/>>
+  
+  @Override
+  public void run ()
+  {
+    boolean status=false;
+    while (true) 
+    {
+
+      <<#
+      if(smq.isPooled())
+      {
+        append(realSb,"      Message m = pool.getNext();");
+      }
+      if(smq.isQueued())
+      {
+        append(realSb,"      Message m = queue.getNext();");
+      }
+      #>>
+      
+      switch (m.type)
+      {
+        <<# 
+        String eveNameSM="";
+        boolean sameEventNameSM=false;
+        List<String> eventListSM=new ArrayList<String>();
+          
+        for(StateMachine sm: uClass.getStateMachines())
+        {
+           for(Event event : sm.getEvents())
+           {
+             for(int i=0; i<eventListSM.size(); i++)
+             {
+               if(eventListSM.get(i).equals(event.getName()))
+               {
+                 sameEventNameSM=true;
+               }
+             }
+             
+             if(sameEventNameSM == false)
+             {
+               if(event.isAutoTransition() == false)
+               {
+                 if(!event.isUnspecified())
+                 {
+                   if( !eveNameSM.equals(event.getName()))
+                   {
+                     eventListSM.add(event.getName());
+                     append(realSb,"\n        case {0}",gen.translate("eventMethod",event));
+                     append(realSb,"_M:");
+                     if (!event.getArgs().equals(""))
+                     {
+                       append(realSb,"\n          status = _{0}(",gen.translate("eventMethod",event));
+                       String allParameters="";
+                       for ( int i=0; i < event.getParams().size(); i++)
+                       {
+                         if (allParameters.length() > 0)
+                         {
+                           allParameters += ", ";
+                         }
+                         allParameters += "("+event.getParam(i).getType()+") m.param.elementAt("+i+")";
+                       }
+                       append(realSb,"{0});",allParameters);
+                     }
+                     else
+                     {
+                       append(realSb,"\n          status = _{0}",gen.translate("eventMethod",event));
+                       append(realSb,"();");
+                     }
+                     append(realSb,"\n          break;");
+                     eveNameSM = event.getName();
+                   }
+                 }
+               }
+             }
+             sameEventNameSM = false;             
+           }
+
+
+           for (StateMachine nsm : sm.getNestedStateMachines())
+           {
+             for (Event e : nsm.getEvents())
+             {
+               for(int i=0; i<eventListSM.size(); i++)
+               {
+                 if(eventListSM.get(i).equals(e.getName()))
+                 {
+                   sameEventNameSM=true;
+                 }
+               }
+
+               if(sameEventNameSM == false)
+               {
+                 if(e.isAutoTransition() == false)
+                 {
+                   if(!e.isUnspecified())
+                   {
+                     if(e.getIsInternal() == false)
+                     {
+                       if( !eveNameSM.equals(e.getName()))
+                       {
+                         eventListSM.add(e.getName());
+                         append(realSb,"\n        case {0}",gen.translate("eventMethod",e));
+                         append(realSb,"_M:");
+                         if (!e.getArgs().equals(""))
+                         {
+                           append(realSb,"\n          status = _{0}(",gen.translate("eventMethod",e));
+                           String allParameters="";
+                           for ( int i=0; i < e.getParams().size(); i++)
+                           {
+                             if (allParameters.length() > 0)
+                             {
+                               allParameters += ", ";
+                             }
+                             allParameters += "("+e.getParam(i).getType()+") m.param.elementAt("+i+")";
+                           }
+                           append(realSb,"{0});",allParameters);
+                         }
+                         else
+                         {
+                           append(realSb,"\n          status = _{0}",gen.translate("eventMethod",e));
+                           append(realSb,"();");
+                         }
+                         append(realSb,"\n          break;");
+                         eveNameSM = e.getName();
+                       }
+                     }
+                   }
+                 }
+               }
+               sameEventNameSM = false;
+             }
+           }
+         }
+           #>> 
+        default:
+      }
+      if(!status)
+      {
+        // Error message is written or  exception is raised
+      }
+    }
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_returnMessageTypesForEachState.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_returnMessageTypesForEachState.ump
@@ -1,0 +1,31 @@
+class UmpleToJava {
+    queued_state_machine_returnMessageTypesForEachState <<!<</*queued_state_machine_returnMessageTypesForEachState*/>><<#
+  append(realSb,"\n  // A method to return a list of message types for each state of the {0}", uClass.getName()); 
+  append(realSb,"state machine");
+  append(realSb,"\n  public List<MessageType> getStateMsgTypeList({0}", gen.translate("type",smq));
+  append(realSb," state){");
+  append(realSb,"\n    List<MessageType> msg = null;");
+  append(realSb,"\n    switch (state)");
+  append(realSb,"\n    {");
+
+  int countNumberOfStates=0;
+  
+  for(State state : smq.getStates()){
+    String stateNumber="";
+    countNumberOfStates++;
+    append(realSb,"\n      case {0}",gen.translate("stateOne",state));
+    append(realSb,":");
+    append(realSb,"\n        msg=state");
+    stateNumber+=countNumberOfStates;
+    append(realSb,stateNumber);
+    append(realSb,"MsgTypeList;");
+    append(realSb,"\n        break;");
+  }
+
+  append(realSb,"\n      default:");
+  append(realSb,"\n    }");
+  append(realSb,"\n    return msg;");
+  append(realSb,"\n  }");
+  append(realSb,"\n");
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode.ump
@@ -1,0 +1,18 @@
+class UmpleToJava {
+    specializationCode <<!<</*specializationCode*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+
+    //Association relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+	  
+	//boolean reqSuperCode = relatedAssoc.getEnd(av.getRelevantEnd()).getNeedsSuperCode();
+	//boolean reqCommonCode = relatedAssoc.getEnd(av.getRelevantEnd()).getNeedsCommonCode();
+	  
+	boolean reqSuperCode = av.getNeedsSuperCode();
+	boolean reqCommonCode = av.getNeedsCommonCode();  
+	  
+	if (reqSuperCode || reqCommonCode)
+	{
+	    continue;
+	}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_AdSet.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_AdSet.ump
@@ -1,0 +1,24 @@
+class UmpleToJava {
+    specializationCode_AdSet <<!<</*specializationCode_AdSet*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+    
+    Association relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+    
+    
+    boolean avTypeCommon = av.getType().equals(relatedAssoc.getCommonClassName());
+    boolean rAvTypeCommon = relatedAssociation.getType().equals(relatedAssoc.getCommonClassName());
+    boolean assocTypeCommon = relatedAssoc.getCommonClassName().equals(uClass.getName());
+    
+    // if the current assocVar's class is equal to it's association's duplicate class...
+    // this may no longer be relevant.
+    if ((avTypeCommon || rAvTypeCommon) && assocTypeCommon)
+    {
+      isRelSpec = true;
+    }
+    
+    // in the case of a specialization, this will let us know what kind of code we nee
+    boolean reqSuperCode = av.getNeedsSuperCode();
+    boolean reqCommonCode = av.getNeedsCommonCode();
+
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_AddAndSet.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_AddAndSet.ump
@@ -1,0 +1,24 @@
+class UmpleToJava {
+    specializationCode_AddAndSet <<!<</*specializationCode_AddAndSet*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+    
+    Association relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+    
+    
+    boolean avTypeCommon = av.getType().equals(relatedAssoc.getCommonClassName());
+    boolean rAvTypeCommon = relatedAssociation.getType().equals(relatedAssoc.getCommonClassName());
+    boolean assocTypeCommon = relatedAssoc.getCommonClassName().equals(uClass.getName());
+    
+    // if the current assocVar's class is equal to it's association's duplicate class...
+    // this may no longer be relevant.
+    if ((avTypeCommon || rAvTypeCommon) && assocTypeCommon)
+    {
+      isRelSpec = true;
+    }
+    
+    // in the case of a specialization, this will let us know what kind of code we need.
+    boolean reqSuperCode = av.getNeedsSuperCode();
+    boolean reqCommonCode = av.getNeedsCommonCode();
+
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_Constructor.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_Constructor.ump
@@ -1,0 +1,19 @@
+class UmpleToJava {
+    specializationCode_Constructor <<!<</*specializationCode_Constructor*/>><<#
+    relatedAssociation = av.getRelatedAssociation();
+    
+    //relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+
+    //reqSuperCode = relatedAssoc.getEnd(av.getRelevantEnd()).getNeedsSuperCode();
+    //reqCommonCode = relatedAssoc.getEnd(av.getRelevantEnd()).getNeedsCommonCode();
+    
+    reqSuperCode = av.getNeedsSuperCode();
+	reqCommonCode = av.getNeedsCommonCode(); 
+    
+    if (reqSuperCode || reqCommonCode)
+    {
+      continue;
+    }
+    
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_Delete.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_Delete.ump
@@ -1,0 +1,12 @@
+class UmpleToJava {
+    specializationCode_Delete <<!<</*specializationCode_Delete*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+    //Association relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+
+    boolean reqSuperCode = av.getNeedsSuperCode();
+    boolean reqCommonCode = av.getNeedsCommonCode();
+    boolean mulChangedToOne = av.getMulChangedToOne();
+    boolean relMulChangedToOne = relatedAssociation.getMulChangedToOne();
+    
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_Get.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_Get.ump
@@ -1,0 +1,16 @@
+class UmpleToJava {
+    specializationCode_Get <<!<</*specializationCode_Get*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+    
+    Association relatedAssoc = null;
+    if (uClass.indexOfAssociationVariable(av) < uClass.getAssociations().length) relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+    
+    // in the case of a specialization, this will let us know what kind of code we need
+
+    boolean reqSuperCode = av.getNeedsSuperCode();
+    boolean reqCommonCode = av.getNeedsCommonCode();
+    boolean mulChangedToOne = av.getMulChangedToOne();
+    boolean relReqSuperCode = relatedAssociation.getNeedsSuperCode();
+
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_Member.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_Member.ump
@@ -1,0 +1,19 @@
+class UmpleToJava {
+    specializationCode_Member <<!<</*specializationCode_Member*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+    
+    Association relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+    
+    
+    Boolean avTypeCommon = av.getType().equals(relatedAssoc.getCommonClassName());
+    Boolean rAvTypeCommon = relatedAssociation.getType().equals(relatedAssoc.getCommonClassName());
+    Boolean assocTypeCommon = relatedAssoc.getCommonClassName().equals(uClass.getName());
+    
+    // if the current assocVar's class is equal to it's association's duplicate class...
+    
+    if ((avTypeCommon || rAvTypeCommon) && assocTypeCommon)
+    {
+      continue;
+    }
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationCode_Set.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_Set.ump
@@ -1,0 +1,17 @@
+class UmpleToJava {
+    specializationCode_Set <<!<</*specializationCode_Set*/>><<#
+    AssociationVariable relatedAssociation = av.getRelatedAssociation();
+    
+    //Association relatedAssoc = uClass.getAssociation(uClass.indexOfAssociationVariable(av));
+
+    boolean reqSuperCode = av.getNeedsSuperCode();
+    boolean reqCommonCode = av.getNeedsCommonCode();
+    boolean relReqCommonCode = relatedAssociation.getNeedsCommonCode();
+    boolean mulChangedToOne = av.getMulChangedToOne();
+    boolean relMulChangedToOne = relatedAssociation.getMulChangedToOne();
+	boolean mulChangedToN = av.getMulChangedToN();
+	boolean reqSetCode = relatedAssociation.getReqSetCode();
+	boolean relReqSetCode = av.getReqSetCode();
+    String scName = av.getScName();
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/specializationSkip.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationSkip.ump
@@ -1,0 +1,5 @@
+class UmpleToJava {
+    specializationSkip <<!<</*specializationSkip*/>><<#
+   /* Method Gen skipped due to special specialization syntax */
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
@@ -1,0 +1,227 @@
+class UmpleToJava {
+    state_machine_Event <<!<</*state_machine_Event*/>><<#
+  int javaLine = realSb.toString().split("\\n").length+7;
+
+  StringBuilder allCases = new StringBuilder();
+  StringBuilder allDeclarations = new StringBuilder();
+  
+  StringBuilder actionLineNumbers = new StringBuilder();
+  StringBuilder actionFileNames = new StringBuilder();
+  StringBuilder actionJavaLineNumbers = new StringBuilder();
+  StringBuilder actionLengths = new StringBuilder();
+  String umpleSourceFileFormat = "\n  @umplesourcefile(line={{0}}, file={{1}}, javaline={{2}}, length={{3}})";
+  String customEventPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("eventMethod",e)));
+  String customEventPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("eventMethod",e)));
+  if(e.getName().startsWith("_")&&(customEventPrefixCode==null||customEventPostfixCode==null))
+  {
+    boolean queued = false;
+    for(StateMachine sm : uClass.getStateMachines(e))
+    {
+      if(sm.isQueued())
+      {
+        queued = true;
+        break;
+      }
+    }
+    if(queued)
+    {
+      if(customEventPrefixCode==null)
+      {
+        customEventPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("eventMethod",e)));
+      }
+      if(customEventPostfixCode==null)
+      {
+        customEventPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("eventMethod",e)));
+      }
+  
+    }
+  }
+  for(StateMachine sm : uClass.getStateMachines(e))
+  {
+    allDeclarations.append(StringFormatter.format("\n    {0} {1} = {2};",gen.translate("type",sm),gen.translate("parameterOne",sm),gen.translate("stateMachineOne", sm)));
+    if(sm.getContainsHistoryState())
+    {     
+      allDeclarations.append(StringFormatter.format("\n    if ({0} != {1}.Null){",gen.translate("stateMachineOne",sm),gen.translate("type",sm)));
+    	allDeclarations.append(StringFormatter.format("{0}H = {1};}",gen.translate("stateMachineOne",sm),gen.translate("stateMachineOne", sm)));    
+      javaLine++;
+    }
+    if(sm.getContainsDeepHistoryState())
+    { 
+      allDeclarations.append(StringFormatter.format("\n    if ({0} != {1}.Null){",gen.translate("stateMachineOne",sm),gen.translate("type",sm)));
+    	allDeclarations.append(StringFormatter.format("{0}HStar = {1};}",gen.translate("stateMachineOne",sm),gen.translate("stateMachineOne", sm)));
+      javaLine++;
+    }
+    allCases.append(StringFormatter.format("\n    switch ({0})\n",gen.translate("parameterOne",sm)));
+    allCases.append(StringFormatter.format("    {\n"));
+    javaLine+=3;
+    for(State state : sm.getStates())
+    {
+  	  TraceItem traceItem = state.getTraced("transition",uClass);
+      List<Transition> allT = state.getTransitionsFor(e);
+  
+      if (allT.size() == 0)
+      {
+        continue;
+      }
+
+      allCases.append(StringFormatter.format("      case {0}:\n",gen.translate("stateOne",state)));
+      javaLine++;
+
+      boolean needsBreak = true;
+      for (Transition t : allT)
+      {
+        
+        State nextState = t.getNextState();
+        String tabSpace = t.getGuard() == null ? "        " : "          ";
+        StateMachine exitSm = state.exitableStateMachine(nextState);
+        
+        String condition = t.getGuard()!=null?gen.translate("Open",t.getGuard()):"if ()\n{";
+        if (!"if ()\n{".equals(condition))
+        {
+          StateMachine sm_temp=sm;
+          if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
+          
+          addUncaughtExceptionVariables(gen.translate("eventMethod",e),
+                                      sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/","").replace("\"",""),
+                                      t.getGuard().getPosition().getLineNumber(),
+                                      javaLine-1,
+                                      condition.split("\\n").length-1);
+          allCases.append(GeneratorHelper.doIndent(condition, "        ")+"\n");
+          javaLine+=1+condition.split("\\n").length;
+          
+        }
+        if (exitSm != null && !e.getIsInternal() && !state.isSameState(nextState,exitSm)) 
+        {
+          allCases.append(StringFormatter.format("{0}{1}();\n",tabSpace,gen.translate("exitMethod",exitSm)));
+          javaLine++;
+        }
+        if (t.getAction() != null)
+        {
+          Action a1 = t.getAction();
+          Position p = a1.getPosition();
+          if (p != null) {
+          
+            StateMachine sm_temp=sm;
+            if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
+            
+            addUncaughtExceptionVariables(gen.translate("eventMethod",e),
+                                        sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/","").replace("\"",""),
+                                        p.getLineNumber(),
+                                        javaLine-2,
+                                        a1.getActionCode().split("\\n").length);
+            allCases.append("        // line " + p.getLineNumber() + " \"" + sm_temp.getUmpleClass().getRelativePath("Java") + "\"\n");
+            javaLine++;
+          }
+          allCases.append(StringFormatter.format("{0}{1}\n",tabSpace,a1.getActionCode()));
+          javaLine+=a1.getActionCode().split("\\n").length;
+        }
+        
+        StateMachineTraceItem traceStmItem = null;
+        
+        traceStmItem = state.getTrace("entry",uClass,t);
+        allCases.append(traceStmItem!=null?traceStmItem.trace(gen, t, "sm_t", uClass)+"\n":"");
+        
+        traceStmItem = state.getTrace("exit",uClass,t);
+        allCases.append(traceStmItem!=null?traceStmItem.trace(gen, t, "sm_t", uClass)+"\n":"");
+        
+        traceStmItem = state.getTrace("state",uClass,t);
+        allCases.append(traceStmItem!=null?traceStmItem.trace(gen, t, "sm_t", uClass)+"\n":"");
+        
+        traceStmItem = state.getTrace("transition",uClass,t);
+        allCases.append(traceStmItem!=null?traceStmItem.trace(gen, t, "sm_t", uClass)+"\n":"");
+        	
+//        allCases.append(traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, t,"sm_t", uClass)+"\n":"");
+        if (nextState.getIsHistoryState() == true)
+        {
+        	allCases.append(StringFormatter.format("{0}{1}({2}{3});\n",tabSpace,gen.translate("setMethod",nextState.getStateMachine()),gen.translate("stateMachineOne",nextState.getStateMachine()),gen.translate("stateOne",nextState)));
+        	
+        }
+        else
+        {
+        	allCases.append(StringFormatter.format("{0}{1}({2}.{3});\n",tabSpace,gen.translate("setMethod",nextState.getStateMachine()),gen.translate("type",nextState.getStateMachine()),gen.translate("stateOne",nextState)));
+		}
+//        allCases.append(traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, t,"sm_t", uClass)+"\n":"");
+
+        
+        allCases.append(StringFormatter.format("{0}wasEventProcessed = true;\n",tabSpace));
+        allCases.append(StringFormatter.format("{0}break;\n",tabSpace));
+        
+        javaLine+=traceItem!=null?4:3;
+        
+        if (!"if ()\n{".equals(condition))
+        {
+          allCases.append(StringFormatter.format("        }\n"));
+          javaLine++;
+        }
+        else
+        {
+          needsBreak = false;
+          //You can only have one *no guard case*
+          break;
+        }
+      }
+  
+      if (needsBreak)
+      {
+        allCases.append(StringFormatter.format("        break;\n"));
+        javaLine++;
+      }
+    } 
+    allCases.append(StringFormatter.format("      default:\n"));
+    allCases.append(StringFormatter.format("        // Other states do respond to this event\n"));
+    
+    for(State s : sm.getStates())
+    {
+      Transition t1=null;
+      Transition t2=null;
+      String exitEvent=null;
+      if (sm.getParentState() != null)
+      {
+        State parentState = sm.getParentState();
+        exitEvent = gen.translate("exitMethod",parentState);
+      }
+      for(Transition tran: s.getTransitions())
+      {
+        if(tran.getEvent().isUnspecified())
+        {
+          t1=tran;
+        }
+        if(tran.getEvent().getName().equals(e.getName()))
+        {
+          t2=tran;
+        }
+      }
+      if(s.getTransitions().contains(t1) && s.getTransitions().contains(t2))
+      {
+        if(!e.isUnspecified() && !e.getName().equals(exitEvent))
+        {
+          allCases.append(StringFormatter.format("        wasEventProcessed = unspecified("));
+          allCases.append(StringFormatter.format("get"));
+          allCases.append(StringFormatter.format("{0}",gen.translate("type",sm)));
+          allCases.append(StringFormatter.format("("));
+          allCases.append(StringFormatter.format(").toString()"));
+          allCases.append(StringFormatter.format(", "));
+          allCases.append(StringFormatter.format("\""));
+          allCases.append(StringFormatter.format(e.getName()));
+          allCases.append(StringFormatter.format("\""));
+          allCases.append(StringFormatter.format(");\n"));
+        }
+      }
+    }
+    allCases.append(StringFormatter.format("    }\n"));
+    javaLine+=3;
+  }
+
+  
+  String scope = e.getIsInternal() || e.isAutoTransition() ? "private" : "public";
+  String eventOutput = allDeclarations.toString() + allCases.toString();#>>
+  <<= scope >> boolean <<#for (StateMachine sm : uClass.getStateMachines()){if((sm.isQueued() && e.getIsInternal() == false && e.isAutoTransition() == false && !e.isUnspecified()) || (sm.isPooled() && e.getIsInternal() == false && e.isAutoTransition() == false && !e.isUnspecified())){append(realSb,"_");}break;}#>><<=gen.translate("eventMethod",e)>>(<<= (e.getArgs()==null?"":e.getArgs())>><<#if(e.isUnspecified()){append(realSb,"String state, String event");}#>>)
+  {<<# if (customEventPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customEventPrefixCode,gen.translate("eventMethod",e));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customEventPrefixCode, "    ")); } #>>
+    boolean wasEventProcessed = false;
+    <<= eventOutput >><<# if (customEventPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customEventPostfixCode,gen.translate("eventMethod",e)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customEventPostfixCode, "    ")); } #>>
+    return wasEventProcessed;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Event_StartStopTimer.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Event_StartStopTimer.ump
@@ -1,0 +1,13 @@
+class UmpleToJava {
+    state_machine_Event_StartStopTimer <<!<</*state_machine_Event_StartStopTimer*/>>
+  private void <<=gen.translate("eventStartMethod",e) >>()
+  {
+    <<= gen.translate("eventHandler",e) >> = new TimedEventHandler(this,"<<= gen.translate("eventMethod",e) >>",<<= e.getTimerInSeconds() >>);
+  }
+
+  private void <<=gen.translate("eventStopMethod",e) >>()
+  {
+    <<= gen.translate("eventHandler",e) >>.stop();
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Event_StartStopTimer_NestedStates.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Event_StartStopTimer_NestedStates.ump
@@ -1,0 +1,13 @@
+class UmpleToJava {
+    state_machine_Event_StartStopTimer_NestedStates <<!<</*state_machine_Event_StartStopTimer_NestedStates*/>>
+  private void <<=gen.translate("eventStartMethod",event) >>()
+  {
+    <<= gen.translate("eventHandler", event) >> = new TimedEventHandler(this,"<<= gen.translate("eventMethod",event) >>",<<= event.getTimerInSeconds() >>);
+  }
+
+  private void <<=gen.translate("eventStopMethod",event) >>()
+  {
+    <<= gen.translate("eventHandler",event) >>.stop();
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Events_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Events_All.ump
@@ -1,0 +1,14 @@
+use state_machine_Event.ump;
+
+
+class UmpleToJava {
+    state_machine_Events_All <<!<</*state_machine_Events_All*/>><<#
+{
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  for(Event e : uClass.getEvents())
+  {
+    #>><<@ UmpleToJava.state_machine_Event >><<#
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Get.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Get.ump
@@ -1,0 +1,8 @@
+class UmpleToJava {
+    state_machine_Get <<!<</*state_machine_Get*/>>
+  public <<=gen.translate("type",sm)>> <<=gen.translate("getMethod",sm)>>()
+  {
+    return <<= gen.translate("stateOne",sm) >>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_GetFull.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_GetFull.ump
@@ -1,0 +1,25 @@
+class UmpleToJava {
+    state_machine_GetFull <<!<</*state_machine_GetFull*/>><<#
+  StringBuilder output = new StringBuilder(); 
+  List<StateMachine> allParents = new ArrayList<StateMachine>();
+  allParents.add(sm);
+  while (allParents.size() > 0) 
+  {
+    StateMachine parentSm = allParents.get(0);
+    allParents.remove(0);
+    for (StateMachine childSm : parentSm.getNestedStateMachines()) 
+    {
+      output.append(StringFormatter.format("\n    if ({0} != {1}.Null) { answer += \".\" + {0}.toString(); }",gen.translate("stateMachineOne",childSm),gen.translate("type",childSm)));
+      allParents.addAll(childSm.getNestedStateMachines());
+    }     
+  }
+  String outputAsString = output.toString();
+#>>
+  public <<=gen.translate("typeFull",sm)>> <<=gen.translate("getFullMethod",sm)>>()
+  {
+    String answer = <<=gen.translate("stateMachineOne",sm)>>.toString();
+    <<# if (outputAsString.length() > 0) { append(realSb, "{0}",outputAsString); } #>>
+    return answer;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Get_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Get_All.ump
@@ -1,0 +1,21 @@
+use state_machine_Get.ump;
+use state_machine_GetFull.ump;
+
+
+class UmpleToJava {
+    state_machine_Get_All <<!<</*state_machine_Get_All*/>><<#
+{
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  isFirst = true;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    #>><<@ UmpleToJava.state_machine_GetFull >><<# 
+  }
+  
+  for(StateMachine sm : uClass.getAllStateMachines())
+  {
+    #>><<@ UmpleToJava.state_machine_Get >><<#
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_IsFinal.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_IsFinal.ump
@@ -1,0 +1,21 @@
+class UmpleToJava {
+    state_machine_IsFinal <<!<</*state_machine_IsFinal*/>><<#
+
+  StringBuilder output = new StringBuilder();
+  for(State state : sm.getFinalStates())
+  {
+    StateMachine finalSm = state.getStateMachine();
+    if (output.length() > 0)
+    {
+      output.append(" && ");
+    }
+    output.append(StringFormatter.format("{0} == {1}.{2}",gen.translate("stateMachineOne",finalSm),gen.translate("type",finalSm),gen.translate("stateOne",state)));
+  }
+  String outputAsString = output.toString();
+#>>
+  private boolean <<=gen.translate("isFinalMethod",sm)>>()
+  {
+    return <<= outputAsString >>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Set.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Set.ump
@@ -1,0 +1,225 @@
+class UmpleToJava {
+    state_machine_Set <<!<</*state_machine_Set*/>><<#
+  boolean hasEntry = false;
+  boolean hasExit = false;
+  boolean isFirstEntry = true;
+  boolean isFirstExit = true;
+  State parentState = sm.getParentState();
+  StateMachine parentSm = parentState != null ? parentState.getStateMachine() : null;
+  String customSetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("setMethod",sm)));
+  String customSetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("setMethod",sm)));
+  String customExitPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("exitMethod",sm)));
+  String customExitPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("exitMethod",sm)));
+  
+  StringBuilder entryActions = new StringBuilder();
+  StringBuilder exitActions = new StringBuilder();
+
+  List<String> entryFileNames = new ArrayList<String>();
+  List<Integer> entryUmpleLineNumbers = new ArrayList<Integer>();
+  List<Integer> entryJavaLineNumbers = new ArrayList<Integer>();
+  List<Integer> entryLengths = new ArrayList<Integer>();
+  int preJavaLine = realSb.toString().split("\\n").length;
+  int entryJavaLine = realSb.toString().split("\\n").length+(customSetPostfixCode != null?customSetPostfixCode.split("\\n").length:0)+(customSetPrefixCode != null?customSetPrefixCode.split("\\n").length:0)+10+(parentState != null?2:0);
+  int exitJavaLine = realSb.toString().split("\\n").length+(customExitPrefixCode != null?customExitPrefixCode.split("\\n").length:0)+7;
+  
+  for(State state : sm.getStates())
+  {
+    boolean hasThisEntry = false;
+    boolean hasThisExit = false;
+    for(Action action : state.getActions())
+    {
+      if ("entry".equals(action.getActionType()))
+      {
+        TraceItem traceItem = state.getTraced("entry",uClass);
+        TraceItem traceItemActivity = state.getTraced("activity",uClass);
+        if (!hasThisEntry)
+        {
+          if (!isFirstEntry)
+          {
+            entryActions.append("\n      ");
+            entryJavaLine++;
+          }
+          entryActions.append(StringFormatter.format("case {0}:",gen.translate("stateOne",state)));
+          entryJavaLine++;
+        }
+        hasEntry = true;
+        hasThisEntry = true;
+        isFirstEntry = false;
+        if(traceItem!=null)
+        {
+          entryActions.append("\n"+traceItem.trace(gen, state,"sm_e", uClass));
+          entryJavaLine++;
+        }
+        Position p = action.getPosition();
+        if (p != null) {
+          StateMachine sm_temp=sm;
+          if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
+          
+          entryActions.append("\n        // line " + p.getLineNumber() + " \"" + sm_temp.getUmpleClass().getRelativePath("Java") + "\"");
+          entryFileNames.add(sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/",""));
+          entryUmpleLineNumbers.add(p.getLineNumber());
+          entryJavaLineNumbers.add(entryJavaLine-1);
+          entryLengths.add(action.getActionCode().split("\\n").length);
+        }
+
+        if (state.getIsDeepHistoryState() == true){
+          
+          String actionCode = action.getActionCode();
+          int x = actionCode.lastIndexOf('.');
+          int y = actionCode.indexOf(')',x);
+          String substate = actionCode.substring(x+1,y);
+          String beginning = actionCode.substring(0,x + 1);
+          String end = actionCode.substring(y);
+          actionCode = beginning.concat("HStar").concat(end);
+          
+          entryActions.append(StringFormatter.format("\n        if({0}HStar == {1}.{2})", gen.translate("stateMachineOne",sm), gen.translate("type",sm), substate));
+          entryJavaLine++;
+          entryActions.append("\n        {");
+          entryJavaLine++;  
+          
+          entryActions.append("\n          " + actionCode);
+          entryJavaLine+=actionCode.split("\\n").length;
+          
+
+          //TODO: add more spaces if deepHistory
+          //entryActions.append(StringFormatter.format("{0}{1}({2}{3});","\n          ",gen.translate("setMethod",state.getStateMachine()),gen.translate("stateMachineOne",state.getStateMachine()),gen.translate("stateOne",state)));
+          //entryJavaLine++;
+          entryActions.append("\n        }");
+          entryJavaLine++;
+        }
+        else if(traceItemActivity!=null)
+        {
+          for (Activity activity : state.getActivities())
+          {
+            entryActions.append("\n        " + action.getActionCode().substring(0, action.getActionCode().length() - 1).concat(traceItemActivity.trace(gen, activity,"sm_di", uClass))+" }");
+            entryJavaLine+=action.getActionCode().split("\\n").length;
+          }
+        }
+        else{
+          entryActions.append("\n        " + action.getActionCode());
+          entryJavaLine+=action.getActionCode().split("\\n").length;
+        }
+
+      }
+      else if ("exit".equals(action.getActionType()))
+      {
+        TraceItem traceItem = state.getTraced("exit",uClass);
+        TraceItem traceItemActivity = state.getTraced("activity",uClass);
+        
+        if (!hasThisExit)
+        {
+          if (!isFirstExit)
+          {
+            exitActions.append("\n      ");
+            exitJavaLine++;
+          }
+          isFirstExit = false;
+          exitActions.append(StringFormatter.format("case {0}:",gen.translate("stateOne",state)));
+          exitJavaLine++;
+        }
+        hasExit = true;
+        hasThisExit = true;
+        isFirstExit = false;
+        if(traceItem!=null)
+        {
+          exitActions.append("\n"+traceItem.trace(gen, state,"sm_x", uClass));
+          exitJavaLine++;
+        }
+        Position p = action.getPosition();
+        if (p != null) {
+          StateMachine sm_temp=sm;
+          if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
+          
+          exitActions.append("\n        // line " + p.getLineNumber() + " \"" + sm_temp.getUmpleClass().getRelativePath("Java") + "\"");
+          addUncaughtExceptionVariables(gen.translate("exitMethod",sm),
+                                        sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/",""),
+                                        p.getLineNumber(),
+                                        exitJavaLine-1,
+                                        action.getActionCode().split("\\n").length);
+        }
+        if(traceItemActivity!=null)
+        {
+          for (Activity activity : state.getActivities())
+          {
+            exitActions.append("\n        " + action.getActionCode().substring(0, action.getActionCode().length() - 1).concat(traceItemActivity.trace(gen, activity,"sm_di", uClass))+" }");
+            exitJavaLine+=action.getActionCode().split("\\n").length;
+            exitJavaLine++;
+          }
+        }
+        else
+        {
+        	exitActions.append("\n        " + action.getActionCode());
+            exitJavaLine+=action.getActionCode().split("\\n").length;
+        }
+      }
+    }
+    
+    if (hasThisEntry)
+    {
+      entryActions.append("\n        break;");
+      entryJavaLine++;
+    }
+    
+    if (hasThisExit)
+    {
+      exitActions.append("\n        break;");
+      exitJavaLine++;
+    }
+    
+  }
+#>>
+<<# if (hasExit) {
+  #>>
+  private void <<=gen.translate("exitMethod",sm)>>()
+  {
+    <<# if (customExitPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customExitPrefixCode,gen.translate("exitMethod",sm));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customExitPrefixCode, "    ")); } #>>
+    switch(<<= gen.translate("stateMachineOne",sm) >>)
+    {
+      <<= exitActions >>
+    }
+    <<# if (customExitPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customExitPostfixCode,gen.translate("exitMethod",sm)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customExitPostfixCode, "    ")); } #>>
+  }
+
+
+<<# 
+    List<Integer> tempList = new ArrayList<Integer>();
+    tempList.addAll(entryJavaLineNumbers);
+    entryJavaLineNumbers.clear();
+    for(Integer i: tempList){
+      entryJavaLineNumbers.add(i+(realSb.toString().split("\\n").length-preJavaLine));
+    }
+  }
+  if(entryJavaLineNumbers.size()>0){
+    String methodName = gen.translate("setMethod",sm);
+    for(int i=0;i<entryJavaLineNumbers.size();++i){
+      addUncaughtExceptionVariables(methodName,entryFileNames.get(i),entryUmpleLineNumbers.get(i),entryJavaLineNumbers.get(i),entryLengths.get(i));
+    }
+  } #>>
+  private void <<=gen.translate("setMethod",sm)>>(<<= gen.translate("type",sm) >> <<= gen.translate("parameterOne",sm) >>)
+  {
+    <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",sm)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+    <<= gen.translate("stateMachineOne",sm) >> = <<= gen.translate("parameterOne",sm) >>;
+<<# if (parentState != null) { #>>
+    if (<<= gen.translate("stateMachineOne",parentSm) >> != <<= gen.translate("type",parentSm) >>.<<= gen.translate("stateOne",parentState) >> && <<= gen.translate("parameterOne",sm) >> != <<= gen.translate("type",sm) >>.<<= gen.translate("stateNull",sm) >>) { <<=gen.translate("setMethod",parentSm)>>(<<= gen.translate("type",parentSm) >>.<<= gen.translate("stateOne",parentState) >>); }
+<<# } #>>
+    <<# if (customSetPostfixCode != null) {  addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",sm));
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+<<# if (hasEntry) { #>>
+
+    // entry actions and do activities
+    switch(<<= gen.translate("stateMachineOne",sm) >>)
+    {
+      <<= entryActions >>
+    }
+<<# } #>>
+<<# if (parentState != null) { #>>
+  <<# if (sm.getContainsDeepHistoryState()) { #>>
+    if (<<= gen.translate("parameterOne",sm) >> == <<= gen.translate("type",sm)  >>.HStar) { <<= gen.translate("stateMachineOne",sm) >> = <<= gen.translate("stateMachineOne", sm) >>HStar;}
+  <<# } #>>
+<<# } #>>
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_SetSimple.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_SetSimple.ump
@@ -1,0 +1,74 @@
+class UmpleToJava {
+    state_machine_SetSimple <<!<</*state_machine_SetSimple*/>><<#
+  StringBuilder allExitCases = new StringBuilder();
+  StringBuilder allEnterCases = new StringBuilder();
+  
+  for(State s : sm.getStates())
+  {
+    boolean hasThisExit = false;
+    boolean hasThisEntry = false;
+    for (Action action : s.getActions())
+    {
+      if ("exit".equals(action.getActionType()))
+      {
+        TraceItem traceItem = s.getTraced("exit",uClass);
+        
+        if (!hasThisExit)
+        {
+          allExitCases.append(StringFormatter.format("    if ({0} == {1}.{2} && {3} != {1}.{2} )\n    {"
+            , gen.translate("stateMachineOne",sm)
+            , gen.translate("type",sm)
+            , gen.translate("stateOne",s)
+            , gen.translate("parameterOne",sm)
+          ));
+        }
+
+        hasThisExit = true;
+
+        allExitCases.append(
+          traceItem!=null/*&&traceItem.getIsPost()*/?traceItem.trace(gen, s,"sm_e", uClass)+"\n":"");
+
+        allExitCases.append("\n      " + action.getActionCode()); 
+      }
+      else if("entry".equals(action.getActionType()))
+      {
+        TraceItem traceItem = s.getTraced("entry",uClass);        
+        
+        if (!hasThisEntry)
+        {
+          allEnterCases.append(StringFormatter.format("    if ({0} != {1}.{2} && {3} == {1}.{2} )\n    {"
+            , gen.translate("stateMachineOne",sm)
+            , gen.translate("type",sm)
+            , gen.translate("stateOne",s)
+            , gen.translate("parameterOne",sm)
+          ));
+        }
+
+        hasThisEntry = true;
+
+        allEnterCases.append(
+            traceItem!=null/*&&traceItem.getIsPost()*/?traceItem.trace(gen, s,"sm_x", uClass)+"\n":"");
+
+        allEnterCases.append("\n      " + action.getActionCode()); 
+      }
+    }
+    if (s.getHasExitAction()){
+     allExitCases.append("\n    }\n");
+    }
+    if (s.getHasEntryAction()){
+     allEnterCases.append("\n    }\n");
+    }
+  }
+  
+  String exitCasesOutput = allExitCases.toString().trim();
+  String enterCasesOutput = allEnterCases.toString().trim();
+#>>
+  public boolean <<=gen.translate("setMethod",sm)>>(<<= gen.translate("type",sm) >> <<= gen.translate("parameterOne",sm) >>)
+  {
+    <<# if (!exitCasesOutput.isEmpty()) { append(realSb, "\n    {0}",exitCasesOutput); } #>>
+    <<# if (!enterCasesOutput.isEmpty()) { append(realSb, "\n    {0}",enterCasesOutput); } #>>
+    <<= gen.translate("stateMachineOne",sm) >> = <<= gen.translate("parameterOne",sm) >>;
+    return true;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Set_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Set_All.ump
@@ -1,0 +1,23 @@
+use state_machine_Set.ump;
+use state_machine_SetSimple.ump;
+
+
+class UmpleToJava {
+    state_machine_Set_All <<!<</*state_machine_Set_All*/>><<#
+{
+  // GENERIC FILE - EDIT IN UmpleToTemplate project, then run "ant -f build.codegen.xml to move into the appropriate projects
+  for (StateMachine sm : uClass.getAllStateMachines())  
+  {
+
+    if (sm.getType() == "Simple" && sm.numberOfStates() > 0)
+    {
+      #>><<@ UmpleToJava.state_machine_SetSimple >><<#
+    }
+    else if (sm.numberOfStates() > 0)
+    {
+      #>><<@ UmpleToJava.state_machine_Set >><<#
+    }
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_doActivity.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_doActivity.ump
@@ -1,0 +1,34 @@
+class UmpleToJava {
+    state_machine_doActivity <<!<</*state_machine_doActivity*/>><<#
+  Event e = activity.getOnCompletionEvent();
+  String postTransition = e != null ? gen.translate("eventMethod",e) : null; 
+#>>
+<<# Position p = activity.getPosition();
+if (p != null) { 
+   int javaline = realSb.toString().split("\\n").length;
+   addUncaughtExceptionVariables(gen.translate("doActivityMethod",activity),p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/",""),p.getLineNumber(),javaline+7,activity.getActivityCode().split("\\n").length); 
+  } #>>
+  private void <<= gen.translate("doActivityMethod",activity)>>()
+  {
+    try
+    {
+      <<= activity.getActivityCode() >>
+      Thread.sleep(1);
+      <<# if (postTransition != null)
+      { 
+        for (Activity a : state.getActivities())
+        {
+          if(a != activity){
+            append(realSb, "\n      {0}.join();",gen.translate("doActivityThread",a));
+          }
+        }
+        append(realSb, "\n      {0}();",postTransition); 
+      } #>>
+    }
+    catch (InterruptedException e)
+    {
+
+    }
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_doActivityThread.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_doActivityThread.ump
@@ -1,0 +1,72 @@
+class UmpleToJava {
+    state_machine_doActivityThread <<!<</*state_machine_doActivityThread*/>><<#   
+  StringBuilder output = new StringBuilder();
+
+  isFirst = true;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    List<StateMachine> allNested = sm.getNestedStateMachines();
+    
+    for (StateMachine nestedSm : allNested)
+    {
+      for (State state : nestedSm.getStates())
+      {
+        for (Activity activity : state.getActivities())
+        {
+          if (isFirst)
+          {
+            output.append(StringFormatter.format("if"));
+            isFirst = false;
+          }
+          else
+          {
+            output.append(StringFormatter.format("\n        else if"));
+          }
+          output.append(StringFormatter.format(" (\"{0}\".equals(doActivityMethodName))\n",gen.translate("doActivityMethod",activity)));
+          output.append(StringFormatter.format("      {\n"));
+          output.append(StringFormatter.format("        controller.{0}();\n",gen.translate("doActivityMethod",activity)));
+          output.append(StringFormatter.format("      }"));
+        }
+      }
+    }
+    
+    for (State state : sm.getStates())
+    {
+      for (Activity activity : state.getActivities())
+      {
+        if (isFirst)
+        {
+          output.append(StringFormatter.format("if"));
+          isFirst = false;
+        }
+        else
+        {
+          output.append(StringFormatter.format("\n        else if"));
+        }
+        output.append(StringFormatter.format(" (\"{0}\".equals(doActivityMethodName))\n",gen.translate("doActivityMethod",activity)));
+        output.append(StringFormatter.format("      {\n"));
+        output.append(StringFormatter.format("        controller.{0}();\n",gen.translate("doActivityMethod",activity)));
+        output.append(StringFormatter.format("      }"));
+      }
+    }
+  }
+#>>
+  private static class DoActivityThread extends Thread
+  {
+    <<=gen.translate("type",uClass)>> controller;
+    String doActivityMethodName;
+    
+    public DoActivityThread(<<=gen.translate("type",uClass)>> aController,String aDoActivityMethodName)
+    {
+      controller = aController;
+      doActivityMethodName = aDoActivityMethodName;
+      start();
+    }
+    
+    public void run()
+    {
+      <<= output >>
+    }
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_doActivity_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_doActivity_All.ump
@@ -1,0 +1,40 @@
+use state_machine_doActivity.ump;
+use state_machine_doActivityThread.ump;
+
+
+class UmpleToJava {
+    state_machine_doActivity_All <<!<</*state_machine_doActivity_All*/>><<#
+{ 
+  boolean hasActivities = false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    List<StateMachine> allNested = sm.getNestedStateMachines();
+    
+    for (StateMachine nestedSm : allNested)
+    {
+      for (State state : nestedSm.getStates())
+      {
+        for (Activity activity : state.getActivities())
+        {
+          hasActivities = true;
+          #>><<@ UmpleToJava.state_machine_doActivity >><<#
+        }
+      }
+    }
+    
+    for (State state : sm.getStates())
+    {
+      for (Activity activity : state.getActivities())
+      {
+        hasActivities = true;
+        #>><<@ UmpleToJava.state_machine_doActivity >><<#
+      }
+    }
+  } 
+  if (hasActivities)
+  {
+    #>><<@ UmpleToJava.state_machine_doActivityThread >><<#
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_All.ump
@@ -1,0 +1,53 @@
+use state_machine_Event_StartStopTimer.ump;
+use state_machine_Event_StartStopTimer_NestedStates.ump;
+use state_machine_timedEvent_Handler.ump;
+
+
+class UmpleToJava {
+    state_machine_timedEvent_All <<!<</*state_machine_timedEvent_All*/>><<#
+{ 
+  boolean hasTimedEvents = false;
+  boolean hasTimedEvents_NestedStates = false;
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    if(sm.getNestedStateMachines().isEmpty())
+    {
+      for (Event e : sm.getEvents())
+      {
+        if (e.getIsTimer())
+        {
+          hasTimedEvents = true;
+          #>><<@ UmpleToJava.state_machine_Event_StartStopTimer >><<#
+        }
+      }
+    }
+    else if(!sm.getNestedStateMachines().isEmpty())
+    {
+      for (Event e : sm.getEvents())
+      {
+        if (e.getIsTimer())
+        {
+          hasTimedEvents = true;
+          #>><<@ UmpleToJava.state_machine_Event_StartStopTimer >><<#
+        }
+      }
+      for(StateMachine nsm : sm.getNestedStateMachines())
+      {
+        for(Event event : nsm.getEvents())
+        {
+          if(event.getIsTimer())
+          {
+            hasTimedEvents_NestedStates = true;
+            #>><<@ UmpleToJava.state_machine_Event_StartStopTimer_NestedStates >><<#
+          }
+        }
+      }
+    }
+  }
+  if (hasTimedEvents || hasTimedEvents_NestedStates)
+  {
+    #>><<@ UmpleToJava.state_machine_timedEvent_Handler >><<#
+  }
+}
+#>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_Handler.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_Handler.ump
@@ -1,0 +1,71 @@
+use state_machine_timedEvent_run.ump;
+use state_machine_timedEvent_run_NestedStates.ump;
+
+
+class UmpleToJava {
+    state_machine_timedEvent_Handler <<!<</*state_machine_timedEvent_Handler*/>><<#
+ 
+
+#>>
+  public static class TimedEventHandler extends TimerTask  
+  {
+    private <<= gen.translate("type",uClass) >> controller;
+    private String timeoutMethodName;
+    private double howLongInSeconds;
+    private Timer timer;
+    
+    public TimedEventHandler(<<= gen.translate("type",uClass) >> aController, String aTimeoutMethodName, double aHowLongInSeconds)
+    {
+      controller = aController;
+      timeoutMethodName = aTimeoutMethodName;
+      howLongInSeconds = aHowLongInSeconds;
+      timer = new Timer();
+      timer.schedule(this, (long)howLongInSeconds*1000);
+    }
+    
+    public void stop()
+    {
+      timer.cancel();
+    }
+    
+    public void run ()
+    {
+<<#
+  for(StateMachine sm : uClass.getStateMachines())
+  {
+    if(sm.getNestedStateMachines().isEmpty())
+    {
+      for (Event e : sm.getEvents())
+      {
+        if (e.getIsTimer())
+        {
+          #>><<@ UmpleToJava.state_machine_timedEvent_run >><<#
+        }
+      }
+    }
+    else if(!sm.getNestedStateMachines().isEmpty())
+    {
+      for (Event e : sm.getEvents())
+      {
+        if (e.getIsTimer())
+        {
+          #>><<@ UmpleToJava.state_machine_timedEvent_run >><<#
+        }
+      }
+      for(StateMachine nsm : sm.getNestedStateMachines())
+      {
+        for(Event event : nsm.getEvents())
+        {
+          if(event.getIsTimer())
+          {
+            #>><<@ UmpleToJava.state_machine_timedEvent_run_NestedStates >><<#
+          }
+        }
+      }
+    }
+  }
+#>>
+    }
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_run.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_run.ump
@@ -1,0 +1,12 @@
+class UmpleToJava {
+    state_machine_timedEvent_run <<!<</*state_machine_timedEvent_run*/>>
+      if ("<<= gen.translate("eventMethod",e) >>".equals(timeoutMethodName))
+      {
+        boolean shouldRestart = !controller.<<= gen.translate("eventMethod",e) >>();
+        if (shouldRestart)
+        {
+          controller.<<= gen.translate("eventStartMethod",e) >>();
+        }
+        return;
+      }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_run_NestedStates.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_timedEvent_run_NestedStates.ump
@@ -1,0 +1,12 @@
+class UmpleToJava {
+    state_machine_timedEvent_run_NestedStates <<!<</*state_machine_timedEvent_run_NestedStates*/>>
+      if ("<<= gen.translate("eventMethod",event) >>".equals(timeoutMethodName))
+      {
+        boolean shouldRestart = !controller.<<= gen.translate("eventMethod",event) >>();
+        if (shouldRestart)
+        {
+          controller.<<= gen.translate("eventStartMethod",event) >>();
+        }
+        return;
+      }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/toString_declare.ump
+++ b/UmpleToJava/UmpleTLTemplates/toString_declare.ump
@@ -1,0 +1,94 @@
+class UmpleToJava {
+    toString_declare <<!<</*toString_declare*/>>
+
+  public String toString()
+  {
+    String outputString = "";<<#
+	  String customToStringPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before","toString"));
+	  String customToStringPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after","toString"));
+	  if (customToStringPrefixCode != null) 
+	  {
+		  append(realSb, "\n{0}",GeneratorHelper.doIndent(customToStringPrefixCode, "    "));
+	  }
+	  if (customToStringPostfixCode != null) 
+	  {
+		  append(realSb, "\n{0}",GeneratorHelper.doIndent(customToStringPostfixCode, "    "));
+	  }
+	  String ret = "";
+
+	  LinkedList<String> displayedAttributes = new LinkedList<String>();
+	  LinkedList<String> nameOfAttributes = new LinkedList<String>();
+	  LinkedList<String> displayedPrimitives = new LinkedList<String>();
+	  LinkedList<String> nameOfPrimitives = new LinkedList<String>();
+	  List<String> keys = new ArrayList<String>();
+	  List<String> reflexiveNames = new ArrayList<String>();
+	  List<String> reflexive = new ArrayList<String>();
+	  for(String k: uClass.getKey().getMembers())
+		  keys.add(k);
+	  for(Attribute av: uClass.getAttributes())
+	  {
+	      
+		  if(!av.getIsList()&&!"internal".equals(av.getModifier())&&!"const".equals(av.getModifier())&&("String".equals(av.getType())||"int".equals(av.getType())||"Integer".equals(av.getType())||"boolean".equals(av.getType().toLowerCase())||"float".equals(av.getType())||"Float".equals(av.getType())||"double".equals(av.getType())||"Double".equals(av.getType())||"byte".equals(av.getType())||"Byte".equals(av.getType())||"char".equals(av.getType())||"Character".equals(av.getType())||"long".equals(av.getType())||"Long".equals(av.getType())||"short".equals(av.getType())||"Short".equals(av.getType())))
+		  {
+			  if(av.getIsAutounique() || keys.contains(av.getName())){
+				  nameOfPrimitives.addFirst(av.getName());
+				  displayedPrimitives.addFirst(gen.translate("getMethod",av)+"()");
+			  }
+			  else {
+				  nameOfPrimitives.addLast(av.getName());
+				  displayedPrimitives.addLast(gen.translate("getMethod",av)+"()");
+			  }
+		  }
+		  else if(!av.getIsList()&&!"const".equals(av.getModifier())&&!"internal".equals(av.getModifier()))
+		  {
+			  if(av.getIsAutounique() || keys.contains(av.getName())){
+				  nameOfAttributes.addFirst(av.getName());
+				  displayedAttributes.addFirst(gen.translate("getMethod",av)+"()");
+			  }
+			  else {
+				  nameOfAttributes.addLast(av.getName());
+				  displayedAttributes.addLast(gen.translate("getMethod",av)+"()");
+			  }
+		  }
+	  }
+	  for(AssociationVariable av: uClass.getAssociationVariables())
+	  {
+	    if(av.isIsNavigable()&&av.getUmpleClass()!=av.getRelatedAssociation().getUmpleClass())
+	    {
+	      if("1".equals(av.getMultiplicity().getMinimum())||"0".equals(av.getMultiplicity().getMinimum())||"1".equals(av.getMultiplicity().getBound()))
+	      {
+	        if("1".equals(av.getMultiplicity().getMaximum())||"1".equals(av.getMultiplicity().getBound()))
+	        {
+	          reflexiveNames.add(av.getName());
+	          reflexive.add(gen.translate("getMethod",av)+"()");
+		    }
+		  }
+		}
+		  
+	  }
+	  ret += "super.toString() + \"[\"";
+	  boolean firstStr = true;
+	  for(int m=0;m<displayedPrimitives.size();m++)
+	  {
+		  if(firstStr)
+			  firstStr = false;
+		  else
+			  ret += "+ \",\" ";
+		  ret += "+\n            \"" + nameOfPrimitives.get(m) + "\" + \":\" + " + displayedPrimitives.get(m); 
+	  }
+	  ret += "+ \"]\"";
+	  for(int m=0;m<displayedAttributes.size();m++)
+	  {          
+		  ret += " + System.getProperties().getProperty(\"line.separator\") +\n            ";      
+		  ret += "\"  \" + " + "\"" + nameOfAttributes.get(m) + "\" + \"=\" + (" + displayedAttributes.get(m) + " != null ? !" + displayedAttributes.get(m) + ".equals(this)  ? " + displayedAttributes.get(m) + ".toString().replaceAll(\"  \",\"    \") : \"this\" : \"null\")";
+
+	  }
+	  for(int m=0;m<reflexive.size();m++){
+	      ret += " + System.getProperties().getProperty(\"line.separator\") +\n            ";
+	      ret += "\"  \" + " +  "\""+reflexiveNames.get(m)+" = \"+("+reflexive.get(m)+"!=null?Integer.toHexString(System.identityHashCode("+reflexive.get(m)+")):\"null\")";
+	  }
+	  ret += "\n     + outputString";
+	  append(realSb,"\n    return {0};", ret);
+	  #>>
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/trace.ump
+++ b/UmpleToJava/UmpleTLTemplates/trace.ump
@@ -1,0 +1,3 @@
+class UmpleToJava {
+    trace <<!<</*trace*/>>!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/uncaught_exception.ump
+++ b/UmpleToJava/UmpleTLTemplates/uncaught_exception.ump
@@ -1,0 +1,132 @@
+class UmpleToJava {
+    uncaught_exception <<!<</*uncaught_exception*/>><<#
+java.util.regex.Pattern lineNumberPattern = java.util.regex.Pattern.compile("// line ([0|1|2|3|4|5|6|7|8|9]*) (.*)");
+public static UmpleClass mainMainClass = null;
+private void addUncaughtExceptionVariables(int javaline, String code, String methodname)
+{
+  String[] lines = code.split("\\n");
+  java.util.regex.Matcher matcher = lineNumberPattern.matcher(lines[0]);
+  if(matcher.matches())
+  {
+    if(!uncaughtExceptions.containsKey(methodname))
+    {
+      uncaughtExceptions.put(methodname,new UncaughtException(globalUmpleClass.getName(), methodname));
+    }
+    uncaughtExceptions.get(methodname).addUncaughtFileName(matcher.group(2));
+    uncaughtExceptions.get(methodname).addUncaughtUmpleLine(Integer.parseInt(matcher.group(1))-1);
+    uncaughtExceptions.get(methodname).addUncaughtJavaLine(javaline+1);
+    uncaughtExceptions.get(methodname).addUncaughtLength(lines.length);
+  }  
+}
+private void addUncaughtExceptionVariables(String methodname, String filename, int umpleline, int javaline, int length)
+{
+  if(!uncaughtExceptions.containsKey(methodname))
+  {
+    uncaughtExceptions.put(methodname,new UncaughtException(globalUmpleClass.getName(), methodname));
+  }
+  
+  uncaughtExceptions.get(methodname).addUncaughtFileName(filename);
+  uncaughtExceptions.get(methodname).addUncaughtUmpleLine(umpleline-1);
+  uncaughtExceptions.get(methodname).addUncaughtJavaLine(javaline+1);
+  uncaughtExceptions.get(methodname).addUncaughtLength(length);
+}
+public String getExceptionHandler(String exceptions) { 
+  StringBuilder realSb = new StringBuilder();#>>
+  public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
+  {
+    public void uncaughtException(Thread t, Throwable e)
+    {
+      translate(e);
+      if(e.getCause()!=null)
+      {
+        translate(e.getCause());
+      }
+      e.printStackTrace();
+    }
+    public void translate(Throwable e)
+    {
+      java.util.List<StackTraceElement> result = new java.util.ArrayList<StackTraceElement>();
+      StackTraceElement[] elements = e.getStackTrace();
+      try
+      {
+        for(StackTraceElement element:elements)
+        {
+          String className = element.getClassName();
+          String methodName = element.getMethodName();
+          boolean methodFound = false;
+          int index = className.lastIndexOf('.')+1;
+          try {
+            java.lang.reflect.Method query = this.getClass().getMethod(className.substring(index)+"_"+methodName,new Class[]{});
+            UmpleSourceData sourceInformation = (UmpleSourceData)query.invoke(this,new Object[]{});
+            for(int i=0;i<sourceInformation.size();++i)
+            {
+              int distanceFromStart = element.getLineNumber()-sourceInformation.getJavaLine(i)-(("main".equals(methodName))?2:0);
+              if(distanceFromStart>=0&&distanceFromStart<=sourceInformation.getLength(i))
+              {
+                result.add(new StackTraceElement(element.getClassName(),element.getMethodName(),sourceInformation.getFileName(i),sourceInformation.getUmpleLine(i)+distanceFromStart));
+                methodFound = true;
+                break;
+              }
+            }
+          }
+          catch (Exception e2){}
+          if(!methodFound)
+          {
+            result.add(element);
+          }
+        }
+      }
+      catch (Exception e1)
+      {
+        e1.printStackTrace();
+      }
+      e.setStackTrace(result.toArray(new StackTraceElement[0]));
+    }
+  //The following methods Map Java lines back to their original Umple file / line    
+<<=exceptions>>
+  }
+  public static class UmpleSourceData
+  {
+    String[] umpleFileNames;
+    Integer[] umpleLines;
+    Integer[] umpleJavaLines;
+    Integer[] umpleLengths;
+    
+    public UmpleSourceData(){
+    }
+    public String getFileName(int i){
+      return umpleFileNames[i];
+    }
+    public Integer getUmpleLine(int i){
+      return umpleLines[i];
+    }
+    public Integer getJavaLine(int i){
+      return umpleJavaLines[i];
+    }
+    public Integer getLength(int i){
+      return umpleLengths[i];
+    }
+    public UmpleSourceData setFileNames(String... filenames){
+      umpleFileNames = filenames;
+      return this;
+    }
+    public UmpleSourceData setUmpleLines(Integer... umplelines){
+      umpleLines = umplelines;
+      return this;
+    }
+    public UmpleSourceData setJavaLines(Integer... javalines){
+      umpleJavaLines = javalines;
+      return this;
+    }
+    public UmpleSourceData setLengths(Integer... lengths){
+      umpleLengths = lengths;
+      return this;
+    }
+    public int size(){
+      return umpleFileNames.length;
+    }
+  } 
+}<<#
+  return realSb.toString();
+}#>>!>>
+}

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -146,6 +146,7 @@
 
     <!-- First compile the Umple templates -->
     <!-- Default to using the stable version of umple since it should always be available -->
+    <!--
     <parallel>
       <java jar="${umple.stable.jar}" fork="true" failonerror="true">
         <arg value="UmpleToJava/UmpleTLTemplates/Master.ump"/>
@@ -159,23 +160,26 @@
       <java jar="${umple.stable.jar}" fork="true" failonerror="true">
         <arg value="UmpleToSql/UmpleTLTemplates/Master.ump"/>
       </java>
-    </parallel>
+    </parallel> -->
 
+    <!-- To compile the following (other than CPP) with Umple templates:
+       1) Uncomment the above parallel
+       2) Change the UmpleTo*/src/cruise/... to UmpleTo*/src-gen-UmpleTL/cruise... -->
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/java" overwrite="true">
-      <fileset dir="UmpleToJava/src/cruise/umple/compiler/java" excludes=".git*" />
+      <fileset dir="UmpleToJava/src/cruise/umple/compiler/java" excludes=".git* UmpleToJava.java" />
     </copy>
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/php" overwrite="true">
-      <fileset dir="UmpleToPhp/src-gen-UmpleTL/cruise/umple/compiler/php" excludes=".git* UmpleToPhp.java" />
+      <fileset dir="UmpleToPhp/src/cruise/umple/compiler/php" excludes=".git* UmpleToPhp.java" />
     </copy>
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/ruby" overwrite="true">
-      <fileset dir="UmpleToRuby/src-gen-UmpleTL/cruise/umple/compiler/ruby" excludes=".git* UmpleToRuby.java" />
+      <fileset dir="UmpleToRuby/src/cruise/umple/compiler/ruby" excludes=".git* UmpleToRuby.java" />
     </copy>
     <!-- OLD CPP DEPRECATED -->
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/cpp" overwrite="true">
       <fileset dir="UmpleToCpp/src/cruise/umple/compiler/cpp" excludes=".git*" />
     </copy>
     <copy todir="cruise.umple/src-gen-jet/cruise/umple/compiler/sql" overwrite="true">
-      <fileset dir="UmpleToSql/src-gen-UmpleTL/cruise/umple/compiler/sql" excludes=".git* UmpleToSql.java" />
+      <fileset dir="UmpleToSql/src/cruise/umple/compiler/sql" excludes=".git* UmpleToSql.java" />
     </copy>
   </target>
 

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -148,6 +148,9 @@
     <!-- Default to using the stable version of umple since it should always be available -->
     <parallel>
       <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+        <arg value="UmpleToJava/UmpleTLTemplates/Master.ump"/>
+      </java>
+      <java jar="${umple.stable.jar}" fork="true" failonerror="true">
         <arg value="UmpleToPhp/UmpleTLTemplates/Master.ump"/>
       </java>
       <java jar="${umple.stable.jar}" fork="true" failonerror="true">

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Mentor.java.txt
@@ -150,7 +150,7 @@ public class Mentor
     return wasRemoved;
   }
 
-  
+
   public void delete()
   {
     ArrayList<Student> copyOfStudents = new ArrayList<Student>(students);

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Student.java.txt
@@ -150,7 +150,7 @@ public class Student
     return wasRemoved;
   }
 
-  
+
   public void delete()
   {
     ArrayList<Mentor> copyOfMentors = new ArrayList<Mentor>(mentors);

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Mentor.java.txt
@@ -135,7 +135,7 @@ public class Mentor
     return wasRemoved;
   }
 
-  
+
   public void delete()
   {
     ArrayList<Student> copyOfStudents = new ArrayList<Student>(students);


### PR DESCRIPTION
This pull request contains the final Umple templates for Java.

As requested, the build will default to using JET, which will result in 19 failed tests, 16 in Ruby and 3 in Java. Most are due to JET including extra spaces, although some are due to it not adding enough blank lines.
