### PR TITLE
Eclipse development env fix

### DIFF
--- a/cruise.umple.nebula/.classpath
+++ b/cruise.umple.nebula/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src-gen-rtcpp-UmpleTL"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/cruise.umple.nebula/.project
+++ b/cruise.umple.nebula/.project
@@ -26,6 +26,13 @@
 			</arguments>
 		</buildCommand>
 	</buildSpec>
+	<linkedResources>
+	  <link>
+		  <name>src-gen-rtcpp-UmpleTL</name>
+		  <type>2</type>
+		  <locationURI>PARENT-1-PROJECT_LOC/UmpleToRTCpp/src-gen-UmpleTL</locationURI>
+	  </link>
+	</linkedResources>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>


### PR DESCRIPTION
## Description

This pull request fixes the bug identified in [issue 948](https://github.com/umple/umple/issues/948). Briefly, the `cruise.umple.nebula` project was not getting access to a required file (`Header.java`) that is generated as part of a full build. This PR changes nebula's `.project` and `.classpath` files to create a link to the generated file that nebula can use to resolve the missing dendency.

## Tests

As per disscussion with @vahdat-ab, no additional tests were added; however, all JUnit tests are passing locally.

Closes #948


