### PR TITLE
Implemented ability to specify parameters for custom code injections

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -27,8 +27,8 @@ class UmpleToJava {
         String methodImplementationModifier = aMethod.getIsAbstract() ? " abstract" : "";
         String methodName = aMethod.getName();
         String methodType = aMethod.getType();
-        String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName()));
-        String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName()));
+        String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
+        String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        
         String customPostconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Postcondition"));
         customPostconditionCode = customPostconditionCode==null?"":customPostconditionCode;

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -441,6 +441,7 @@ class CodeInjection
   type;
   operation;
   lazy operationSource = "generated";
+  lazy String[] parameters;
   CodeBlock snippet;
   lazy constraintParameterName;
   * -> 1 UmpleClassifier;

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2616,6 +2616,38 @@ class UmpleInternalParser
     return value;
   }
 
+  private String getOperationParameters(Token aToken)
+  {
+    StringBuilder operationParameters = new StringBuilder();  
+    String delimeter = "";
+    for(Token subToken : aToken.getSubTokens())
+    {
+      if(subToken.is("parameterType"))
+      {
+        operationParameters.append(delimeter+subToken.getValue());
+        delimeter = ",";
+      } 
+      else if(subToken.is("parameterTypes")) 
+      {
+        operationParameters.append(delimeter+getOperationParameters(subToken));
+      }
+    }
+    return operationParameters.toString();
+  }
+
+  private ArrayList<String> getOperationsParameters(Token aToken)
+  {
+    ArrayList<String> operationsParameters = new ArrayList<String>();
+    for(Token subToken : aToken.getSubTokens())
+    {
+      if(subToken.is("injectionOperation"))
+      {
+        operationsParameters.add(getOperationParameters(subToken));
+      }
+    }
+    return operationsParameters;
+  }
+
   private String getOperationSource(Token aToken)
   {
     StringBuilder operationSource = new StringBuilder();
@@ -2640,6 +2672,11 @@ class UmpleInternalParser
       {
         operationName.append(comma+subToken.getValue());
         comma = ",";
+      } 
+      else if(subToken.is("injectionOperation")) 
+      {
+        operationName.append(comma+getOperationName(subToken));
+        comma = ",";
       }
     }
     return operationName.toString();
@@ -2659,6 +2696,11 @@ class UmpleInternalParser
 
     CodeInjection injection = new CodeInjection(type,operationName,"",uClassifier);
     injection.setOperationSource(operationSource);
+
+    ArrayList<String> operationsParameters = getOperationsParameters(injectToken);
+    for(String operationParameters : operationsParameters) {
+      injection.addParameter(operationParameters);      
+    }
 
     makeCodeInject(injectToken,injection,cb,uClassifier);
     injection.setSnippet(cb);

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2640,7 +2640,7 @@ class UmpleInternalParser
     return operationParameters.toString();
   }
 
-  private ArrayList<String> getOperationsParameters(Token aToken)
+  private List<String> getOperationsParameters(Token aToken)
   {
     ArrayList<String> operationsParameters = new ArrayList<String>();
     for(Token subToken : aToken.getSubTokens())
@@ -2702,7 +2702,7 @@ class UmpleInternalParser
     CodeInjection injection = new CodeInjection(type,operationName,"",uClassifier);
     injection.setOperationSource(operationSource);
 
-    ArrayList<String> operationsParameters = getOperationsParameters(injectToken);
+    List<String> operationsParameters = getOperationsParameters(injectToken);
     for(String operationParameters : operationsParameters) {
       injection.addParameter(operationParameters);      
     }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -388,7 +388,20 @@ class UmpleInternalParser
     {
       for(Token injectToken : entry.getValue())
       {
-        checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
+        String operationSource = getOperationSource(injectToken);
+        if("all".equals(operationSource))
+        {
+          checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
+          checkCodeInjectionValidityCustom(injectToken, (UmpleClass) entry.getKey());
+        }
+        else if("custom".equals(operationSource)) 
+        {
+          checkCodeInjectionValidityCustom(injectToken, (UmpleClass) entry.getKey());
+        }
+        else
+        {
+          checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
+        }
       }
     } 
   }
@@ -2631,6 +2644,9 @@ class UmpleInternalParser
       {
         return getOperationParameters(subToken);
       }
+      else if(subToken.is("parameterListing")) {
+        return getOperationParameters(subToken);
+      }
     }
     
     if(aToken.is("injectionOperation")) {
@@ -2723,6 +2739,60 @@ class UmpleInternalParser
       ((UmpleTrait)uClassifier).addCodeInjection(injection);
     }
   }
+  
+  private boolean checkCodeInjectionValidityCustom(Token injectToken, UmpleClass uClass) {
+    List<Method> methods = uClass.getMethods();
+    String[] allOperations = getOperationName(injectToken).split(",");
+    List<String> allParameters = getOperationsParameters(injectToken);
+
+    for(int opInd = 0; opInd < allOperations.length; opInd++)
+    {
+      String operation = allOperations[opInd];
+      String currentParameters = allParameters.get(opInd);
+
+      Boolean matches = false;
+
+      for(Method method : methods) 
+      { 
+        boolean tmpMatches = false;
+
+        // Check if method matches operation
+        if (uClass.matchOperationMethod(operation, method.getName())) {
+          tmpMatches = true;
+        }
+      
+        // Check if method parameters match injection parameters
+        boolean isParameterMatch = true;
+        List<MethodParameter> parameters = method.getMethodParameters();
+
+        if("...".equals(currentParameters) || (parameters.size() == 0 && "".equals(currentParameters))) {
+          isParameterMatch = true;
+        }
+        else if(parameters.size() != currentParameters.split(",").length)
+        {
+          isParameterMatch = false;
+        }
+        else {
+          int indx = 0;
+          for(String parameterType : currentParameters.split(",")) {
+            if(!parameterType.equals(parameters.get(indx).getType())) {
+              isParameterMatch = false;
+            }
+            indx++;
+          }
+        }
+
+        tmpMatches &= isParameterMatch;
+        matches = matches || tmpMatches;
+      }
+
+      if(!matches) {
+        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+      }
+    }
+    
+    return false;
+  } 
 
   private boolean checkCodeInjectionValidity(Token injectToken, UmpleClass uClass) {
     ArrayList<String> methodNames = new ArrayList<String>();

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2629,9 +2629,14 @@ class UmpleInternalParser
       } 
       else if(subToken.is("parameterTypes")) 
       {
-        operationParameters.append(delimeter+getOperationParameters(subToken));
+        return getOperationParameters(subToken);
       }
     }
+    
+    if(aToken.is("injectionOperation")) {
+      return "...";
+    }
+
     return operationParameters.toString();
   }
 

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -1483,17 +1483,18 @@ class UmpleClass
         boolean isCurrentMatch = formattedMethod.matches(regexOperation);
 
         boolean isParameterMatch = true;
+        String currentParameters = code.getParameters()[opInd];
 
-        if("...".equals(code.getParameters()[opInd])) {
+        if("...".equals(currentParameters)) {
           isParameterMatch = true;
         }
-        else if(parameters.size() != code.getParameters()[opInd].split(",").length)
+        else if(parameters.size() != currentParameters.split(",").length)
         {
           isParameterMatch = false;
         } 
         else {
           int indx = 0;
-          for(String parameterType : code.getParameters()[opInd].split(",")) {
+          for(String parameterType : currentParameters.split(",")) {
             if(!parameterType.equals(parameters.get(indx).getType())) {
               isParameterMatch = false;
             }

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -1439,7 +1439,7 @@ class UmpleClass
   }
 
   // Gets applicable code injectiosn for custom defined methods
-  public List<CodeInjection> getApplicableCodeInjectionsCustomMethod(String type, String method)
+  public List<CodeInjection> getApplicableCodeInjectionsCustomMethod(String type, String method, List<MethodParameter> parameters)
   {
     ArrayList<CodeInjection> all = new ArrayList<CodeInjection>();
     if (type == null || method == null)
@@ -1460,8 +1460,9 @@ class UmpleClass
       TriState isMatchOnExclude = new TriState(true);
 
       String[] allOperations = code.getOperation().split(",");
-      for (String operation : allOperations)
+      for (int opInd = 0; opInd < allOperations.length; opInd++)
       {
+        String operation = allOperations[opInd];
 
         boolean isNot = false;
         if (operation.startsWith("!"))
@@ -1481,20 +1482,26 @@ class UmpleClass
         regexOperation = regexOperation.replace("_~", "");
         boolean isCurrentMatch = formattedMethod.matches(regexOperation);
 
-        // Determine whether the paremeters of the injection match the parameters
-        // of this method
-/*
         boolean isParameterMatch = true;
-        int i = 0;
-        for(String parameterType : code.getParameters().split(",")) {
-          if(!parameterType.equals(parameters.get(i).getType())) {
-            isParameterMatch = false;
-          }
-          i++;
+
+        if("...".equals(code.getParameters()[opInd])) {
+          isParameterMatch = true;
         }
+        else if(parameters.size() != code.getParameters()[opInd].split(",").length)
+        {
+          isParameterMatch = false;
+        } 
+        else {
+          int indx = 0;
+          for(String parameterType : code.getParameters()[opInd].split(",")) {
+            if(!parameterType.equals(parameters.get(indx).getType())) {
+              isParameterMatch = false;
+            }
+            indx++;
+          }
+        } 
 
         isCurrentMatch &= isParameterMatch;
-*/
 
         if (isNot && isCurrentMatch)
         {

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -1308,11 +1308,6 @@ class UmpleClass
   public ArrayList<String> getMethodNames()
   {
     ArrayList<String> methodNames = new ArrayList<String>();
-    for(Method aMethod : this.getMethods())
-    {
-      methodNames.add(aMethod.getName());
-    }
-
     for(Attribute attr : this.getAttributes())
     {
       methodNames.addAll(attr.getMethodNames());
@@ -1485,7 +1480,7 @@ class UmpleClass
         boolean isParameterMatch = true;
         String currentParameters = code.getParameters()[opInd];
 
-        if("...".equals(currentParameters)) {
+        if((parameters.size() == 0 && "".equals(currentParameters)) || "...".equals(currentParameters)) {
           isParameterMatch = true;
         }
         else if(parameters.size() != currentParameters.split(",").length)

--- a/cruise.umple/src/umple_patterns.grammar
+++ b/cruise.umple/src/umple_patterns.grammar
@@ -27,6 +27,8 @@ keyDefinition- : [[defaultKey]] | [[key]]
 // Aspect oriented code injection: [*BeforeandAfterStatements*]
 codeInjection- : [[beforeCode]] | [[afterCode]]
 
-beforeCode : before ([=operationSource:custom|generated|all])? [operationName] ( , [operationName] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
-afterCode : after ([=operationSource:custom|generated|all])? [operationName] ( , [operationName] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
+parameterTypes : [parameterType] (, [parameterType])*
+injectionOperation : [operationName] (OPEN_ROUND_BRACKET [[parameterTypes]] CLOSE_ROUND_BRACKET)? 
 
+beforeCode : before ([=operationSource:custom|generated|all])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
+afterCode : after ([=operationSource:custom|generated|all])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*

--- a/cruise.umple/src/umple_patterns.grammar
+++ b/cruise.umple/src/umple_patterns.grammar
@@ -28,7 +28,7 @@ keyDefinition- : [[defaultKey]] | [[key]]
 codeInjection- : [[beforeCode]] | [[afterCode]]
 
 parameterTypes : [parameterType] (, [parameterType])*
-injectionOperation : [operationName] (OPEN_ROUND_BRACKET [[parameterTypes]] CLOSE_ROUND_BRACKET)? 
+injectionOperation : [operationName] (OPEN_ROUND_BRACKET ([[parameterTypes]])? CLOSE_ROUND_BRACKET)? 
 
 beforeCode : before ([=operationSource:custom|generated|all])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
 afterCode : after ([=operationSource:custom|generated|all])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*

--- a/cruise.umple/src/umple_patterns.grammar
+++ b/cruise.umple/src/umple_patterns.grammar
@@ -28,7 +28,9 @@ keyDefinition- : [[defaultKey]] | [[key]]
 codeInjection- : [[beforeCode]] | [[afterCode]]
 
 parameterTypes : [parameterType] (, [parameterType])*
-injectionOperation : [operationName] (OPEN_ROUND_BRACKET ([[parameterTypes]])? CLOSE_ROUND_BRACKET)? 
+parameterListing : OPEN_ROUND_BRACKET ([[parameterTypes]])? CLOSE_ROUND_BRACKET
+
+injectionOperation : [operationName] ([[parameterListing]])?
 
 beforeCode : before ([=operationSource:custom|generated|all])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
 afterCode : after ([=operationSource:custom|generated|all])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*

--- a/cruise.umple/test/cruise/umple/compiler/UmpleInternalParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleInternalParserTest.java
@@ -214,8 +214,8 @@ public class UmpleInternalParserTest extends UmpleParserTest
     fileToOutputs.put("018_key.ump","[classDefinition][name:Student][attribute][name:id][attribute][name:name][key][keyId:id][keyId:name][classDefinition][name:Mentor][attribute][name:employeeId][key][keyId:employeeId][classDefinition][name:Course][attribute][name:code][defaultKey]");
     fileToOutputs.put("018_cannotHaveDuplicateKeys.ump", "[classDefinition][name:Student][attribute][name:id][attribute][name:name][attribute][name:age][key][keyId:id][keyId:name][key][keyId:age]");
     fileToOutputs.put("018_inheritedKeys.ump", "[classDefinition][name:Student][attribute][type:Integer][name:a][classDefinition][name:Mentor][extendsName:Student][attribute][type:Integer][name:b][key][keyId:a][keyId:b]");
-    fileToOutputs.put("019_before.ump","[classDefinition][name:Student][attribute][name:name][beforeCode][operationName:setName][code:doSomething();]");
-    fileToOutputs.put("019_after.ump","[classDefinition][name:Student][attribute][name:name][afterCode][operationName:getName][code:notReallyPossible();]");
+    fileToOutputs.put("019_before.ump","[classDefinition][name:Student][attribute][name:name][beforeCode][injectionOperation][operationName:setName][code:doSomething();]");
+    fileToOutputs.put("019_after.ump","[classDefinition][name:Student][attribute][name:name][afterCode][injectionOperation][operationName:getName][code:notReallyPossible();]");
     fileToOutputs.put("020_enumEmpty.ump","[classDefinition][name:Student][stateMachine][enum][name:status]");
     fileToOutputs.put("020_enum.ump","[classDefinition][name:Student][stateMachine][enum][name:status][stateName:FullTime][stateName:PartTime][stateName:MidTime][stateMachine][enum][name:grade][stateName:High]");
     fileToOutputs.put("020_enumLongHand.ump","[classDefinition][name:Student][stateMachine][inlineStateMachine][name:status][state][stateName:FullTime][state][stateName:PartTime]");

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsParametersBasic.ump
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsParametersBasic.ump
@@ -1,0 +1,24 @@
+class Student {
+  String foo(int a) {
+    if(a < 0) {
+      return 4;
+    }
+
+    return 3;
+  }
+
+  String foo(int a, String b) {
+    if(a > 0 && "".equals(b))
+      return 3;
+
+    return 1;
+  }
+
+  after custom foo(int) {
+    System.out.println("Returning from foo, a: " + a);
+  }
+
+  after custom foo(int, String) {
+    System.out.println("Returning from foo, a: " + a ", b: " + b);
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsParametersMulti.ump
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsParametersMulti.ump
@@ -1,0 +1,40 @@
+class Student {
+  String foo(int a) {
+    if(a < 0) {
+      return 4;
+    }
+
+    return 3;
+  }
+
+  String foo(int a, String b) {
+    if(a > 0 && "".equals(b))
+      return 3;
+
+    return 1;
+  }
+
+  String bar() {
+    int a = 4;
+
+    if(a == 3) return 2;
+    
+    return 1;
+  }
+
+  before custom foo(int),foo(int,String) {
+    System.out.println("Starting foo...");
+  }
+
+  after custom foo(int, String) {
+    System.out.println("Returning from foo, a: " + a ", b: " + b);
+  }
+
+  before custom bar() {
+    // TODO: fix asap
+  }
+
+  before custom foo(int),bar {
+    System.out.println("Starting execution...");
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsParametersUnspecified.ump
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsParametersUnspecified.ump
@@ -1,0 +1,24 @@
+class Student {
+  String foo(int a) {
+    if(a < 0) {
+      return 4;
+    }
+
+    return 3;
+  }
+
+  String foo(int a, String b) {
+    if(a > 0 && "".equals(b))
+      return 3;
+
+    return 1;
+  }
+
+  after custom foo {
+    System.out.println("Returning from foo, a: " + a);
+  }
+
+  before custom foo(...) {
+    System.out.println("Starting foo...");
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Mentor.java.txt
@@ -150,7 +150,7 @@ public class Mentor
     return wasRemoved;
   }
 
-  
+
   public void delete()
   {
     ArrayList<Student> copyOfMyStudents = new ArrayList<Student>(myStudents);

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Student.java.txt
@@ -150,7 +150,7 @@ public class Student
     return wasRemoved;
   }
 
-  
+
   public void delete()
   {
     ArrayList<Mentor> copyOfProfs = new ArrayList<Mentor>(Profs);

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersBasic.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersBasic.java.txt
@@ -1,0 +1,46 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-dab6b48 modeling language!*/
+
+
+
+public class Student
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Student()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+  public String foo(int a){
+    if(a < 0) {      
+      System.out.println("Returning from foo, a: " + a);
+      return 4;
+    }    
+    System.out.println("Returning from foo, a: " + a);
+    return 3;
+
+  }
+
+  public String foo(int a, String b){
+    if(a > 0 && "".equals(b)) {      
+      System.out.println("Returning from foo, a: " + a ", b: " + b);
+      return 3;
+    }    
+    System.out.println("Returning from foo, a: " + a ", b: " + b);
+    return 1;
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersMulti.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersMulti.java.txt
@@ -1,0 +1,57 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-dab6b48 modeling language!*/
+
+
+
+public class Student
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Student()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+  public String foo(int a){
+    System.out.println("Starting foo...");
+    System.out.println("Starting execution...");
+    if(a < 0) {
+      return 4;
+    }
+
+    return 3;
+  }
+
+  public String foo(int a, String b){
+    System.out.println("Starting foo...");
+    if(a > 0 && "".equals(b)) {      
+      System.out.println("Returning from foo, a: " + a ", b: " + b);
+      return 3;
+    }    
+    System.out.println("Returning from foo, a: " + a ", b: " + b);
+    return 1;
+  }
+
+  public String bar(){
+    // TODO: fix asap
+    System.out.println("Starting execution...");
+    int a = 4;
+
+    if(a == 3) return 2;
+    
+    return 1;
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersUnspecified.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersUnspecified.java.txt
@@ -1,0 +1,48 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-dab6b48 modeling language!*/
+
+
+
+public class Student
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Student()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+  public String foo(int a){
+    System.out.println("Starting foo...");
+    if(a < 0) {      
+      System.out.println("Returning from foo, a: " + a);
+      return 4;
+    }    
+    System.out.println("Returning from foo, a: " + a);
+    return 3;
+
+  }
+
+  public String foo(int a, String b){
+    System.out.println("Starting foo...");
+    if(a > 0 && "".equals(b)) {      
+      System.out.println("Returning from foo, a: " + a);
+      return 3;
+    }    
+    System.out.println("Returning from foo, a: " + a);
+    return 1;
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -97,6 +97,23 @@ public class JavaClassTemplateTest extends ClassTemplateTest
     assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsSingleLine.ump", languagePath + "/ClassTemplateTest_CodeInjectionsSingleLine." + languagePath + ".txt", "Student");
   }
 
+  public void ClassCodeInjections_ParametersBasic()
+  {
+    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsParametersBasic.ump", languagePath + "/ClassTemplateTest_CodeInjectionsParametersBasic." + languagePath + ".txt", "Student");
+  }
+
+  @Test
+  public void ClassCodeInjections_ParametersUnspecified()
+  {
+    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsParametersUnspecified.ump", languagePath + "/ClassTemplateTest_CodeInjectionsParametersUnspecified." + languagePath + ".txt", "Student");
+  }
+
+  @Test
+  public void ClassCodeInjections_ParametersMulti()
+  {
+    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsParametersMulti.ump", languagePath + "/ClassTemplateTest_CodeInjectionsParametersMulti." + languagePath + ".txt", "Student");
+  }
+
   @Test
   public void InternalAndConstantAndDerivedAttributeComments()
   {


### PR DESCRIPTION
## Description

This is a working version of the functionality to allow code injections into user defined methods with parameters specified. For example:

```
class A {
  void foo(String a) {
    [...]
  }

  void foo(int a) {
    [..]
  }
}
```

You can now specify the parameters in certain ways to target those methods specifically:

If you want to inject into the first method and only the first method:

```
before custom foo(String) {
  [...]
}
```

Or if you want to inject only into the second method:

```
before custom foo(int) {
  [...]
}
```

Or if you want to inject into both:

```
before custom foo(...) {
  [...]
}
```

This also injects into both (if parameters unspecified -- it is presumed that you don't care about them):

```
before custom foo {
  [...]
}
```

You can also just use multiple code injections on the same line and specify parameters for all of them:

```
before custom foo(int),foo(String) {
  [...]
}
```
## Tests

Cleaned up some of the tests that needed to be changed (for minor and justifiable reasons) due to my changes to the grammar. Added in new test files to test this functionality -- covering all of the examples that I mentioned above.
