### PR TITLE
reinitialization enabled for and-cross transitions

### DIFF
--- a/cruise.umple/src/NuSMVCoordinationUnit.ump
+++ b/cruise.umple/src/NuSMVCoordinationUnit.ump
@@ -49,9 +49,9 @@ class NuSMVCoordinator
   	private NuSMVModule generateParentModule( StateMachine sm, UmpleClass uClass ) {
   		  		
 		VarDeclaration vdec = new VarDeclaration( getStateList( sm ) );
+		vdec.addVariableSpecifier( getEventList( sm ) );
 		for( VariableSpecifier vs : generateSpecifiersForAttributesOf( uClass ) )
 			vdec.addVariableSpecifier(vs);
-		vdec.addVariableSpecifier( getEventList( sm ) );
 		ModuleBody body = new ModuleBody( vdec );
   		body.addModuleElement( vdec );
 		
@@ -258,8 +258,7 @@ class NuSMVCoordinator
   		//Generates the parent state machine  		
   		NuSMVModule module = generateParentModule( sm, uClass );
   		temp.add(module);
-  		StateMachine root = sm;
-  		for( NuSMVModule mod : generateModuleForCompositeStatesOf( root, sm ) )
+  		for( NuSMVModule mod : generateModuleForCompositeStatesOf( sm, sm ) )
   			temp.add( mod );
 			
 		//Generating the main module for the statemachine
@@ -577,7 +576,7 @@ class NuSMVCoordinator
 			for(StateMachine region : smm.getImmediateNestedStateMachines())
 				if( !region.equals(sm) )
 					for(State st : getEmbeddedStates(smm))
-						if(!has(friendStates,st))
+						if( !has( friendStates, st))
 							friendStates.add(st);
 		}
 		
@@ -588,27 +587,39 @@ class NuSMVCoordinator
 			if(!has(embeddedStates, tr.getNextState()) && has(friendStates, tr.getNextState()))
 				andCrossTransitions.add(tr);
 		}
-		
 		return andCrossTransitions;
+	}
+	
+	//This computes and-cross transitions of a given state.
+	private List<Transition> getAndCross( State state ) {
+		List<Transition> andCross = new ArrayList<Transition>();
+		if( ! state.isIsConcurrent() )
+			return andCross;
+		
+		for( StateMachine sm : state.getNestedStateMachines() )
+			for( Transition transition : andCross( sm ) )
+				andCross.add( transition );
+		return andCross;
 	}
 	
 	//Computes the exit transitions for a concurrent region
 	private List<Transition> getExitTransitionsForConcurrentRegion(StateMachine region, StateMachine root){
-		List<Transition> trans = getAllEnablingTransitions(getParentState(region));
+		List<Transition> trans = getAllEnablingTransitions( getParentState(region) );
 		List<Transition> temp = new ArrayList<Transition>();
 		for( Transition tr : root.getAllTransitions() )
 			if( !has( trans, tr ) )
-				temp.add(tr);
+				temp.add( tr ); //adds to temp every other transitions not enclosed by the parent state 
 	
 		//adding and-cross transitions for a given region
-		for(Transition tr : andCross(region))
-			if( !has( temp, tr ) )
+		List<State> embeddedStates = getEmbeddedStates( region );
+		for( Transition tr : getAndCross( getParentState( region ) ) )
+			if( !has( embeddedStates, tr.getNextState() ) )
 				temp.add(tr);
 		return temp;
 	}
 	
 	//Computes exit transitions for non-orthogonal composite state
-	private List<Transition> getExitTransitions(State st, StateMachine root){
+	private List<Transition> getExitTransitions(State st, StateMachine root) {
 		List<Transition> transitions = new ArrayList<Transition>();
 		for( Transition transition : root.getAllTransitions() ){
 			if(st.hasNestedStateMachines() && !st.isIsConcurrent() )				
@@ -628,18 +639,15 @@ class NuSMVCoordinator
 		return transitions;
 	}
 	
-	private List<State> getEmbeddedStates(StateMachine sm ){
+	private List<State> getEmbeddedStates(StateMachine sm ) {
 		List<State> embeddedStates = new ArrayList<State>();
-		for(State state : sm.getStates() ){
+		for(State state : sm.getStates() ) {
 			if(!state.hasNestedStateMachines())
 				embeddedStates.add(state);
-			else {
-				for( StateMachine stm : generateStateMachineList(sm) ){
+			else
+				for( StateMachine stm : generateStateMachineList(sm) )
 					for(State st : getEmbeddedStates(stm))
-						embeddedStates.add(st);
-					//checks if statemachine stm has wrapper --- to-do here!						
-				}
-			}
+						embeddedStates.add(st);						
 		}
 		return embeddedStates;
 	}
@@ -657,21 +665,19 @@ class NuSMVCoordinator
 		int counter = 0;
 		BasicExpression rt = new BasicExpression("root");
 		List<Transition> trans;
-		if(!(getParentState(sm).isIsConcurrent())){
-			if(sm.equals(root))
-				return null;
-			trans = getExitTransitions( getParentState(sm), root );
+		if(!( getParentState( sm ).isIsConcurrent() )) {
+			if( sm.equals(root) ) return null;
+			trans = getExitTransitions( getParentState( sm ), root );
 		}
 		else
 			trans = getExitTransitionsForConcurrentRegion(sm, root);
 
 		for( Transition tr : trans ) {
-				BasicExpression bexp;
-				bexp = new BasicExpression("_"+changeNameCase(root.getFullName(),0)+".t"+getObjectIdentity( root, tr) );	
-				rt = getExpressionTreeFor( rt, bexp );
-				counter++;
+			BasicExpression bexp;
+			bexp = new BasicExpression("_"+changeNameCase(root.getFullName(),0)+".t"+getObjectIdentity( root, tr) );	
+			rt = getExpressionTreeFor( rt, bexp );
+			counter++;
 		}
-		
 		if(counter > 0) {
   			BasicExpression state = new BasicExpression( "null" ); 
   			return new CaseStatement( rt, state );
@@ -692,21 +698,7 @@ class NuSMVCoordinator
 				bexp = new BasicExpression("t"+getObjectIdentity( parent, tr) );
   			root = getExpressionTreeFor( root, bexp );	
   			counter++;
-  		}
-  		/*if( st.isIsStartState() && st.getStateMachine().getParentState() != null ) {
-  			State bioparent = st.getStateMachine().getParentState();
-  			BasicExpression bexp1 = new BasicExpression("_"+changeNameCase(bioparent.getStateMachine().getFullName(), 0)+".state");
-  			BasicExpression bexp2 = new BasicExpression(changeNameCase(tr.getFromState().getStateMachine().getFullName(),1)+"_"+bioparent.getName());
-  			BasicExpression bexp3 = new BasicExpression("expr");
-  			bexp3.addChild(bexp1);
-  			bexp3.addChild(bexp2);
-  			bexp3.setOperator( bexp1.getOperator().EQ );
-  			if(root.getChildren().size() == 0)
-  				root = bexp3;
-  			else
-  				root = getExpressionTreeFor( root, bexp3 );
-  			counter++;
-  		}*/  			
+  		} 			
   		if(counter > 0) {
   			BasicExpression state = new BasicExpression( changeNameCase(st.getStateMachine().getFullName(),1)+"_"+st.getName() ); 
   			return new CaseStatement( root, state );

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ArbitraryExample.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ArbitraryExample.nusmv.txt
@@ -84,7 +84,7 @@ MODULE SmBB ( _sm )
        _sm.t8 | _sm.t12 : SmBB_b2;
        _sm.t7 | _sm.t11 : SmBB_b3;
        _sm.t10 : SmBB_b4;
-       _sm.t5 : null;
+       _sm.t5 | _sm.t18 : null;
        _sm.state = Sm_s2 & state = null : SmBB_b1;
        TRUE : state;
      esac;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.nusmv.txt
@@ -10,12 +10,12 @@ MODULE State ( _stateDrive )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_neutral , State_reverse , State_drive };
+     event : { ev_selectReverse , ev_selectDrive , ev_selectFirst , ev_selectSecond , ev_selectNeutral , ev_reachSecondSpeed , ev_reachThirdSpeed , ev_dropBelowSecondSpeed , ev_dropBelowThirdSpeed , ev_null };
      driveSelected : boolean;
      notdriveSelected : boolean;
      a : integer;
      b : integer;
      c : integer;
-     event : { ev_selectReverse , ev_selectDrive , ev_selectFirst , ev_selectSecond , ev_selectNeutral , ev_reachSecondSpeed , ev_reachThirdSpeed , ev_dropBelowSecondSpeed , ev_dropBelowThirdSpeed , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/DigitalWatchFlat.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/DigitalWatchFlat.nusmv.txt
@@ -10,6 +10,7 @@ MODULE Sm
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_time , Sm_date , Sm_paused , Sm_running , Sm_lapRunning , Sm_lapPaused , Sm_bothOff , Sm_chimeOn , Sm_bothOn , Sm_alarmOn , Sm_alarmTime , Sm_alarmHour , Sm_alarmMinute , Sm_second , Sm_minute , Sm_hour , Sm_month , Sm_day , Sm_year };
+     event : { ev_s1 , ev_s2 , ev_s3 , ev_s3during2Secs , ev_notS1 , ev_notS2 , ev_null };
      day : integer;
      month : integer;
      year : integer;
@@ -20,7 +21,6 @@ MODULE Sm
      alarmMinute : integer;
      alarmSecond : integer;
      timer : integer;
-     event : { ev_s1 , ev_s2 , ev_s3 , ev_s3during2Secs , ev_notS1 , ev_notS2 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/Elevator.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/Elevator.nusmv.txt
@@ -10,10 +10,10 @@ MODULE Elevator_state_machine ( _elevator_state_machinePrepareUp , _elevator_sta
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Elevator_state_machine_Idle , Elevator_state_machine_PrepareUp , Elevator_state_machine_PrepareDown , Elevator_state_machine_InMotion , Elevator_state_machine_OnFloor };
+     event : { ev_upRequest , ev_downRequest , ev_started , ev_doorClosed , ev_approachingFloor , ev_approachedFloor , ev_stopped , ev_doorOpened , ev_timeoutAtFloorToDoorClosing , ev_doorClosingRequest , ev_doorCLosed , ev_obstruction , ev_doorOpeningRequest , ev_noRequest , ev_null };
      timer : integer;
      floorRequested : boolean;
      obstruction : boolean;
-     event : { ev_upRequest , ev_downRequest , ev_started , ev_doorClosed , ev_approachingFloor , ev_approachedFloor , ev_stopped , ev_doorOpened , ev_timeoutAtFloorToDoorClosing , ev_doorClosingRequest , ev_doorCLosed , ev_obstruction , ev_doorOpeningRequest , ev_noRequest , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile2.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile2.nusmv.txt
@@ -10,10 +10,10 @@ MODULE LockState
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { LockState_BothDoorsClosedLockFull , LockState_OpeningUpperGate , LockState_UpperGateOpen , LockState_ClosingUpperGate , LockState_LoweringWater , LockState_BothDoorsClosedLockEmpty , LockState_OpeningLowerGate , LockState_LowerGateOpen , LockState_ClosingLowerGate , LockState_RaisingWater };
+     event : { ev_boatRequestsToEnterAndGoDown , ev_boatRequestsToEnterAndGoUp , ev_upperGateFullyOpen , ev_boatInLockRequestingToGoDown , ev_after3minutes , ev_upperGateFullyClosed , ev_waterLevelMatchesDownStream , ev_lowerGateFullyOpen , ev_boatInLockRequestingToGoUp , ev_lowerGateFullyClosed , ev_waterLevelMatchesUpStream , ev_null };
      boatGoingDown : boolean;
      boatGoingUp : boolean;
      boatBlockingGate : boolean;
-     event : { ev_boatRequestsToEnterAndGoDown , ev_boatRequestsToEnterAndGoUp , ev_upperGateFullyOpen , ev_boatInLockRequestingToGoDown , ev_after3minutes , ev_upperGateFullyClosed , ev_waterLevelMatchesDownStream , ev_lowerGateFullyOpen , ev_boatInLockRequestingToGoUp , ev_lowerGateFullyClosed , ev_waterLevelMatchesUpStream , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/FurnaceControlSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/FurnaceControlSystem.nusmv.txt
@@ -10,6 +10,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { HeatSystem_heatSys , null };
+     event : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 , ev_null };
      tooCold : boolean;
      tooHot : boolean;
      requestHeat : boolean;
@@ -20,7 +21,6 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
      warmUpTimer : integer;
      coolDownTimer : integer;
      waitedForCool : integer;
-     event : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/GrantApplication.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/GrantApplication.nusmv.txt
@@ -10,8 +10,8 @@ MODULE Status
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Status_Planned , Status_InProgress , Status_EvaluationByInstitution , Status_VerifiedByInstitution , Status_SubmittedByInstitution , Status_UnderAdministrativeReview , Status_UnderExpertReview , Status_AwaitingFinalDecision , Status_Accepted , Status_Rejected , Status_Withdrawn };
-     adminCheckOk : boolean;
      event : { ev_createApplication , ev_researcherDeclaresComplete , ev_editByResearcher , ev_returnToResearcher , ev_verified , ev_editByInstitution , ev_reOpen , ev_submit , ev_withdraw , ev_acceptForReview , ev_submissionCheck , ev_acceptForExpertReview , ev_bypassExpertReviewDueToMinorChanges , ev_returnToInstitition , ev_expertReviewsReturned , ev_finalAccept , ev_minorRevisionsNeeded , ev_reject , ev_tryAgain , ev_null };
+     adminCheckOk : boolean;
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/JavaDataTypes.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/JavaDataTypes.nusmv.txt
@@ -10,6 +10,7 @@ MODULE Sm
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_s1 , Sm_s2 };
+     event : { ev_e1 , ev_e2 , ev_e3 , ev_null };
      a : integer;
      b : integer;
      c : real;
@@ -18,7 +19,6 @@ MODULE Sm
      h : boolean;
      f : integer;
      g : integer;
-     event : { ev_e1 , ev_e2 , ev_e3 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/NestedWatch.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/NestedWatch.nusmv.txt
@@ -10,6 +10,7 @@ MODULE Sm ( _smRegular , _smRegularUpdate , _smChronometer , _smChronometerChron
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_regular , Sm_chronometer , Sm_alarmStatus , Sm_alarmUpdate };
+     event : { ev_s3 , ev_notS2 , ev_s1 , ev_s2 , ev_s3during2Secs , ev_notS1 , ev_null };
      day : integer;
      month : integer;
      year : integer;
@@ -20,7 +21,6 @@ MODULE Sm ( _smRegular , _smRegularUpdate , _smChronometer , _smChronometerChron
      alarmMinute : integer;
      alarmSecond : integer;
      timer : integer;
-     event : { ev_s3 , ev_notS2 , ev_s1 , ev_s2 , ev_s3during2Secs , ev_notS1 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/myTemporaryTest.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/myTemporaryTest.nusmv.txt
@@ -10,6 +10,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { HeatSystem_heatSys , null };
+     event : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 , ev_null };
      tooCold : boolean;
      tooHot : boolean;
      requestHeat : boolean;
@@ -20,7 +21,6 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
      warmUpTimer : integer;
      coolDownTimer : integer;
      waitedForCool : integer;
-     event : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE


### PR DESCRIPTION
In this PR, we enable the reinitialization of sibling state machines, say k,j...  of an orthogonal state machine, say m such that if there is an and-cross transition t whose destination is m then k,j... are reinitialized.  
