### PR TITLE
refining disabling transitions for sub-state machines and handling of…

### DIFF
--- a/cruise.umple/src/NuSMVCoordinationUnit.ump
+++ b/cruise.umple/src/NuSMVCoordinationUnit.ump
@@ -59,7 +59,7 @@ class NuSMVCoordinator
   		body.addModuleElement( vdec );
 		
   		//Adding define declaration to module body
-  		body.addModuleElement( getDefineDeclaration( sm ) );
+  		body.addModuleElement( getDefineDeclaration( sm, uClass ) );
   		body.addModuleElement( getAssignConstraint( sm, sm) );
 			body.addModuleElement( getEventAssignConstraint( sm ) );
 		
@@ -230,6 +230,7 @@ class NuSMVCoordinator
 		
 		List<NuSMVModule> temp = new ArrayList<NuSMVModule>();
 		StringBuilder output = new StringBuilder();
+		double elapsedMemory = 0;
 		
 		for( UmpleClass uClass : uModel.getUmpleClasses() )	{
 			
@@ -247,11 +248,14 @@ class NuSMVCoordinator
 				temp.add( capsuleModule );
 				capsules.add( capsuleModule );
 
+				double startTime = (double) (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
 				//Generates invariance specifications for non-determinism
 				for( InvarConstraint spec : generateSpecForTransitionDeterminism( sMachine, capsuleModule ) ){
 					nonDeterminism.add( spec );
 					properties.add( spec );
 				}
+				double stopTime = (double) (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
+      	elapsedMemory = stopTime - startTime;
 			
 				//Generates reachability specifications for the nested state machines of hierarchical system under generation.
 				for( StateMachine machine : generateStateMachineList( sMachine ) ) {
@@ -272,6 +276,8 @@ class NuSMVCoordinator
 		for( NuSMVModule module : temp )
 			output.append( module.toString() +"\n" );
 	
+		//output.append( "--Elapsed Memory to discover non-determinism (ms): "+elapsedMemory);		
+				
 		return output;
 	}
 	
@@ -1030,32 +1036,34 @@ class NuSMVCoordinator
 		List<AssignConstraint> constraints = new ArrayList<AssignConstraint>();
 		
 		for( Attribute attribute : uClass.getAllAttributes() ) {
-			BasicExpression bexp = new BasicExpression("");
+			if( !attribute.isConstant() ) {
+				BasicExpression bexp = new BasicExpression("");
 			
-			if( attribute.getValue() != null ){
-				String value = attribute.getValue();
-				switch( value ){
-					case "true" : bexp = new BasicExpression("TRUE"); break;
-					case "false" : bexp = new BasicExpression("FALSE"); break;
-					default : bexp = new BasicExpression(value);
+				if( attribute.getValue() != null ){
+					String value = attribute.getValue();
+					switch( value ){
+						case "true" : bexp = new BasicExpression("TRUE"); break;
+						case "false" : bexp = new BasicExpression("FALSE"); break;
+						default : bexp = new BasicExpression(value);
+					}
 				}
-			}
-			else if( attribute.getValue() == null && (attribute.getType().equals("Boolean") || attribute.getType().equals("boolean")))
-				bexp = new BasicExpression("FALSE");
-			else if( attribute.getValue() == null && (attribute.getType().equals("Integer") || attribute.getType().equals("int")
-				|| attribute.getType().equals("long") || attribute.getType().equals("Long") 
-				|| attribute.getType().equals("short") || attribute.getType().equals("Short")))
-				bexp = new BasicExpression("0");
-			else if( attribute.getValue() == null && (attribute.getType().equals("Float") || attribute.getType().equals("float") 
-				|| attribute.getType().equals("double") || attribute.getType().equals("Double")))
-				bexp = new BasicExpression("0.0");
+				else if( attribute.getValue() == null && (attribute.getType().equals("Boolean") || attribute.getType().equals("boolean")))
+					bexp = new BasicExpression("FALSE");
+				else if( attribute.getValue() == null && (attribute.getType().equals("Integer") || attribute.getType().equals("int")
+					|| attribute.getType().equals("long") || attribute.getType().equals("Long") 
+					|| attribute.getType().equals("short") || attribute.getType().equals("Short")))
+					bexp = new BasicExpression("0");
+				else if( attribute.getValue() == null && (attribute.getType().equals("Float") || attribute.getType().equals("float") 
+					|| attribute.getType().equals("double") || attribute.getType().equals("Double")))
+					bexp = new BasicExpression("0.0");
 			
-			InitAssign initialVal = new InitAssign(attribute.getName(), bexp);
-			AssignConstraint assignConstraint = new AssignConstraint( initialVal );
-			constraints.add( assignConstraint );
+				InitAssign initialVal = new InitAssign(attribute.getName(), bexp);
+				AssignConstraint assignConstraint = new AssignConstraint( initialVal );
+				constraints.add( assignConstraint );
+			}
 		}
-  		return constraints;
-  	}
+  	return constraints;
+  }
 	
 	private CaseStatement initializeCompositeStartState( State state ) {
 		
@@ -1244,16 +1252,22 @@ class NuSMVCoordinator
 		return enclosedTransitions;
 	}
 
+  
+
 	//Computes the exit transitions for a concurrent region
-	private List<Transition> getExitTransitionsForConcurrentRegion( StateMachine region ){
+	private List<Transition> getExitTransitionsForConcurrentRegion( StateMachine region ) {
 		State parent = getParentState( region );
-		List<Transition> trans = getEnclosedTransitions( parent );		
+		List<Transition> temp = getExternalTransitions( parent );
+		
+
+		/*List<Transition> trans = getEnclosedTransitions( parent );		
 		List<Transition> temp = new ArrayList<Transition>();
 		
 		for( Transition tr : parent.getStateMachine().getAllTransitions() )
 			if( !has( trans, tr ) )
 				temp.add( tr ); //adds to temp every other transitions not enclosed by the parent state 
-	
+		*/
+
 		//adding and-cross transitions for a given region
 		List<State> embeddedStates = getEmbeddedStates( region );
 		for( Transition tr : getAndCross( getParentState( region ) ) )
@@ -1263,8 +1277,11 @@ class NuSMVCoordinator
 	}
 	
 	//Computes exit transitions for non-orthogonal composite state
-	private List<Transition> getExitTransitions(State st ) {
+	private List<Transition> getExitTransitions( State st ) {
 		List<Transition> transitions = new ArrayList<Transition>();
+		
+
+
 		for( Transition transition : st.getStateMachine().getAllTransitions() ){
 			if(st.hasNestedStateMachines() && !st.isIsConcurrent() )				
 				for( StateMachine sm : st.getNestedStateMachines() ){
@@ -1282,6 +1299,8 @@ class NuSMVCoordinator
 		}
 		return transitions;
 	}
+
+  
 	
 	private List<State> getEmbeddedStates(StateMachine sm ) {
 		List<State> embeddedStates = new ArrayList<State>();
@@ -1309,9 +1328,9 @@ class NuSMVCoordinator
 		int counter = 0;
 		BasicExpression rt = new BasicExpression("root");
 		List<Transition> trans;
-		if(!( getParentState( sm ).isIsConcurrent() )) {
+		if(!( getParentState( sm ).isIsConcurrent() ) ) {
 			if( sm.equals(root) ) return null;
-			trans = getExitTransitions( getParentState( sm ) );
+			trans = getExternalTransitions( getParentState( sm ) );
 		}
 		else
 			trans = getExitTransitionsForConcurrentRegion( sm );
@@ -1328,8 +1347,38 @@ class NuSMVCoordinator
   		}
   		return null;
 	}
+
+  private List<Transition> getExternalTransitions( State state ) {
+		
+		StateMachine sm = state.getStateMachine();
+		List<Transition> highLevelTransitions = new ArrayList<Transition>();
+
+		if( sm.getParentState() != null ) {
+		
+			State ancestor = sm.getParentState();
+			StateMachine smm = ancestor.getStateMachine();	
+			for( Transition transition : smm.getAllTransitions() )
+				if( transition.getFromState().equals( ancestor ) )
+					highLevelTransitions.add( transition );
+		}
+			
+		List<Transition> embeddedTransitions = new ArrayList<Transition>();
+		for( Transition transition : getAllEnablingTransitions( state ) )
+			if( transition.getNextState().equals( state ) )
+					continue;
+			else
+				embeddedTransitions.add( transition );
+		
+		List<Transition> enablingTransitions = sm.getAllTransitions();
+		enablingTransitions.addAll( highLevelTransitions );
+		enablingTransitions.removeAll( embeddedTransitions );
+
+		return enablingTransitions;		
+	}
+
+  
   	
-  	private CaseStatement getCaseStatement( StateMachine sm, State st, StateMachine parent ) {
+  private CaseStatement getCaseStatement( StateMachine sm, State st, StateMachine parent ) {
   		int counter = 0;
   		BasicExpression root = new BasicExpression("root");
   		for( Transition tr : getAllEnablingTransitions(st) ) {
@@ -1418,30 +1467,32 @@ class NuSMVCoordinator
 		List<VariableSpecifier> attributes = new ArrayList<VariableSpecifier>();
 		
 		for( Attribute attribute : uClass.getAllAttributes() ){
-			VariableSpecifier vs = new VariableSpecifier( attribute.getName() );
-			String type = attribute.getFullType();
-			//System.out.println( attribute.getValue() );
-			switch( type ){
-				case "Float" : vs.addTypeSpecifier("real"); attributes.add( vs ); break; 
-				case "Boolean" : vs.addTypeSpecifier("boolean"); attributes.add( vs ); break;
-				case "Integer" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
-				case "Long" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
-				case "long" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
-				case "Short" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
-				case "short" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
-				case "Double" : vs.addTypeSpecifier("real"); attributes.add( vs ); break;
-				case "double" : vs.addTypeSpecifier("real"); attributes.add( vs ); break;
-				case "float" : vs.addTypeSpecifier("real"); attributes.add( vs ); break; 
-				case "boolean" : vs.addTypeSpecifier("boolean"); attributes.add( vs ); break;
-				case "int" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
-				default : ;
-			}
+			if( !attribute.isConstant() ) { 
+				VariableSpecifier vs = new VariableSpecifier( attribute.getName() );
+				String type = attribute.getFullType();
+	
+				switch( type ) {
+					case "Float" : vs.addTypeSpecifier("real"); attributes.add( vs ); break; 
+					case "Boolean" : vs.addTypeSpecifier("boolean"); attributes.add( vs ); break;
+					case "Integer" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
+					case "Long" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
+					case "long" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
+					case "Short" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
+					case "short" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
+					case "Double" : vs.addTypeSpecifier("real"); attributes.add( vs ); break;
+					case "double" : vs.addTypeSpecifier("real"); attributes.add( vs ); break;
+					case "float" : vs.addTypeSpecifier("real"); attributes.add( vs ); break; 
+					case "boolean" : vs.addTypeSpecifier("boolean"); attributes.add( vs ); break;
+					case "int" : vs.addTypeSpecifier("integer"); attributes.add( vs ); break;
+					default : ;
+				}
+      }
 		}
 		return attributes;
 	}
   		
   	//Generates the define part for all the transitions of the system
-  	private DefineDeclaration getDefineDeclaration( StateMachine sm ) {
+  	private DefineDeclaration getDefineDeclaration( StateMachine sm, UmpleClass uClass ) {
   		BasicExpression temp = composeExpressionForStability( sm );
   		DefineBody stable = new DefineBody( sm.getFullName()+"_stable", temp );
   		DefineDeclaration ddec = new DefineDeclaration( stable );
@@ -1450,10 +1501,18 @@ class NuSMVCoordinator
   			DefineBody dBody = new DefineBody("t"+getObjectIdentity( sm, tr) , bexp);
   			ddec.addDefineBody(dBody);
   		}
-		for( Guard gr : sm.getAllGuards() ) {
+
+			for( Guard gr : sm.getAllGuards() ) {
   			DefineBody dBody = new DefineBody("g"+getObjectIdentity( sm, gr) , generateRHS( gr ));
   			ddec.addDefineBody(dBody);
   		}
+
+			for( Attribute attr : uClass.getAllAttributes() )
+				if( attr.isConstant() ) {
+					DefineBody dBody = new DefineBody( attr.getName() , new BasicExpression( attr.getValue() ) );
+  				ddec.addDefineBody(dBody);
+				}
+      
   		//ddec.removeDefineBody(dnull);
   		return ddec;
   	}

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlSystem.nusmv.txt
@@ -136,7 +136,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t1 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 : null;
+       _cruiseControlSystem.t1 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t2 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 : null;
        _cruiseControlSystem.t3 | _cruiseControlSystem.t13 : CruiseControlSystemControlCruiseControllerCruiseControllerActive_tempState;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_active & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerActive_tempState;
        TRUE : state;
@@ -153,7 +153,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t14 : null;
+       _cruiseControlSystem.t2 | _cruiseControlSystem.t14 | _cruiseControlSystem.t3 : null;
        _cruiseControlSystem.t13 : CruiseControlSystemControlCruiseControllerCruiseControllerActiveTempState_tempState_1;
        _cruiseControlSystemControlCruiseControllerCruiseControllerActive.state = CruiseControlSystemControlCruiseControllerCruiseControllerActive_tempState & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerActiveTempState_tempState_1;
        TRUE : state;
@@ -170,7 +170,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t1 | _cruiseControlSystem.t3 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 : null;
+       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t1 | _cruiseControlSystem.t3 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 : null;
        _cruiseControlSystem.t6 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 : CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState;
        _cruiseControlSystem.t8 | _cruiseControlSystem.t16 : CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState_1;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_cruising & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState;
@@ -188,7 +188,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t15 | _cruiseControlSystem.t17 : null;
+       _cruiseControlSystem.t17 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t15 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 : null;
        _cruiseControlSystem.t16 : CruiseControlSystemControlCruiseControllerCruiseControllerCruisingTempState_1_tempState_2;
        _cruiseControlSystemControlCruiseControllerCruiseControllerCruising.state = CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState_1 & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerCruisingTempState_1_tempState_2;
        TRUE : state;
@@ -205,7 +205,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t1 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t20 : null;
+       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t1 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t20 : null;
        _cruiseControlSystem.t10 : CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState;
        _cruiseControlSystem.t11 | _cruiseControlSystem.t19 : CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState_1;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_standby & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState;
@@ -223,7 +223,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t18 | _cruiseControlSystem.t20 : null;
+       _cruiseControlSystem.t20 | _cruiseControlSystem.t10 | _cruiseControlSystem.t18 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 : null;
        _cruiseControlSystem.t19 : CruiseControlSystemControlCruiseControllerCruiseControllerStandbyTempState_1_tempState_2;
        _cruiseControlSystemControlCruiseControllerCruiseControllerStandby.state = CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState_1 & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerStandbyTempState_1_tempState_2;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlWithTerminalState.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AdaptiveCruiseControlWithTerminalState.nusmv.txt
@@ -126,7 +126,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t21 : null;
+       _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t21 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 | _cruiseControlSystem.t1 : null;
        _cruiseControlSystem.t2 : CruiseControlSystemControlCruiseControllerCruiseControllerInactive_tempState;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_inactive & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerInactive_tempState;
        TRUE : state;
@@ -143,7 +143,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 | _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t21 : null;
+       _cruiseControlSystem.t3 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t21 | _cruiseControlSystem.t2 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 | _cruiseControlSystem.t1 : null;
        _cruiseControlSystem.t4 | _cruiseControlSystem.t14 : CruiseControlSystemControlCruiseControllerCruiseControllerActive_tempState;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_active & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerActive_tempState;
        TRUE : state;
@@ -160,7 +160,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t15 : null;
+       _cruiseControlSystem.t3 | _cruiseControlSystem.t15 | _cruiseControlSystem.t4 : null;
        _cruiseControlSystem.t14 : CruiseControlSystemControlCruiseControllerCruiseControllerActiveTempState_tempState_1;
        _cruiseControlSystemControlCruiseControllerCruiseControllerActive.state = CruiseControlSystemControlCruiseControllerCruiseControllerActive_tempState & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerActiveTempState_tempState_1;
        TRUE : state;
@@ -177,7 +177,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t9 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t19 | _cruiseControlSystem.t21 : null;
+       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t19 | _cruiseControlSystem.t21 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t11 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t18 | _cruiseControlSystem.t20 | _cruiseControlSystem.t1 : null;
        _cruiseControlSystem.t7 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 : CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState;
        _cruiseControlSystem.t9 | _cruiseControlSystem.t17 : CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState_1;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_cruising & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState;
@@ -195,7 +195,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t16 | _cruiseControlSystem.t18 : null;
+       _cruiseControlSystem.t18 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t16 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 : null;
        _cruiseControlSystem.t17 : CruiseControlSystemControlCruiseControllerCruiseControllerCruisingTempState_1_tempState_2;
        _cruiseControlSystemControlCruiseControllerCruiseControllerCruising.state = CruiseControlSystemControlCruiseControllerCruiseControllerCruising_tempState_1 & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerCruisingTempState_1_tempState_2;
        TRUE : state;
@@ -212,7 +212,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t12 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t21 : null;
+       _cruiseControlSystem.t2 | _cruiseControlSystem.t4 | _cruiseControlSystem.t6 | _cruiseControlSystem.t8 | _cruiseControlSystem.t10 | _cruiseControlSystem.t14 | _cruiseControlSystem.t16 | _cruiseControlSystem.t18 | _cruiseControlSystem.t21 | _cruiseControlSystem.t3 | _cruiseControlSystem.t5 | _cruiseControlSystem.t7 | _cruiseControlSystem.t9 | _cruiseControlSystem.t13 | _cruiseControlSystem.t15 | _cruiseControlSystem.t17 | _cruiseControlSystem.t19 | _cruiseControlSystem.t1 : null;
        _cruiseControlSystem.t11 : CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState;
        _cruiseControlSystem.t12 | _cruiseControlSystem.t20 : CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState_1;
        _cruiseControlSystemControlCruiseControllerCruiseController.state = CruiseControlSystemControlCruiseControllerCruiseController_standby & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState;
@@ -230,7 +230,7 @@ MODULE CruiseControlSystemCruiseControlSystemControlCruiseControllerCruiseContro
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _cruiseControlSystem.t19 | _cruiseControlSystem.t21 : null;
+       _cruiseControlSystem.t21 | _cruiseControlSystem.t11 | _cruiseControlSystem.t19 | _cruiseControlSystem.t10 | _cruiseControlSystem.t12 : null;
        _cruiseControlSystem.t20 : CruiseControlSystemControlCruiseControllerCruiseControllerStandbyTempState_1_tempState_2;
        _cruiseControlSystemControlCruiseControllerCruiseControllerStandby.state = CruiseControlSystemControlCruiseControllerCruiseControllerStandby_tempState_1 & state = null : CruiseControlSystemControlCruiseControllerCruiseControllerStandbyTempState_1_tempState_2;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossExample.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossExample.nusmv.txt
@@ -89,7 +89,7 @@ MODULE AStateState12State12State122 ( _state , _stateState12State12 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t8 | _state.t6 | _state.t9 : null;
+       _state.t6 | _state.t9 | _state.t8 | _state.t5 : null;
        _state.t4 | _state.t7 : StateState12State12State122_state1221;
        _stateState12State12.state = StateState12State12_state122 & state = null : StateState12State12State122_state1221;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedState.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedState.nusmv.txt
@@ -90,7 +90,7 @@ MODULE AStateState12State12State122 ( _state , _stateState12State12 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t7 | _state.t9 | _state.t6 | _state.t8 | _state.t10 : null;
+       _state.t8 | _state.t10 | _state.t6 | _state.t9 | _state.t5 : null;
        _state.t7 | _state.t4 : StateState12State12State122_state1221;
        _stateState12State12.state = StateState12State12_state122 & state = null : StateState12State12State122_state1221;
        TRUE : state;
@@ -107,7 +107,7 @@ MODULE AStateState12State12State122State1221 ( _state , _stateState12State12Stat
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t9 | _state.t10 : null;
+       _state.t10 | _state.t9 | _state.t8 : null;
        _state.t4 : StateState12State12State122State1221_state12211;
        _stateState12State12State122.state = StateState12State12State122_state1221 & state = null : StateState12State12State122State1221_state12211;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedStateCase2.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/AndCrossFromDeeplyNestedStateCase2.nusmv.txt
@@ -88,7 +88,7 @@ MODULE AStateState12State12State1221State1221 ( _state , _stateState12State12 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t8 | _state.t6 | _state.t9 : null;
+       _state.t6 | _state.t9 | _state.t8 | _state.t5 : null;
        _state.t4 | _state.t7 : StateState12State12State1221State1221_state12211;
        _stateState12State12.state = StateState12State12_state122 & state = null : StateState12State12State1221State1221_state12211;
        TRUE : state;
@@ -105,7 +105,7 @@ MODULE AStateState12State12State1222State1222 ( _state , _stateState12State12 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t8 | _state.t6 | _state.t9 : null;
+       _state.t6 | _state.t9 | _state.t8 | _state.t5 : null;
        _stateState12State12.state = StateState12State12_state122 & state = null : StateState12State12State1222State1222_state12221;
        TRUE : state;
      esac;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/BigStateMachineWithNakedTransition.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/BigStateMachineWithNakedTransition.nusmv.txt
@@ -77,7 +77,7 @@ MODULE BigStateMachineTestSmZxabZx ( _sm , _smZxab )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm.t6 | _sm.t8 | _sm.t5 | _sm.t7 | _sm.t10 : null;
+       _sm.t6 | _sm.t8 | _sm.t1 | _sm.t5 | _sm.t7 | _sm.t10 | _sm.t2 : null;
        _sm.t9 | _sm.t3 : SmZxabZx_X;
        _smZxab.state = SmZxab_Zx & state = null : SmZxabZx_Z;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ConstantTest.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ConstantTest.nusmv.txt
@@ -1,0 +1,60 @@
+-- This file is generated from ConstantTest.ump --
+
+-- PLEASE DO NOT EDIT THIS CODE --
+-- This code was generated using the UMPLE @UMPLE_VERSION@ modeling language! --
+
+
+-- This defines a NuSMV module for CruiseControlSystemSm --
+MODULE CruiseControlSystemSm
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     state : { Sm_s1 , Sm_s2 };
+     event : { ev_a , ev_null };
+     c : integer;
+
+   -- This part defines macros that summarize the transitions and guards (if any) of the given NuSMV module --
+   DEFINE
+     sm_stable :=  !( event = ev_a );
+     t1 := event = ev_a & state = Sm_s1;
+     aa := 5;
+     bb := 5;
+     cc := 5.00;
+
+   -- This part defines logic for the assignment of values to state variable "state" of this NuSMV module --
+   ASSIGN
+     init( state ) := Sm_s1;
+     next( state ) := case
+       t1 : Sm_s2;
+       TRUE : state;
+     esac;
+
+   -- This part defines logic for the assignment of values to state variable "event" of this NuSMV module --
+   ASSIGN
+     init( event ) := ev_null;
+     next( event ) := case
+       sm_stable : { ev_a };
+       TRUE : ev_null;
+     esac;
+
+   -- This part defines logic for the assignment of values to state variable "c" of this NuSMV module --
+   ASSIGN
+     init( c ) := 0;
+
+-- This defines a NuSMV module for CruiseControlSystemSm_Machine --
+MODULE CruiseControlSystemSm_Machine
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     cruiseControlSystemSm : CruiseControlSystemSm;
+
+-- This defines a NuSMV module for main --
+MODULE main
+
+   -- This part declares state variables for the given NuSMV module --
+   VAR
+     cruiseControlSystemSm_Machine : CruiseControlSystemSm_Machine;
+
+   -- The following properties are specified to certify that non-symbolic state(s) of this model is (or are) reachable. 
+   CTLSPEC   EF( cruiseControlSystemSm_Machine.cruiseControlSystemSm.state = Sm_s1 )
+   CTLSPEC   EF( cruiseControlSystemSm_Machine.cruiseControlSystemSm.state = Sm_s2 )

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/ConstantTest.ump
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/ConstantTest.ump
@@ -1,0 +1,12 @@
+class CruiseControlSystem 
+{
+  const Integer aa = 5;
+  const int bb = 5;
+  const float cc = 5.00;
+  Integer c;
+  sm {
+    s1 {
+      a ->/{ b = aa + 2; } s2;
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/FurnaceControlSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/FurnaceControlSystem.nusmv.txt
@@ -235,7 +235,7 @@ MODULE HeatingSystemHeatSystemHouseControllerControllerControllerOn ( _heatSyste
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _heatSystem.t11 | _heatSystem.t13 | _heatSystem.t15 | _heatSystem.t12 | _heatSystem.t14 | _heatSystem.t16 : null;
+       _heatSystem.t12 | _heatSystem.t14 | _heatSystem.t11 | _heatSystem.t13 | _heatSystem.t15 : null;
        _heatSystem.t17 : HeatSystemHouseControllerControllerControllerOn_idle;
        _heatSystem.t16 | _heatSystem.t18 : HeatSystemHouseControllerControllerControllerOn_heaterActive;
        _heatSystemHouseControllerController.state = HeatSystemHouseControllerController_ControllerOn & state = null : HeatSystemHouseControllerControllerControllerOn_idle;
@@ -253,7 +253,7 @@ MODULE HeatingSystemHeatSystemHouseControllerControllerControllerOnHeaterActive 
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _heatSystem.t16 | _heatSystem.t17 : null;
+       _heatSystem.t16 | _heatSystem.t12 | _heatSystem.t17 | _heatSystem.t13 : null;
        _heatSystem.t18 : HeatSystemHouseControllerControllerControllerOnHeaterActive_heaterRun;
        _heatSystemHouseControllerControllerControllerOn.state = HeatSystemHouseControllerControllerControllerOn_heaterActive & state = null : HeatSystemHouseControllerControllerControllerOnHeaterActive_actHeater;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/MultiLevelStateMachineExample.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/MultiLevelStateMachineExample.nusmv.txt
@@ -66,7 +66,7 @@ MODULE ASmS2S21 ( _sm , _smS2 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm.t4 | _sm.t5 : null;
+       _sm.t5 | _sm.t4 | _sm.t3 : null;
        _smS2.state = SmS2_s21 & state = null : SmS2S21_s211;
        TRUE : state;
      esac;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/MultiLevelStateMachineExampleCase2.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/MultiLevelStateMachineExampleCase2.nusmv.txt
@@ -66,7 +66,7 @@ MODULE ASmS2S21 ( _sm , _smS2 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm.t4 | _sm.t5 : null;
+       _sm.t5 | _sm.t4 | _sm.t3 : null;
        _smS2.state = SmS2_s21 & state = null : SmS2S21_s211;
        TRUE : state;
      esac;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/NestedWatch.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/NestedWatch.nusmv.txt
@@ -195,7 +195,7 @@ MODULE DigitalWatchSmChronometerChronoNormal ( _sm , _smChronometer )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm.t24 | _sm.t22 | _sm.t29 : null;
+       _sm.t22 | _sm.t29 | _sm.t24 | _sm.t1 : null;
        _sm.t28 | _sm.t27 | _sm.t25 : SmChronometerChronoNormal_paused;
        _sm.t26 | _sm.t23 : SmChronometerChronoNormal_running;
        _smChronometer.state = SmChronometer_chronoNormal & state = null : SmChronometerChronoNormal_paused;
@@ -251,6 +251,7 @@ MODULE DigitalWatchSmAlarmUpdateHourMinuteUpdate ( _sm , _smAlarmUpdate )
    ASSIGN
      init( state ) := null;
      next( state ) := case
+       _sm.t3 : null;
        _sm.t37 | _sm.t35 | _sm.t38 : SmAlarmUpdateHourMinuteUpdate_alarmHour;
        _sm.t36 | _sm.t34 | _sm.t39 : SmAlarmUpdateHourMinuteUpdate_alarmMinute;
        _smAlarmUpdate.state = SmAlarmUpdate_hourMinuteUpdate & state = null : SmAlarmUpdateHourMinuteUpdate_alarmHour;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/NuSMVTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/NuSMVTemplateTest.java
@@ -61,6 +61,14 @@ public class NuSMVTemplateTest extends TemplateTest{
 	    SampleFileWriter.destroy(pathToInput + "/nusmv/SimpleCaseOfNondeterminism.smv");
 	    SampleFileWriter.destroy(pathToInput + "/nusmv/SingleLaneBridge.smv");
 	    SampleFileWriter.destroy(pathToInput + "/nusmv/RoomHeatingSystem.smv");
+	    SampleFileWriter.destroy(pathToInput + "/nusmv/ConstantTest.smv");
+	  }
+
+	  @Test //@Ignore  // TEMPORARY IGNORE BY TIM ISSUE 740
+	  public void ConstantTest()
+	  {
+	  		assertUmpleTemplateFor("nusmv/ConstantTest.ump","nusmv/ConstantTest.nusmv.txt");
+	  		Assert.assertEquals(true, (new File(pathToInput + "/nusmv/ConstantTest.smv")).exists());
 	  }
 	  
 	  @Test //@Ignore  // TEMPORARY IGNORE BY TIM ISSUE 740

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/RoomHeatingSystem.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/RoomHeatingSystem.nusmv.txt
@@ -258,7 +258,7 @@ MODULE HeatControlSystemSmHouseControllerControllerControllerOn ( _sm , _smHouse
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm.t12 | _sm.t14 | _sm.t11 | _sm.t13 | _sm.t15 : null;
+       _sm.t11 | _sm.t13 | _sm.t12 | _sm.t14 : null;
        _sm.t16 : SmHouseControllerControllerControllerOn_idle;
        _sm.t15 | _sm.t17 : SmHouseControllerControllerControllerOn_heaterActive;
        _smHouseControllerController.state = SmHouseControllerController_controllerOn & state = null : SmHouseControllerControllerControllerOn_idle;
@@ -276,7 +276,7 @@ MODULE HeatControlSystemSmHouseControllerControllerControllerOnHeaterActive ( _s
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm.t15 | _sm.t16 : null;
+       _sm.t15 | _sm.t12 | _sm.t16 | _sm.t13 : null;
        _sm.t17 : SmHouseControllerControllerControllerOnHeaterActive_heaterRun;
        _smHouseControllerControllerControllerOn.state = SmHouseControllerControllerControllerOn_heaterActive & state = null : SmHouseControllerControllerControllerOnHeaterActive_actHeater;
        TRUE : state;
@@ -606,7 +606,7 @@ MODULE HeatControlSystemSm1HouseControllerControllerControllerOn ( _sm1 , _sm1Ho
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm1.t12 | _sm1.t14 | _sm1.t11 | _sm1.t13 | _sm1.t15 : null;
+       _sm1.t11 | _sm1.t13 | _sm1.t12 | _sm1.t14 : null;
        _sm1.t16 : Sm1HouseControllerControllerControllerOn_idle;
        _sm1.t15 | _sm1.t17 : Sm1HouseControllerControllerControllerOn_heaterActive;
        _sm1HouseControllerController.state = Sm1HouseControllerController_controllerOn & state = null : Sm1HouseControllerControllerControllerOn_idle;
@@ -624,7 +624,7 @@ MODULE HeatControlSystemSm1HouseControllerControllerControllerOnHeaterActive ( _
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _sm1.t15 | _sm1.t16 : null;
+       _sm1.t15 | _sm1.t12 | _sm1.t16 | _sm1.t13 : null;
        _sm1.t17 : Sm1HouseControllerControllerControllerOnHeaterActive_heaterRun;
        _sm1HouseControllerControllerControllerOn.state = Sm1HouseControllerControllerControllerOn_heaterActive & state = null : Sm1HouseControllerControllerControllerOnHeaterActive_actHeater;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/myTemporaryTest.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/myTemporaryTest.nusmv.txt
@@ -235,7 +235,7 @@ MODULE HeatingSystemHeatSystemHouseControllerControllerControllerOn ( _heatSyste
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _heatSystem.t11 | _heatSystem.t13 | _heatSystem.t15 | _heatSystem.t12 | _heatSystem.t14 | _heatSystem.t16 : null;
+       _heatSystem.t12 | _heatSystem.t14 | _heatSystem.t11 | _heatSystem.t13 | _heatSystem.t15 : null;
        _heatSystem.t17 : HeatSystemHouseControllerControllerControllerOn_idle;
        _heatSystem.t16 | _heatSystem.t18 : HeatSystemHouseControllerControllerControllerOn_heaterActive;
        _heatSystemHouseControllerController.state = HeatSystemHouseControllerController_ControllerOn & state = null : HeatSystemHouseControllerControllerControllerOn_idle;
@@ -253,7 +253,7 @@ MODULE HeatingSystemHeatSystemHouseControllerControllerControllerOnHeaterActive 
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _heatSystem.t16 | _heatSystem.t17 : null;
+       _heatSystem.t16 | _heatSystem.t12 | _heatSystem.t17 | _heatSystem.t13 : null;
        _heatSystem.t18 : HeatSystemHouseControllerControllerControllerOnHeaterActive_heaterRun;
        _heatSystemHouseControllerControllerControllerOn.state = HeatSystemHouseControllerControllerControllerOn_heaterActive & state = null : HeatSystemHouseControllerControllerControllerOnHeaterActive_actHeater;
        TRUE : state;

--- a/cruise.umple/test/cruise/umple/implementation/nusmv/nestedConcurrentMachine.nusmv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/nusmv/nestedConcurrentMachine.nusmv.txt
@@ -88,7 +88,7 @@ MODULE AStateState12State12State122 ( _state , _stateState12State12 )
    ASSIGN
      init( state ) := null;
      next( state ) := case
-       _state.t7 | _state.t5 | _state.t8 : null;
+       _state.t5 | _state.t8 | _state.t7 | _state.t4 : null;
        _state.t6 : StateState12State12State122_state1221;
        _stateState12State12.state = StateState12State12_state122 & state = null : StateState12State12State122_state1221;
        TRUE : state;


### PR DESCRIPTION
In this PR, we implemented a new algorithm for the computation of disabling transitions set. The algorithm systematically computes a minimal subset of transitions of the SSUA and removes the set of enabling transitions corresponding to the sub-state machine.

Similarly, our translator now support the translation of constant variables from Umple to SMV.  
