### PR TITLE
Warnings

### DIFF
--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -203,6 +203,9 @@
       <classpath refid="validator.project.classpath"/>
       <classpath refid="core.ivy.classpath" />
       <classpath refid="test.ivy.classpath" />
+	    <!-- Add compiler arguments here, see https://ant.apache.org/manual/using.html#arg for details, example below
+			  <compilerarg value="-Xlint:deprecation" />
+		-->
     </javac>
     
     <copy todir="${bin.path}" overwrite="true">

--- a/cruise.umple.validator/src/Validator_CodeGenJava.ump
+++ b/cruise.umple.validator/src/Validator_CodeGenJava.ump
@@ -63,7 +63,7 @@ class JavaCodeGenValidator {
   }
 
 	 protected static  CompilationUnit parse(String source){
-    ASTParser parser = ASTParser.newParser(AST.JLS4); 
+    ASTParser parser = ASTParser.newParser(AST.JLS8); 
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(source.toCharArray()); // set source
 	    // In order to parse 1.7 code, some compiler options need to be set to 1.7

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTracerTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTracerTest.java
@@ -9,8 +9,6 @@
 
 package cruise.umple.compiler;
 
-import junit.framework.Assert;
-
 import java.io.File;
 
 import org.junit.*;

--- a/cruise.umple/test/cruise/umple/implementation/OneToManyUnidirectionalTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/OneToManyUnidirectionalTest.java
@@ -13,8 +13,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import junit.framework.Assert;
-
 import org.junit.*;
 
 public class OneToManyUnidirectionalTest extends TemplateTest

--- a/cruise.umple/test/cruise/umple/implementation/alloy/AlloyTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/alloy/AlloyTemplateTest.java
@@ -2,8 +2,7 @@ package cruise.umple.implementation.alloy;
 
 import java.io.File;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/cruise.umple/test/cruise/umple/implementation/ecore/EcoreGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/ecore/EcoreGeneratorTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.ecore;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/NuSMVTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/NuSMVTemplateTest.java
@@ -2,8 +2,7 @@ package cruise.umple.implementation.nusmv;
 
 import java.io.File;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/cruise.umple/test/cruise/umple/implementation/papyrus/PapyrusGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/papyrus/PapyrusGeneratorTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.papyrus;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/implementation/simulate/SimulateGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/simulate/SimulateGeneratorTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.simulate;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/implementation/sql/SqlAttributeTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/sql/SqlAttributeTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.sql;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/implementation/test/TestTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/test/TestTemplateTest.java
@@ -2,8 +2,7 @@ package cruise.umple.implementation.test;
 
 import java.io.File;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/cruise.umple/test/cruise/umple/implementation/textuml/TextUmlGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/textuml/TextUmlGeneratorTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.textuml;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/implementation/umple/UmpleGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/umple/UmpleGeneratorTest.java
@@ -2,8 +2,7 @@ package cruise.umple.implementation.umple;
 
 import java.io.File;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/cruise.umple/test/cruise/umple/implementation/umpleself/UmpleSelfGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/umpleself/UmpleSelfGeneratorTest.java
@@ -2,8 +2,7 @@ package cruise.umple.implementation.umpleself;
 
 import java.io.File;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/cruise.umple/test/cruise/umple/implementation/use/UseGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/use/UseGeneratorTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.use;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/implementation/xmi/XmiGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/xmi/XmiGeneratorTest.java
@@ -1,10 +1,10 @@
 package cruise.umple.implementation.xmi;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/IX.php
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/IX.php
@@ -1,0 +1,9 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-dab6b48 modeling language!*/
+
+interface IX
+{
+  
+}
+?>

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/IX.php
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/IX.php
@@ -1,9 +1,0 @@
-<?php
-/*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE 1.24.0-dab6b48 modeling language!*/
-
-interface IX
-{
-  
-}
-?>

--- a/cruise.umple/test/cruise/umple/test/harness/compiler/JavaInternalCompiler.java
+++ b/cruise.umple/test/cruise/umple/test/harness/compiler/JavaInternalCompiler.java
@@ -52,7 +52,8 @@ import cruise.umple.test.harness.compiler.JavaMemoryObjectBuilder.InternalJavaCl
 import cruise.umple.test.harness.compiler.JavaMemoryObjectBuilder.JavaMemoryObjectLoader;
 import cruise.umple.test.harness.compiler.interfaces.ICompiler;
 import cruise.umple.test.harness.compiler.interfaces.IMemoryLanguageObjectBuilder;
-import junit.framework.Assert;
+
+import org.junit.Assert;
 
 public class JavaInternalCompiler implements ICompiler {
 	private String tempClassFiles;

--- a/cruise.umple/test/cruise/umple/test/harness/compiler/JavaMemoryObjectBuilder.java
+++ b/cruise.umple/test/cruise/umple/test/harness/compiler/JavaMemoryObjectBuilder.java
@@ -36,7 +36,8 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 
 import cruise.umple.test.harness.compiler.interfaces.IMemoryLanguageObjectBuilder;
-import junit.framework.Assert;
+
+import org.junit.Assert;
 
 public class JavaMemoryObjectBuilder implements IMemoryLanguageObjectBuilder<SimpleJavaFileObject> {
 	List<SimpleJavaFileObject> objects;

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestParseValidation.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestParseValidation.java
@@ -29,7 +29,8 @@ import cruise.umple.compiler.UmpleModel;
 import cruise.umple.compiler.UmpleParser;
 import cruise.umple.compiler.java.JavaClassGenerator;
 import cruise.umple.parser.analysis.RuleBasedParser;
-import junit.framework.Assert;
+
+import org.junit.Assert;
 
 public class TestParseValidation {
 

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
@@ -40,7 +40,8 @@ import cruise.umple.parser.analysis.RuleBasedParser;
 import cruise.umple.test.harness.compiler.JavaInternalCompiler;
 import cruise.umple.test.harness.compiler.interfaces.ICompiler;
 import cruise.umple.util.SampleFileWriter;
-import junit.framework.Assert;
+
+import org.junit.Assert;
 
 public class TestResource {
 	public static final int timeout = 10000; 

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/log4j/JavaLog4jConfigurationTest.java
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/log4j/JavaLog4jConfigurationTest.java
@@ -11,8 +11,6 @@ package cruise.umple.tracer.implementation.java.log4j;
 
 import java.io.File;
 
-import junit.framework.Assert;
-
 import org.junit.*;
 
 import cruise.umple.implementation.TemplateTest;

--- a/cruise.umple/test/cruise/umple/util/AssertHelper.java
+++ b/cruise.umple/test/cruise/umple/util/AssertHelper.java
@@ -8,12 +8,13 @@
  */
 
 package cruise.umple.util;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.StringReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 public class AssertHelper 
 {

--- a/cruise.umple/test/cruise/umple/util/LanguageTest.java
+++ b/cruise.umple/test/cruise/umple/util/LanguageTest.java
@@ -9,8 +9,6 @@
 
 package cruise.umple.util;
 
-import junit.framework.Assert;
-
 import org.junit.*;
 
 import cruise.umple.util.Language;

--- a/cruise.umplificator/src/Parser_Java.ump
+++ b/cruise.umplificator/src/Parser_Java.ump
@@ -15,7 +15,7 @@ class JavaParser {
 	 // Parses a complete Java Class
 	 public CompilationUnit parseUnit(String source){
 	 		//logger.debug("Parsing Compilation Unit");
-	   		ASTParser parser = ASTParser.newParser(AST.JLS4); 
+	   		ASTParser parser = ASTParser.newParser(AST.JLS8); 
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
 			parser.setSource(source.toCharArray()); // set source
 		    // In order to parse 1.7 code, some compiler options need to be set to 1.7
@@ -36,7 +36,7 @@ class JavaParser {
 	 // Parses independent Java body declarations
 	public ASTNode parseBodyDeclarations(String source){
 			//logger.debug("Parsing Body Declarations from source");
-    	    ASTParser parser = ASTParser.newParser(AST.JLS4); 
+    	    ASTParser parser = ASTParser.newParser(AST.JLS8); 
 			parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 			parser.setSource(source.toCharArray()); // set source
 		    // In order to parse 1.7 code, some compiler options need to be set to 1.7

--- a/testbed/test/cruise/attributes/test/ManyAttributeTest.java
+++ b/testbed/test/cruise/attributes/test/ManyAttributeTest.java
@@ -34,7 +34,7 @@ public class ManyAttributeTest
     m1.addWork(3);
     Assert.assertEquals(1, m1.getWork(0).intValue());
     Integer[] works = {1,2,3};
-    Assert.assertEquals(works, m1.getWorks());
+    Assert.assertArrayEquals(works, m1.getWorks());
   }
 //test hasAttribute and getAttributeNumber
   @Test

--- a/testbed_ruby/src/LocalHarness.ump
+++ b/testbed_ruby/src/LocalHarness.ump
@@ -34,5 +34,5 @@ class DoorG
 
 class ExtraCodeTest
 {
-  extracode
+  // extracode
 }


### PR DESCRIPTION
Code changes for https://github.com/umple/umple/issues/862 to remove unneeded warnings in the build. Mostly replacing deprecated functions with their up-to-date equivalents.
