### PR TITLE
a bug related to implementing interfaces through traits was fixed.

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1407,7 +1407,7 @@ class UmpleInternalParser
         && !(uClass.hasMethodInTraits(aMethod)) && !(uClass.isIsAbstract()) && shouldAddMethod)
         {
           aMethod.setIsImplemented("".equals(aMethod.getMethodBody().getExtraCode("")));
-          
+          aMethod.setSource(Method.Source.fAuto);
           uClass.addMethod(aMethod);
         }
       }

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -1677,6 +1677,10 @@ class UmpleClass
 	          }
 	          if(allSame)
 	          {
+	          	if (aMethod.getSource()==Method.Source.fAuto){
+	        		  this.removeMethod(aMethod);
+	        		  return false;
+	        	  }
 	            return true;
 	          }
 	        }

--- a/cruise.umple/test/cruise/umple/compiler/UmpleTraitTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleTraitTest.java
@@ -3,6 +3,7 @@ package cruise.umple.compiler;
 
 import org.junit.*;
 
+import cruise.umple.compiler.Method.Source;
 import cruise.umple.util.SampleFileWriter;
 
 public class UmpleTraitTest {
@@ -1570,6 +1571,18 @@ public class UmpleTraitTest {
 		
 	}	
 
+	@Test
+	public void templateInCode04Test() {
+		String code = "interface B {  Boolean isEmpty();  void push(String e,String b);}"
+				+"class A{  isA B;  isA TStack <T=String>; }"
+				+"trait TStack<T>{    Boolean isEmpty() {   return true;   }   void push(T e,T b) {  	  } }";
+		UmpleModel model = getRunModel(code);
+		Assert.assertEquals(Source.fTrait, model.getUmpleClass("A").getMethod(0).getSource());
+		Assert.assertEquals(Source.fTrait, model.getUmpleClass("A").getMethod(1).getSource());
+		
+	}	
+	
+	
 	@Test
 	public void InterfaceForTemplates001() {
 		String code = "class A{isA T< X = B >;} class B{} interface I{} trait T<X isA I>{}";


### PR DESCRIPTION
There was a bug related to implementing interfaces with traits. In Umple, we generate an automatic implementation for interfaces' methods. Through traits,  I overwrite them to make sure we'll get correct implementations. However, having template parameters makes this process complicated. I fixed the bug that comes from that complexity.
