### PR TITLE
Namespace issue

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -4058,17 +4058,17 @@ class UmpleInternalParser
     String currentNameSpace="";
     boolean twice = false;
     boolean resetClass = false;
-    int index=-1;
+    //int index=-1;
     for(int i = 0; i<inToken.getParentToken().getSubTokens().size();i++){
       Token t1 = inToken.getParentToken().getSubTokens().get(i);
       if (t1.equals(inToken)) {
-    	  index=i;
+    	  //index=i;
     	  break;
       }
       if (t1.getName().equals("classDefinition")) {
     	  resetClass=true;
     	  twice =false;
-    	  currentNameSpace="";
+    	 // currentNameSpace="";
       }
       if (t1.getName().equals("namespace")&& !t1.getValue().equals("STATIC"))  {
     	  currentNameSpace = t1.getValue();
@@ -4084,33 +4084,34 @@ class UmpleInternalParser
     	  }
       }
     }
-    boolean finalCheck = false;
-    String extraNamespace = "";
-    int counter = -1;
-    Token forReport = null;
-    for (int j=index+1;j<inToken.getParentToken().getSubTokens().size();j++){
-    	Token t1 = inToken.getParentToken().getSubTokens().get(j);
-    	if (t1.getName().equals("classDefinition")) {
-        finalCheck = true;
-    	} else if (t1.getName().equals("namespace") && !t1.getValue().equals("STATIC")){
-        extraNamespace = t1.getValue();
-        counter++;
-        forReport = t1;
-    	}
-    }
-    if (finalCheck) return currentNameSpace;
-    if (counter<0) return  currentNameSpace; 
-    else if(counter==0 ) {
-    	if (currentNameSpace!=""){
-        setFailedPosition(forReport.getPosition(),31,currentPackageName,forReport.getValue());
-        return  currentNameSpace; 
-    	} else{
-        return extraNamespace;
-    	}
-    } else {
-    	setFailedPosition(forReport.getPosition(),31,currentPackageName,forReport.getValue());
-    	return extraNamespace;
-    }
+    return currentNameSpace;
+//    boolean finalCheck = false;
+//    String extraNamespace = "";
+//    int counter = -1;
+//    Token forReport = null;
+//    for (int j=index+1;j<inToken.getParentToken().getSubTokens().size();j++){
+//    	Token t1 = inToken.getParentToken().getSubTokens().get(j);
+//    	if (t1.getName().equals("classDefinition")) {
+//        finalCheck = true;
+//    	} else if (t1.getName().equals("namespace") && !t1.getValue().equals("STATIC")){
+//        extraNamespace = t1.getValue();
+//        counter++;
+//        forReport = t1;
+//    	}
+//    }
+//    if (finalCheck) return currentNameSpace;
+//    if (counter<0) return  currentNameSpace; 
+//    else if(counter==0 ) {
+//    	if (currentNameSpace!=""){
+//        setFailedPosition(forReport.getPosition(),31,currentPackageName,forReport.getValue());
+//        return  currentNameSpace; 
+//    	} else{
+//        return extraNamespace;
+//    	}
+//    } else {
+//    	setFailedPosition(forReport.getPosition(),31,currentPackageName,forReport.getValue());
+//    	return extraNamespace;
+//    }
 	}
   
 } 

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -92,14 +92,11 @@ class UmpleInternalParser
     }      
     else if (t.is("namespace"))
     {
-      if(!packageNameUsed && !t.getValue().equals(currentPackageName))
-        setFailedPosition(t.getPosition(),31,currentPackageName,t.getValue());
       currentPackageName = t.getValue();
       if (model.getDefaultNamespace() == null)
       {
         model.setDefaultNamespace(currentPackageName);  
       }
-      packageNameUsed = false;
     }
     else if (t.is("inlineComment"))
     {
@@ -881,14 +878,13 @@ class UmpleInternalParser
     {
       aClass.setIsSingleton(true);
     }
-    if(!"".equals(aClass.getPackageName()) && !currentPackageName.equals(aClass.getPackageName()) && !packageNameUsed){
+    if(!"".equals(aClass.getPackageName()) && !currentPackageName.equals(aClass.getPackageName())){
       setFailedPosition(classToken.getPosition(), 30, aClass.getName(), currentPackageName);
-      aClass.setPackageName(currentPackageName);    
     }    
     if("".equals(aClass.getPackageName())){
-      aClass.setPackageName(currentPackageName);
+      String pkgName = getCurrentNameSpace(classToken);
+      aClass.setPackageName( pkgName!="" ? pkgName : currentPackageName);
   }
-  packageNameUsed = true;
     if (aClass.getIsSingleton()) 
     {
       classToken.setName(classToken.getName());  
@@ -943,7 +939,7 @@ class UmpleInternalParser
   	//Checks list of extends tokens to prevent multiple class inheritance
     if(numberOfExtendsClass(extendsTokenList) > 1)
 	{
-	  Token t = extendsTokenList.get(0);			
+	  Token t = extendsTokenList.get(0);    	
 	  getParseResult().addErrorMessage(new ErrorMessage(34,t.getPosition(),aClassifier.getName(),t.getValue()));
 	}
   }
@@ -955,7 +951,7 @@ class UmpleInternalParser
 	for(Token t : extList)
 	{	
 	  if(isAnUmpleClass(t.getValue("extendsName")))
-		counter++;
+    counter++;
 	}
 	return counter;
   }
@@ -967,9 +963,9 @@ class UmpleInternalParser
 	{
 	  if(aClass != null)
 	  {
-		String nam = aClass.getName();
-		if(nam.equals(name))
-		  return true;
+    String nam = aClass.getName();
+    if(nam.equals(name))
+      return true;
 	  }
 	}
 	return false;
@@ -1042,14 +1038,13 @@ class UmpleInternalParser
       anInterface.addComment(new Comment("@umplesource " + path +" "+thePosition.getLineNumber()));
     }
   
-    if(!"".equals(anInterface.getPackageName()) && !currentPackageName.equals(anInterface.getPackageName()) && !packageNameUsed){
+    if(!"".equals(anInterface.getPackageName()) && !currentPackageName.equals(anInterface.getPackageName())){
       setFailedPosition(interfaceToken.getPosition(), 30, anInterface.getName(), currentPackageName);
-      anInterface.setPackageName(currentPackageName);    
     }    
     if("".equals(anInterface.getPackageName())){
-      anInterface.setPackageName(currentPackageName);
+      String pkgName = getCurrentNameSpace(interfaceToken);
+      anInterface.setPackageName( pkgName!="" ? pkgName : currentPackageName);
     }
-    packageNameUsed = true;
     analyzeInterface(interfaceToken,anInterface);
     return anInterface;
   }
@@ -1472,7 +1467,7 @@ class UmpleInternalParser
     ArrayList<Association> visited = new ArrayList<Association>();
     int aLLB, aLUB, aRLB, aRUB, bLLB, bLUB, bRLB, bRUB;
     Boolean lLowerBoundOK, rLowerBoundOK, lUpperBoundOK, rUpperBoundOK, boundsOK, subclassOK, namesOK, reverseNames,
-    		lMulChToOne, rMulChToOne, lMulChToN, rMulChToN, lNeedsSetCode, rNeedsSetCode;
+        lMulChToOne, rMulChToOne, lMulChToN, rMulChToN, lNeedsSetCode, rNeedsSetCode;
     String aLName, aRName, bLName, bRName;
     ArrayList<String> leftHierarchy, rightHierarchy;
     UmpleClass currentLeftClass, currentRightClass, parentLeftClass, parentRightClass;
@@ -1570,7 +1565,7 @@ class UmpleInternalParser
       	rLowerBoundOK = (bRLB <= aRLB);
       	lUpperBoundOK = (bLUB >= aLUB);
       	rUpperBoundOK = (bRUB >= aRUB);
-      		  
+            
       	if (bLUB != 1 && aLUB == 1)
           lMulChToOne = true;
           
@@ -1582,7 +1577,7 @@ class UmpleInternalParser
           
         if (aRUB == aRLB && bRLB == 0 && bRUB > 1) //  && aRUB > 1
           rMulChToN = true;
-      		  
+            
       	// changed to MN (or M*) -- this may need to change when set method generation is fixed	  
         if (aLUB >= aLLB && aLLB != 0 && aLUB > 1 && ((bLLB == 0 && bLUB > 1) || bLUB == -1))
           lMulChToN = true;
@@ -1590,7 +1585,7 @@ class UmpleInternalParser
         // changed to MN (or M*)
         if (aRUB >= aRLB && aRLB != 0 && aRUB > 1 && ((bRLB == 0 && bRUB > 1) || bRUB == -1))
           rMulChToN = true;	  
-      		 
+           
         // special case for * multiplicity
       	if ( bLUB == -1 ) 
       	{ 
@@ -2220,8 +2215,8 @@ class UmpleInternalParser
         {
         	if( (cb.getCode("") != null) && (!cb.getCode("").equals("")) && (!cb.getCode("").equals("\n")))	  
         	getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
-	    		  	  aMethod.getName(),aMethod.getClass().getName(), implementationPositions.get("").getLineNumber()+"", implementationPositions.get("").getFilename(),
-	    		  	  token.getPosition().getLineNumber()+"", token.getPosition().getFilename(), ""));
+	          	  aMethod.getName(),aMethod.getClass().getName(), implementationPositions.get("").getLineNumber()+"", implementationPositions.get("").getFilename(),
+	          	  token.getPosition().getLineNumber()+"", token.getPosition().getFilename(), ""));
           else
           {
 	          cb.setCode(token.getValue());
@@ -2238,11 +2233,11 @@ class UmpleInternalParser
           {
         	  if( (cb.getCode(str) != null) && (!cb.getCode(str).equals("")) && (!cb.getCode(str).equals("\n")))	  
 	        	  getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
-	    	    		  	  aMethod.getName(),aMethod.getClass().getName(), implementationPositions.get(str).getLineNumber()+"", implementationPositions.get(str).getFilename(),
-	    	    		  	  token.getPosition().getLineNumber()+"", token.getPosition().getFilename(), str));
+	    	          	  aMethod.getName(),aMethod.getClass().getName(), implementationPositions.get(str).getLineNumber()+"", implementationPositions.get(str).getFilename(),
+	    	          	  token.getPosition().getLineNumber()+"", token.getPosition().getFilename(), str));
         	  else
         	  {
-        		implementationPositions.put(iValue, iPosition);
+            implementationPositions.put(iValue, iPosition);
 	            cb.setCode(str,/*(cb.getCode(str)!=null?cb.getCode(str)+"\n":"")+*/ token.getValue());
 	            if("Java".equals(str))
 	            {
@@ -2301,39 +2296,39 @@ class UmpleInternalParser
     	  List<String> implementations = new ArrayList<String>();
     	  
     	  for(String l : langsImplementation)
-    		  if(actualMethod.getExistsInLanguage(l))
-    			  implementations.add(l);
-    		  else
-    		  {
-    			  if(!l.equals(""))
-    			    actualMethod.getMethodBody().setExtraCode(l, aMethod.getMethodBody().getExtraCode(l));
-    			  else
-    				actualMethod.getMethodBody().setExtraCode("", aMethod.getMethodBody().getExtraCode(l));
-				  
-    			  actualMethod.getMethodBody().getImplementationPositions().put(l, aMethod.getMethodBody().getImplementationPositions().get(l));
-    		  }
-    		  
+          if(actualMethod.getExistsInLanguage(l))
+        	  implementations.add(l);
+          else
+          {
+        	  if(!l.equals(""))
+        	    actualMethod.getMethodBody().setExtraCode(l, aMethod.getMethodBody().getExtraCode(l));
+        	  else
+            actualMethod.getMethodBody().setExtraCode("", aMethod.getMethodBody().getExtraCode(l));
+          
+        	  actualMethod.getMethodBody().getImplementationPositions().put(l, aMethod.getMethodBody().getImplementationPositions().get(l));
+          }
+          
     	  if(!implementations.isEmpty())
     	  {
-    		  for(String l : implementations)
-    		  {
-    			  if((actualMethod.getMethodBody().getExtraCode(l).equals("") || 
-    				  actualMethod.getMethodBody().getExtraCode(l).equals("\n"))&&
-    				 (!aMethod.getMethodBody().getExtraCode(l).equals("") ||
-    			      !aMethod.getMethodBody().getExtraCode(l).equals("\n")) &&
-    			     (!actualMethod.getMethodBody().getExtraCode(l).equals(aMethod.getMethodBody().getExtraCode(l))))
-    			  {
-    				  actualMethod.getMethodBody().setExtraCode(l, aMethod.getMethodBody().getExtraCode(l));
-    				  actualMethod.getMethodBody().getImplementationPositions().put(l, aMethod.getMethodBody().getImplementationPositions().get(l));
-    			  }
-    			  else
-    			  {
-    				  getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
-    		    		  	  aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
-    		    		  	  aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
-    			  }
-    			  
-    		  }
+          for(String l : implementations)
+          {
+        	  if((actualMethod.getMethodBody().getExtraCode(l).equals("") || 
+              actualMethod.getMethodBody().getExtraCode(l).equals("\n"))&&
+             (!aMethod.getMethodBody().getExtraCode(l).equals("") ||
+        	      !aMethod.getMethodBody().getExtraCode(l).equals("\n")) &&
+        	     (!actualMethod.getMethodBody().getExtraCode(l).equals(aMethod.getMethodBody().getExtraCode(l))))
+        	  {
+              actualMethod.getMethodBody().setExtraCode(l, aMethod.getMethodBody().getExtraCode(l));
+              actualMethod.getMethodBody().getImplementationPositions().put(l, aMethod.getMethodBody().getImplementationPositions().get(l));
+        	  }
+        	  else
+        	  {
+              getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
+                  	  aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
+                  	  aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
+        	  }
+        	  
+          }
     	  }
     	  
     	  /*
@@ -2341,14 +2336,14 @@ class UmpleInternalParser
     	  if ((actualMethod.getMethodBody().getExtraCode().isEmpty()) &&
     	      (!aMethod.getMethodBody().getExtraCode().isEmpty()))
     	  {
-    		  actualMethod.setMethodBody(aMethod.getMethodBody());
-    		  actualMethod.setPosition(aMethod.getPosition());
+          actualMethod.setMethodBody(aMethod.getMethodBody());
+          actualMethod.setPosition(aMethod.getPosition());
     	  }
     	  else
     	  {
     	    getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
-    		  	  aMethod.getName(),uClass.getName(), actualMethod.getPosition().getLineNumber()+"", actualMethod.getPosition().getFilename(),
-    			  aMethod.getPosition().getLineNumber()+"", aMethod.getPosition().getFilename()));
+          	  aMethod.getName(),uClass.getName(), actualMethod.getPosition().getLineNumber()+"", actualMethod.getPosition().getFilename(),
+        	  aMethod.getPosition().getLineNumber()+"", aMethod.getPosition().getFilename()));
     	  }    
     	  
     	  */
@@ -2386,11 +2381,11 @@ class UmpleInternalParser
         if (!uTrait.hasMethod(aMethod)) // && shouldAddMethod)
         {
         	String msg = "Please do not modify the following method.";
-			aMethod.addCommentAt(new Comment(msg),0);
+    	aMethod.addCommentAt(new Comment(msg),0);
         	msg = "The following method comes from trait "+uTrait.getName()+".";
-			aMethod.addCommentAt(new Comment(msg),1);
-			msg = "Trait "+uTrait.getName()+" has been used in classes: ";
-			aMethod.addCommentAt(new Comment(msg),2);
+    	aMethod.addCommentAt(new Comment(msg),1);
+    	msg = "Trait "+uTrait.getName()+" has been used in classes: ";
+    	aMethod.addCommentAt(new Comment(msg),2);
         	uTrait.addMethod(aMethod); 
         } 
 
@@ -2994,15 +2989,15 @@ class UmpleInternalParser
       //Issue #449
 	UmpleClass child = aClass;
 	while(unlinkedExtends.get(child) != null){
-		for(Attribute parentAttribute : model.getUmpleClass(unlinkedExtends.get(child).get(0)).getAttributes())
-		{
-			if(parentAttribute.getName().equals(tokenVal))
-		    {
-			tokenMatch = true;
-			break;
-			}
-		}
-		child = model.getUmpleClass(unlinkedExtends.get(child).get(0));  
+    for(Attribute parentAttribute : model.getUmpleClass(unlinkedExtends.get(child).get(0)).getAttributes())
+    {
+    	if(parentAttribute.getName().equals(tokenVal))
+        {
+    	tokenMatch = true;
+    	break;
+    	}
+    }
+    child = model.getUmpleClass(unlinkedExtends.get(child).get(0));  
 	}
    
     if(!aClass.hasAttributes() && !aClass.hasAssociations() && !aClass.hasStateMachines() && !tokenMatch)
@@ -3453,9 +3448,9 @@ class UmpleInternalParser
         String bound = "";
         //case of mandatory constraint
     	if(nonConstraintEndLower.equals(nonConstraintEndUpper))
-    		bound = nonConstraintEndLower;
+        bound = nonConstraintEndLower;
     	else	
-    		bound = "[" +nonConstraintEndLower+", "+nonConstraintEndUpper+"]";
+        bound = "[" +nonConstraintEndLower+", "+nonConstraintEndUpper+"]";
         setFailedPosition(associationToken.getPosition(), 36, bound);
       }
     }
@@ -3489,7 +3484,7 @@ class UmpleInternalParser
     
     if(isAutounique || attributeToken.getValue("modifier") != null){
     	if(attributeAutouniqueImmutable == null)
-    		attributeAutouniqueImmutable = new HashMap<Token, UmpleClass>();
+        attributeAutouniqueImmutable = new HashMap<Token, UmpleClass>();
     	attributeAutouniqueImmutable.put(attributeToken, aClass);
     }
     
@@ -4058,4 +4053,64 @@ class UmpleInternalParser
       setFailedPosition(position,1502,identifier);
     }
   }
+  
+  private String getCurrentNameSpace(Token inToken) {
+    String currentNameSpace="";
+    boolean twice = false;
+    boolean resetClass = false;
+    int index=-1;
+    for(int i = 0; i<inToken.getParentToken().getSubTokens().size();i++){
+      Token t1 = inToken.getParentToken().getSubTokens().get(i);
+      if (t1.equals(inToken)) {
+    	  index=i;
+    	  break;
+      }
+      if (t1.getName().equals("classDefinition")) {
+    	  resetClass=true;
+    	  twice =false;
+    	  currentNameSpace="";
+      }
+      if (t1.getName().equals("namespace")&& !t1.getValue().equals("STATIC"))  {
+    	  currentNameSpace = t1.getValue();
+    	  if (!twice){
+          twice = true;
+          resetClass = false;
+
+    	  } else {
+          	if (!resetClass){
+              setFailedPosition(t1.getPosition(),31,currentPackageName,t1.getValue());
+              continue;
+          	}
+    	  }
+      }
+    }
+    boolean finalCheck = false;
+    String extraNamespace = "";
+    int counter = -1;
+    Token forReport = null;
+    for (int j=index+1;j<inToken.getParentToken().getSubTokens().size();j++){
+    	Token t1 = inToken.getParentToken().getSubTokens().get(j);
+    	if (t1.getName().equals("classDefinition")) {
+        finalCheck = true;
+    	} else if (t1.getName().equals("namespace") && !t1.getValue().equals("STATIC")){
+        extraNamespace = t1.getValue();
+        counter++;
+        forReport = t1;
+    	}
+    }
+    if (finalCheck) return currentNameSpace;
+    if (counter<0) return  currentNameSpace; 
+    else if(counter==0 ) {
+    	if (currentNameSpace!=""){
+        setFailedPosition(forReport.getPosition(),31,currentPackageName,forReport.getValue());
+        return  currentNameSpace; 
+    	} else{
+        return extraNamespace;
+    	}
+    } else {
+    	setFailedPosition(forReport.getPosition(),31,currentPackageName,forReport.getValue());
+    	return extraNamespace;
+    }
+	}
+  
 } 

--- a/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
@@ -117,10 +117,12 @@ class UmpleInternalParser
     }
     
     if("".equals(aTrait.getPackageName())){
+      //If one day traits are going to be a modular-runtime elements and there is a need for package use, the following code can be useful.
+      //setFailedPosition(classToken.getPosition(), 30, aClass.getName(), currentPackageName);
+      //aClass.setPackageName(currentPackageName); 
       aTrait.setPackageName(currentPackageName);
   	}
   	
- 	packageNameUsed = true;
     if (aTrait.getIsSingleton()) 
     {
       traitToken.setName(traitToken.getName());  

--- a/cruise.umple/test/cruise/umple/compiler/213_mixin_namespaces_1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/213_mixin_namespaces_1.ump
@@ -2,4 +2,5 @@ namespace A;
 class X {}
 namespace B;
 class Y {}
+
 class X {}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2385,7 +2385,7 @@ public class UmpleParserTest
 	  Assert.assertEquals("B",parser.getModel().getUmpleClass("Y").getPackageName());
 
 	  assertHasWarningsParse("213_mixin_namespaces_3.ump",30);
-	  Assert.assertEquals("C",parser.getModel().getUmpleClass("X").getPackageName());
+	  Assert.assertEquals("A",parser.getModel().getUmpleClass("X").getPackageName());
 	  Assert.assertEquals("B",parser.getModel().getUmpleClass("Y").getPackageName());
 
   }

--- a/cruise.umplificator/.project
+++ b/cruise.umplificator/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -18,5 +23,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/cruise.umplificator/src/UmplificatorVersion.ump
+++ b/cruise.umplificator/src/UmplificatorVersion.ump
@@ -1,4 +1,4 @@
-namespace cruise.umplificator;
+namespace cruise.umplificator.core;
 
 class Umplificator
 {

--- a/cruise.umplificator/src/Umplificator_traces.ump
+++ b/cruise.umplificator/src/Umplificator_traces.ump
@@ -7,15 +7,7 @@ The file that actually gets packaged with the final .jar is: cruise.umplificator
 */
 
 tracer log4j noconfig;
-
 // MOTL trace specification
-
-class Umplificator {
-	//trace needSubDirectories where [ needSubDirectories==true ] record "umplificator will create subdirectories based on the namespace of the model" logLevel info;
-	trace outputFolder where [outputFolder==null] logLevel fatal;
-	trace filesUmplified;
-	trace umplifyCPP record "not implemented yet" logLevel error;
-}
 
 class JavaParser {
   trace parseUnit logLevel debug record "Parsing Compilation Unit";
@@ -36,4 +28,12 @@ class RuleRunner {
   trace insertUmpleModel logLevel debug record "RuleRunner.insertUmpleModel - Insert Umple Model into working memory";	
   trace insertUmpleInterface logLevel debug record "RuleRunner.insertUmpleInterface- Insert uInterface into working memory";
   trace fireAllRules logLevel debug record "RuleRunner.fireAllRules - Fire rules";
+}
+
+namespace cruise.umplificator.core;
+class Umplificator {
+  //trace needSubDirectories where [ needSubDirectories==true ] record "umplificator will create subdirectories based on the namespace of the model" logLevel info;
+  trace outputFolder where [outputFolder==null] logLevel fatal;
+  trace filesUmplified;
+  trace umplifyCPP record "not implemented yet" logLevel error;
 }

--- a/umpleonline/.project
+++ b/umpleonline/.project
@@ -5,7 +5,13 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/umpleonline/ump/BankingSystemA.ump
+++ b/umpleonline/ump/BankingSystemA.ump
@@ -87,12 +87,32 @@ class Division{
 }
 //$?[End_of_model]$?
 // Positioning
+namespace BankingSystem.core.intangableResources;
 class Account
 {
   position 438 270 189 96;
   position.association Account__AccountType 190,15 0,27;
 }
+class AccountType
+{
+  position 665 258 152 79;
+  position.association AccountType__Privilege 70,0 67,62;
+}
+class Privilege
+{
+  position 668 146 149 62;
+}
 
+class MortgageAccount
+{
+  position 565 416 137 58;
+}
+class CreditCardAccount
+{
+  position 391 416 139 58;
+  position.association Card__CreditCardAccount 0,14 153,15;
+}
+namespace BankingSystem.core.humanResources;
 class Client
 {
   position 444 125 166 96;
@@ -104,47 +124,6 @@ class Person
   position 35 45 166 96;
   position.association Person__PersonRole 167,10 0,24;
 }
-
-class Branch
-{
-  position 200 283 171 79;
-  position.association Account__Branch 172,15 0,28;
-}
-
-class AccountType
-{
-  position 665 258 152 79;
-  position.association AccountType__Privilege 70,0 67,62;
-}
-
-class Card
-{
-  position 161 415 153 58;
-}
-
-class Privilege
-{
-  position 668 146 149 62;
-}
-
-class MortgageAccount
-{
-  position 565 416 137 58;
-}
-
-class CreditCardAccount
-{
-  position 391 416 139 58;
-  position.association Card__CreditCardAccount 0,14 153,15;
-}
-
-class Division
-{
-  position 86 185 112 77;
-  position.association Division__Employee 112,0 0,31;
-  position.association Division__Division:subDivision 0,63 10,77;
-}
-
 class Manager
 {
   position 252 216 109 41;
@@ -160,3 +139,21 @@ class PersonRole
 {
   position 350 31 110 45;
 }
+namespace BankingSystem.core.tangableResources;
+class Branch
+{
+  position 200 283 171 79;
+  position.association Account__Branch 172,15 0,28;
+}
+class Card
+{
+  position 161 415 153 58;
+}
+
+class Division
+{
+  position 86 185 112 77;
+  position.association Division__Employee 112,0 0,31;
+  position.association Division__Division:subDivision 0,63 10,77;
+}
+

--- a/umpleonline/ump/ElevatorSystemB.ump
+++ b/umpleonline/ump/ElevatorSystemB.ump
@@ -56,6 +56,7 @@ class ConsoleCallButton
 }
 //$?[End_of_model]$?
 //Positioning
+namespace Elevator.core;
 class Elevator
 {
   position 276 380 217 96;
@@ -63,14 +64,15 @@ class Elevator
   position.association DownCallButton__Elevator 180,0 49,45;
   position.association Elevator__UpCallButton 140,0 52,45;
 }
-class Button
-{
-  position 303 35 135 62;
-}
 class FloorNumberDisplay
 {
   position 37 491 140 45;
   position.association Floor__FloorNumberDisplay 70,0 56,45;
+}
+namespace Elevator.core.Buttons;
+class Button
+{
+  position 303 35 135 62;
 }
 class ConsoleCallButton
 {
@@ -98,6 +100,7 @@ class CloseDoorButton
   position 298 202 121 45;
   position.association CloseDoorButton__Elevator 54,45 84,0;
 }
+namespace Elevator.core;
 class FullSystem
 {
   position 576 399 109 41;

--- a/umpleonline/ump/ManufactoringPlantController.ump
+++ b/umpleonline/ump/ManufactoringPlantController.ump
@@ -83,7 +83,7 @@ class OrderLineItem {
  * Robot;
 }*/
 //$?[End_of_model]$?
-
+namespace MFP.core.black;
 class ProductRun
 {
   displayColour lightgrey;
@@ -108,6 +108,7 @@ class ProductType
   position.association Product__ProductType 70,0 80,79;
 }
 
+namespace MFP.core.red;
 class RobotAllocation
 {
   displayColour pink;
@@ -116,6 +117,7 @@ class RobotAllocation
   position.association Robot__RobotAllocation 145,15 0,13;
 }
 
+namespace MFP.core.blue;
 class OrderLineItem
 {
   displayColour lightblue;
@@ -123,6 +125,7 @@ class OrderLineItem
   position.association OrderLineItem__Product 0,12 160,22;
 }
 
+namespace MFP.core.green;
 class BillOfMaterialsLineItem
 {
   displayColour lightgreen;
@@ -131,13 +134,14 @@ class BillOfMaterialsLineItem
   position.association BillOfMaterialsLineItem:bill__ProductType 61,0 50,62;
   position.association BillOfMaterialsLineItem__ProductType:consistsOf 110,0 99,58;
 }
-
 class Product
 {
   displayColour lightgreen;
   position 256 50 160 79;
   position.association Product__Product:packagedWith 0,64 11,79;
 }
+
+namespace MFP.core.red;
 class AssemblyStep
 {
   displayColour pink;
@@ -150,7 +154,7 @@ class Robot
   displayColour pink;
   position 291 442 125 58;
 }
-
+namespace MFP.core.green;
 class Supplier
 {
   displayColour lightgreen;


### PR DESCRIPTION
I have noticed several inconsistencies in the use of `namespace' specially with mixins. Unfortunately, other people have developed their own code based on these wrong rules. In this PR, I have tried to resolve some of them. However, still there might be some cases that need to be concerted. 
The rules are these.
if there are several class inside a Umple files, each one can have its own namespace. However, if others don't have it will look for the one defined before. If it's a mixin class, the developer  must make sure they both have the same namespaces. Otherwise, the user will get a warning and the Umple will accept the first definition of the namespace. 
namespaces must be defined before classes.

I had to fix many test cases to make this works. I also had to modify a part of Umplificator in which a class had two namespaces. 
I think we should spend more time on developing real-cases studies and make sure the user-manual is concrete and talks about the all wrong or correct cases. 
