### PR TITLE
Committing fixes for #853

### DIFF
--- a/cruise.umple/src/StateMachine.ump
+++ b/cruise.umple/src/StateMachine.ump
@@ -181,7 +181,7 @@ class Action
   	codeblock.setCode(lang,code);
   }
   
-  key { actionType, actionCode } 
+  key { actionType, actionCode, position } 
 }
 
 class Event

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
@@ -240,6 +240,12 @@ public class StateMachineTest extends StateMachineTemplateTest
   }
 
   @Test
+  public void entryExitActionDuplicates()
+  {
+  assertUmpleTemplateFor("entryExitActionDuplicates.ump",languagePath + "/entryExitActionDuplicates." + languagePath + ".txt", "Duplicate");    
+  }
+  
+  @Test
   public void externalStateMachine()
   {
     assertUmpleTemplateFor("externalStateMachine.ump",languagePath + "/externalStateMachine."+ languagePath +".txt","Course");

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/entryExitActionDuplicates.ump
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/entryExitActionDuplicates.ump
@@ -1,0 +1,20 @@
+namespace example;
+
+class Duplicate{
+    sm{
+      s0{
+        entry / {s0_entr1();}
+        entry / {s0_entry2();}
+        e0 -> s1;
+        exit /{s0_exit1();}
+        exit /{s0_exit2();}
+      }
+      s1{
+        entry / {s1_entry1();}
+        entry / {s1_entry1();}
+        e0 -> s1;
+        exit /{s1_exit1();}
+        exit /{s1_exit1();}
+      }
+  }
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/entryExitActionDuplicates.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/entryExitActionDuplicates.java.txt
@@ -1,0 +1,100 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-7aed471 modeling language!*/
+
+package example;
+
+public class Duplicate
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Duplicate State Machines
+  public enum Sm { s0, s1 }
+  private Sm sm;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Duplicate()
+  {
+    setSm(Sm.s0);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public String getSmFullName()
+  {
+    String answer = sm.toString();
+    return answer;
+  }
+
+  public Sm getSm()
+  {
+    return sm;
+  }
+
+  public boolean e0()
+  {
+    boolean wasEventProcessed = false;
+    
+    Sm aSm = sm;
+    switch (aSm)
+    {
+      case s0:
+        exitSm();
+        setSm(Sm.s1);
+        wasEventProcessed = true;
+        break;
+      case s1:
+        setSm(Sm.s1);
+        wasEventProcessed = true;
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  private void exitSm()
+  {
+    switch(sm)
+    {
+      case s0:
+        s0_exit1();
+        s0_exit2();
+        break;
+      case s1:
+        s1_exit1();
+        s1_exit1();
+        break;
+    }
+  }
+
+  private void setSm(Sm aSm)
+  {
+    sm = aSm;
+
+    // entry actions and do activities
+    switch(sm)
+    {
+      case s0:
+        s0_entr1();
+        s0_entry2();
+        break;
+      case s1:
+        s1_entry1();
+        s1_entry1();
+        break;
+    }
+  }
+
+  public void delete()
+  {}
+
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/PhpStateMachineTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/PhpStateMachineTemplateTest.java
@@ -35,6 +35,7 @@ public class PhpStateMachineTemplateTest extends StateMachineTest
     SampleFileWriter.destroy(pathToInput + "statemachine/php/Mentor.php");
     SampleFileWriter.destroy(pathToInput + "statemachine/php/Course.php");
     SampleFileWriter.destroy(pathToInput + "statemachine/php/Light.php");
+    SampleFileWriter.destroy(pathToInput + "/Duplicate.php");
     SampleFileWriter.destroy(pathToInput + "/LightFixture.php");
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/entryExitActionDuplicates.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/entryExitActionDuplicates.php.txt
@@ -1,0 +1,102 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.24.0-7aed471 modeling language!*/
+
+class Duplicate
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Duplicate State Machines
+  private static $SmS0 = 1;
+  private static $SmS1 = 2;
+  private $sm;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct()
+  {
+    $this->setSm(self::$SmS0);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getSmFullName()
+  {
+    $answer = $this->getSm();
+    return $answer;
+  }
+
+  public function getSm()
+  {
+    if ($this->sm == self::$SmS0) { return "SmS0"; }
+    elseif ($this->sm == self::$SmS1) { return "SmS1"; }
+    return null;
+  }
+
+  public function e0()
+  {
+    $wasEventProcessed = false;
+    
+    $aSm = $this->sm;
+    if ($aSm == self::$SmS0)
+    {
+      $this->exitSm();
+      $this->setSm(self::$SmS1);
+      $wasEventProcessed = true;
+    }
+    elseif ($aSm == self::$SmS1)
+    {
+      $this->setSm(self::$SmS1);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  private function exitSm()
+  {
+    if ($this->sm == self::$SmS0)
+    {
+      s0_exit1();
+      s0_exit2();
+    }
+    elseif ($this->sm == self::$SmS1)
+    {
+      s1_exit1();
+      s1_exit1();
+    }
+  }
+
+  private function setSm($aSm)
+  {
+    $this->sm = $aSm;
+
+    // entry actions and do activities
+    if ($this->sm == self::$SmS0)
+    {
+      s0_entr1();
+      s0_entry2();
+    }
+    elseif ($this->sm == self::$SmS1)
+    {
+      s1_entry1();
+      s1_entry1();
+    }
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+}
+?>


### PR DESCRIPTION
## Description

Please see my comments in #853 for an explanation of rationale and changes.
Briefly, a one line change to StateMachine.ump allows duplicate entry and exit actions in a single state. 
## Tests

A new test was created, based on the example in the raised issue. Code generated for PHP and Java reflects the fixed issue.

Closes #853.
