### PR TITLE
Fix#682 - added warning for exclusion operation

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3111,19 +3111,20 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 
       Boolean matches = false;
       
-      Boolean exclusionMatch = true;
+      Boolean exclusionMatch = false;
 
       for(String methodName : methodNames) 
       { 
         if (uClass.matchOperationMethod(operation, methodName)) {
           matches = true;
+          exclusionMatch = true;
         }
         
         // issue#682
         else if(operation.charAt(0) =='!') {
           matches = true;
-          if (!uClass.matchOperationMethod(operation.substring(1), methodName)) {
-            exclusionMatch = false;
+          if (uClass.matchOperationMethod(operation.substring(1), methodName)) {
+            exclusionMatch = true;
           }
         }
       }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3096,7 +3096,9 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 
   private void checkCodeInjectionValidity(Token injectToken, UmpleClass uClass) {
     ArrayList<String> methodNames = getAllMethodNames(uClass);
+    
     String[] allOperations = getOperationName(injectToken).split(",");
+    
     List<String> allParameters = getOperationsParameters(injectToken);
 
     String operationSource = getOperationSource(injectToken);
@@ -3108,38 +3110,35 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     {
       String operation = allOperations[opInd];
       String currentParameters = allParameters.get(opInd);
+      Boolean hasExclusion = false;
+      if(operation.charAt(0) == '!') {
+        hasExclusion = true;
+      	operation = operation.substring(1);
+      }
 
       Boolean matches = false;
-      
-      Boolean exclusionMatch = false;
 
       for(String methodName : methodNames) 
       { 
         if (uClass.matchOperationMethod(operation, methodName)) {
           matches = true;
-          exclusionMatch = true;
         }
         
-        // issue#682
-        else if(operation.charAt(0) =='!') {
-          matches = true;
-          if (uClass.matchOperationMethod(operation.substring(1), methodName)) {
-            exclusionMatch = true;
-          }
-        }
       }
 
       if(!matches) {
-        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+        if(hasExclusion) {
+          getParseResult().addErrorMessage(new ErrorMessage(1014, injectToken.getPosition(), operation));
+        }
+        else {
+          getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
+      	}
       }
 
       if(!"...".equals(currentParameters)) {
         getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
       }
-      
-      if(!exclusionMatch) {
-        getParseResult().addErrorMessage(new ErrorMessage(1014, injectToken.getPosition(), operation));
-      }
+       
     }
   }
   

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3110,15 +3110,21 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       String currentParameters = allParameters.get(opInd);
 
       Boolean matches = false;
+      
+      Boolean exclusionMatch = true;
 
       for(String methodName : methodNames) 
       { 
         if (uClass.matchOperationMethod(operation, methodName)) {
           matches = true;
         }
+        
         // issue#682
-        if(operation.charAt(0) =='!') {
+        else if(operation.charAt(0) =='!') {
           matches = true;
+          if (!uClass.matchOperationMethod(operation.substring(1), methodName)) {
+            exclusionMatch = false;
+          }
         }
       }
 
@@ -3128,6 +3134,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 
       if(!"...".equals(currentParameters)) {
         getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
+      }
+      
+      if(!exclusionMatch) {
+        getParseResult().addErrorMessage(new ErrorMessage(1014, injectToken.getPosition(), operation));
       }
     }
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3116,6 +3116,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         if (uClass.matchOperationMethod(operation, methodName)) {
           matches = true;
         }
+        // issue#682
+        if(operation.charAt(0) =='!') {
+          matches = true;
+        }
       }
 
       if(!matches) {

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -176,6 +176,7 @@
 1011: 3, "http://cruise.eecs.uottawa.ca/umple/W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
 1012: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' cannot be found. Injection was ignored. ;
 1013: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
+1014: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
 
 1500 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: '{0}' not understood ; 
 1501 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 

--- a/cruise.umple/test/cruise/umple/compiler/1012_operationNotFound1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1012_operationNotFound1.ump
@@ -1,0 +1,6 @@
+class X
+{
+  before m1 { 
+    System.out.println("accessing the name");
+  }
+}

--- a/cruise.umple/test/cruise/umple/compiler/1014_operationNotFound1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1014_operationNotFound1.ump
@@ -1,0 +1,6 @@
+class X
+{
+  before !m1 { 
+    System.out.println("accessing the name"); 
+  }
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -455,14 +455,21 @@ public class UmpleParserTest
     assertHasWarningsParse("015_mixin_sameMethod5.ump", 49);
     assertHasWarningsParse("015_mixin_sameMethod6.ump", 49);
     
+    //Issue 771
     //same method name, different types
     assertHasWarningsParse("015_mixin_sameMethod7.ump", 71);
     assertHasWarningsParse("015_mixin_sameMethod8.ump", 71);
     assertHasWarningsParse("015_mixin_sameMethod9.ump", 71);
     assertHasWarningsParse("015_mixin_sameMethod10.ump", 71);
     assertHasWarningsParse("015_mixin_sameMethod11.ump", 71);
-
-
+  }
+  
+  //Issue 682
+  @Test
+  public void operationNotFound()
+  {
+	  assertHasWarningsParse("1012_operationNotFound1.ump", 1012);
+	  assertHasWarningsParse("1014_operationNotFound1.ump", 1014);
   }
 
   @Test


### PR DESCRIPTION
## Description

The original issue was already handled.

I added warning 1014: 

> 1014: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;  

This will raise when there is an exclusion method like "!getMyBirth", and getMyBirth method does not exist.

## Tests

All tests were passed and no new test was added.

