### PR TITLE
displays warning when parameters are specified for generated injections

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2801,6 +2801,11 @@ class UmpleInternalParser
     ArrayList<String> todoExtendedClasses = new ArrayList<String>();
     ArrayList<String> todoInheritedInterfaces = new ArrayList<String>();
 
+    String operationSource = getOperationSource(injectToken);
+    if("".equals(operationSource)) {
+      operationSource = "generated";
+    }
+
     todoExtendedClasses.add(uClass.getName());
     while(!todoExtendedClasses.isEmpty())
     {
@@ -2847,8 +2852,14 @@ class UmpleInternalParser
       }
     }
 
-    for(String operation : operationName.split(","))
+    String[] allOperations = getOperationName(injectToken).split(",");
+    List<String> allParameters = getOperationsParameters(injectToken);
+
+    for(int opInd = 0; opInd < allOperations.length; opInd++)
     {
+      String operation = allOperations[opInd];
+      String currentParameters = allParameters.get(opInd);
+
       Boolean matches = false;
 
       for(String methodName : methodNames) 
@@ -2860,6 +2871,10 @@ class UmpleInternalParser
 
       if(!matches) {
         getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+      }
+
+      if(!"...".equals(currentParameters)) {
+        getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
       }
     }
     

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -391,8 +391,7 @@ class UmpleInternalParser
         String operationSource = getOperationSource(injectToken);
         if("all".equals(operationSource))
         {
-          checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
-          checkCodeInjectionValidityCustom(injectToken, (UmpleClass) entry.getKey());
+          checkCodeInjectionValidityAll(injectToken, (UmpleClass) entry.getKey());
         }
         else if("custom".equals(operationSource)) 
         {
@@ -2739,72 +2738,35 @@ class UmpleInternalParser
       ((UmpleTrait)uClassifier).addCodeInjection(injection);
     }
   }
-  
-  private boolean checkCodeInjectionValidityCustom(Token injectToken, UmpleClass uClass) {
-    List<Method> methods = uClass.getMethods();
-    String[] allOperations = getOperationName(injectToken).split(",");
-    List<String> allParameters = getOperationsParameters(injectToken);
 
-    for(int opInd = 0; opInd < allOperations.length; opInd++)
+  private boolean checkParameterMatch(List<MethodParameter> parameters, String currentParameters) {
+    // Check if method parameters match injection parameters
+    boolean isParameterMatch = true;
+
+    if("...".equals(currentParameters) || (parameters.size() == 0 && "".equals(currentParameters))) {
+      isParameterMatch = true;
+    }
+    else if(parameters.size() != currentParameters.split(",").length)
     {
-      String operation = allOperations[opInd];
-      String currentParameters = allParameters.get(opInd);
-
-      Boolean matches = false;
-
-      for(Method method : methods) 
-      { 
-        boolean tmpMatches = false;
-
-        // Check if method matches operation
-        if (uClass.matchOperationMethod(operation, method.getName())) {
-          tmpMatches = true;
-        }
-      
-        // Check if method parameters match injection parameters
-        boolean isParameterMatch = true;
-        List<MethodParameter> parameters = method.getMethodParameters();
-
-        if("...".equals(currentParameters) || (parameters.size() == 0 && "".equals(currentParameters))) {
-          isParameterMatch = true;
-        }
-        else if(parameters.size() != currentParameters.split(",").length)
-        {
+      isParameterMatch = false;
+    }
+    else {
+      int indx = 0;
+      for(String parameterType : currentParameters.split(",")) {
+        if(!parameterType.equals(parameters.get(indx).getType())) {
           isParameterMatch = false;
         }
-        else {
-          int indx = 0;
-          for(String parameterType : currentParameters.split(",")) {
-            if(!parameterType.equals(parameters.get(indx).getType())) {
-              isParameterMatch = false;
-            }
-            indx++;
-          }
-        }
-
-        tmpMatches &= isParameterMatch;
-        matches = matches || tmpMatches;
-      }
-
-      if(!matches) {
-        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+        indx++;
       }
     }
-    
-    return false;
-  } 
 
-  private boolean checkCodeInjectionValidity(Token injectToken, UmpleClass uClass) {
+    return isParameterMatch;
+  }
+
+  ArrayList<String> getAllMethodNames(UmpleClass uClass) {
     ArrayList<String> methodNames = new ArrayList<String>();
-    String operationName = getOperationName(injectToken);
-
     ArrayList<String> todoExtendedClasses = new ArrayList<String>();
     ArrayList<String> todoInheritedInterfaces = new ArrayList<String>();
-
-    String operationSource = getOperationSource(injectToken);
-    if("".equals(operationSource)) {
-      operationSource = "generated";
-    }
 
     todoExtendedClasses.add(uClass.getName());
     while(!todoExtendedClasses.isEmpty())
@@ -2852,8 +2814,91 @@ class UmpleInternalParser
       }
     }
 
+    return methodNames;
+  }
+
+  
+  private void checkCodeInjectionValidityCustom(Token injectToken, UmpleClass uClass) {
+    List<Method> methods = uClass.getMethods();
     String[] allOperations = getOperationName(injectToken).split(",");
     List<String> allParameters = getOperationsParameters(injectToken);
+
+    String operationSource = getOperationSource(injectToken);
+    if("".equals(operationSource)) {
+      operationSource = "generated";
+    }
+
+    for(int opInd = 0; opInd < allOperations.length; opInd++)
+    {
+      String operation = allOperations[opInd];
+      String currentParameters = allParameters.get(opInd);
+
+      Boolean matches = false;
+
+      for(Method method : methods) 
+      { 
+        boolean tmpMatches = uClass.matchOperationMethod(operation, method.getName()) && checkParameterMatch(method.getMethodParameters(), currentParameters);
+        matches = matches || tmpMatches;
+      }
+
+      if(!matches) {
+        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+      }
+    }
+  } 
+
+  private void checkCodeInjectionValidityAll(Token injectToken, UmpleClass uClass) {
+    List<Method> methods = uClass.getMethods();
+    ArrayList<String> methodNames = getAllMethodNames(uClass);
+    String[] allOperations = getOperationName(injectToken).split(",");
+    List<String> allParameters = getOperationsParameters(injectToken);
+
+    String operationSource = getOperationSource(injectToken);
+    if("".equals(operationSource)) {
+      operationSource = "generated";
+    }
+
+    for(int opInd = 0; opInd < allOperations.length; opInd++)
+    {
+      String operation = allOperations[opInd];
+      String currentParameters = allParameters.get(opInd);
+
+      Boolean matches = false;
+
+      // check against generated methods
+      for(String methodName : methodNames) 
+      { 
+        if (uClass.matchOperationMethod(operation, methodName)) {
+          matches = true;
+        }
+      }
+
+      // check against custom methods
+      for(Method method : methods) 
+      { 
+        boolean tmpMatches = uClass.matchOperationMethod(operation, method.getName()) && checkParameterMatch(method.getMethodParameters(), currentParameters);
+        matches = matches || tmpMatches;
+      }
+
+      if(!matches) {
+        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+      }
+
+      if(!"...".equals(currentParameters)) {
+        getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
+      }
+    }
+  }
+
+  private void checkCodeInjectionValidity(Token injectToken, UmpleClass uClass) {
+    ArrayList<String> methodNames = getAllMethodNames(uClass);
+    String[] allOperations = getOperationName(injectToken).split(",");
+    List<String> allParameters = getOperationsParameters(injectToken);
+
+    String operationSource = getOperationSource(injectToken);
+    if("".equals(operationSource)) {
+      operationSource = "generated";
+    }
 
     for(int opInd = 0; opInd < allOperations.length; opInd++)
     {
@@ -2877,8 +2922,6 @@ class UmpleInternalParser
         getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
       }
     }
-    
-    return false;
   }
   
   //TODO I changed the parameter's type. please remove this comment;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -169,6 +169,7 @@
 1010: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Constraint syntax, {0}, could not be processed. It has been considered as Extra Code ;
 1011: 3, "http://cruise.eecs.uottawa.ca/umple/W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
 1012: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' cannot be found. Injection was ignored. ;
+1013: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
 
 1500 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: '{0}' not understood ; 
 1501 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 

--- a/cruise.umple/test/cruise/umple/compiler/UmpleClassTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleClassTest.java
@@ -824,6 +824,28 @@ public class UmpleClassTest
   }
 
   @Test
+  public void getCodeInjectionParametersIgnoredError()
+  {
+    boolean custom = false;
+    boolean generated = false;
+    String code = "class A{a; void foo(int k) { foo(k-1); } after custom foo(int) { return true; } after generated setA(int) { return true; }}";
+    try {
+      UmpleModel model = getModel(code);
+      model.run();
+      ParseResult result = model.getLastResult();
+      List<ErrorMessage> errors = result.getErrorMessages();
+
+      Assert.assertEquals(errors.size(), 2);
+    } catch (Exception e) {
+      generated = generated || (e.getMessage().contains("1013") && e.getMessage().contains("generated"));
+      custom = custom || (e.getMessage().contains("1013") && e.getMessage().contains("custom"));
+    } finally {
+      Assert.assertTrue(generated);
+      Assert.assertFalse(custom);
+    }
+  }
+
+  @Test
   public void getCodeInjectionUnfoundAssociationsMethodError_TwoSided()
   {
     boolean addChildren = false;


### PR DESCRIPTION
## Description

Implemented functionality to display warning when parameters were specified. This deals with issue #804.
## Tests

I added in a single test case for this functionality. It tests both that (1) there is in fact a warning printed for the case where there are parameters specified for generated injections and that (2) there is **not** a warning for the case where there are parameters specified for custom injections.
