### PR TITLE
Fixes issue 766

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
@@ -74,6 +74,7 @@ class UmpleToJava {
         State nextState = t.getNextState();
         String tabSpace = t.getGuard() == null ? "        " : "          ";
         StateMachine exitSm = state.exitableStateMachine(nextState);
+        StateMachine exitSmSelfTransition = state.exitableSelfTransition(nextState);
         
         String condition = t.getGuard()!=null?gen.translate("Open",t.getGuard()):"if ()\n{";
         if (!"if ()\n{".equals(condition))
@@ -90,7 +91,12 @@ class UmpleToJava {
           javaLine+=1+condition.split("\\n").length;
           
         }
-        if (exitSm != null && !e.getIsInternal() && !state.isSameState(nextState,exitSm)) 
+        if (exitSmSelfTransition != null)
+        {
+          allCases.append(StringFormatter.format("{0}{1}();\n",tabSpace,gen.translate("exitMethod",exitSmSelfTransition)));
+          javaLine++;
+        }
+        else if (exitSm != null && !e.getIsInternal() && !state.isSameState(nextState,exitSm)) 
         {
           allCases.append(StringFormatter.format("{0}{1}();\n",tabSpace,gen.translate("exitMethod",exitSm)));
           javaLine++;

--- a/cruise.umple/src/StateMachine_Code.ump
+++ b/cruise.umple/src/StateMachine_Code.ump
@@ -622,6 +622,15 @@ class State
     }
     return null;
   }
+  
+  public StateMachine exitableSelfTransition(State nextState)
+  {
+    if (getHasExitAction() && equals(nextState))
+    {
+      return getStateMachine();
+    }
+    return null;
+  }
 
   public void visit()
   {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
@@ -238,6 +238,12 @@ public class StateMachineTest extends StateMachineTemplateTest
   {
     assertUmpleTemplateFor("exitAction.ump",languagePath + "/exitAction."+ languagePath +".txt","LightFixture");
   }
+  
+  @Test 
+  public void exitActionSelfTransition()
+  {
+    assertUmpleTemplateFor("exitActionSelfTransition.ump",languagePath + "/exitActionSelfTransition."+ languagePath +".txt","A");
+  }
 
   @Test 
   public void entryExitTransitionAction()

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/exitActionSelfTransition.ump
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/exitActionSelfTransition.ump
@@ -1,0 +1,14 @@
+class A{
+  boolean result = false;
+  sm{
+    created{
+      exit /{execute_exit_code();}
+      entry /{execute_entry_code();}
+      init [b==false] -> created;
+      init [b==true] -> initialized;
+    }
+    initialized{
+      getback ->created;
+    }
+  } 
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/entryExitActionDuplicates.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/entryExitActionDuplicates.java.txt
@@ -51,6 +51,7 @@ public class Duplicate
         wasEventProcessed = true;
         break;
       case s1:
+        exitSm();
         setSm(Sm.s1);
         wasEventProcessed = true;
         break;

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/exitActionSelfTransition.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/exitActionSelfTransition.java.txt
@@ -1,0 +1,140 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE ${last.version} modeling language!*/
+
+
+
+public class A
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //A Attributes
+  private boolean result;
+
+  //A State Machines
+  public enum Sm { created, initialized }
+  private Sm sm;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public A()
+  {
+    result = false;
+    setSm(Sm.created);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public boolean setResult(boolean aResult)
+  {
+    boolean wasSet = false;
+    result = aResult;
+    wasSet = true;
+    return wasSet;
+  }
+
+  public boolean getResult()
+  {
+    return result;
+  }
+
+  public String getSmFullName()
+  {
+    String answer = sm.toString();
+    return answer;
+  }
+
+  public Sm getSm()
+  {
+    return sm;
+  }
+
+  public boolean init()
+  {
+    boolean wasEventProcessed = false;
+    
+    Sm aSm = sm;
+    switch (aSm)
+    {
+      case created:
+        if (b.equals(false))
+        {
+          exitSm();
+          setSm(Sm.created);
+          wasEventProcessed = true;
+          break;
+        }
+        if (b.equals(true))
+        {
+          exitSm();
+          setSm(Sm.initialized);
+          wasEventProcessed = true;
+          break;
+        }
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  public boolean getback()
+  {
+    boolean wasEventProcessed = false;
+    
+    Sm aSm = sm;
+    switch (aSm)
+    {
+      case initialized:
+        setSm(Sm.created);
+        wasEventProcessed = true;
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  private void exitSm()
+  {
+    switch(sm)
+    {
+      case created:
+        execute_exit_code();
+        break;
+    }
+  }
+
+  private void setSm(Sm aSm)
+  {
+    sm = aSm;
+
+    // entry actions and do activities
+    switch(sm)
+    {
+      case created:
+        execute_entry_code();
+        break;
+    }
+  }
+
+  public void delete()
+  {}
+
+
+  public String toString()
+  {
+    String outputString = "";
+    return super.toString() + "["+
+            "result" + ":" + getResult()+ "]"
+     + outputString;
+  }
+}

--- a/testbed/src/TestHarnessStateMachineJava.ump
+++ b/testbed/src/TestHarnessStateMachineJava.ump
@@ -406,3 +406,24 @@ class StateMachineWithNegativeNumberGaurd{
     }
   }
 }
+
+class ExitActionSelfTransition{
+  boolean b = false;
+  boolean exitCodeCalled = false;
+  
+  void execute_exit_code()
+  {
+    setExitCodeCalled(true);
+  }
+  
+  sm{
+    created{
+      exit /{execute_exit_code();}
+      init [b==false] -> created;
+      init [b==true] -> initialized;
+    }
+    initialized{
+      getback ->created;
+    }
+  } 
+}

--- a/testbed/test/cruise/statemachine/test/EntryAndExitActionTest.java
+++ b/testbed/test/cruise/statemachine/test/EntryAndExitActionTest.java
@@ -48,4 +48,13 @@ public class EntryAndExitActionTest
     Assert.assertEquals("Exit Off 2", course.getLog(3));
   }
 
+  @Test
+  public void ExitActionSelfTransition()
+  {
+    ExitActionSelfTransition sm = new ExitActionSelfTransition();
+	Assert.assertEquals(ExitActionSelfTransition.Sm.created, sm.getSm());
+	sm.init();
+	Assert.assertEquals(ExitActionSelfTransition.Sm.created, sm.getSm());
+	Assert.assertTrue(sm.getExitCodeCalled());
+  }
 }


### PR DESCRIPTION
**IMPORTANT**: By submitting a patch, you agree that your work will be licensed under the [license](https://github.com/umple/umple/blob/master/LICENSE.md) used by the project.

If your pull request does not pass CI, it will **not** be merged (unless *heavily* justified). 

## Description

Issue 766 - added logic to make exit actions be called even on self transitions

## Tests

Testbed - added the test ExitActionSelfTransition. It executes the state machine state self transition and verifies that the exit action was executed.

StateMachineTest 
- updated the entryExitActionDuplicates test to have the exit action for the state machine's self transition
- created the test exitActioNSelfTransition - verifies that an umple class that has an exit action and state self transition creates the correct code


