### PR TITLE
[ci skip] correcting text in download page

### DIFF
--- a/umpleonline/download_eclipse_umple_plugin.html
+++ b/umpleonline/download_eclipse_umple_plugin.html
@@ -59,15 +59,17 @@
 
   <p>Umple can be used on Mac-OS, Windows or Linux.</p>
 
-  <h3>For Eclipse</h3>
-  <ul>
-    <li>Eclipse with Modelling tools. It is known to work under Indigo, Juno or Kepler.</li>
-  </ul>
 
     <h3>For command-line use</h3>
    <ul>
-     <li>An up-to-date JVM. Java 7 recommended.
+     <li>An up-to-date Java 8 JVM (see instructions at the end of this page)
    </ul>
+
+  <h3>For Eclipse</h3>
+  <ul>
+    <li>Eclipse with Modelling tools.</li>
+  </ul>
+
   &nbsp; <br/>
 
 
@@ -88,20 +90,7 @@
     features so should not be used in critical applications.<br />&nbsp;<br />
 
     <li>To obtain the full tree with source code (including the Umple compiler as a jar, which is necessary to
-    compile Umple itself, select one of the following: <br />&nbsp;<br />
-
-    <ul>
-    <li><b>Definitive Subversion Master With Lastest Software</b>: svn checkout http://umple.googlecode.com/svn/trunk/ umple-read-only
-
-    <li><b>UOttawa git mirror (updated automatically after every commit once the continuous integration server has verified that all tests pass)</b>: git clone http://cruise.site.uottawa.ca/git/umple-svn-git-mirror/.git
-
-    <li><b><a href="https://github.com/umple/Umple">Github mirror main page</a></b>: git clone https://github.com/umple/Umple.git
-
-    <li><b><a href="https://sourceforge.net/projects/umple/">SourceForge mirror main page</a></b>
-
-    <li>Release tarballs or zip files, available at Github as described above.
-
-    </ul><br />&nbsp;<br />
+    compile Umple itself, select <a href="https://github.com/umple/Umple">go to the Github  main page</a><br />
 
 
    <li><b>Recent changes:</b> <a href="https://github.com/umple/Umple/issues?utf8=&#10003;&q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+">The list of completed changes applied in the last six months can be found by clicking here</a>
@@ -115,7 +104,7 @@
 
    <h3>B.2 Installing and running the Umple compiler in Eclipse</h3>
 
-   <p>Full directions for <a href="https://code.google.com/p/umple/wiki/Install_Eclipse_Plugin">installing the Eclipse plugin can be found on this Umple Wiki Page.</a></p>
+   <p>Full directions for <a href="https://github.com/umple/umple/wiki/InstallEclipsePlugin">installing the Eclipse plugin can be found on this Umple Wiki Page.</a></p>
 
 
 


### PR DESCRIPTION
The download page http://dl.umple.org had some obsolete references
