### PR TITLE
Fix for Issue833

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -98,17 +98,27 @@ public <<# if (uClass.getIsAbstract()) { append(realSb, "{0} ", "abstract"); } #
 for (StateMachine smq : uClass.getStateMachines())
   {
     if (smq.isQueued())
-    {
-      append(realSb," implements Runnable");
+    { 
+      if (uClass.hasParentInterface() == false){
+        append(realSb," implements Runnable");
+      }
+      else{
+        append(realSb,", Runnable");
+      } 
       break;
     }
     else if(smq.isPooled())
     {
-      append(realSb," implements Runnable");
+      if (uClass.hasParentInterface() == false){
+        append(realSb," implements Runnable");
+      }
+      else{
+        append(realSb,", Runnable");
+      } 
       break;
     }
   }
-
+  
 #>>
 {
   <<#getMemberCode(realSb, model,uClass,gClass,gen,isFirst);

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
@@ -146,6 +146,7 @@ public class StateMachineTest extends StateMachineTemplateTest
 	  assertUmpleTemplateFor("EventTransitionSpacing.ump",languagePath + "/EventTransition_NewState."+ languagePath +".txt","Light");
   }
   
+ 
   /**
    * Test spacing issues by changing the spacing in the test file for {@link #EventTransitionNewState()}.
    * @see #stateNameSpacingForNoStates()
@@ -638,4 +639,13 @@ public class StateMachineTest extends StateMachineTemplateTest
   {
     assertUmpleTemplateFor("pooledStateMachine_timedTransition_2.ump",languagePath + "/pooledStateMachine_timedTransition_2."+ languagePath +".txt","X");
   }
+  //Implementing an interface for classes containing queued and pooled state machines
+  @Test
+  public void queuedStateMachine_implements()
+  {
+	assertUmpleTemplateFor("queuedStateMachine_implementsInterface.ump",languagePath + "/queuedStateMachine_interfaceX."+ languagePath +".txt","IX");
+    assertUmpleTemplateFor("queuedStateMachine_implementsInterface.ump",languagePath + "/queuedStateMachine_implementsInterface."+ languagePath +".txt","X");
+    
+  }
+  
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_implementsInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_implementsInterface.java.txt
@@ -1,0 +1,154 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+package example;
+import java.util.*;
+import java.lang.Thread;
+
+public class X implements IX, Runnable
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //X State Machines
+  public enum Sm { s1 }
+  private Sm sm;
+  
+  //enumeration type of messages accepted by X
+  protected enum MessageType { e_M }
+  
+  MessageQueue queue;
+  Thread removal;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public X()
+  {
+    setSm(Sm.s1);
+    queue = new MessageQueue();
+    removal=new Thread(this);
+    //start the thread of X
+    removal.start();
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public String getSmFullName()
+  {
+    String answer = sm.toString();
+    return answer;
+  }
+
+  public Sm getSm()
+  {
+    return sm;
+  }
+
+  public boolean _e()
+  {
+    boolean wasEventProcessed = false;
+    
+    Sm aSm = sm;
+    switch (aSm)
+    {
+      case s1:
+        setSm(Sm.s1);
+        wasEventProcessed = true;
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  private void setSm(Sm aSm)
+  {
+    sm = aSm;
+  }
+
+  public void delete()
+  {}
+
+  protected class Message
+  {
+    MessageType type;
+    
+    //Message parameters
+    Vector<Object> param;
+    
+    public Message(MessageType t, Vector<Object> p)
+    {
+      type = t; 
+      param = p;
+    }
+
+    @Override
+    public String toString()
+    {
+      return type + "," + param;
+    }
+  }
+  
+  protected class MessageQueue {
+    Queue<Message> messages = new LinkedList<Message>();
+    
+    public synchronized void put(Message m)
+    {
+      messages.add(m); 
+      notify();
+    }
+
+    public synchronized Message getNext()
+    {
+      try {
+        while (messages.isEmpty()) 
+        {
+          wait();
+        }
+      } catch (InterruptedException e) { e.printStackTrace(); } 
+
+      //The element to be removed
+      Message m = messages.remove(); 
+      return (m);
+    }
+  }
+
+  //------------------------------
+  //messages accepted 
+  //------------------------------
+
+  public void e ()
+  {
+    queue.put(new Message(MessageType.e_M, null));
+  }
+
+  
+  @Override
+  public void run ()
+  {
+    boolean status=false;
+    while (true) 
+    {
+      Message m = queue.getNext();
+      
+      switch (m.type)
+      {
+        case e_M:
+          status = _e();
+          break; 
+        default:
+      }
+      if(!status)
+      {
+        // Error message is written or  exception is raised
+      }
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_interfaceX.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_interfaceX.java.txt
@@ -1,0 +1,7 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+package example;
+public interface IX
+{
+  
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/queuedStateMachine_implementsInterface.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/queuedStateMachine_implementsInterface.php.txt
@@ -1,0 +1,68 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-02ecd5d modeling language!*/
+
+class X implements IX
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //X State Machines
+  private static $SmS1 = 1;
+  private $sm;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct()
+  {
+    $this->setSm(self::$SmS1);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getSmFullName()
+  {
+    $answer = $this->getSm();
+    return $answer;
+  }
+
+  public function getSm()
+  {
+    if ($this->sm == self::$SmS1) { return "SmS1"; }
+    return null;
+  }
+
+  public function e()
+  {
+    $wasEventProcessed = false;
+    
+    $aSm = $this->sm;
+    if ($aSm == self::$SmS1)
+    {
+      $this->setSm(self::$SmS1);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  private function setSm($aSm)
+  {
+    $this->sm = $aSm;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/queuedStateMachine_interfaceX.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/queuedStateMachine_interfaceX.php.txt
@@ -1,0 +1,9 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-02ecd5d modeling language!*/
+
+interface IX
+{
+  
+}
+?>

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/queuedStateMachine_implementsInterface.ump
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/queuedStateMachine_implementsInterface.ump
@@ -1,0 +1,11 @@
+namespace example;
+interface IX{
+}
+class X{
+  isA IX;
+  queued sm{
+    s1{
+      e->s1; 
+    }
+  }
+}


### PR DESCRIPTION
This pull fixes the issue of double implements keywords for queued and pooled state machines when the containing class implements an interface.
