### PR TITLE
Fixed #970

### DIFF
--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -867,9 +867,8 @@ Page.showGeneratedCode = function(code,language,tabnumber)
   if(language == "java" || language == "php" || language == "cpp" 
     || language == "ruby" || language == "xml" || language == "sql" || language == "alloy" || language == "nusmv")
   {
-		jQuery("#innerGeneratedCodeRow" + tabnumber).html(
-			formatOnce('<pre class="brush: {1};">{0}</pre>',generatedMarkup,language)
-		)
+		jQuery("#innerGeneratedCodeRow" + tabnumber).innerHTML = 
+		  formatOnce('<pre class="brush: {1};">{0}</pre>', generatedMarkup, language);
     SyntaxHighlighter.highlight("code");
 
 		if(tabnumber == ""){

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -867,7 +867,7 @@ Page.showGeneratedCode = function(code,language,tabnumber)
   if(language == "java" || language == "php" || language == "cpp" 
     || language == "ruby" || language == "xml" || language == "sql" || language == "alloy" || language == "nusmv")
   {
-		jQuery("#innerGeneratedCodeRow" + tabnumber).innerHTML = 
+		document.querySelector("#innerGeneratedCodeRow" + tabnumber).innerHTML = 
 		  formatOnce('<pre class="brush: {1};">{0}</pre>', generatedMarkup, language);
     SyntaxHighlighter.highlight("code");
 


### PR DESCRIPTION
## Description

When using `jQuery#html()` it will format html tags, this wasn't being done in the non-tabbed way, but was being done when using tabs. I replaced it with `.innerHTML`. 

Closes #970. Please verify that this works (it is working locally). 

