### PR TITLE
Dev tools scripts now show correct build status if there are test pro…

### DIFF
--- a/dev-tools/bumple
+++ b/dev-tools/bumple
@@ -7,4 +7,16 @@ echo Doing FULL build of Umple at $UMPLEROOT using ant -Dmyenv=local
 echo If you are running on Windows you would need to use wlocal
 echo This should take 2-5 minutes. Do not interrupt.
 echo You should always have done 'git pull' before running this and resolved conflicts
-ant -Dmyenv=local
+set logfile="/tmp/umplebuildlog$$.txt"
+ant -Dmyenv=local | tee $logfile
+grep -qi failed $logfile
+if ($status == 0) then
+  echo "************************"
+  echo The word FAILED was found in the above. Build was NOT SUCCESSFUL.
+  echo Build log is at $logfile
+  echo Test log can be opened in a web browser at $UMPLEROOT/dist/qa/index.php
+else
+  rm $logfile
+endif
+
+

--- a/dev-tools/qbumple
+++ b/dev-tools/qbumple
@@ -3,8 +3,19 @@ if ! $?UMPLEROOT then
   setenv UMPLEROOT ~/umple
 endif
 cd $UMPLEROOT/build
-echo Doing quick build of Umple at $UMPLEROOT ( umpleSelf compile packageMainJar )
+echo "Doing quick build of Umple at $UMPLEROOT ( codegen umpleParser rtcpp umpleSelf compile packageMainJar )"
 echo This should take 10-20 seconds. Do not interrupt
 echo This only builds the main command line jar, not umplesync.jar, for that use qfbumple
 echo You should always have done 'git pull' before running this and have resolved conflicts
-ant -Dmyenv=local -f build.umple.xml codegen umpleParser rtcpp umpleSelf compile packageMainJar
+set logfile="/tmp/umplebuildlog$$.txt"
+ant -Dmyenv=local -f build.umple.xml ç | tee $logfile
+grep -qi failed $logfile
+set failedstatus=$status
+grep -qi error $logfile
+if ($status == 0 || $failedstatus == 0) then
+  echo "************************"
+  echo The word FAILED or ERROR was found in the above. Build was NOT SUCCESSFUL.
+  echo Build log is at $logfile
+else
+  rm $logfile
+endif

--- a/dev-tools/qfbumple
+++ b/dev-tools/qfbumple
@@ -3,7 +3,18 @@ if ! $?UMPLEROOT then
   setenv UMPLEROOT ~/umple
 endif
 cd $UMPLEROOT/build
-echo Doing quick build of Umple and its jars at $UMPLEROOT ( umpleSelf compile packageJars )
+echo "Doing quick build of Umple and its jars at $UMPLEROOT ( codegen umpleParser rtcpp umpleSelf compile packageJars )"
 echo This should take 12-25 seconds. Do not interrupt
 echo You should always have done 'git pull' before running this and have resolved conflicts
-ant -Dmyenv=local -f build.umple.xml codegen umpleParser rtcpp umpleSelf compile packageJars
+set logfile="/tmp/umplebuildlog$$.txt"
+ant -Dmyenv=local -f build.umple.xml codegen umpleParser rtcpp umpleSelf compile packageJars | tee $logfile
+grep -qi failed $logfile
+set failedstatus=$status
+grep -qi error $logfile
+if ($status == 0 || $failedstatus == 0) then
+  echo "************************"
+  echo The word FAILED or ERROR was found in the above. Build was NOT SUCCESSFUL.
+  echo Build log is at $logfile
+else
+  rm $logfile
+endif

--- a/dev-tools/tumple
+++ b/dev-tools/tumple
@@ -3,5 +3,19 @@ if ! $?UMPLEROOT then
   setenv UMPLEROOT ~/umple
 endif
 echo Running basic tests in $UMPLEROOT using template.test
+echo This does not run the testbed tests. Do a full build for those.
 cd $UMPLEROOT/build
-ant -Dmyenv=local -f build.umple.xml template.test
+set logfile="/tmp/umplebuildlog$$.txt"
+ant -Dmyenv=local -f build.umple.xml template.test | tee $logfile
+grep -qi failed $logfile
+set failedstatus=$status
+grep -qi error $logfile
+if ($status == 0 || $failedstatus == 0) then
+  echo "************************"
+  echo The word FAILED or ERROR was found in the above. Build was NOT SUCCESSFUL.
+  echo Build log is at $logfile
+  echo Test log can be opened in a web browser at $UMPLEROOT/dist/qa/index.php
+else
+  rm $logfile
+endif
+


### PR DESCRIPTION
This fixes the dev tools bumple, qbumple, qfbumple and tumple so that if compilation or tests fail, a message appears at the end saying that building was not successful. Previously the SUCCESSFUL message was misleading for beginners. These scripts work on Linux and Mac, as before.
