### PR TITLE
'minierrorinfo'

### DIFF
--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -1588,19 +1588,6 @@ class JavaGenerator
     }
   }
   
-  private void addJavaLttngImport(){
-    for(UmpleClass umpleClass : getModel().getUmpleClasses())
-    {
-    	CodeBlock cb = new CodeBlock("LTTngAgent lttngAgent = LTTngAgent.getLTTngAgent();");
-      CodeInjection init = new CodeInjection("after","constructor", cb, umpleClass);
-      init.setIsInternal(true);
-      umpleClass.addCodeInjection(init);
-      Attribute loggerAttr = new Attribute("logger", "Logger", "const", "Logger.getLogger("+umpleClass.getName()+".class.getName())", false, umpleClass);
-      umpleClass.addAttribute(loggerAttr);
-      umpleClass.addDepend(new Depend("java.util.logging.*"));
-      umpleClass.addDepend(new Depend("org.lttng.ust.agent.LTTngAgent"));
-    }
-  }
 
   public static String typeOf(String aType)
   {

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -446,7 +446,7 @@ class CodeInjection
 
   type;
   operation;
-  lazy operationSource = "generated";
+  operationSource = "generated";
   lazy String[] parameters;
   CodeBlock snippet;
   lazy constraintParameterName;
@@ -581,7 +581,7 @@ class UmpleClass
 
   before addDepend { if (depends.contains(aDepend)) { return false; } }
 
-  before setImmutable { if (!canBeImmutable()) { return false; } }
+  //---before setImmutable { if (!canBeImmutable()) { return false; } }
 
   before addAssociationVariable { if (!immutabilityAssociationRulesSatisfied(aAssociationVariable, this.isImmutable())) { return false; } }
 
@@ -657,11 +657,11 @@ class UmpleTrait {
 
   //--- before addDepend { if (depends.contains(aDepend)) { return false; } }
 
-  before setImmutable { if (!canBeImmutable()) { return false; } }
+  //--- before setImmutable { if (!canBeImmutable()) { return false; } }
 
   //--- before addAssociationVariable { if (!immutabilityAssociationRulesSatisfied(aAssociationVariable, this.isImmutable())) { return false; } }
 
-  before setExtendsTrait { if (!enforceImmutabilityInheritanceRules(aExtendsClass)) { return false; } }
+  //--- before setExtendsTrait { if (!enforceImmutabilityInheritanceRules(aExtendsClass)) { return false; } }
 
   before addStateMachine { if (isImmutable()) { return false; } }
 


### PR DESCRIPTION
Update the build so that redundant warnings are not issued 

in one place the build said that 'lazy' was not necessary and there was a warning; the lazy keyword is removed

in another place there was a duplicate method being ignored -- this removes the method
