### PR TITLE
event names associated to autotransitions should not be distinct

### DIFF
--- a/cruise.umple/src/NuSMVCoordinationUnit.ump
+++ b/cruise.umple/src/NuSMVCoordinationUnit.ump
@@ -247,12 +247,12 @@ class NuSMVCoordinator
   		int pos = 1;
 		if( obj instanceof Transition ){
 			for(Transition trans : sm.getAllTransitions() ) {
-				//System.out.println( trans.getEvent().getName()+"["+trans.getFromState().getName() +" -- "+trans.getNextState().getName()+"]");
+				//System.out.println( getEventName( trans.getEvent() )+"["+trans.getFromState().getName() +" -- "+trans.getNextState().getName()+"]");
 				if(trans.equals( (Transition) obj) )
 					return pos;
 				pos++;
 			}
-			//System.out.println( ((Transition)obj).getEvent().getName()+"["+((Transition)obj).getFromState().getName() +" -- "+((Transition)obj).getNextState().getName()+"]");
+			//System.out.println( getEventName(((Transition)obj).getEvent())+"["+((Transition)obj).getFromState().getName() +" -- "+((Transition)obj).getNextState().getName()+"]");
 		}
 		if( obj instanceof Guard ) {
 			pos = 1;
@@ -309,39 +309,32 @@ class NuSMVCoordinator
     	}
   	}*/
 	
-	private void generateSpecForTransitionDeterminism( StateMachine root, ModuleBody body ) {
+	private void generateSpecForTransitionDeterminism( StateMachine sm, ModuleBody body ) {
 		BasicExpression bexp1;
 		BasicExpression bexp2;
-		for( StateMachine sm : generateStateMachineList(root))
-			for(State st : sm.getStates() )
-				for( HashMap<Transition,Transition> entry : matchMakeTransitions( st ) )
-					for( HashMap.Entry<Transition,Transition> map : entry.entrySet() ) {
-						Transition key = map.getKey();
-						int i = getObjectIdentity( sm, key );
-						Transition value = map.getValue();
-						int j = getObjectIdentity( sm, value );
+		for(State st : sm.getStates() )
+			for( HashMap<Transition,Transition> entry : matchMakeTransitions( st ) )
+				for( HashMap.Entry<Transition,Transition> map : entry.entrySet() ) {
+					Transition key = map.getKey();
+					int i = getObjectIdentity( sm, key );
+					Transition value = map.getValue();
+					int j = getObjectIdentity( sm, value );
 					
-						if( sm.equals(root) ) 
-							bexp1 = new BasicExpression("t"+i);
-						else
-							bexp1 = new BasicExpression(changeNameCase(sm.getFullName(), 0)+".t"+i);
-						if( sm.equals(root) ) 
-							bexp2 = new BasicExpression("t"+j);
-						else
-							bexp2 = new BasicExpression(changeNameCase(sm.getFullName(), 0)+".t"+j);
-						BasicExpression bexp3 = new BasicExpression("temp");
-						bexp3.addChild(bexp1);
-						bexp3.addChild(bexp2);				
+					bexp1 = new BasicExpression("t"+i);
+					bexp2 = new BasicExpression("t"+j);
+					BasicExpression bexp3 = new BasicExpression("temp");
+					bexp3.addChild(bexp1);
+					bexp3.addChild(bexp2);				
 				
-						InvarExpression cexp = new InvarExpression("ctl");
-						cexp.addChild(bexp3);
-						cexp.addChild( generateDestinationStatesExpr( sm, mapIdentity( sm, i), mapIdentity( sm, j) ));
-						cexp.setOperator( BasicExpression.Operator.IMPLY );
-						cexp.setBracketed(true);
+					InvarExpression cexp = new InvarExpression("ctl");
+					cexp.addChild(bexp3);
+					cexp.addChild( generateDestinationStatesExpr( sm, mapIdentity( sm, i), mapIdentity( sm, j) ));
+					cexp.setOperator( BasicExpression.Operator.IMPLY );
+					cexp.setBracketed(true);
 				
-						InvarConstraint cspec = new InvarConstraint(cexp);
-						body.addModuleElement(cspec);
-					}
+					InvarConstraint cspec = new InvarConstraint(cexp);
+					body.addModuleElement(cspec);
+				}
   	}
 	//scans through the list and returns true whenever what to find is contained in the list
 	private <Transition> boolean has( List< HashMap<Transition,Transition> > objectList, HashMap<Transition,Transition> whatToFind ) {
@@ -369,9 +362,9 @@ class NuSMVCoordinator
 			int j = 0;
 			if( !defaulted ) 
 				j = i + 1;
-			while( j < y ) {
+			while( j < y ) { //( tr.getEvent().equals( trans.getEvent() ) || getEventName( tr.getEvent() ).equals( getEventName( trans.getEvent()) ))
 				HashMap<Transition, Transition> entry = new HashMap();
-				if( first.get(i).getEvent().equals( second.get(j).getEvent() ) 
+				if( ( first.get(i).getEvent().equals( second.get(j).getEvent() ) || getEventName(first.get(i).getEvent()).equals( getEventName(second.get(j).getEvent()) )) 
 					&& !first.get(i).getNextState().equals( second.get(j).getNextState() ) ) {
 					entry.put(first.get(i), second.get(j));
 					for( HashMap.Entry<Transition,Transition> map : entry.entrySet() )
@@ -451,7 +444,9 @@ class NuSMVCoordinator
 					State source = trans.getFromState();
 					List<State> external = getExternalStateOf( source, state );
 					for( Transition tr : state.getStateMachine().getAllTransitions() )
-						if( has( external, tr.getFromState() ) && tr.getEvent().equals( trans.getEvent() ) && !tr.getNextState().equals( trans.getNextState()) ) {
+						if( has( external, tr.getFromState() ) && 
+							( tr.getEvent().equals( trans.getEvent() ) || getEventName( tr.getEvent() ).equals( getEventName( trans.getEvent()) )) && 
+							!tr.getNextState().equals( trans.getNextState()) ) {
 							HashMap<Transition, Transition> entry = new HashMap();
 							entry.put(trans, tr);
 							for( HashMap.Entry<Transition,Transition> map : entry.entrySet() )
@@ -459,7 +454,8 @@ class NuSMVCoordinator
 									pairable.add( entry );
 						}
 					for( Transition tr : highLevelTransitions ){
-						if( tr.getEvent().equals( trans.getEvent() ) && !tr.getNextState().equals( trans.getNextState()) ) {
+						if( ( tr.getEvent().equals( trans.getEvent() ) || getEventName( tr.getEvent() ).equals( getEventName( trans.getEvent()) )) && 
+							!tr.getNextState().equals( trans.getNextState()) ) {
 							HashMap<Transition, Transition> entry = new HashMap();
 							entry.put(trans, tr);
 							for( HashMap.Entry<Transition,Transition> map : entry.entrySet() )
@@ -586,8 +582,8 @@ class NuSMVCoordinator
 	private AssignConstraint getEventAssignConstraint( StateMachine sm) {
 
 		VariableSpecifier eventset = new VariableSpecifier("events");
-		for( Event event : sm.getAllEvents() )
-			eventset.addTypeSpecifier( "ev_"+event.getName() );
+		for( String event : getAllEventNames( sm ) )
+			eventset.addTypeSpecifier( "ev_"+ event );
 			
 		BasicExpression lhs = new BasicExpression( sm.getFullName()+"_stable" );
     	BasicExpression rhs = new BasicExpression( "{ "+eventset.print()+" }" );
@@ -916,7 +912,7 @@ class NuSMVCoordinator
   		BasicExpression root = new BasicExpression("root");
   		for( Transition tr : getAllEnablingTransitions(st) ) {
 			
-			//System.out.println( tr.getEvent().getName()+"["+tr.getFromState().getName() +" -- "+tr.getNextState().getName()+"]");
+			//System.out.println( getEventName(tr.getEvent())+"["+tr.getFromState().getName() +" -- "+tr.getNextState().getName()+"]");
 			BasicExpression bexp;
 			if(!parent.equals(sm))
 				bexp = new BasicExpression("_"+changeNameCase(parent.getFullName(),0)+".t"+getObjectIdentity( parent, tr) );	
@@ -980,8 +976,8 @@ class NuSMVCoordinator
   	private  VariableSpecifier getEventList( StateMachine sm ) {
 		
   		VariableSpecifier vs = new VariableSpecifier("event");
-  		for( Event event : sm.getAllEvents() ) 
-  			vs.addTypeSpecifier("ev_"+event.getName());
+  		for( String event : getAllEventNames(sm) ) 
+  			vs.addTypeSpecifier("ev_"+event );
   		vs.addTypeSpecifier("ev_null");
   		return vs;
   	}
@@ -1050,7 +1046,7 @@ class NuSMVCoordinator
   	
   	private BasicExpression composeExpressionFor( Transition tr, StateMachine sm ) {
   		BasicExpression bexp1 = new BasicExpression("event");
-  		BasicExpression bexp2 = new BasicExpression("ev_"+tr.getEvent().getName());
+  		BasicExpression bexp2 = new BasicExpression("ev_" + getEventName( tr.getEvent() ));
   		BasicExpression bexp3 = new BasicExpression("eventExpr"); 
   		bexp3.addChild(bexp1);
   		bexp3.addChild(bexp2);
@@ -1086,12 +1082,26 @@ class NuSMVCoordinator
   		return bexp;
   	}
 	
+	//we exterminate uniqueness of auto-transitions
+	public Set<String> getAllEventNames( StateMachine sm ) {
+		Set<String> allEvents = new HashSet<String>();
+		for( Event event : sm.getAllEvents() )
+			allEvents.add( getEventName( event ) );	
+		return allEvents;
+	}
+	
+	private String getEventName( Event event ){
+		if( event.getName().length() > "__autotransition".length() && event.getName().substring( 0, 16).equals( "__autotransition" ) )
+			return event.getName().substring( 0, 16)+"__";
+		return event.getName();
+	}
+	
 	private BasicExpression composeExpressionForStability( StateMachine sm ) {
 		BasicExpression root = new BasicExpression("root");
 		BasicExpression bexp3;
-		for(Event event : sm.getAllEvents() ){
+		for( String event : getAllEventNames( sm ) ){
 			BasicExpression bexp1 = new BasicExpression("event");
-			BasicExpression bexp2 = new BasicExpression("ev_"+event.getName());
+			BasicExpression bexp2 = new BasicExpression("ev_"+ event );
 			bexp3 = new BasicExpression("eventExpr"); 
 			bexp3.addChild(bexp1);
 			bexp3.addChild(bexp2);

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AbstractConcurrentSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AbstractConcurrentSystem.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State ( _stateState11State11 , _stateState12State12 )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_state1 , State_state2 };
-     event : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_e1 | event = ev_e2 | event = ev_e5 | event = ev_e4 | event = ev_e3 );
+     state_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e5 & _stateState11State11.state != null;
      t2 := event = ev_e1 & _stateState11State11.state = StateState11State11_state111;
      t3 := event = ev_e4 & _stateState11State11.state = StateState11State11_state112;
@@ -35,7 +35,7 @@ MODULE State ( _stateState11State11 , _stateState12State12 )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 };
+       state_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlSystem.nusmv.txt
@@ -10,11 +10,11 @@ MODULE CruiseControlSystem ( _cruiseControlSystemControlCruiseController , _crui
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { CruiseControlSystem_adaptiveControlSystem , null };
-     event : { ev_engineOn , ev_engineOff , ev_on , ev_off , ev_resume , ev_brake , ev_accelerator , ev_setThrottle , ev_speed , ev_zoom , ev_clearSpeed , ev_recordSpeed , ev_enableControl , ev_disableControl , ev_null };
+     event : { ev_resume , ev_engineOff , ev_accelerator , ev_engineOn , ev_zoom , ev_enableControl , ev_recordSpeed , ev_disableControl , ev_off , ev_speed , ev_brake , ev_setThrottle , ev_clearSpeed , ev_on , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     cruiseControlSystem_stable :=  !( event = ev_engineOn | event = ev_on | event = ev_resume | event = ev_accelerator | event = ev_speed | event = ev_clearSpeed | event = ev_enableControl | event = ev_engineOff | event = ev_off | event = ev_brake | event = ev_setThrottle | event = ev_zoom | event = ev_recordSpeed | event = ev_disableControl );
+     cruiseControlSystem_stable :=  !( event = ev_resume | event = ev_accelerator | event = ev_zoom | event = ev_recordSpeed | event = ev_off | event = ev_brake | event = ev_clearSpeed | event = ev_engineOff | event = ev_engineOn | event = ev_enableControl | event = ev_disableControl | event = ev_speed | event = ev_setThrottle | event = ev_on );
      t1 := event = ev_engineOn & _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_inactive;
      t2 := event = ev_engineOff & _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_active;
      t3 := event = ev_on & _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_active;
@@ -68,7 +68,7 @@ MODULE CruiseControlSystem ( _cruiseControlSystemControlCruiseController , _crui
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       cruiseControlSystem_stable : { ev_engineOn , ev_engineOff , ev_on , ev_off , ev_resume , ev_brake , ev_accelerator , ev_setThrottle , ev_speed , ev_zoom , ev_clearSpeed , ev_recordSpeed , ev_enableControl , ev_disableControl };
+       cruiseControlSystem_stable : { ev_resume , ev_engineOff , ev_accelerator , ev_engineOn , ev_zoom , ev_enableControl , ev_recordSpeed , ev_disableControl , ev_off , ev_speed , ev_brake , ev_setThrottle , ev_clearSpeed , ev_on };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t29 & t1 -> next( state = CruiseControlSystem_adaptiveControlSystem & _cruiseControlSystemControlCruiseControllerCruiseControllerInactive.state = CruiseControlSystemControlCruiseControllerCruiseControllerInactive_tempState ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlWithTerminalState.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlWithTerminalState.nusmv.txt
@@ -10,11 +10,11 @@ MODULE CruiseControlSystem ( _cruiseControlSystemControlCruiseController , _crui
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { CruiseControlSystem_adaptiveControlSystem , CruiseControlSystem_terminal };
-     event : { ev_term , ev_engineOn , ev_engineOff , ev_on , ev_off , ev_resume , ev_brake , ev_accelerator , ev_setThrottle , ev_zoom , ev_speed , ev_clearSpeed , ev_recordSpeed , ev_enableControl , ev_disableControl , ev_null };
+     event : { ev_resume , ev_engineOff , ev_accelerator , ev_engineOn , ev_zoom , ev_enableControl , ev_recordSpeed , ev_disableControl , ev_off , ev_speed , ev_brake , ev_setThrottle , ev_term , ev_clearSpeed , ev_on , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     cruiseControlSystem_stable :=  !( event = ev_engineOn | event = ev_on | event = ev_resume | event = ev_accelerator | event = ev_zoom | event = ev_clearSpeed | event = ev_enableControl | event = ev_term | event = ev_engineOff | event = ev_off | event = ev_brake | event = ev_setThrottle | event = ev_speed | event = ev_recordSpeed | event = ev_disableControl );
+     cruiseControlSystem_stable :=  !( event = ev_engineOff | event = ev_engineOn | event = ev_enableControl | event = ev_disableControl | event = ev_speed | event = ev_setThrottle | event = ev_clearSpeed | event = ev_resume | event = ev_accelerator | event = ev_zoom | event = ev_recordSpeed | event = ev_off | event = ev_brake | event = ev_term | event = ev_on );
      t1 := event = ev_term & _cruiseControlSystemControlCruiseControllerCruiseController.state != null;
      t2 := event = ev_engineOn & _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_inactive;
      t3 := event = ev_engineOff & _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_active;
@@ -74,7 +74,7 @@ MODULE CruiseControlSystem ( _cruiseControlSystemControlCruiseController , _crui
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       cruiseControlSystem_stable : { ev_term , ev_engineOn , ev_engineOff , ev_on , ev_off , ev_resume , ev_brake , ev_accelerator , ev_setThrottle , ev_zoom , ev_speed , ev_clearSpeed , ev_recordSpeed , ev_enableControl , ev_disableControl };
+       cruiseControlSystem_stable : { ev_resume , ev_engineOff , ev_accelerator , ev_engineOn , ev_zoom , ev_enableControl , ev_recordSpeed , ev_disableControl , ev_off , ev_speed , ev_brake , ev_setThrottle , ev_term , ev_clearSpeed , ev_on };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t32 & t2 -> next( state = CruiseControlSystem_adaptiveControlSystem & _cruiseControlSystemControlCruiseControllerCruiseControllerInactive.state = CruiseControlSystemControlCruiseControllerCruiseControllerInactive_tempState ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossExample.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossExample.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_state1 , State_state2 };
-     event : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_e1 | event = ev_e2 | event = ev_e5 | event = ev_e4 | event = ev_e3 );
+     state_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e5 & _stateState11State11.state != null;
      t2 := event = ev_e1 & _stateState11State11.state = StateState11State11_state111;
      t3 := event = ev_e4 & _stateState11State11.state = StateState11State11_state112;
@@ -38,7 +38,7 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 };
+       state_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t4 & t6 -> next( _stateState12State12State122.state = StateState12State12State122_state1221 & _stateState12State12.state = StateState12State12_state122 ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedState.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedState.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_state1 , State_state2 };
-     event : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_e1 | event = ev_e2 | event = ev_e5 | event = ev_e4 | event = ev_e3 );
+     state_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e5 & _stateState11State11.state != null;
      t2 := event = ev_e1 & _stateState11State11.state = StateState11State11_state111;
      t3 := event = ev_e4 & _stateState11State11.state = StateState11State11_state112;
@@ -39,7 +39,7 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 };
+       state_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t4 & t6 -> next( _stateState12State12State122State1221.state = StateState12State12State122State1221_state12211 & _stateState12State12.state = StateState12State12_state122 ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedStateCase2.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedStateCase2.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_state1 , State_state2 };
-     event : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e6 , ev_null };
+     event : { ev_e5 , ev_e6 , ev_e1 , ev_e2 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_e1 | event = ev_e2 | event = ev_e5 | event = ev_e4 | event = ev_e6 );
+     state_stable :=  !( event = ev_e6 | event = ev_e2 | event = ev_e5 | event = ev_e1 | event = ev_e4 );
      t1 := event = ev_e5 & _stateState11State11.state != null;
      t2 := event = ev_e1 & _stateState11State11.state = StateState11State11_state111;
      t3 := event = ev_e4 & _stateState11State11.state = StateState11State11_state112;
@@ -38,7 +38,7 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e6 };
+       state_stable : { ev_e5 , ev_e6 , ev_e1 , ev_e2 , ev_e4 };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t4 & t6 -> next( _stateState12State12State1221State1221.state = StateState12State12State1221State1221_state12211 & _stateState12State12.state = StateState12State12_state122 ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/BigStateMachineTest.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/BigStateMachineTest.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Sm ( _smZxab , _smZxabZx , _smGe )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_Zxab , Sm_Da , Sm_Ge };
-     event : { ev_e5 , ev_e2 , ev_e3 , ev_e1 , ev_e4 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_e2 | event = ev_e1 | event = ev_e5 | event = ev_e3 | event = ev_e4 );
+     sm_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e5 & state = Sm_Da;
      t2 := event = ev_e2 & state = Sm_Da;
      t3 := event = ev_e5 & _smZxab.state = SmZxab_Aa;
@@ -50,7 +50,7 @@ MODULE Sm ( _smZxab , _smZxabZx , _smGe )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_e5 , ev_e2 , ev_e3 , ev_e1 , ev_e4 };
+       sm_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/BigStateMachineWithNakedTransition.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/BigStateMachineWithNakedTransition.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Sm ( _smZxab , _smZxabZx , _smGe )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_Zxab , Sm_D , Sm_Ge };
-     event : { ev_e1 , ev_e4 , ev_e5 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_e4 | event = ev_e2 | event = ev_e1 | event = ev_e5 | event = ev_e3 );
+     sm_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e1 & state = Sm_Zxab;
      t2 := event = ev_e4 & state = Sm_Zxab;
      t3 := event = ev_e5 & state = Sm_D;
@@ -43,7 +43,7 @@ MODULE Sm ( _smZxab , _smZxabZx , _smGe )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_e1 , ev_e4 , ev_e5 , ev_e2 , ev_e3 };
+       sm_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/CarTransmission.nusmv.txt
@@ -10,7 +10,7 @@ MODULE State ( _stateDrive )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_neutral , State_reverse , State_drive };
-     event : { ev_selectReverse , ev_selectDrive , ev_selectFirst , ev_selectSecond , ev_selectNeutral , ev_reachSecondSpeed , ev_reachThirdSpeed , ev_dropBelowSecondSpeed , ev_dropBelowThirdSpeed , ev_null };
+     event : { ev_selectDrive , ev_selectFirst , ev_selectNeutral , ev_reachSecondSpeed , ev_selectSecond , ev_reachThirdSpeed , ev_dropBelowSecondSpeed , ev_selectReverse , ev_dropBelowThirdSpeed , ev_null };
      driveSelected : boolean;
      notdriveSelected : boolean;
      a : integer;
@@ -19,7 +19,7 @@ MODULE State ( _stateDrive )
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_selectDrive | event = ev_selectSecond | event = ev_reachSecondSpeed | event = ev_dropBelowSecondSpeed | event = ev_selectReverse | event = ev_selectFirst | event = ev_selectNeutral | event = ev_reachThirdSpeed | event = ev_dropBelowThirdSpeed );
+     state_stable :=  !( event = ev_selectFirst | event = ev_reachSecondSpeed | event = ev_reachThirdSpeed | event = ev_selectReverse | event = ev_selectDrive | event = ev_selectNeutral | event = ev_selectSecond | event = ev_dropBelowSecondSpeed | event = ev_dropBelowThirdSpeed );
      t1 := event = ev_selectReverse & state = State_neutral;
      t2 := event = ev_selectDrive & state = State_neutral;
      t3 := event = ev_selectFirst & state = State_neutral;
@@ -71,7 +71,7 @@ MODULE State ( _stateDrive )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_selectReverse , ev_selectDrive , ev_selectFirst , ev_selectSecond , ev_selectNeutral , ev_reachSecondSpeed , ev_reachThirdSpeed , ev_dropBelowSecondSpeed , ev_dropBelowThirdSpeed };
+       state_stable : { ev_selectDrive , ev_selectFirst , ev_selectNeutral , ev_reachSecondSpeed , ev_selectSecond , ev_reachThirdSpeed , ev_dropBelowSecondSpeed , ev_selectReverse , ev_dropBelowThirdSpeed };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/CourseSection.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/CourseSection.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Status
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Status_Planned , Status_OpenNotEnoughStudents , Status_OpenEnoughStudents , Status_Cancelled , Status_Closed };
-     event : { ev_cancel , ev_openRegistration , ev_requestToRegister , ev_closeRegistration , ev_classSizeExceedsMinimum , ev_classSizeExceedsMaximum , ev_null };
+     event : { ev_cancel , ev_classSizeExceedsMinimum , ev_openRegistration , ev_requestToRegister , ev_classSizeExceedsMaximum , ev_closeRegistration , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     status_stable :=  !( event = ev_cancel | event = ev_requestToRegister | event = ev_classSizeExceedsMinimum | event = ev_openRegistration | event = ev_closeRegistration | event = ev_classSizeExceedsMaximum );
+     status_stable :=  !( event = ev_cancel | event = ev_openRegistration | event = ev_classSizeExceedsMaximum | event = ev_classSizeExceedsMinimum | event = ev_requestToRegister | event = ev_closeRegistration );
      t1 := event = ev_cancel & state = Status_Planned;
      t2 := event = ev_openRegistration & state = Status_Planned;
      t3 := event = ev_requestToRegister & state = Status_OpenNotEnoughStudents;
@@ -42,7 +42,7 @@ MODULE Status
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       status_stable : { ev_cancel , ev_openRegistration , ev_requestToRegister , ev_closeRegistration , ev_classSizeExceedsMinimum , ev_classSizeExceedsMaximum };
+       status_stable : { ev_cancel , ev_classSizeExceedsMinimum , ev_openRegistration , ev_requestToRegister , ev_classSizeExceedsMaximum , ev_closeRegistration };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/CourseSectionNested.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/CourseSectionNested.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Status ( _statusOpen )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Status_Planned , Status_Open , Status_Cancelled , Status_Closed };
-     event : { ev_cancel , ev_openRegistration , ev_requestToRegister , ev_closeRegistration , ev_classSizeExceedsMinimum , ev_classSizeExceedsMaximum , ev_null };
+     event : { ev_cancel , ev_classSizeExceedsMinimum , ev_openRegistration , ev_requestToRegister , ev_classSizeExceedsMaximum , ev_closeRegistration , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     status_stable :=  !( event = ev_cancel | event = ev_requestToRegister | event = ev_classSizeExceedsMinimum | event = ev_openRegistration | event = ev_closeRegistration | event = ev_classSizeExceedsMaximum );
+     status_stable :=  !( event = ev_cancel | event = ev_openRegistration | event = ev_classSizeExceedsMaximum | event = ev_classSizeExceedsMinimum | event = ev_requestToRegister | event = ev_closeRegistration );
      t1 := event = ev_cancel & state = Status_Planned;
      t2 := event = ev_openRegistration & state = Status_Planned;
      t3 := event = ev_cancel & state = Status_Open;
@@ -40,7 +40,7 @@ MODULE Status ( _statusOpen )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       status_stable : { ev_cancel , ev_openRegistration , ev_requestToRegister , ev_closeRegistration , ev_classSizeExceedsMinimum , ev_classSizeExceedsMaximum };
+       status_stable : { ev_cancel , ev_classSizeExceedsMinimum , ev_openRegistration , ev_requestToRegister , ev_classSizeExceedsMaximum , ev_closeRegistration };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/DigitalWatchFlat.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/DigitalWatchFlat.nusmv.txt
@@ -10,7 +10,7 @@ MODULE Sm
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_time , Sm_date , Sm_paused , Sm_running , Sm_lapRunning , Sm_lapPaused , Sm_bothOff , Sm_chimeOn , Sm_bothOn , Sm_alarmOn , Sm_alarmTime , Sm_alarmHour , Sm_alarmMinute , Sm_second , Sm_minute , Sm_hour , Sm_month , Sm_day , Sm_year };
-     event : { ev_s1 , ev_s2 , ev_s3 , ev_s3during2Secs , ev_notS1 , ev_notS2 , ev_null };
+     event : { ev_s3 , ev_s3during2Secs , ev_notS2 , ev_notS1 , ev_s1 , ev_s2 , ev_null };
      day : integer;
      month : integer;
      year : integer;
@@ -24,7 +24,7 @@ MODULE Sm
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_s1 | event = ev_s3 | event = ev_notS1 | event = ev_s2 | event = ev_s3during2Secs | event = ev_notS2 );
+     sm_stable :=  !( event = ev_s3 | event = ev_notS2 | event = ev_s1 | event = ev_s3during2Secs | event = ev_notS1 | event = ev_s2 );
      t1 := event = ev_s1 & state = Sm_time;
      t2 := event = ev_s2 & state = Sm_time;
      t3 := event = ev_s3 & state = Sm_time;
@@ -108,7 +108,7 @@ MODULE Sm
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_s1 , ev_s2 , ev_s3 , ev_s3during2Secs , ev_notS1 , ev_notS2 };
+       sm_stable : { ev_s3 , ev_s3during2Secs , ev_notS2 , ev_notS1 , ev_s1 , ev_s2 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/Elevator.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/Elevator.nusmv.txt
@@ -10,14 +10,14 @@ MODULE Elevator_state_machine ( _elevator_state_machinePrepareUp , _elevator_sta
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Elevator_state_machine_Idle , Elevator_state_machine_PrepareUp , Elevator_state_machine_PrepareDown , Elevator_state_machine_InMotion , Elevator_state_machine_OnFloor };
-     event : { ev_upRequest , ev_downRequest , ev_started , ev_doorClosed , ev_approachingFloor , ev_approachedFloor , ev_stopped , ev_doorOpened , ev_timeoutAtFloorToDoorClosing , ev_doorClosingRequest , ev_doorCLosed , ev_obstruction , ev_doorOpeningRequest , ev_noRequest , ev_null };
+     event : { ev_stopped , ev_obstruction , ev_upRequest , ev_doorClosed , ev_doorCLosed , ev_started , ev_approachedFloor , ev_downRequest , ev_approachingFloor , ev_doorOpened , ev_doorOpeningRequest , ev_timeoutAtFloorToDoorClosing , ev_doorClosingRequest , ev_noRequest , ev_null };
      timer : integer;
      floorRequested : boolean;
      obstruction : boolean;
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     elevator_state_machine_stable :=  !( event = ev_upRequest | event = ev_started | event = ev_approachingFloor | event = ev_stopped | event = ev_timeoutAtFloorToDoorClosing | event = ev_doorCLosed | event = ev_doorOpeningRequest | event = ev_downRequest | event = ev_doorClosed | event = ev_approachedFloor | event = ev_doorOpened | event = ev_doorClosingRequest | event = ev_obstruction | event = ev_noRequest );
+     elevator_state_machine_stable :=  !( event = ev_stopped | event = ev_upRequest | event = ev_doorCLosed | event = ev_approachedFloor | event = ev_approachingFloor | event = ev_doorOpeningRequest | event = ev_doorClosingRequest | event = ev_obstruction | event = ev_doorClosed | event = ev_started | event = ev_downRequest | event = ev_doorOpened | event = ev_timeoutAtFloorToDoorClosing | event = ev_noRequest );
      t1 := event = ev_upRequest & state = Elevator_state_machine_Idle;
      t2 := event = ev_downRequest & state = Elevator_state_machine_Idle;
      t3 := event = ev_started & state = Elevator_state_machine_PrepareUp;
@@ -56,7 +56,7 @@ MODULE Elevator_state_machine ( _elevator_state_machinePrepareUp , _elevator_sta
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       elevator_state_machine_stable : { ev_upRequest , ev_downRequest , ev_started , ev_doorClosed , ev_approachingFloor , ev_approachedFloor , ev_stopped , ev_doorOpened , ev_timeoutAtFloorToDoorClosing , ev_doorClosingRequest , ev_doorCLosed , ev_obstruction , ev_doorOpeningRequest , ev_noRequest };
+       elevator_state_machine_stable : { ev_stopped , ev_obstruction , ev_upRequest , ev_doorClosed , ev_doorCLosed , ev_started , ev_approachedFloor , ev_downRequest , ev_approachingFloor , ev_doorOpened , ev_doorOpeningRequest , ev_timeoutAtFloorToDoorClosing , ev_doorClosingRequest , ev_noRequest };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/EnhancedBitCounter.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/EnhancedBitCounter.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Sm ( _smBit1Bit1 , _smBit2Bit2 , _smStatusStatus , _smStatusStatusBit3Bit
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_stable , Sm_Counter };
-     event : { ev_e0 , ev_e1 , ev_e2 , ev_reset , ev_null };
+     event : { ev_reset , ev_e0 , ev_e1 , ev_e2 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_e0 | event = ev_e2 | event = ev_e1 | event = ev_reset );
+     sm_stable :=  !( event = ev_reset | event = ev_e1 | event = ev_e0 | event = ev_e2 );
      t1 := event = ev_e0 & state = Sm_stable;
      t2 := event = ev_e1 & _smBit1Bit1.state = SmBit1Bit1_Bit11;
      t3 := event = ev_e2 & _smBit1Bit1.state = SmBit1Bit1_Bit12;
@@ -36,7 +36,7 @@ MODULE Sm ( _smBit1Bit1 , _smBit2Bit2 , _smStatusStatus , _smStatusStatusBit3Bit
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_e0 , ev_e1 , ev_e2 , ev_reset };
+       sm_stable : { ev_reset , ev_e0 , ev_e1 , ev_e2 };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t5 & t3 -> next( _smStatusStatus.state = SmStatusStatus_Max & _smBit1Bit1.state = SmBit1Bit1_Bit11 ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Status
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Status_Open , Status_Closing , Status_Closed , Status_Opening , Status_HalfOpen };
-     event : { ev_buttonOrObstacle , ev_reachBottom , ev_reachTop , ev_null };
+     event : { ev_reachBottom , ev_reachTop , ev_buttonOrObstacle , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     status_stable :=  !( event = ev_reachBottom | event = ev_buttonOrObstacle | event = ev_reachTop );
+     status_stable :=  !( event = ev_reachTop | event = ev_reachBottom | event = ev_buttonOrObstacle );
      t1 := event = ev_buttonOrObstacle & state = Status_Open;
      t2 := event = ev_buttonOrObstacle & state = Status_Closing;
      t3 := event = ev_reachBottom & state = Status_Closing;
@@ -39,7 +39,7 @@ MODULE Status
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       status_stable : { ev_buttonOrObstacle , ev_reachBottom , ev_reachTop };
+       status_stable : { ev_reachBottom , ev_reachTop , ev_buttonOrObstacle };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile1.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile1.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_newBooking , State_seatAssigned , State_checkedIn , State_cancelled , State_completed };
-     event : { ev_assignSeat , ev_cancel , ev_checkIn , ev_complete , ev_null };
+     event : { ev_cancel , ev_checkIn , ev_assignSeat , ev_complete , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_assignSeat | event = ev_checkIn | event = ev_cancel | event = ev_complete );
+     state_stable :=  !( event = ev_cancel | event = ev_assignSeat | event = ev_checkIn | event = ev_complete );
      t1 := event = ev_assignSeat & state = State_newBooking;
      t2 := event = ev_cancel & state = State_newBooking;
      t3 := event = ev_cancel & state = State_seatAssigned;
@@ -37,7 +37,7 @@ MODULE State
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_assignSeat , ev_cancel , ev_checkIn , ev_complete };
+       state_stable : { ev_cancel , ev_checkIn , ev_assignSeat , ev_complete };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile2.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ExampleFile2.nusmv.txt
@@ -10,14 +10,14 @@ MODULE LockState
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { LockState_BothDoorsClosedLockFull , LockState_OpeningUpperGate , LockState_UpperGateOpen , LockState_ClosingUpperGate , LockState_LoweringWater , LockState_BothDoorsClosedLockEmpty , LockState_OpeningLowerGate , LockState_LowerGateOpen , LockState_ClosingLowerGate , LockState_RaisingWater };
-     event : { ev_boatRequestsToEnterAndGoDown , ev_boatRequestsToEnterAndGoUp , ev_upperGateFullyOpen , ev_boatInLockRequestingToGoDown , ev_after3minutes , ev_upperGateFullyClosed , ev_waterLevelMatchesDownStream , ev_lowerGateFullyOpen , ev_boatInLockRequestingToGoUp , ev_lowerGateFullyClosed , ev_waterLevelMatchesUpStream , ev_null };
+     event : { ev_upperGateFullyClosed , ev_boatRequestsToEnterAndGoDown , ev_waterLevelMatchesUpStream , ev_boatInLockRequestingToGoDown , ev_lowerGateFullyClosed , ev_upperGateFullyOpen , ev_lowerGateFullyOpen , ev_boatInLockRequestingToGoUp , ev_waterLevelMatchesDownStream , ev_boatRequestsToEnterAndGoUp , ev_after3minutes , ev_null };
      boatGoingDown : boolean;
      boatGoingUp : boolean;
      boatBlockingGate : boolean;
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     lockState_stable :=  !( event = ev_boatRequestsToEnterAndGoUp | event = ev_boatInLockRequestingToGoDown | event = ev_upperGateFullyClosed | event = ev_lowerGateFullyOpen | event = ev_lowerGateFullyClosed | event = ev_boatRequestsToEnterAndGoDown | event = ev_upperGateFullyOpen | event = ev_after3minutes | event = ev_waterLevelMatchesDownStream | event = ev_boatInLockRequestingToGoUp | event = ev_waterLevelMatchesUpStream );
+     lockState_stable :=  !( event = ev_boatRequestsToEnterAndGoDown | event = ev_boatInLockRequestingToGoDown | event = ev_upperGateFullyOpen | event = ev_boatInLockRequestingToGoUp | event = ev_boatRequestsToEnterAndGoUp | event = ev_upperGateFullyClosed | event = ev_waterLevelMatchesUpStream | event = ev_lowerGateFullyClosed | event = ev_lowerGateFullyOpen | event = ev_waterLevelMatchesDownStream | event = ev_after3minutes );
      t1 := event = ev_boatRequestsToEnterAndGoDown & state = LockState_BothDoorsClosedLockFull;
      t2 := event = ev_boatRequestsToEnterAndGoUp & state = LockState_BothDoorsClosedLockFull;
      t3 := event = ev_upperGateFullyOpen & state = LockState_OpeningUpperGate;
@@ -61,7 +61,7 @@ MODULE LockState
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       lockState_stable : { ev_boatRequestsToEnterAndGoDown , ev_boatRequestsToEnterAndGoUp , ev_upperGateFullyOpen , ev_boatInLockRequestingToGoDown , ev_after3minutes , ev_upperGateFullyClosed , ev_waterLevelMatchesDownStream , ev_lowerGateFullyOpen , ev_boatInLockRequestingToGoUp , ev_lowerGateFullyClosed , ev_waterLevelMatchesUpStream };
+       lockState_stable : { ev_upperGateFullyClosed , ev_boatRequestsToEnterAndGoDown , ev_waterLevelMatchesUpStream , ev_boatInLockRequestingToGoDown , ev_lowerGateFullyClosed , ev_upperGateFullyOpen , ev_lowerGateFullyOpen , ev_boatInLockRequestingToGoUp , ev_waterLevelMatchesDownStream , ev_boatRequestsToEnterAndGoUp , ev_after3minutes };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/FurnaceControlSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/FurnaceControlSystem.nusmv.txt
@@ -10,7 +10,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { HeatSystem_heatSys , null };
-     event : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 , ev_null };
+     event : { ev_t5 , ev_heatSwitchOn , ev_furnaceReset , ev_furnaceFault , ev_furnaceRunning , ev_deactivate , ev_t21 , ev_t20 , ev_heatSwitchOff , ev_t23 , ev_t22 , ev_t24 , ev_activate , ev_t15 , ev_userReset , ev_t18 , ev_t17 , ev_t19 , ev_null };
      tooCold : boolean;
      tooHot : boolean;
      requestHeat : boolean;
@@ -24,7 +24,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     heatSystem_stable :=  !( event = ev_furnaceFault | event = ev_heatSwitchOn | event = ev_userReset | event = ev_deactivate | event = ev_furnaceRunning | event = ev_t17 | event = ev_t20 | event = ev_t19 | event = ev_t24 | event = ev_furnaceReset | event = ev_heatSwitchOff | event = ev_activate | event = ev_t5 | event = ev_t15 | event = ev_t18 | event = ev_t21 | event = ev_t22 | event = ev_t23 );
+     heatSystem_stable :=  !( event = ev_t5 | event = ev_furnaceReset | event = ev_furnaceRunning | event = ev_t21 | event = ev_heatSwitchOff | event = ev_t22 | event = ev_activate | event = ev_userReset | event = ev_t17 | event = ev_heatSwitchOn | event = ev_furnaceFault | event = ev_deactivate | event = ev_t20 | event = ev_t23 | event = ev_t24 | event = ev_t15 | event = ev_t18 | event = ev_t19 );
      t1 := event = ev_t15 & _heatSystemHouseRoomRoomNoHeatReq.state = HeatSystemHouseRoomRoomNoHeatReq_idleNoHeat & g1;
      t2 := event = ev_t17 & _heatSystemHouseRoomRoomNoHeatReq.state = HeatSystemHouseRoomRoomNoHeatReq_waitForHeat & g2;
      t3 := event = ev_t18 & _heatSystemHouseRoomRoomNoHeatReq.state = HeatSystemHouseRoomRoomNoHeatReq_waitForHeat & g3;
@@ -77,7 +77,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       heatSystem_stable : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 };
+       heatSystem_stable : { ev_t5 , ev_heatSwitchOn , ev_furnaceReset , ev_furnaceFault , ev_furnaceRunning , ev_deactivate , ev_t21 , ev_t20 , ev_heatSwitchOff , ev_t23 , ev_t22 , ev_t24 , ev_activate , ev_t15 , ev_userReset , ev_t18 , ev_t17 , ev_t19 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/GrantApplication.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/GrantApplication.nusmv.txt
@@ -10,12 +10,12 @@ MODULE Status
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Status_Planned , Status_InProgress , Status_EvaluationByInstitution , Status_VerifiedByInstitution , Status_SubmittedByInstitution , Status_UnderAdministrativeReview , Status_UnderExpertReview , Status_AwaitingFinalDecision , Status_Accepted , Status_Rejected , Status_Withdrawn };
-     event : { ev_createApplication , ev_researcherDeclaresComplete , ev_editByResearcher , ev_returnToResearcher , ev_verified , ev_editByInstitution , ev_reOpen , ev_submit , ev_withdraw , ev_acceptForReview , ev_submissionCheck , ev_acceptForExpertReview , ev_bypassExpertReviewDueToMinorChanges , ev_returnToInstitition , ev_expertReviewsReturned , ev_finalAccept , ev_minorRevisionsNeeded , ev_reject , ev_tryAgain , ev_null };
+     event : { ev_reOpen , ev_returnToInstitition , ev_expertReviewsReturned , ev_submit , ev_verified , ev_tryAgain , ev_acceptForReview , ev_returnToResearcher , ev_acceptForExpertReview , ev_bypassExpertReviewDueToMinorChanges , ev_editByResearcher , ev_createApplication , ev_minorRevisionsNeeded , ev_reject , ev_researcherDeclaresComplete , ev_editByInstitution , ev_submissionCheck , ev_finalAccept , ev_withdraw , ev_null };
      adminCheckOk : boolean;
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     status_stable :=  !( event = ev_researcherDeclaresComplete | event = ev_returnToResearcher | event = ev_editByInstitution | event = ev_submit | event = ev_acceptForReview | event = ev_acceptForExpertReview | event = ev_returnToInstitition | event = ev_finalAccept | event = ev_reject | event = ev_createApplication | event = ev_editByResearcher | event = ev_verified | event = ev_reOpen | event = ev_withdraw | event = ev_submissionCheck | event = ev_bypassExpertReviewDueToMinorChanges | event = ev_expertReviewsReturned | event = ev_minorRevisionsNeeded | event = ev_tryAgain );
+     status_stable :=  !( event = ev_returnToInstitition | event = ev_submit | event = ev_tryAgain | event = ev_returnToResearcher | event = ev_bypassExpertReviewDueToMinorChanges | event = ev_createApplication | event = ev_reject | event = ev_editByInstitution | event = ev_finalAccept | event = ev_reOpen | event = ev_expertReviewsReturned | event = ev_verified | event = ev_acceptForReview | event = ev_acceptForExpertReview | event = ev_editByResearcher | event = ev_minorRevisionsNeeded | event = ev_researcherDeclaresComplete | event = ev_submissionCheck | event = ev_withdraw );
      t1 := event = ev_createApplication & state = Status_Planned;
      t2 := event = ev_researcherDeclaresComplete & state = Status_InProgress;
      t3 := event = ev_editByResearcher & state = Status_InProgress;
@@ -63,7 +63,7 @@ MODULE Status
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       status_stable : { ev_createApplication , ev_researcherDeclaresComplete , ev_editByResearcher , ev_returnToResearcher , ev_verified , ev_editByInstitution , ev_reOpen , ev_submit , ev_withdraw , ev_acceptForReview , ev_submissionCheck , ev_acceptForExpertReview , ev_bypassExpertReviewDueToMinorChanges , ev_returnToInstitition , ev_expertReviewsReturned , ev_finalAccept , ev_minorRevisionsNeeded , ev_reject , ev_tryAgain };
+       status_stable : { ev_reOpen , ev_returnToInstitition , ev_expertReviewsReturned , ev_submit , ev_verified , ev_tryAgain , ev_acceptForReview , ev_returnToResearcher , ev_acceptForExpertReview , ev_bypassExpertReviewDueToMinorChanges , ev_editByResearcher , ev_createApplication , ev_minorRevisionsNeeded , ev_reject , ev_researcherDeclaresComplete , ev_editByInstitution , ev_submissionCheck , ev_finalAccept , ev_withdraw };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/NestedWatch.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/NestedWatch.nusmv.txt
@@ -10,7 +10,7 @@ MODULE Sm ( _smRegular , _smRegularUpdate , _smChronometer , _smChronometerChron
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_regular , Sm_chronometer , Sm_alarmStatus , Sm_alarmUpdate };
-     event : { ev_s3 , ev_notS2 , ev_s1 , ev_s2 , ev_s3during2Secs , ev_notS1 , ev_null };
+     event : { ev_s3 , ev_notS2 , ev_s3during2Secs , ev_notS1 , ev_s1 , ev_s2 , ev_null };
      day : integer;
      month : integer;
      year : integer;
@@ -24,7 +24,7 @@ MODULE Sm ( _smRegular , _smRegularUpdate , _smChronometer , _smChronometerChron
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_s3 | event = ev_s1 | event = ev_s3during2Secs | event = ev_notS2 | event = ev_s2 | event = ev_notS1 );
+     sm_stable :=  !( event = ev_s3 | event = ev_s3during2Secs | event = ev_s1 | event = ev_notS2 | event = ev_notS1 | event = ev_s2 );
      t1 := event = ev_s3 & state = Sm_chronometer;
      t2 := event = ev_notS2 & state = Sm_alarmStatus;
      t3 := event = ev_s3 & state = Sm_alarmUpdate;
@@ -80,7 +80,7 @@ MODULE Sm ( _smRegular , _smRegularUpdate , _smChronometer , _smChronometerChron
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_s3 , ev_notS2 , ev_s1 , ev_s2 , ev_s3during2Secs , ev_notS1 };
+       sm_stable : { ev_s3 , ev_notS2 , ev_s3during2Secs , ev_notS1 , ev_s1 , ev_s2 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/NuSMVTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/NuSMVTemplateTest.java
@@ -60,6 +60,22 @@ public class NuSMVTemplateTest extends TemplateTest{
 	    SampleFileWriter.destroy(pathToInput + "/nusmv/AdaptiveCruiseControlWithTerminalState.smv");
 	    SampleFileWriter.destroy(pathToInput + "/nusmv/SingleEventMachine.smv");
 	    SampleFileWriter.destroy(pathToInput + "/nusmv/SimpleCaseOfNondeterminism.smv");
+	    SampleFileWriter.destroy(pathToInput + "/nusmv/SingleLaneBridge.smv");
+	    SampleFileWriter.destroy(pathToInput + "/nusmv/RoomHeatingSystem.smv");
+	  }
+	  
+	  @Test //@Ignore  // TEMPORARY IGNORE BY TIM ISSUE 740
+	  public void RoomHeatingSystem()
+	  {
+	  		assertUmpleTemplateFor("nusmv/RoomHeatingSystem.ump","nusmv/RoomHeatingSystem.nusmv.txt");
+	  		Assert.assertEquals(true, (new File(pathToInput + "/nusmv/RoomHeatingSystem.smv")).exists());
+	  }
+	  
+	  @Test //@Ignore  // TEMPORARY IGNORE BY TIM ISSUE 740
+	  public void SingleLaneBridge()
+	  {
+	  		assertUmpleTemplateFor("nusmv/SingleLaneBridge.ump","nusmv/SingleLaneBridge.nusmv.txt");
+	  		Assert.assertEquals(true, (new File(pathToInput + "/nusmv/SingleLaneBridge.smv")).exists());
 	  }
 	  
 	  @Test //@Ignore  // TEMPORARY IGNORE BY TIM ISSUE 740

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/OutgoingTransitionOfConcurrentState.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/OutgoingTransitionOfConcurrentState.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Sm ( _smS21S21 , _smS22S22 )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_s1 , Sm_s2 };
-     event : { ev_e1 , ev_e4 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_e1 | event = ev_e2 | event = ev_e4 | event = ev_e3 );
+     sm_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e1 & state = Sm_s1;
      t2 := event = ev_e4 & state = Sm_s2;
      t3 := event = ev_e1 & _smS21S21.state = SmS21S21_a;
@@ -42,7 +42,7 @@ MODULE Sm ( _smS21S21 , _smS22S22 )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_e1 , ev_e4 , ev_e2 , ev_e3 };
+       sm_stable : { ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t7 & t9 -> next( state = Sm_s1 & _smS22S22.state = SmS22S22_e ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/OutgoingTransitionOfConcurrentStateWithAndCross1.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/OutgoingTransitionOfConcurrentStateWithAndCross1.nusmv.txt
@@ -10,11 +10,11 @@ MODULE Sm ( _smS21S21 , _smS22S22 )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { Sm_s1 , Sm_s2 };
-     event : { ev_e1 , ev_e4 , ev_e5 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     sm_stable :=  !( event = ev_e4 | event = ev_e2 | event = ev_e1 | event = ev_e5 | event = ev_e3 );
+     sm_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e1 & state = Sm_s1;
      t2 := event = ev_e4 & state = Sm_s2;
      t3 := event = ev_e1 & _smS21S21.state = SmS21S21_a;
@@ -44,7 +44,7 @@ MODULE Sm ( _smS21S21 , _smS22S22 )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       sm_stable : { ev_e1 , ev_e4 , ev_e5 , ev_e2 , ev_e3 };
+       sm_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
    INVARSPEC   ( t8 & t11 -> next( state = Sm_s1 & _smS22S22.state = SmS22S22_e ) )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/RoomHeatingSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/RoomHeatingSystem.nusmv.txt
@@ -1,0 +1,386 @@
+-- This file is generated from RoomHeatingSystem.ump --
+
+-- PLEASE DO NOT EDIT THIS CODE --
+-- This code was generated using the UMPLE @UMPLE_VERSION@ modeling language! --
+
+
+-- This defines a NuSMV module for Sm --
+MODULE Sm ( _smHouseRoom , _smHouseRoomRoom , _smHouseRoomRoomNoHeatReq , _smHouseRoomRoomHeatReq , _smHouseController , _smHouseControllerController , _smHouseControllerControllerControllerOn , _smHouseControllerControllerControllerOnHeaterActive , _smHouse , _smFurnaceFurnace , _smFurnaceFurnaceFurnaceNormal )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { Sm_heatingSystem , null };
+     event : { ev_heatSwitchOn , ev_heatSwitchOff , ev___autotransition__ , ev_userReset , ev_furnaceFault , ev_null };
+     furnaceStartUpTime : integer;
+     furnaceTimer : integer;
+     setTemp : integer;
+     actualTemp : integer;
+     waitedForWarm : integer;
+     warmUpTimer : integer;
+     valvePos : integer;
+     waitedForCool : integer;
+     coolDownTimer : integer;
+     furnaceRunning : boolean;
+     activate : boolean;
+     deactivate : boolean;
+     requestHeat : boolean;
+     furnaceReset : boolean;
+
+   -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
+   DEFINE
+     sm_stable :=  !( event = ev_heatSwitchOff | event = ev_userReset | event = ev_heatSwitchOn | event = ev___autotransition__ | event = ev_furnaceFault );
+     t1 := event = ev___autotransition__ & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_idleNotHeat & g1;
+     t2 := event = ev___autotransition__ & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & g2;
+     t3 := event = ev___autotransition__ & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & g3;
+     t4 := event = ev___autotransition__ & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & g4;
+     t5 := event = ev___autotransition__ & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & g5;
+     t6 := event = ev___autotransition__ & _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_idleHeat & g6;
+     t7 := event = ev___autotransition__ & _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_waitForCool & g7;
+     t8 := event = ev___autotransition__ & _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_waitForCool & g8;
+     t9 := event = ev___autotransition__ & _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_waitForCool & g9;
+     t10 := event = ev_heatSwitchOn & _smHouseControllerController.state = SmHouseControllerController_off;
+     t11 := event = ev_heatSwitchOff & _smHouseControllerController.state = SmHouseControllerController_controllerOn;
+     t12 := event = ev_furnaceFault & _smHouseControllerController.state = SmHouseControllerController_controllerOn;
+     t13 := event = ev_userReset & _smHouseControllerController.state = SmHouseControllerController_error;
+     t14 := event = ev___autotransition__ & _smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_idle & g10;
+     t15 := event = ev___autotransition__ & _smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_heaterActive & g11;
+     t16 := event = ev___autotransition__ & _smHouseControllerControllerControllerOnHeaterActive.state = SmHouseControllerControllerControllerOnHeaterActive_actHeater & g12;
+     t17 := event = ev_furnaceFault & _smFurnaceFurnace.state = SmFurnaceFurnace_furnaceNormal;
+     t18 := event = ev___autotransition__ & _smFurnaceFurnace.state = SmFurnaceFurnace_furnaceErr & g13;
+     t19 := event = ev___autotransition__ & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceOff & g14;
+     t20 := event = ev___autotransition__ & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceAct & g15;
+     t21 := event = ev___autotransition__ & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceAct & g16;
+     t22 := event = ev___autotransition__ & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceAct & g17;
+     t23 := event = ev___autotransition__ & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceRun & g15;
+     g1 := (setTemp - actualTemp) > 2;
+     g2 := waitedForWarm < warmUpTimer;
+     g3 := (valvePos != 2) & (waitedForWarm = warmUpTimer);
+     g4 := ((setTemp - actualTemp) <= 2);
+     g5 := (waitedForWarm = warmUpTimer) & (valvePos = 2) & ((setTemp - actualTemp) > 2);
+     g6 := (actualTemp - setTemp) > 2;
+     g7 := (valvePos != 0) & (coolDownTimer = waitedForCool);
+     g8 := waitedForCool < coolDownTimer;
+     g9 := ((actualTemp - setTemp) <= 2);
+     g10 := requestHeat = TRUE;
+     g11 := requestHeat = FALSE;
+     g12 := furnaceRunning = TRUE;
+     g13 := furnaceReset = TRUE;
+     g14 := activate = TRUE;
+     g15 := deactivate = TRUE;
+     g16 := furnaceStartUpTime < furnaceTimer;
+     g17 := furnaceStartUpTime = furnaceTimer;
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := Sm_heatingSystem;
+     next( state ) := case
+       t1 | t3 | t9 | t7 | t11 | t10 | t14 | t12 | t20 | t19 | t22 | t4 | t2 | t5 | t6 | t8 | t13 | t15 | t16 | t18 | t23 | t21 | t17 : Sm_heatingSystem;
+       TRUE : state;
+     esac;
+
+   -- This part defines logic for the assignment of values to state variable "event" of this NuSMV module --
+   ASSIGN
+     init( event ) := ev_null;
+     next( event ) := case
+       sm_stable : { ev_heatSwitchOn , ev_heatSwitchOff , ev___autotransition__ , ev_userReset , ev_furnaceFault };
+       TRUE : ev_null;
+     esac;
+
+   -- This part defines logic for the assignment of values to state variable "furnaceStartUpTime" of this NuSMV module --
+   ASSIGN
+     init( furnaceStartUpTime ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "furnaceTimer" of this NuSMV module --
+   ASSIGN
+     init( furnaceTimer ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "setTemp" of this NuSMV module --
+   ASSIGN
+     init( setTemp ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "actualTemp" of this NuSMV module --
+   ASSIGN
+     init( actualTemp ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "waitedForWarm" of this NuSMV module --
+   ASSIGN
+     init( waitedForWarm ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "warmUpTimer" of this NuSMV module --
+   ASSIGN
+     init( warmUpTimer ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "valvePos" of this NuSMV module --
+   ASSIGN
+     init( valvePos ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "waitedForCool" of this NuSMV module --
+   ASSIGN
+     init( waitedForCool ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "coolDownTimer" of this NuSMV module --
+   ASSIGN
+     init( coolDownTimer ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "furnaceRunning" of this NuSMV module --
+   ASSIGN
+     init( furnaceRunning ) := FALSE;
+
+   -- This part defines logic for the assignment of values to state variable "activate" of this NuSMV module --
+   ASSIGN
+     init( activate ) := FALSE;
+
+   -- This part defines logic for the assignment of values to state variable "deactivate" of this NuSMV module --
+   ASSIGN
+     init( deactivate ) := FALSE;
+
+   -- This part defines logic for the assignment of values to state variable "requestHeat" of this NuSMV module --
+   ASSIGN
+     init( requestHeat ) := FALSE;
+
+   -- This part defines logic for the assignment of values to state variable "furnaceReset" of this NuSMV module --
+   ASSIGN
+     init( furnaceReset ) := FALSE;
+   INVARSPEC   ( t2 & t4 -> next( _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_idleNotHeat ) )
+   INVARSPEC   ( t2 & t5 -> next( _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & _smHouseRoomRoom.state = SmHouseRoomRoom_heatReq ) )
+   INVARSPEC   ( t3 & t4 -> next( _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_idleNotHeat ) )
+   INVARSPEC   ( t3 & t5 -> next( _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat & _smHouseRoomRoom.state = SmHouseRoomRoom_heatReq ) )
+   INVARSPEC   ( t4 & t5 -> next( _smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_idleNotHeat & _smHouseRoomRoom.state = SmHouseRoomRoom_heatReq ) )
+   INVARSPEC   ( t7 & t9 -> next( _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_waitForCool & _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_idleHeat ) )
+   INVARSPEC   ( t8 & t9 -> next( _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_waitForCool & _smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_idleHeat ) )
+   INVARSPEC   ( t15 & t16 -> next( _smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_idle & _smHouseControllerControllerControllerOnHeaterActive.state = SmHouseControllerControllerControllerOnHeaterActive_heaterRun ) )
+   INVARSPEC   ( t20 & t21 -> next( _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceOff & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceAct ) )
+   INVARSPEC   ( t20 & t22 -> next( _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceOff & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceRun ) )
+   INVARSPEC   ( t21 & t22 -> next( _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceAct & _smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceRun ) )
+
+-- This defines a NuSMV module for SmHouseRoom --
+MODULE SmHouseRoom ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseRoom_room , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t9 | _sm.t7 | _sm.t4 | _sm.t2 | _sm.t5 | _sm.t6 | _sm.t8 : SmHouseRoom_room;
+       _sm.state = Sm_heatingSystem & state = null : SmHouseRoom_room;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseRoomRoom --
+MODULE SmHouseRoomRoom ( _sm , _smHouse )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseRoomRoom_noHeatReq , SmHouseRoomRoom_heatReq , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t18 | _sm.t20 | _sm.t22 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : null;
+       _sm.t4 | _sm.t2 | _sm.t1 | _sm.t3 : SmHouseRoomRoom_noHeatReq;
+       _sm.t9 | _sm.t7 | _sm.t5 | _sm.t6 | _sm.t8 : SmHouseRoomRoom_heatReq;
+       _smHouse.state = SmHouse_house & state = null : SmHouseRoomRoom_noHeatReq;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseRoomRoomNoHeatReq --
+MODULE SmHouseRoomRoomNoHeatReq ( _sm , _smHouseRoomRoom )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseRoomRoomNoHeatReq_idleNotHeat , SmHouseRoomRoomNoHeatReq_waitForHeat , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : null;
+       _sm.t4 : SmHouseRoomRoomNoHeatReq_idleNotHeat;
+       _sm.t2 | _sm.t1 | _sm.t3 : SmHouseRoomRoomNoHeatReq_waitForHeat;
+       _smHouseRoomRoom.state = SmHouseRoomRoom_noHeatReq & state = null : SmHouseRoomRoomNoHeatReq_idleNotHeat;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseRoomRoomHeatReq --
+MODULE SmHouseRoomRoomHeatReq ( _sm , _smHouseRoomRoom )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseRoomRoomHeatReq_idleHeat , SmHouseRoomRoomHeatReq_waitForCool , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t2 | _sm.t4 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t1 | _sm.t3 | _sm.t5 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : null;
+       _sm.t9 : SmHouseRoomRoomHeatReq_idleHeat;
+       _sm.t7 | _sm.t6 | _sm.t8 : SmHouseRoomRoomHeatReq_waitForCool;
+       _smHouseRoomRoom.state = SmHouseRoomRoom_heatReq & state = null : SmHouseRoomRoomHeatReq_idleHeat;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseController --
+MODULE SmHouseController ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseController_controller , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t13 | _sm.t15 | _sm.t16 | _sm.t11 | _sm.t10 | _sm.t14 | _sm.t12 : SmHouseController_controller;
+       _sm.state = Sm_heatingSystem & state = null : SmHouseController_controller;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseControllerController --
+MODULE SmHouseControllerController ( _sm , _smHouse )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseControllerController_off , SmHouseControllerController_controllerOn , SmHouseControllerController_error , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t18 | _sm.t20 | _sm.t22 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : null;
+       _sm.t11 | _sm.t13 : SmHouseControllerController_off;
+       _sm.t10 | _sm.t14 | _sm.t15 | _sm.t16 : SmHouseControllerController_controllerOn;
+       _sm.t12 : SmHouseControllerController_error;
+       _smHouse.state = SmHouse_house & state = null : SmHouseControllerController_off;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseControllerControllerControllerOn --
+MODULE SmHouseControllerControllerControllerOn ( _sm , _smHouseControllerController )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseControllerControllerControllerOn_idle , SmHouseControllerControllerControllerOn_heaterActive , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : null;
+       _sm.t15 : SmHouseControllerControllerControllerOn_idle;
+       _sm.t14 | _sm.t16 : SmHouseControllerControllerControllerOn_heaterActive;
+       _smHouseControllerController.state = SmHouseControllerController_controllerOn & state = null : SmHouseControllerControllerControllerOn_idle;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouseControllerControllerControllerOnHeaterActive --
+MODULE SmHouseControllerControllerControllerOnHeaterActive ( _sm , _smHouseControllerControllerControllerOn )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouseControllerControllerControllerOnHeaterActive_actHeater , SmHouseControllerControllerControllerOnHeaterActive_heaterRun , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : null;
+       _sm.t16 : SmHouseControllerControllerControllerOnHeaterActive_heaterRun;
+       _smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_heaterActive & state = null : SmHouseControllerControllerControllerOnHeaterActive_actHeater;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmHouse --
+MODULE SmHouse ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmHouse_house , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t4 | _sm.t2 | _sm.t5 | _sm.t6 | _sm.t8 | _sm.t13 | _sm.t15 | _sm.t16 | _sm.t1 | _sm.t3 | _sm.t9 | _sm.t7 | _sm.t11 | _sm.t10 | _sm.t14 | _sm.t12 : SmHouse_house;
+       _sm.state = Sm_heatingSystem & state = null : SmHouse_house;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmFurnaceFurnace --
+MODULE SmFurnaceFurnace ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmFurnaceFurnace_furnaceNormal , SmFurnaceFurnace_furnaceErr , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t18 | _sm.t23 | _sm.t21 | _sm.t20 | _sm.t19 | _sm.t22 : SmFurnaceFurnace_furnaceNormal;
+       _sm.t17 : SmFurnaceFurnace_furnaceErr;
+       _sm.state = Sm_heatingSystem & state = null : SmFurnaceFurnace_furnaceNormal;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmFurnaceFurnaceFurnaceNormal --
+MODULE SmFurnaceFurnaceFurnaceNormal ( _sm , _smFurnaceFurnace )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmFurnaceFurnaceFurnaceNormal_furnaceOff , SmFurnaceFurnaceFurnaceNormal_furnaceAct , SmFurnaceFurnaceFurnaceNormal_furnaceRun , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 : null;
+       _sm.t20 | _sm.t23 : SmFurnaceFurnaceFurnaceNormal_furnaceOff;
+       _sm.t19 | _sm.t21 : SmFurnaceFurnaceFurnaceNormal_furnaceAct;
+       _sm.t22 : SmFurnaceFurnaceFurnaceNormal_furnaceRun;
+       _smFurnaceFurnace.state = SmFurnaceFurnace_furnaceNormal & state = null : SmFurnaceFurnaceFurnaceNormal_furnaceOff;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for main --
+MODULE main
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     sm : Sm( smHouseRoom , smHouseRoomRoom , smHouseRoomRoomNoHeatReq , smHouseRoomRoomHeatReq , smHouseController , smHouseControllerController , smHouseControllerControllerControllerOn , smHouseControllerControllerControllerOnHeaterActive , smHouse , smFurnaceFurnace , smFurnaceFurnaceFurnaceNormal );
+     smHouseRoom : SmHouseRoom( sm );
+     smHouseRoomRoom : SmHouseRoomRoom( sm , smHouse );
+     smHouseRoomRoomNoHeatReq : SmHouseRoomRoomNoHeatReq( sm , smHouseRoomRoom );
+     smHouseRoomRoomHeatReq : SmHouseRoomRoomHeatReq( sm , smHouseRoomRoom );
+     smHouseController : SmHouseController( sm );
+     smHouseControllerController : SmHouseControllerController( sm , smHouse );
+     smHouseControllerControllerControllerOn : SmHouseControllerControllerControllerOn( sm , smHouseControllerController );
+     smHouseControllerControllerControllerOnHeaterActive : SmHouseControllerControllerControllerOnHeaterActive( sm , smHouseControllerControllerControllerOn );
+     smHouse : SmHouse( sm );
+     smFurnaceFurnace : SmFurnaceFurnace( sm );
+     smFurnaceFurnaceFurnaceNormal : SmFurnaceFurnaceFurnaceNormal( sm , smFurnaceFurnace );
+CTLSPEC   EF( sm.state = Sm_heatingSystem )
+CTLSPEC   EF( smHouseRoom.state = SmHouseRoom_room )
+CTLSPEC   EF( smHouseRoomRoom.state = SmHouseRoomRoom_noHeatReq )
+CTLSPEC   EF( smHouseRoomRoom.state = SmHouseRoomRoom_heatReq )
+CTLSPEC   EF( smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_idleNotHeat )
+CTLSPEC   EF( smHouseRoomRoomNoHeatReq.state = SmHouseRoomRoomNoHeatReq_waitForHeat )
+CTLSPEC   EF( smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_idleHeat )
+CTLSPEC   EF( smHouseRoomRoomHeatReq.state = SmHouseRoomRoomHeatReq_waitForCool )
+CTLSPEC   EF( smHouseController.state = SmHouseController_controller )
+CTLSPEC   EF( smHouseControllerController.state = SmHouseControllerController_off )
+CTLSPEC   EF( smHouseControllerController.state = SmHouseControllerController_controllerOn )
+CTLSPEC   EF( smHouseControllerController.state = SmHouseControllerController_error )
+CTLSPEC   EF( smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_idle )
+CTLSPEC   EF( smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_heaterActive )
+CTLSPEC   EF( smHouseControllerControllerControllerOnHeaterActive.state = SmHouseControllerControllerControllerOnHeaterActive_actHeater )
+CTLSPEC   EF( smHouseControllerControllerControllerOnHeaterActive.state = SmHouseControllerControllerControllerOnHeaterActive_heaterRun )
+CTLSPEC   EF( smHouse.state = SmHouse_house )
+CTLSPEC   EF( smFurnaceFurnace.state = SmFurnaceFurnace_furnaceNormal )
+CTLSPEC   EF( smFurnaceFurnace.state = SmFurnaceFurnace_furnaceErr )
+CTLSPEC   EF( smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceOff )
+CTLSPEC   EF( smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceAct )
+CTLSPEC   EF( smFurnaceFurnaceFurnaceNormal.state = SmFurnaceFurnaceFurnaceNormal_furnaceRun )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/RoomHeatingSystem.ump
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/RoomHeatingSystem.ump
@@ -1,0 +1,93 @@
+class HeatControlSystem {
+
+	int furnaceStartUpTime;
+	int furnaceTimer;
+	int setTemp;
+	int actualTemp;
+	int waitedForWarm;
+	int warmUpTimer;
+	int valvePos;
+	int waitedForCool;
+	int coolDownTimer;
+
+	//internally generated events
+	boolean furnaceRunning;
+	boolean activate;
+	boolean deactivate;
+	boolean requestHeat;
+	boolean furnaceReset;
+
+
+	sm {
+		heatingSystem {
+			house {
+				room {
+					noHeatReq {
+						idleNotHeat {
+							[(setTemp - actualTemp) > 2] / { valvePos++; waitedForWarm = 0; } ->	waitForHeat;					
+						}
+						waitForHeat {
+							[waitedForWarm < warmUpTimer] /{ waitedForWarm++; } -> waitForHeat;
+							[(valvePos != 2) & (waitedForWarm == warmUpTimer)] /{ valvePos++; waitedForWarm = 0; } -> waitForHeat;
+							[!((setTemp - actualTemp) > 2)] -> idleNotHeat;
+							[(waitedForWarm == warmUpTimer) & (valvePos == 2) & ((setTemp - actualTemp) > 2)] / { requestHeat = true; } -> heatReq;
+						}
+					}
+					heatReq {
+						idleHeat {
+							[(actualTemp - setTemp) > 2]	/ { valvePos--; waitedForCool = 0; } ->	waitForCool;		
+						}
+						waitForCool {
+							[(valvePos != 0) & (coolDownTimer == waitedForCool)] / { valvePos--; waitedForCool = 0; } -> waitForCool;	
+							[waitedForCool < coolDownTimer] / { waitedForCool++; } -> waitForCool;
+							[!((actualTemp - setTemp) > 2)] -> idleHeat;
+						}
+					}
+				}
+				||
+				controller {
+					off {
+						heatSwitchOn -> controllerOn;
+					}
+					controllerOn {
+						heatSwitchOff / { deactivate = true; } -> off;
+						furnaceFault -> error;
+						idle {
+							[requestHeat == true] / { activate = true; } -> heaterActive;
+						}
+						heaterActive {
+							[requestHeat == false] / { deactivate = true; } -> idle;
+							actHeater {
+								[furnaceRunning == true] -> heaterRun;
+							}
+							heaterRun { }
+						}
+					}
+					error {
+						userReset / { furnaceReset = true; } -> off;
+					}
+				}
+			}
+			||
+			furnace {
+				furnaceNormal {
+					furnaceFault -> furnaceErr;
+					furnaceOff {
+						[activate == true] / { furnaceStartUpTime = 0; } -> furnaceAct;
+					}
+					furnaceAct {
+						[deactivate == true] -> furnaceOff;
+						[furnaceStartUpTime < furnaceTimer] / { furnaceStartUpTime++ } -> furnaceAct;
+						[furnaceStartUpTime == furnaceTimer] / { furnaceRunning = true; } -> furnaceRun;
+					}
+					furnaceRun {
+						[deactivate == true] -> furnaceOff;
+					}
+				}
+				furnaceErr {
+					[furnaceReset == true] -> furnaceNormal;
+				}
+			}
+		}
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/SingleLaneBridge.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/SingleLaneBridge.nusmv.txt
@@ -1,0 +1,494 @@
+-- This file is generated from SingleLaneBridge.ump --
+
+-- PLEASE DO NOT EDIT THIS CODE --
+-- This code was generated using the UMPLE @UMPLE_VERSION@ modeling language! --
+
+
+-- This defines a NuSMV module for Sm --
+MODULE Sm ( _smBridgeCar , _smBridgeCarRedCarRedA , _smBridgeCarRedCarRedARedA , _smBridgeCarRedCarRedB , _smBridgeCarRedCarRedBRedB , _smBridgeCarRedCar , _smBridgeCarBlueCarBlueA , _smBridgeCarBlueCarBlueABlueA , _smBridgeCarBlueCarBlueB , _smBridgeCarBlueCarBlueBBlueB , _smBridgeCarBlueCar , _smBridgeBridgeStatus , _smBridgeBridgeStatusBridgeStatus , _smBridge , _smCoordCoordRed , _smCoordCoordRedRedCoordEntRedCoordEnt , _smCoordCoordRedRedCoordExitRedCoordExit , _smCoordCoordBlue , _smCoordCoordBlueBlueCoordEntBlueCoordEnt , _smCoordCoordBlueBlueCoordExitBlueCoordExit , _smCoord )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { Sm_SingleLaneBridge , null };
+     event : { ev_inBlue , ev_entRedA , ev_exitBlueB , ev_exitBlueA , ev_enterBlueB , ev_entRedB , ev_enterRedA , ev_outRed , ev_enterRedB , ev_enterBlueA , ev_outBlue , ev_inRed , ev_exitRedA , ev_entBlueB , ev_exitRedB , ev_entBlueA , ev_null };
+     numRed : integer;
+     numBlue : integer;
+
+   -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
+   DEFINE
+     sm_stable :=  !( event = ev_inBlue | event = ev_exitBlueB | event = ev_enterBlueB | event = ev_enterRedA | event = ev_enterRedB | event = ev_outBlue | event = ev_exitRedA | event = ev_exitRedB | event = ev_entRedA | event = ev_exitBlueA | event = ev_entRedB | event = ev_outRed | event = ev_enterBlueA | event = ev_inRed | event = ev_entBlueB | event = ev_entBlueA );
+     t1 := event = ev_enterRedA & _smBridgeCarRedCarRedARedA.state = SmBridgeCarRedCarRedARedA_waitRedA & g1;
+     t2 := event = ev_exitRedA & _smBridgeCarRedCarRedARedA.state = SmBridgeCarRedCarRedARedA_onRedA;
+     t3 := event = ev_enterRedB & _smBridgeCarRedCarRedBRedB.state = SmBridgeCarRedCarRedBRedB_waitRedB & g1;
+     t4 := event = ev_exitRedB & _smBridgeCarRedCarRedBRedB.state = SmBridgeCarRedCarRedBRedB_onRedB;
+     t5 := event = ev_enterBlueA & _smBridgeCarBlueCarBlueABlueA.state = SmBridgeCarBlueCarBlueABlueA_waitBlueA & g2;
+     t6 := event = ev_exitBlueA & _smBridgeCarBlueCarBlueABlueA.state = SmBridgeCarBlueCarBlueABlueA_onBlueA;
+     t7 := event = ev_enterBlueB & _smBridgeCarBlueCarBlueBBlueB.state = SmBridgeCarBlueCarBlueBBlueB_waitBlueB & g2;
+     t8 := event = ev_exitBlueB & _smBridgeCarBlueCarBlueBBlueB.state = SmBridgeCarBlueCarBlueBBlueB_onBlueB;
+     t9 := event = ev_inRed & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_empty;
+     t10 := event = ev_inBlue & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_empty;
+     t11 := event = ev_outRed & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_oneRed;
+     t12 := event = ev_inRed & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_oneRed;
+     t13 := event = ev_outBlue & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_oneBlue;
+     t14 := event = ev_inBlue & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_oneBlue;
+     t15 := event = ev_outRed & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_twoRed;
+     t16 := event = ev_outBlue & _smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_twoBlue;
+     t17 := event = ev_entRedA & _smCoordCoordRedRedCoordEntRedCoordEnt.state = SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedA;
+     t18 := event = ev_entRedB & _smCoordCoordRedRedCoordEntRedCoordEnt.state = SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedB;
+     t19 := event = ev_exitRedA & _smCoordCoordRedRedCoordExitRedCoordExit.state = SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedA;
+     t20 := event = ev_exitRedB & _smCoordCoordRedRedCoordExitRedCoordExit.state = SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedB;
+     t21 := event = ev_entBlueA & _smCoordCoordBlueBlueCoordEntBlueCoordEnt.state = SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueA;
+     t22 := event = ev_entBlueB & _smCoordCoordBlueBlueCoordEntBlueCoordEnt.state = SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueB;
+     t23 := event = ev_exitBlueA & _smCoordCoordBlueBlueCoordExitBlueCoordExit.state = SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueA;
+     t24 := event = ev_exitBlueB & _smCoordCoordBlueBlueCoordExitBlueCoordExit.state = SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueB;
+     g1 := numRed < 2 & numBlue = 0;
+     g2 := numBlue < 2 & numRed = 0;
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := Sm_SingleLaneBridge;
+     next( state ) := case
+       t2 | t4 | t6 | t8 | t11 | t9 | t10 | t12 | t18 | t20 | t22 | t24 | t1 | t3 | t5 | t7 | t13 | t15 | t16 | t14 | t17 | t19 | t21 | t23 : Sm_SingleLaneBridge;
+       TRUE : state;
+     esac;
+
+   -- This part defines logic for the assignment of values to state variable "event" of this NuSMV module --
+   ASSIGN
+     init( event ) := ev_null;
+     next( event ) := case
+       sm_stable : { ev_inBlue , ev_entRedA , ev_exitBlueB , ev_exitBlueA , ev_enterBlueB , ev_entRedB , ev_enterRedA , ev_outRed , ev_enterRedB , ev_enterBlueA , ev_outBlue , ev_inRed , ev_exitRedA , ev_entBlueB , ev_exitRedB , ev_entBlueA };
+       TRUE : ev_null;
+     esac;
+
+   -- This part defines logic for the assignment of values to state variable "numRed" of this NuSMV module --
+   ASSIGN
+     init( numRed ) := 0;
+
+   -- This part defines logic for the assignment of values to state variable "numBlue" of this NuSMV module --
+   ASSIGN
+     init( numBlue ) := 0;
+
+-- This defines a NuSMV module for SmBridgeCar --
+MODULE SmBridgeCar ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCar_Car , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 : SmBridgeCar_Car;
+       _sm.state = Sm_SingleLaneBridge & state = null : SmBridgeCar_Car;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarRedCarRedA --
+MODULE SmBridgeCarRedCarRedA ( _sm , _smBridgeCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarRedCarRedA_RedA , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t2 | _sm.t1 : SmBridgeCarRedCarRedA_RedA;
+       _smBridgeCar.state = SmBridgeCar_Car & state = null : SmBridgeCarRedCarRedA_RedA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarRedCarRedARedA --
+MODULE SmBridgeCarRedCarRedARedA ( _sm , _smBridgeCarRedCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarRedCarRedARedA_waitRedA , SmBridgeCarRedCarRedARedA_onRedA , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t2 : SmBridgeCarRedCarRedARedA_waitRedA;
+       _sm.t1 : SmBridgeCarRedCarRedARedA_onRedA;
+       _smBridgeCarRedCar.state = SmBridgeCarRedCar_RedCar & state = null : SmBridgeCarRedCarRedARedA_waitRedA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarRedCarRedB --
+MODULE SmBridgeCarRedCarRedB ( _sm , _smBridgeCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarRedCarRedB_RedB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t4 | _sm.t3 : SmBridgeCarRedCarRedB_RedB;
+       _smBridgeCar.state = SmBridgeCar_Car & state = null : SmBridgeCarRedCarRedB_RedB;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarRedCarRedBRedB --
+MODULE SmBridgeCarRedCarRedBRedB ( _sm , _smBridgeCarRedCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarRedCarRedBRedB_waitRedB , SmBridgeCarRedCarRedBRedB_onRedB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t4 : SmBridgeCarRedCarRedBRedB_waitRedB;
+       _sm.t3 : SmBridgeCarRedCarRedBRedB_onRedB;
+       _smBridgeCarRedCar.state = SmBridgeCarRedCar_RedCar & state = null : SmBridgeCarRedCarRedBRedB_waitRedB;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarRedCar --
+MODULE SmBridgeCarRedCar ( _sm , _smBridge )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarRedCar_RedCar , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t2 | _sm.t4 | _sm.t1 | _sm.t3 : SmBridgeCarRedCar_RedCar;
+       _smBridge.state = SmBridge_Bridge & state = null : SmBridgeCarRedCar_RedCar;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarBlueCarBlueA --
+MODULE SmBridgeCarBlueCarBlueA ( _sm , _smBridgeCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarBlueCarBlueA_BlueA , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t6 | _sm.t5 : SmBridgeCarBlueCarBlueA_BlueA;
+       _smBridgeCar.state = SmBridgeCar_Car & state = null : SmBridgeCarBlueCarBlueA_BlueA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarBlueCarBlueABlueA --
+MODULE SmBridgeCarBlueCarBlueABlueA ( _sm , _smBridgeCarBlueCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarBlueCarBlueABlueA_waitBlueA , SmBridgeCarBlueCarBlueABlueA_onBlueA , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t2 | _sm.t4 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t6 : SmBridgeCarBlueCarBlueABlueA_waitBlueA;
+       _sm.t5 : SmBridgeCarBlueCarBlueABlueA_onBlueA;
+       _smBridgeCarBlueCar.state = SmBridgeCarBlueCar_BlueCar & state = null : SmBridgeCarBlueCarBlueABlueA_waitBlueA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarBlueCarBlueB --
+MODULE SmBridgeCarBlueCarBlueB ( _sm , _smBridgeCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarBlueCarBlueB_BlueB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t8 | _sm.t7 : SmBridgeCarBlueCarBlueB_BlueB;
+       _smBridgeCar.state = SmBridgeCar_Car & state = null : SmBridgeCarBlueCarBlueB_BlueB;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarBlueCarBlueBBlueB --
+MODULE SmBridgeCarBlueCarBlueBBlueB ( _sm , _smBridgeCarBlueCar )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarBlueCarBlueBBlueB_waitBlueB , SmBridgeCarBlueCarBlueBBlueB_onBlueB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t2 | _sm.t4 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t8 : SmBridgeCarBlueCarBlueBBlueB_waitBlueB;
+       _sm.t7 : SmBridgeCarBlueCarBlueBBlueB_onBlueB;
+       _smBridgeCarBlueCar.state = SmBridgeCarBlueCar_BlueCar & state = null : SmBridgeCarBlueCarBlueBBlueB_waitBlueB;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeCarBlueCar --
+MODULE SmBridgeCarBlueCar ( _sm , _smBridge )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeCarBlueCar_BlueCar , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t6 | _sm.t8 | _sm.t5 | _sm.t7 : SmBridgeCarBlueCar_BlueCar;
+       _smBridge.state = SmBridge_Bridge & state = null : SmBridgeCarBlueCar_BlueCar;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeBridgeStatus --
+MODULE SmBridgeBridgeStatus ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeBridgeStatus_BridgeStatus , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t11 | _sm.t9 | _sm.t10 | _sm.t12 | _sm.t13 | _sm.t15 | _sm.t16 | _sm.t14 : SmBridgeBridgeStatus_BridgeStatus;
+       _sm.state = Sm_SingleLaneBridge & state = null : SmBridgeBridgeStatus_BridgeStatus;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridgeBridgeStatusBridgeStatus --
+MODULE SmBridgeBridgeStatusBridgeStatus ( _sm , _smBridge )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridgeBridgeStatusBridgeStatus_empty , SmBridgeBridgeStatusBridgeStatus_oneRed , SmBridgeBridgeStatusBridgeStatus_oneBlue , SmBridgeBridgeStatusBridgeStatus_twoRed , SmBridgeBridgeStatusBridgeStatus_twoBlue , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 | _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 : null;
+       _sm.t11 | _sm.t13 : SmBridgeBridgeStatusBridgeStatus_empty;
+       _sm.t9 | _sm.t15 : SmBridgeBridgeStatusBridgeStatus_oneRed;
+       _sm.t10 | _sm.t16 : SmBridgeBridgeStatusBridgeStatus_oneBlue;
+       _sm.t12 : SmBridgeBridgeStatusBridgeStatus_twoRed;
+       _sm.t14 : SmBridgeBridgeStatusBridgeStatus_twoBlue;
+       _smBridge.state = SmBridge_Bridge & state = null : SmBridgeBridgeStatusBridgeStatus_empty;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmBridge --
+MODULE SmBridge ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmBridge_Bridge , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t11 | _sm.t9 | _sm.t10 | _sm.t12 | _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t13 | _sm.t15 | _sm.t16 | _sm.t14 : SmBridge_Bridge;
+       _sm.state = Sm_SingleLaneBridge & state = null : SmBridge_Bridge;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoordCoordRed --
+MODULE SmCoordCoordRed ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoordCoordRed_CoordRed , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t18 | _sm.t20 | _sm.t17 | _sm.t19 : SmCoordCoordRed_CoordRed;
+       _sm.state = Sm_SingleLaneBridge & state = null : SmCoordCoordRed_CoordRed;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoordCoordRedRedCoordEntRedCoordEnt --
+MODULE SmCoordCoordRedRedCoordEntRedCoordEnt ( _sm , _smCoordCoordRed )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedA , SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t21 | _sm.t23 | _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t22 | _sm.t24 : null;
+       _sm.t18 : SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedA;
+       _sm.t17 : SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedB;
+       _smCoordCoordRed.state = SmCoordCoordRed_CoordRed & state = null : SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoordCoordRedRedCoordExitRedCoordExit --
+MODULE SmCoordCoordRedRedCoordExitRedCoordExit ( _sm , _smCoordCoordRed )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedA , SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t21 | _sm.t23 | _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t22 | _sm.t24 : null;
+       _sm.t20 : SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedA;
+       _sm.t19 : SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedB;
+       _smCoordCoordRed.state = SmCoordCoordRed_CoordRed & state = null : SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoordCoordBlue --
+MODULE SmCoordCoordBlue ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoordCoordBlue_CoordBlue , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t22 | _sm.t24 | _sm.t21 | _sm.t23 : SmCoordCoordBlue_CoordBlue;
+       _sm.state = Sm_SingleLaneBridge & state = null : SmCoordCoordBlue_CoordBlue;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoordCoordBlueBlueCoordEntBlueCoordEnt --
+MODULE SmCoordCoordBlueBlueCoordEntBlueCoordEnt ( _sm , _smCoordCoordBlue )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueA , SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 : null;
+       _sm.t22 : SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueA;
+       _sm.t21 : SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueB;
+       _smCoordCoordBlue.state = SmCoordCoordBlue_CoordBlue & state = null : SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoordCoordBlueBlueCoordExitBlueCoordExit --
+MODULE SmCoordCoordBlueBlueCoordExitBlueCoordExit ( _sm , _smCoordCoordBlue )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueA , SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueB , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t1 | _sm.t3 | _sm.t5 | _sm.t7 | _sm.t9 | _sm.t11 | _sm.t13 | _sm.t15 | _sm.t17 | _sm.t19 | _sm.t2 | _sm.t4 | _sm.t6 | _sm.t8 | _sm.t10 | _sm.t12 | _sm.t14 | _sm.t16 | _sm.t18 | _sm.t20 : null;
+       _sm.t24 : SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueA;
+       _sm.t23 : SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueB;
+       _smCoordCoordBlue.state = SmCoordCoordBlue_CoordBlue & state = null : SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueA;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for SmCoord --
+MODULE SmCoord ( _sm )
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { SmCoord_Coord , null };
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := null;
+     next( state ) := case
+       _sm.t18 | _sm.t20 | _sm.t22 | _sm.t24 | _sm.t17 | _sm.t19 | _sm.t21 | _sm.t23 : SmCoord_Coord;
+       _sm.state = Sm_SingleLaneBridge & state = null : SmCoord_Coord;
+       TRUE : state;
+     esac;
+
+-- This defines a NuSMV module for main --
+MODULE main
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     sm : Sm( smBridgeCar , smBridgeCarRedCarRedA , smBridgeCarRedCarRedARedA , smBridgeCarRedCarRedB , smBridgeCarRedCarRedBRedB , smBridgeCarRedCar , smBridgeCarBlueCarBlueA , smBridgeCarBlueCarBlueABlueA , smBridgeCarBlueCarBlueB , smBridgeCarBlueCarBlueBBlueB , smBridgeCarBlueCar , smBridgeBridgeStatus , smBridgeBridgeStatusBridgeStatus , smBridge , smCoordCoordRed , smCoordCoordRedRedCoordEntRedCoordEnt , smCoordCoordRedRedCoordExitRedCoordExit , smCoordCoordBlue , smCoordCoordBlueBlueCoordEntBlueCoordEnt , smCoordCoordBlueBlueCoordExitBlueCoordExit , smCoord );
+     smBridgeCar : SmBridgeCar( sm );
+     smBridgeCarRedCarRedA : SmBridgeCarRedCarRedA( sm , smBridgeCar );
+     smBridgeCarRedCarRedARedA : SmBridgeCarRedCarRedARedA( sm , smBridgeCarRedCar );
+     smBridgeCarRedCarRedB : SmBridgeCarRedCarRedB( sm , smBridgeCar );
+     smBridgeCarRedCarRedBRedB : SmBridgeCarRedCarRedBRedB( sm , smBridgeCarRedCar );
+     smBridgeCarRedCar : SmBridgeCarRedCar( sm , smBridge );
+     smBridgeCarBlueCarBlueA : SmBridgeCarBlueCarBlueA( sm , smBridgeCar );
+     smBridgeCarBlueCarBlueABlueA : SmBridgeCarBlueCarBlueABlueA( sm , smBridgeCarBlueCar );
+     smBridgeCarBlueCarBlueB : SmBridgeCarBlueCarBlueB( sm , smBridgeCar );
+     smBridgeCarBlueCarBlueBBlueB : SmBridgeCarBlueCarBlueBBlueB( sm , smBridgeCarBlueCar );
+     smBridgeCarBlueCar : SmBridgeCarBlueCar( sm , smBridge );
+     smBridgeBridgeStatus : SmBridgeBridgeStatus( sm );
+     smBridgeBridgeStatusBridgeStatus : SmBridgeBridgeStatusBridgeStatus( sm , smBridge );
+     smBridge : SmBridge( sm );
+     smCoordCoordRed : SmCoordCoordRed( sm );
+     smCoordCoordRedRedCoordEntRedCoordEnt : SmCoordCoordRedRedCoordEntRedCoordEnt( sm , smCoordCoordRed );
+     smCoordCoordRedRedCoordExitRedCoordExit : SmCoordCoordRedRedCoordExitRedCoordExit( sm , smCoordCoordRed );
+     smCoordCoordBlue : SmCoordCoordBlue( sm );
+     smCoordCoordBlueBlueCoordEntBlueCoordEnt : SmCoordCoordBlueBlueCoordEntBlueCoordEnt( sm , smCoordCoordBlue );
+     smCoordCoordBlueBlueCoordExitBlueCoordExit : SmCoordCoordBlueBlueCoordExitBlueCoordExit( sm , smCoordCoordBlue );
+     smCoord : SmCoord( sm );
+CTLSPEC   EF( sm.state = Sm_SingleLaneBridge )
+CTLSPEC   EF( smBridgeCar.state = SmBridgeCar_Car )
+CTLSPEC   EF( smBridgeCarRedCarRedA.state = SmBridgeCarRedCarRedA_RedA )
+CTLSPEC   EF( smBridgeCarRedCarRedARedA.state = SmBridgeCarRedCarRedARedA_waitRedA )
+CTLSPEC   EF( smBridgeCarRedCarRedARedA.state = SmBridgeCarRedCarRedARedA_onRedA )
+CTLSPEC   EF( smBridgeCarRedCarRedB.state = SmBridgeCarRedCarRedB_RedB )
+CTLSPEC   EF( smBridgeCarRedCarRedBRedB.state = SmBridgeCarRedCarRedBRedB_waitRedB )
+CTLSPEC   EF( smBridgeCarRedCarRedBRedB.state = SmBridgeCarRedCarRedBRedB_onRedB )
+CTLSPEC   EF( smBridgeCarRedCar.state = SmBridgeCarRedCar_RedCar )
+CTLSPEC   EF( smBridgeCarBlueCarBlueA.state = SmBridgeCarBlueCarBlueA_BlueA )
+CTLSPEC   EF( smBridgeCarBlueCarBlueABlueA.state = SmBridgeCarBlueCarBlueABlueA_waitBlueA )
+CTLSPEC   EF( smBridgeCarBlueCarBlueABlueA.state = SmBridgeCarBlueCarBlueABlueA_onBlueA )
+CTLSPEC   EF( smBridgeCarBlueCarBlueB.state = SmBridgeCarBlueCarBlueB_BlueB )
+CTLSPEC   EF( smBridgeCarBlueCarBlueBBlueB.state = SmBridgeCarBlueCarBlueBBlueB_waitBlueB )
+CTLSPEC   EF( smBridgeCarBlueCarBlueBBlueB.state = SmBridgeCarBlueCarBlueBBlueB_onBlueB )
+CTLSPEC   EF( smBridgeCarBlueCar.state = SmBridgeCarBlueCar_BlueCar )
+CTLSPEC   EF( smBridgeBridgeStatus.state = SmBridgeBridgeStatus_BridgeStatus )
+CTLSPEC   EF( smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_empty )
+CTLSPEC   EF( smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_oneRed )
+CTLSPEC   EF( smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_oneBlue )
+CTLSPEC   EF( smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_twoRed )
+CTLSPEC   EF( smBridgeBridgeStatusBridgeStatus.state = SmBridgeBridgeStatusBridgeStatus_twoBlue )
+CTLSPEC   EF( smBridge.state = SmBridge_Bridge )
+CTLSPEC   EF( smCoordCoordRed.state = SmCoordCoordRed_CoordRed )
+CTLSPEC   EF( smCoordCoordRedRedCoordEntRedCoordEnt.state = SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedA )
+CTLSPEC   EF( smCoordCoordRedRedCoordEntRedCoordEnt.state = SmCoordCoordRedRedCoordEntRedCoordEnt_coordEntRedB )
+CTLSPEC   EF( smCoordCoordRedRedCoordExitRedCoordExit.state = SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedA )
+CTLSPEC   EF( smCoordCoordRedRedCoordExitRedCoordExit.state = SmCoordCoordRedRedCoordExitRedCoordExit_coordExitRedB )
+CTLSPEC   EF( smCoordCoordBlue.state = SmCoordCoordBlue_CoordBlue )
+CTLSPEC   EF( smCoordCoordBlueBlueCoordEntBlueCoordEnt.state = SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueA )
+CTLSPEC   EF( smCoordCoordBlueBlueCoordEntBlueCoordEnt.state = SmCoordCoordBlueBlueCoordEntBlueCoordEnt_coordEntBlueB )
+CTLSPEC   EF( smCoordCoordBlueBlueCoordExitBlueCoordExit.state = SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueA )
+CTLSPEC   EF( smCoordCoordBlueBlueCoordExitBlueCoordExit.state = SmCoordCoordBlueBlueCoordExitBlueCoordExit_coordExitBlueB )
+CTLSPEC   EF( smCoord.state = SmCoord_Coord )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/SingleLaneBridge.ump
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/SingleLaneBridge.ump
@@ -1,0 +1,122 @@
+/*
+Source - Model Checking Template-Semantics Specifications 
+Technical Report by Y. Liu, Joanne Atlee, Nancy A. Day
+Publication Date - 2004 (University of Waterloo)
+*/
+
+class System {
+  int numRed;
+  int numBlue;
+  sm {
+  	SingleLaneBridge {
+  		//Bridge definition
+    	Bridge { 
+    		//Definitions of the Car state machine starts here
+    		Car {
+    	    RedCar {   
+    	      RedA {
+    	        waitRedA { 
+    	          enterRedA [numRed < 2 & numBlue == 0] -> onRedA;
+    	        }
+    	        onRedA {
+    	          exitRedA -> waitRedA;
+    	        }
+    	      }
+    	      ||
+    	      RedB {
+    	        waitRedB { 
+    	          enterRedB [numRed < 2 & numBlue == 0] -> onRedB;
+    	        }
+    	        onRedB {
+    	          exitRedB -> waitRedB;
+    	        }
+    	      }
+    	    }
+    	    ||
+    	    BlueCar {   
+    	      BlueA {
+    	        waitBlueA { 
+    	          enterBlueA [numBlue < 2 & numRed == 0] -> onBlueA;
+    	        }
+    	        onBlueA {
+    	          exitBlueA -> waitBlueA;
+    	        }
+    	      }
+    	      ||
+    	      BlueB {
+    	        waitBlueB { 
+    	          enterBlueB [numBlue < 2 & numRed == 0] -> onBlueB;
+    	        }
+    	        onBlueB {
+    	          exitBlueB -> waitBlueB;
+    	        }
+    	      }
+    	    }
+				}
+    		||
+    		BridgeStatus {
+    	  	empty {
+    	    	inRed / { numRed = numRed + 1; } -> oneRed;
+    	    	inBlue / { numBlue = numBlue + 1; } -> oneBlue;
+    	  	}
+    	  	oneRed {
+    	    	outRed / { numRed = numRed - 1; } -> empty;
+						inRed / { numRed = numRed + 1; } -> twoRed;
+    	  	}
+    	  	oneBlue {
+    	    	outBlue / { numBlue = numBlue - 1; } -> empty;
+						inBlue / { numBlue = numBlue + 1; } -> twoBlue;
+    	  	}
+					twoRed {
+						outRed / { numRed = numRed - 1; } -> oneRed;
+					}
+					twoBlue {
+						outBlue / { numBlue = numBlue -1; } -> oneBlue;
+					}
+    		}
+  		}
+			||
+			Coord {
+				CoordRed {
+					redCoordEnt {
+						coordEntRedA {
+							entRedA -> coordEntRedB;
+						}
+						coordEntRedB {
+							entRedB -> coordEntRedA;
+						}
+					}
+					||
+					redCoordExit {
+						coordExitRedA { 
+							exitRedA -> coordExitRedB; 
+						}
+						coordExitRedB {
+							exitRedB -> coordExitRedA;
+						}
+					}
+				}
+				||
+				CoordBlue {
+					blueCoordEnt {
+						coordEntBlueA {
+							entBlueA -> coordEntBlueB;
+						}
+						coordEntBlueB {
+							entBlueB -> coordEntBlueA;
+						}
+					}
+					||
+					blueCoordExit {
+						coordExitBlueA { 
+							exitBlueA -> coordExitBlueB; 
+						}
+						coordExitBlueB {
+							exitBlueB -> coordExitBlueA;
+						}
+					}
+				}			
+			}
+		} 	 
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/Test.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/Test.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_newBooking , State_seatAssigned , State_checkedIn , State_cancelled , State_completed };
-     event : { ev_assignSeat , ev_cancel , ev_checkIn , ev_cance , ev_complete , ev_null };
+     event : { ev_cancel , ev_cance , ev_checkIn , ev_assignSeat , ev_complete , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_cancel | event = ev_cance | event = ev_assignSeat | event = ev_checkIn | event = ev_complete );
+     state_stable :=  !( event = ev_cance | event = ev_assignSeat | event = ev_cancel | event = ev_checkIn | event = ev_complete );
      t1 := event = ev_assignSeat & state = State_newBooking;
      t2 := event = ev_cancel & state = State_newBooking;
      t3 := event = ev_cancel & state = State_seatAssigned;
@@ -38,7 +38,7 @@ MODULE State
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_assignSeat , ev_cancel , ev_checkIn , ev_cance , ev_complete };
+       state_stable : { ev_cancel , ev_cance , ev_checkIn , ev_assignSeat , ev_complete };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/concurrentMachineExample.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/concurrentMachineExample.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State ( _stateAA , _stateBB , _stateBBS24 )
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_s1 , State_s2 };
-     event : { ev_e2 , ev_e1 , ev_e5 , ev_e7 , ev_e11 , ev_e3 , ev_e9 , ev_e10 , ev_null };
+     event : { ev_e5 , ev_e7 , ev_e11 , ev_e9 , ev_e10 , ev_e1 , ev_e2 , ev_e3 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_e2 | event = ev_e5 | event = ev_e11 | event = ev_e9 | event = ev_e1 | event = ev_e7 | event = ev_e3 | event = ev_e10 );
+     state_stable :=  !( event = ev_e5 | event = ev_e11 | event = ev_e10 | event = ev_e2 | event = ev_e7 | event = ev_e9 | event = ev_e1 | event = ev_e3 );
      t1 := event = ev_e2 & _stateAA.state = StateAA_s11;
      t2 := event = ev_e1 & _stateAA.state = StateAA_s12;
      t3 := event = ev_e5 & _stateBB.state = StateBB_s21;
@@ -38,7 +38,7 @@ MODULE State ( _stateAA , _stateBB , _stateBBS24 )
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_e2 , ev_e1 , ev_e5 , ev_e7 , ev_e11 , ev_e3 , ev_e9 , ev_e10 };
+       state_stable : { ev_e5 , ev_e7 , ev_e11 , ev_e9 , ev_e10 , ev_e1 , ev_e2 , ev_e3 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/myTemporaryTest.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/myTemporaryTest.nusmv.txt
@@ -10,7 +10,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { HeatSystem_heatSys , null };
-     event : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 , ev_null };
+     event : { ev_t5 , ev_heatSwitchOn , ev_furnaceReset , ev_furnaceFault , ev_furnaceRunning , ev_deactivate , ev_t21 , ev_t20 , ev_heatSwitchOff , ev_t23 , ev_t22 , ev_t24 , ev_activate , ev_t15 , ev_userReset , ev_t18 , ev_t17 , ev_t19 , ev_null };
      tooCold : boolean;
      tooHot : boolean;
      requestHeat : boolean;
@@ -24,7 +24,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     heatSystem_stable :=  !( event = ev_furnaceFault | event = ev_heatSwitchOn | event = ev_userReset | event = ev_deactivate | event = ev_furnaceRunning | event = ev_t17 | event = ev_t20 | event = ev_t19 | event = ev_t24 | event = ev_furnaceReset | event = ev_heatSwitchOff | event = ev_activate | event = ev_t5 | event = ev_t15 | event = ev_t18 | event = ev_t21 | event = ev_t22 | event = ev_t23 );
+     heatSystem_stable :=  !( event = ev_t5 | event = ev_furnaceReset | event = ev_furnaceRunning | event = ev_t21 | event = ev_heatSwitchOff | event = ev_t22 | event = ev_activate | event = ev_userReset | event = ev_t17 | event = ev_heatSwitchOn | event = ev_furnaceFault | event = ev_deactivate | event = ev_t20 | event = ev_t23 | event = ev_t24 | event = ev_t15 | event = ev_t18 | event = ev_t19 );
      t1 := event = ev_t15 & _heatSystemHouseRoomRoomNoHeatReq.state = HeatSystemHouseRoomRoomNoHeatReq_idleNoHeat & g1;
      t2 := event = ev_t17 & _heatSystemHouseRoomRoomNoHeatReq.state = HeatSystemHouseRoomRoomNoHeatReq_waitForHeat & g2;
      t3 := event = ev_t18 & _heatSystemHouseRoomRoomNoHeatReq.state = HeatSystemHouseRoomRoomNoHeatReq_waitForHeat & g3;
@@ -77,7 +77,7 @@ MODULE HeatSystem ( _heatSystemHouseRoom , _heatSystemHouseRoomRoom , _heatSyste
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       heatSystem_stable : { ev_furnaceFault , ev_furnaceReset , ev_heatSwitchOn , ev_heatSwitchOff , ev_userReset , ev_activate , ev_deactivate , ev_t5 , ev_furnaceRunning , ev_t15 , ev_t17 , ev_t18 , ev_t20 , ev_t21 , ev_t19 , ev_t22 , ev_t24 , ev_t23 };
+       heatSystem_stable : { ev_t5 , ev_heatSwitchOn , ev_furnaceReset , ev_furnaceFault , ev_furnaceRunning , ev_deactivate , ev_t21 , ev_t20 , ev_heatSwitchOff , ev_t23 , ev_t22 , ev_t24 , ev_activate , ev_t15 , ev_userReset , ev_t18 , ev_t17 , ev_t19 };
        TRUE : ev_null;
      esac;
 

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/nestedConcurrentMachine.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/nestedConcurrentMachine.nusmv.txt
@@ -10,11 +10,11 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    -- This part declares state variables for the given NuSMV module --
    VAR
      state : { State_state1 , State_state2 };
-     event : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 , ev_null };
+     event : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 , ev_null };
 
    -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
    DEFINE
-     state_stable :=  !( event = ev_e1 | event = ev_e2 | event = ev_e5 | event = ev_e4 | event = ev_e3 );
+     state_stable :=  !( event = ev_e1 | event = ev_e3 | event = ev_e5 | event = ev_e2 | event = ev_e4 );
      t1 := event = ev_e5 & _stateState11State11.state != null;
      t2 := event = ev_e1 & _stateState11State11.state = StateState11State11_state111;
      t3 := event = ev_e4 & _stateState11State11.state = StateState11State11_state112;
@@ -37,7 +37,7 @@ MODULE State ( _stateState11State11 , _stateState12State12 , _stateState12State1
    ASSIGN
      init( event ) := ev_null;
      next( event ) := case
-       state_stable : { ev_e5 , ev_e1 , ev_e4 , ev_e2 , ev_e3 };
+       state_stable : { ev_e5 , ev_e1 , ev_e2 , ev_e3 , ev_e4 };
        TRUE : ev_null;
      esac;
 


### PR DESCRIPTION
In this PR, we added real-world test cases encountered in the literature. While analyzing these case studies for non-determinism, we observed that Umple associate unique events to autotransitions thus hiding non-deterministic cases whose consequences are critical safety-wise. As a result, we tune the generator to associate an event name (i.e. **autotransition**) to all autotransitions in the model.

By doing this, we were able to uncover these issues. Further discussions as to why Umple allowed this will be delayed to my next meeting with @TimLethbridge.   
