### PR TITLE
guard and transition labels finalized

### DIFF
--- a/cruise.umple/src/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvStateDiagram.ump
@@ -27,8 +27,8 @@ class GvStateDiagramGenerator
 {
   Boolean hideActions = false;
   Boolean hideGuards = false;
-  Boolean hideTransitionLabels = false;
-  Boolean hideGuardLabels = false;
+  Boolean showTransitionLabels = false;
+  Boolean showGuardLabels = false;
   lazy StateMachine root;
  
   internal Map<Transition,String> internalBoundaryTrans
@@ -71,8 +71,8 @@ digraph "<<=filename>>" {
     
     hideActions = hasSuboption("hideactions");
     hideGuards = hasSuboption("hideguards");
-    hideTransitionLabels = hasSuboption("hidetransitionlabels");
-    hideGuardLabels = hasSuboption("hideguardlabels");
+    showTransitionLabels = hasSuboption("showtransitionlabels");
+    showGuardLabels = hasSuboption("showguardlabels");
     
     // Output basic gv file header
     _graphStart(0,code,model.getUmpleFile().getSimpleFileName());
@@ -388,8 +388,8 @@ node [shape = circle, fixedsize = true, width=.3];
       {
         event = t.getEvent();
         action = t.getAction();
-        hideTransitionLabels = true;
-        if ( hideTransitionLabels ) {
+        //showTransitionLabels = true;
+        if ( !showTransitionLabels ) {
           transitionLabel = "";
         }
         else {
@@ -433,8 +433,8 @@ node [shape = circle, fixedsize = true, width=.3];
         if (guard == null || hideGuards) guardString = "";
         else 
         {
-          hideGuardLabels = true;
-          if ( hideGuardLabels ) {
+          //showGuardLabels = true;
+          if ( !showGuardLabels ) {
           	guardLabel = "";
           }
           else {

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -178,6 +178,14 @@ Action.clicked = function(event)
   {
     Action.toggleTraits();
   }  
+  else if (action == "ToggleTransitionLabels")
+  {
+    Action.toggleTransitionLabels();
+  }  
+  else if (action == "ToggleGuardLabels")
+  {
+    Action.toggleGuardLabels();
+  }
   else if(action == "StructureLink")
   {
     Action.generateStructureDiagramFile();
@@ -1505,6 +1513,8 @@ Action.updateUmpleDiagramForce = function(forceUpdate)
   // append any suboptions needed for GvStateDiagram
   if(Page.useGvStateDiagram) { 
     if(!Page.showActions) language=language+".hideactions";
+    if(Page.showTransitionLabels) language=language+".showtransitionlabels";
+    if(Page.showGuardLabels) language=language+".showguardlabels";
   }
   // append any suboptions needed for GvClassDiagram
   if(Page.useGvClassDiagram) { 
@@ -1721,6 +1731,18 @@ Action.toggleMethods = function()
 Action.toggleActions = function()
 {
   Page.showActions = !Page.showActions;
+  Action.redrawDiagram()
+}
+
+Action.toggleTransitionLabels = function()
+{
+  Page.showTransitionLabels = !Page.showTransitionLabels;
+  Action.redrawDiagram()
+}
+
+Action.toggleGuardLabels = function()
+{
+  Page.showGuardLabels = !Page.showGuardLabels;
   Action.redrawDiagram()
 }
 
@@ -2029,6 +2051,22 @@ Mousetrap.bind(['ctrl+r'], function(e){
   if(jQuery('.focus').length != 0)
   {
     Page.clickToggleTraits();
+    return false; //equivalent to e.preventDefault();
+  }
+});
+
+Mousetrap.bind(['ctrl+i'], function(e){
+  if(jQuery('.focus').length != 0)
+  {
+    Page.clickToggleTransitionLabels();
+    return false; //equivalent to e.preventDefault();
+  }
+});
+
+Mousetrap.bind(['ctrl+k'], function(e){
+  if(jQuery('.focus').length != 0)
+  {
+    Page.clickToggleGuardLabels();
     return false; //equivalent to e.preventDefault();
   }
 });

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -34,6 +34,8 @@ Page.showAttributes = true;
 Page.showMethods = false;
 Page.showActions = true;
 Page.showTraits = false;
+Page.showTransitionLabels = false;
+Page.showGuardLabels = false;
 Page.modifiedDiagrams = false;
 
 // The following is set called from umple.php
@@ -111,8 +113,8 @@ Page.initPaletteArea = function()
   Page.initHighlighter("buttonToggleMethods");
   Page.initHighlighter("buttonToggleAttributes");
   Page.initHighlighter("buttonToggleActions");
-  Page.initHighlighter("buttonToggleTransitionLabel");
-  Page.initHighlighter("buttonToggleGuardLabel");
+  Page.initHighlighter("buttonToggleTransitionLabels");
+  Page.initHighlighter("buttonToggleGuardLabels");
   Page.initHighlighter("buttonToggleTraits");
   
   Page.initToggleTool("buttonAddClass");
@@ -158,8 +160,8 @@ Page.initPaletteArea = function()
   Page.initAction("buttonToggleAttributes");
   Page.initAction("buttonToggleActions");
   Page.initAction("buttonToggleTraits");
-  Page.initAction("buttonToggleTransitionLabel");
-  Page.initAction("buttonToggleGuardLabel");
+  Page.initAction("buttonToggleTransitionLabels");
+  Page.initAction("buttonToggleGuardLabels");
   
   Page.initLabels();
 
@@ -207,8 +209,8 @@ Page.initOptions = function()
 	jQuery("#ttTabsCheckbox").hide();
   jQuery("#buttonToggleAttributes").prop('checked',true);
   jQuery("#buttonToggleActions").prop('checked',true);
-  jQuery("#buttonToggleTransitionLabel").prop('checked',true);
-  jQuery("#buttonToggleGuardLabel").prop('checked',true);
+  jQuery("#buttonToggleTransitionLabels").prop('checked',false);
+  jQuery("#buttonToggleGuardLabels").prop('checked',false);
   jQuery("#buttonToggleTraits").prop('checked',false);
   
   if(Page.useEditableClassDiagram)
@@ -384,6 +386,8 @@ Page.initCodeMirrorEditor = function() {
           "Ctrl-A": function(cm) {Page.clickToggleAttributes()},
           "Ctrl-M": function(cm) {Page.clickToggleMethods()},
           "Ctrl-R": function(cm) {Page.clickToggleTraits()},
+          "Ctrl-I": function(cm) {Page.clickToggleTransitionLabels()},
+          "Ctrl-K": function(cm) {Page.clickToggleGuardLabels()},
           "Esc": function(cm) {cm.getInputField().blur()}
           }
         }
@@ -431,6 +435,13 @@ Page.clickToggleTraits = function() {
   jQuery('#buttonToggleTraits').trigger('click');
 }
 
+Page.clickToggleTransitionLabels = function() {
+  jQuery('#buttonToggleTransitionLabels').trigger('click');
+}
+
+Page.clickToggleGuardLabels = function() {
+  jQuery('#buttonToggleGuardLabels').trigger('click');
+}
 
 Page.isPhotoReady = function()
 {

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -386,13 +386,13 @@ $output = readTemporaryFile("ump/" . $filename);
               <input id="buttonToggleTraits" class="checkbox" type="checkbox"/> 
               <a id="labelToggleTraits" class="buttonExtend">Traits</a> 
             </li>
-            <li id="ttToggleTransitionLabel" class="layoutListItem"> 
-              <input id="buttonToggleTransitionLabel" class="checkbox" type="checkbox"/> 
-              <a id="labelToggleTransitionLabel" class="buttonExtend">Transition Label</a> 
+            <li id="ttToggleTransitionLabels" class="layoutListItem"> 
+              <input id="buttonToggleTransitionLabels" class="checkbox" type="checkbox"/> 
+              <a id="labelToggleTransitionLabels" class="buttonExtend">Transition Labels</a> 
             </li>
-            <li id="ttToggleGuardLabel" class="layoutListItem"> 
-              <input id="buttonToggleGuardLabel" class="checkbox" type="checkbox"/> 
-              <a id="labelToggleGuardLabel" class="buttonExtend">Guard Label</a> 
+            <li id="ttToggleGuardLabels" class="layoutListItem"> 
+              <input id="buttonToggleGuardLabels" class="checkbox" type="checkbox"/> 
+              <a id="labelToggleGuardLabels" class="buttonExtend">Guard Labels</a> 
             </li>
           </ul>
           <ul class="second">


### PR DESCRIPTION
In this PR, we finalized the generation of transition and guard labels. The labels by default are not shown on the state diagrams. The user checks boxes "Transition Labels" and "Guard Labels" to activate these modes. Commands "CTRL+I" and "CTRL+K" enables/disables these modes for transition and guard labels respectively.
