### PR TITLE
Fixed incorrectly generating reference comments and added @umplesource to interfaces

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -91,8 +91,7 @@ class JavaClassGenerator {
 
 <<# if (uClass.numberOfComments() > 0) { append(realSb, "\n{0}", Comment.format("Javadoc",uClass.getComments())); } #>>
 <<# for (Position p : uClass.getPositions()) { #>>
-<<# uClass.setSourceFilename( p.getFilename() ); #>>
-// line <<= p.getLineNumber() >> "<<= uClass.getRelativePath("Java") >>"
+// line <<= p.getLineNumber() >> "<<= uClass.getRelativePath(p.getFilename(),"Java") >>"
 <<# } #>>
 public <<# if (uClass.getIsAbstract()) { append(realSb, "{0} ", "abstract"); } #>>class <<=uClass.getName()>><<= gen.translate("isA",uClass) >><<#
 

--- a/UmpleToJava/UmpleTLTemplates/JavaInterfaceGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaInterfaceGenerator.ump
@@ -9,6 +9,7 @@ namespace cruise.umple.compiler.java;
 external interface ILang{}
 
 class JavaInterfaceGenerator {
+    depend cruise.umple.parser.Position;
     depend cruise.umple.compiler.*;
     depend cruise.umple.util.*;
     depend java.util.*;
@@ -47,6 +48,10 @@ class JavaInterfaceGenerator {
 #>>
 <<=gen.translate("packageDefinition",uInterface)>><<@ UmpleToJava.import_packages_interface >>
 
+<<# if (uInterface.numberOfComments() > 0) { append(realSb, "\n{0}", Comment.format("Javadoc",uInterface.getComments())); } #>>
+<<# for (Position p : uInterface.getPositions()) { #>>
+// line <<= p.getLineNumber() >> "<<= uInterface.getRelativePath(p.getFilename(),"Java") >>"
+<<# } #>>
 public interface <<=uInterface.getName()>><<= gen.translate("isA",uInterface) >>
 {
   <<=extraCode>>

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -15,8 +15,7 @@ class UmpleToJava {
         
         if (p != null) {
 //        use annotations instead
-        uClass.setSourceFilename( p.getFilename() );
-        positionHeader = "  // line " + p.getLineNumber() + " \"" + uClass.getRelativePath("Java") + "\"\n";
+        positionHeader = "  // line " + p.getLineNumber() + " \"" + uClass.getRelativePath(p.getFilename(),"Java") + "\"\n";
 //        positionHeader = "\n  @umplesourcefile(line={"+p.getLineNumber()+"},file={\""+p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/","")+ "\"},javaline={"+(javaline+4)+"},length={"+(aMethod.getIsImplemented()?2: aMethod.getMethodBody().getExtraCode().split("\\n").length+2)+"})";          
         }
         else 

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
@@ -82,7 +82,7 @@ class UmpleToJava {
           if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
           
           addUncaughtExceptionVariables(gen.translate("eventMethod",e),
-                                      sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/","").replace("\"",""),
+                                      sm_temp.getUmpleClass().getRelativePath(t.getGuard().getPosition().getFilename(),"Java").replace("\\","/").replaceAll(".*/","").replace("\"",""),
                                       t.getGuard().getPosition().getLineNumber(),
                                       javaLine-1,
                                       condition.split("\\n").length-1);
@@ -104,12 +104,14 @@ class UmpleToJava {
             StateMachine sm_temp=sm;
             if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
             
+            final String relativePath = sm_temp.getUmpleClass().getRelativePath(p.getFilename(),"Java");
+            
             addUncaughtExceptionVariables(gen.translate("eventMethod",e),
-                                        sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/","").replace("\"",""),
+                                        relativePath.replace("\\","/").replaceAll(".*/","").replace("\"",""),
                                         p.getLineNumber(),
                                         javaLine-2,
                                         a1.getActionCode().split("\\n").length);
-            allCases.append("        // line " + p.getLineNumber() + " \"" + sm_temp.getUmpleClass().getRelativePath("Java") + "\"\n");
+            allCases.append("        // line " + p.getLineNumber() + " \"" + relativePath + "\"\n");
             javaLine++;
           }
           allCases.append(StringFormatter.format("{0}{1}\n",tabSpace,a1.getActionCode()));

--- a/UmpleToJava/UmpleTLTemplates/state_machine_Set.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Set.ump
@@ -54,9 +54,9 @@ class UmpleToJava {
         if (p != null) {
           StateMachine sm_temp=sm;
           if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
-          
-          entryActions.append("\n        // line " + p.getLineNumber() + " \"" + sm_temp.getUmpleClass().getRelativePath("Java") + "\"");
-          entryFileNames.add(sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/",""));
+          final String relativePath = sm_temp.getUmpleClass().getRelativePath(p.getFilename(),"Java");
+          entryActions.append("\n        // line " + p.getLineNumber() + " \"" + relativePath + "\"");
+          entryFileNames.add(relativePath.replace("\\","/").replaceAll(".*/",""));
           entryUmpleLineNumbers.add(p.getLineNumber());
           entryJavaLineNumbers.add(entryJavaLine-1);
           entryLengths.add(action.getActionCode().split("\\n").length);
@@ -130,9 +130,11 @@ class UmpleToJava {
           StateMachine sm_temp=sm;
           if (sm.getUmpleClass()==null) sm_temp=sm.getRootStateMachine();
           
-          exitActions.append("\n        // line " + p.getLineNumber() + " \"" + sm_temp.getUmpleClass().getRelativePath("Java") + "\"");
+          final String relativePath = sm_temp.getUmpleClass().getRelativePath(p.getFilename(),"Java");
+          
+          exitActions.append("\n        // line " + p.getLineNumber() + " \"" + relativePath + "\"");
           addUncaughtExceptionVariables(gen.translate("exitMethod",sm),
-                                        sm_temp.getUmpleClass().getRelativePath("Java").replace("\\","/").replaceAll(".*/",""),
+                                        relativePath.replace("\\","/").replaceAll(".*/",""),
                                         p.getLineNumber(),
                                         exitJavaLine-1,
                                         action.getActionCode().split("\\n").length);

--- a/UmpleToRTCpp/src/cruise/umple/cpp/util/UmpleCPPGenerationUtil.java
+++ b/UmpleToRTCpp/src/cruise/umple/cpp/util/UmpleCPPGenerationUtil.java
@@ -71,7 +71,7 @@ public class UmpleCPPGenerationUtil {
 		    stringBuffer.append("// line "); //$NON-NLS-1$
 		    stringBuffer.append( p.getLineNumber() );
 		    stringBuffer.append(" \""); //$NON-NLS-1$
-		    stringBuffer.append( umpleClass.getRelativePath(language) );
+		    stringBuffer.append( umpleClass.getRelativePath( p.getFilename(), language) );
 		    stringBuffer.append("\""); //$NON-NLS-1$
 		    positions.add(stringBuffer.toString());
 		}

--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -72,7 +72,7 @@ class GeneratorHelper
            
           Position p = inject.getPosition();
 	      if (p != null) {
-	          positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+	          positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
 	      }
         }
         else

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -495,6 +495,8 @@ class UmpleInterface
 
   * -> 0..* UmpleInterface extendsInterface;
 
+  // The comments associated with the Umple Interface (such as the Javadoc above it).
+  1 -> * Comment;
 
   before setPackageName { if (aPackageName == null) { return false; } }
   before addDepend { if (depends.contains(aDepend)) { return false; } }

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -478,7 +478,6 @@ class UmpleClassifier
   * -> * Depend;
   
   UmpleModel sourceModel;
-  String sourceFilename = "";
 
   // The constants contained within the Umple Classifier.
   1 -> 0..* Constant;

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -812,7 +812,7 @@ class UmpleInternalParser
     if(classToken.is("associationClassDefinition")){
         aClass = model.addAssociationClass(classToken.getValue("name"));
     }else{
-        aClass = model.addUmpleClass(classToken.getValue("name"),classToken.getPosition().getFilename());
+        aClass = model.addUmpleClass(classToken.getValue("name"));
     }
     if ( classToken.is("classDefinition") && "external".equals(aClass.getModifier()) )
       aClass.setModifier(""); // Remove the external modifier if a non-external specification of this class is found.
@@ -995,7 +995,6 @@ class UmpleInternalParser
     }
   
     UmpleInterface newInterface = new UmpleInterface(t.getValue("name"),model);
-    newInterface.setSourceFilename(t.getPosition().getFilename());
     model.addUmpleInterface(newInterface);
     if(!"".equals(newInterface.getPackageName()) && !currentPackageName.equals(newInterface.getPackageName()) && !packageNameUsed){
       setFailedPosition(t.getPosition(), 30, newInterface.getName(), currentPackageName);
@@ -1159,7 +1158,7 @@ class UmpleInternalParser
       if (!isATrait && !isAClass && !isAInterface && !isTraitTypeParameter) //item referenced not a class or interface or a trait or a type parameter
       {
       	//TODO traits' error
-        UmpleClass aClass = model.addUmpleClass(e.getValue(), e.getKey().getFilename());
+        UmpleClass aClass = model.addUmpleClass(e.getValue());
         aClass.setPackageName(model.getDefaultNamespace());
         setFailedPosition(e.getKey(), 5, e.getValue());
         return false;
@@ -3597,8 +3596,8 @@ class UmpleInternalParser
       }
 
       CodeBlock cb = new CodeBlock();
-      String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath("Java"));
-      String otherComment = ("// line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath("Java"));
+      String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath( exception.getPosition().getFilename(), "Java"));
+      String otherComment = ("// line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath( exception.getPosition().getFilename(), "Java"));
 
       cb.setCode(otherComment);
       cb.setCode("Ruby", rubyComment);
@@ -3623,7 +3622,7 @@ class UmpleInternalParser
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath("Java"));
+      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath( exception.getPosition().getFilename(), "Java"));
       aClass.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1006, sub.getValue("name"));
     }
@@ -3638,7 +3637,7 @@ class UmpleInternalParser
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath("Java"));
+      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aClass.getRelativePath( exception.getPosition().getFilename(), "Java"));
       aClass.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1008, sub.getValue("name"));
     }
@@ -3703,9 +3702,10 @@ class UmpleInternalParser
         extraCode += ";";
       }
 
+      //String relativePath = aInterface.getRelativePath( exception.getPosition().getFilename(), "Java");
       CodeBlock cb = new CodeBlock();
-      //String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " " + aInterface.getRelativePath("Java"));
-      //String otherComment = ("// line " + exception.getPosition().getLineNumber() + " " + aInterface.getRelativePath("Java"));
+      //String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " " + relativePath);
+      //String otherComment = ("// line " + exception.getPosition().getLineNumber() + " " + relativePath);
 
       //cb.setCode(otherComment);
       //cb.setCode("Ruby", rubyComment);
@@ -3730,7 +3730,7 @@ class UmpleInternalParser
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      //aInterface.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aInterface.getRelativePath("Java"));
+      //aInterface.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aInterface.getRelativePath( exception.getPosition().getFilename(), "Java"));
       aInterface.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1006, sub.getValue("name"));
     }
@@ -3745,7 +3745,7 @@ class UmpleInternalParser
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      //aInterface.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aInterface.getRelativePath("Java"));
+      //aInterface.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aInterface.getRelativePath( exception.getPosition().getFilename(), "Java"));
       aInterface.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1008, sub.getValue("name"));
     }
@@ -3758,7 +3758,7 @@ class UmpleInternalParser
     //Append #line comment to indicate line and position of source
     if (token.getPosition() != null)
     {
-      String extraCodeLineNumberComment = " line " + token.getPosition().getLineNumber() + " " + aClass.getRelativePath("Java");
+      String extraCodeLineNumberComment = " line " + token.getPosition().getLineNumber() + " " + aClass.getRelativePath( token.getPosition().getFilename(), "Java");
 	  String rubyComment = "#" + extraCodeLineNumberComment;
 	  String otherComment = "//" + extraCodeLineNumberComment;
  	  if(aClass.hasExtraCode())

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -980,32 +980,66 @@ class UmpleInternalParser
     return anInterface;
   }
 
-  private UmpleInterface analyzeInterface(Token t)
+  private UmpleInterface analyzeInterface(Token interfaceToken)
   {
-    String interfaceName = t.getValue("name");   
+    String interfaceName = interfaceToken.getValue("name");   
     //Check to ensure the name is valid (starts with a letter, and only contains letters, numbers, or underscores
     if (Token.isValidIdentifier(interfaceName, "[A-Za-z|@]") != true) {
       if(!interfaceName.matches("[A-Za-z|@]+<.+>"))
       {
-        setFailedPosition(t.getPosition(), 110, interfaceName);
+        setFailedPosition(interfaceToken.getPosition(), 110, interfaceName);
       }
     }
     else if ( interfaceName.matches("[a-z].*") ){ // Warn when interface name doesn't start with a capital letter.
-      setFailedPosition(t.getPosition(), 111, interfaceName);
+      setFailedPosition(interfaceToken.getPosition(), 111, interfaceName);
+    }
+    
+    UmpleInterface anInterface = new UmpleInterface(interfaceToken.getValue("name"),model);
+    model.addUmpleInterface(anInterface);
+    
+    Position thePosition = interfaceToken.getPosition();
+    Position endPosition = interfaceToken.getEndPosition();
+
+    // Set the original .ump file and line number
+    anInterface.addPosition(thePosition);
+    anInterface.addEndPosition(endPosition);
+
+    // Add all the comments in the comment list to the Umple class.
+    // But add them before any umplesource special comments
+    int regularCommentCountEnd = 0;
+    for (Comment c : anInterface.getComments()) {
+      if(c.getText().startsWith("@umplesource")) break;
+      regularCommentCountEnd++;
+    }
+
+    for (Comment c : lastComments)
+    {
+      anInterface.addCommentAt(c,regularCommentCountEnd);
+      regularCommentCountEnd++;
+    }
+    
+    // Add special position comment at the end if @outputumplesource had been 
+    // detected earlier in a comment
+    if(outputUmpleSource == true) {  
+      String path = null;
+      if( thePosition.getFilename() == null ){
+        path = "";
+      }else{
+        path = Paths.get(thePosition.getFilename()).getFileName().toString();
+      }
+      anInterface.addComment(new Comment("@umplesource " + path +" "+thePosition.getLineNumber()));
     }
   
-    UmpleInterface newInterface = new UmpleInterface(t.getValue("name"),model);
-    model.addUmpleInterface(newInterface);
-    if(!"".equals(newInterface.getPackageName()) && !currentPackageName.equals(newInterface.getPackageName()) && !packageNameUsed){
-      setFailedPosition(t.getPosition(), 30, newInterface.getName(), currentPackageName);
-      newInterface.setPackageName(currentPackageName);    
+    if(!"".equals(anInterface.getPackageName()) && !currentPackageName.equals(anInterface.getPackageName()) && !packageNameUsed){
+      setFailedPosition(interfaceToken.getPosition(), 30, anInterface.getName(), currentPackageName);
+      anInterface.setPackageName(currentPackageName);    
     }    
-    if("".equals(newInterface.getPackageName())){
-      newInterface.setPackageName(currentPackageName);
-  }
-  packageNameUsed = true;
-    analyzeInterface(t,newInterface);
-    return newInterface;
+    if("".equals(anInterface.getPackageName())){
+      anInterface.setPackageName(currentPackageName);
+    }
+    packageNameUsed = true;
+    analyzeInterface(interfaceToken,anInterface);
+    return anInterface;
   }
 
   private void analyzeInterface(Token interfaceToken, UmpleInterface aInterface)

--- a/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
@@ -60,7 +60,7 @@ class UmpleInternalParser
       setFailedPosition(traitToken.getPosition(), 201, traitName);
     }  
     UmpleTrait aTrait;
-    aTrait = model.addUmpleTrait(traitToken.getValue("name"),traitToken.getPosition().getFilename());
+    aTrait = model.addUmpleTrait(traitToken.getValue("name"));
     
     Position thePosition = traitToken.getPosition();
     Position endPosition = traitToken.getEndPosition();
@@ -481,7 +481,7 @@ class UmpleInternalParser
     //Append #line comment to indicate line and position of source
     if (token.getPosition() != null)
     {
-      String extraCodeLineNumberComment = " line " + token.getPosition().getLineNumber() + " " + aTrait.getRelativePath("Java");
+      String extraCodeLineNumberComment = " line " + token.getPosition().getLineNumber() + " " + aTrait.getRelativePath(token.getPosition().getFilename(),"Java");
 	  String rubyComment = "#" + extraCodeLineNumberComment;
 	  String otherComment = "//" + extraCodeLineNumberComment;
  	  if(aTrait.hasExtraCode())
@@ -656,9 +656,10 @@ class UmpleInternalParser
         extraCode += ";";
       }
 
+      final String relativePath = aTrait.getRelativePath(exception.getPosition().getFilename(),"Java");
       CodeBlock cb = new CodeBlock();
-      String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " " + aTrait.getRelativePath("Java"));
-      String otherComment = ("// line " + exception.getPosition().getLineNumber() + " " + aTrait.getRelativePath("Java"));
+      String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " " + relativePath);
+      String otherComment = ("// line " + exception.getPosition().getLineNumber() + " " + relativePath);
 
       cb.setCode(otherComment);
       cb.setCode("Ruby", rubyComment);
@@ -683,7 +684,7 @@ class UmpleInternalParser
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      aTrait.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aTrait.getRelativePath("Java"));
+      aTrait.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aTrait.getRelativePath(exception.getPosition().getFilename(),"Java"));
       aTrait.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1006, sub.getValue("name"));
     }
@@ -698,7 +699,7 @@ class UmpleInternalParser
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      aTrait.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aTrait.getRelativePath("Java"));
+      aTrait.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " " + aTrait.getRelativePath(exception.getPosition().getFilename(),"Java"));
       aTrait.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1008, sub.getValue("name"));
     }

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -79,18 +79,6 @@ class UmpleModel
     }
     return newInterface;
   }
-  
-  public UmpleInterface addUmpleInterface(String name, String sourceFilename )
-  {
-    UmpleInterface newInterface = getUmpleInterface(name);
-    if (newInterface == null)
-    {
-      newInterface = new UmpleInterface(name, this);
-      newInterface.setSourceFilename(sourceFilename);
-      addUmpleInterface(newInterface);
-    }
-    return newInterface;
-  }
 
   public UmpleClass addUmpleClass(String name)
   {
@@ -99,18 +87,6 @@ class UmpleModel
     {
       newClass = new UmpleClass(name, this);
       addUmpleClass(newClass);
-    }
-    return newClass;
-  }
-  
-  public UmpleClass addUmpleClass(String name, String sourceFilename)
-  {
-    UmpleClass newClass = getUmpleClass(name);
-    if (newClass == null)
-    {
-       newClass = new UmpleClass(name, this);
-       newClass.setSourceFilename(sourceFilename);
-       addUmpleClass(newClass);
     }
     return newClass;
   }
@@ -1197,14 +1173,13 @@ class UmpleClassifier{
   Obtains the relative path between the source file for the UmpleClassifier and 
   and the package name given the target language
   
+  @param filename the file name to get the relative path from
   @param language The language target to compare
   
   @return The string relative path between the parent and position
   */
-  public String getRelativePath(String language)
-  {
-    String filename = getSourceFilename();
-    
+  public String getRelativePath(String filename, String language)
+  {    
     String p = getPackageName();
  	
     if (filename == null)

--- a/cruise.umple/src/Umple_Code_Trait.ump
+++ b/cruise.umple/src/Umple_Code_Trait.ump
@@ -27,17 +27,6 @@ class UmpleModel {
     return newTrait;
   }
   
-  public UmpleTrait addUmpleTrait(String name, String sourceFilename)
-  {
-    UmpleTrait newTrait = getUmpleTrait(name);
-    if (newTrait == null)
-    {
-      newTrait = new UmpleTrait(name, this);
-      newTrait.setSourceFilename(sourceFilename);
-      addUmpleTrait(newTrait);
-    }
-    return newTrait;
-  }
 }
 //---------------------------------------------------------------------------------------------
 //------------------------------------class end------------------------------------------------


### PR DESCRIPTION
This PR fixes incorrectly generating line statements. This was originally mentioned in issue #768 and was thought to be resolved in PR #773, though originally the fix didn't cover every case.

This also adds generation support for `@umplesource` tags in umple Interfaces, as this feature was previously absent. 

The changes remove some modifications added in a previous PR, and reverts `<UmpleClassifier>.getRelativePath(...)` to rely on a filename -- as the previous implementation was the cause of the issue.
