### PR TITLE
Fix generation of php code with abstract class.

### DIFF
--- a/UmpleToPhp/UmpleTLTemplates/phpClassGenerator.ump
+++ b/UmpleToPhp/UmpleTLTemplates/phpClassGenerator.ump
@@ -79,7 +79,7 @@ class PhpClassGenerator {
 
 
 <<# if (uClass.numberOfComments() > 0) { if (!uClass.getComments().get(0).getIsInline()) {append(realSb, "\n{0}", Comment.format("Multiline",uClass.getComments()));} else {append(realSb, "\n{0}", Comment.format("Slashes",uClass.getComments())); } } #>>
-<<# append(realSb, System.getProperty("line.separator")); #>>
+<<# append(realSb, System.lineSeparator()); #>>
 <<# if (uClass.getIsAbstract()) { append(realSb, "{0} ", "abstract"); } #>>class <<= uClass.getName() >><<= gen.translate("isA",uClass) >>
 {<<@ UmpleToPhp.members_AllStatics >><<@ UmpleToPhp.members_AllAttributes >><<@ UmpleToPhp.members_AllStateMachines >><<@ UmpleToPhp.members_AllDoActivities >><<@ UmpleToPhp.members_AllAssociations >><<@ UmpleToPhp.members_AllHelpers >>
 

--- a/UmpleToPhp/UmpleTLTemplates/phpClassGenerator.ump
+++ b/UmpleToPhp/UmpleTLTemplates/phpClassGenerator.ump
@@ -79,7 +79,8 @@ class PhpClassGenerator {
 
 
 <<# if (uClass.numberOfComments() > 0) { if (!uClass.getComments().get(0).getIsInline()) {append(realSb, "\n{0}", Comment.format("Multiline",uClass.getComments()));} else {append(realSb, "\n{0}", Comment.format("Slashes",uClass.getComments())); } } #>>
-class <<= uClass.getName() >><<= gen.translate("isA",uClass) >>
+<<# append(realSb, System.getProperty("line.separator")); #>>
+<<# if (uClass.getIsAbstract()) { append(realSb, "{0} ", "abstract"); } #>>class <<= uClass.getName() >><<= gen.translate("isA",uClass) >>
 {<<@ UmpleToPhp.members_AllStatics >><<@ UmpleToPhp.members_AllAttributes >><<@ UmpleToPhp.members_AllStateMachines >><<@ UmpleToPhp.members_AllDoActivities >><<@ UmpleToPhp.members_AllAssociations >><<@ UmpleToPhp.members_AllHelpers >>
 
   //------------------------

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_AbstractClass.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_AbstractClass.php.txt
@@ -1,0 +1,32 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.25.0-9e8af9e modeling language!*/
+
+abstract class Student
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_AbstractClass.ump
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_AbstractClass.ump
@@ -1,0 +1,7 @@
+generate Php;
+namespace example;
+
+class Student
+{
+	abstract;
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/PhpClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/php/PhpClassTemplateTest.java
@@ -50,6 +50,14 @@ public class PhpClassTemplateTest extends ClassTemplateTest
     language = null;
     assertUmpleTemplateFor("php/ClassTemplateTest_ExtraCode.ump","php/ClassTemplateTest_ExtraCode.php.txt","Mentor");
   }
+  
+  @Test
+  public void abstractClass()
+  {
+	language = "Php";
+	assertUmpleTemplateFor("php/ClassTemplateTest_AbstractClass.ump","php/ClassTemplateTest_AbstractClass.php.txt", "Student");
+  }
+  
   @Test
   public void GeneratePathTest()
   {


### PR DESCRIPTION
## Description

This PR fixes PHP code generation for abstract classes. Previously, a class declared as abstract in Umple generated a normal class in PHP generation, missing the abstract keyword.

## Tests

Added a PHP generation test to ensure this code generates for abstract classes properly.

