### PR TITLE
Moving the source for simpletest to github instead of sourceforge

### DIFF
--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -31,7 +31,7 @@
 
   <property name="php.simpletest.version" value="1.1" />
   <property name="php.simpletest.url" 
-            value="http://downloads.sourceforge.net/project/simpletest/simpletest/simpletest_${php.simpletest.version}/simpletest_${php.simpletest.version}.0.tar.gz" />
+            value="https://downloads.sourceforge.net/project/simpletest/simpletest/simpletest_${php.simpletest.version}/simpletest_${php.simpletest.version}.0.tar.gz" />
   <property name="php.libs.dir" value="${dist.dir}/libs/php" />
 
   <path id="project.classpath">

--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -31,7 +31,7 @@
 
   <property name="php.simpletest.version" value="1.1" />
   <property name="php.simpletest.url" 
-            value="https://downloads.sourceforge.net/project/simpletest/simpletest/simpletest_${php.simpletest.version}/simpletest_${php.simpletest.version}.0.tar.gz" />
+            value="https://github.com/git-mirror/simpletest/archive/${php.simpletest.version}.0.tar.gz" />
   <property name="php.libs.dir" value="${dist.dir}/libs/php" />
 
   <path id="project.classpath">

--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -123,6 +123,9 @@
         <untar  src="${php.simpletest.dir}.tar"
                 dest="${php.libs.dir}/" />
         <delete file="${php.simpletest.dir}.tar" />
+        <move todir="${php.simpletest.dir}">
+          <fileset dir="${php.simpletest.dir}-${php.simpletest.version}.0"/>
+        </move>        
       </then>
     </if>
 


### PR DESCRIPTION
Travis was failing on attempting to obtain the simpltest php testing utility from sourceforge. This PR moves the sourcing of that to be from github. Minor renaming turned out to be required since the untarred directory had a different name