### PR TITLE
Minor change to debug string to ensure debugger does not crash

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -944,7 +944,7 @@ class Multiplicity
   lazy minimum;
   lazy maximum;
 
-  parserable = { getBound() != null ? getBound() : getMinimum().equals("0") && getMaximum().equals("*") ? "*" : getMinimum() + ".." + getMaximum() }
+  parserable = { getBound() != null ? getBound() : ( (getMinimum() == null ||  getMinimum().equals("0")) && (getMaximum() == null || getMaximum().equals("*")) ? "*" : ""+ getMinimum() + ".." + getMaximum()) }
 
   key { bound, minimum, maximum }
 


### PR DESCRIPTION
When running a debugger, instances of Multiplicity were being displayed, but this calls the printString method which was sometimes in turn calling equals() on a null. This simply avoids doing that so null pointer exceptions are not raised in the debugger.