### PR TITLE
Fix issue 923

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
+++ b/UmpleToJava/UmpleTLTemplates/state_machine_Event.ump
@@ -1,5 +1,28 @@
 class UmpleToJava {
     state_machine_Event <<!<</*state_machine_Event*/>><<#
+  
+  // Issue 923 Fix: Prevent default implmentation of interface methods when a state machine implements them
+  boolean implementsInterfaceMethod = false;
+  for (UmpleInterface uInterface : uClass.getParentInterface())
+  {
+  	for (Method m : uInterface.getMethods())
+  	{
+  		Method eventMethod = new Method("",e.getName(),e.getType().toLowerCase(),false);
+  		eventMethod.setMethodParameters(e.getParams());
+  		if (m.compareWithTheMethod(eventMethod))
+  		{
+  			uClass.removeMethod(m);
+  			implementsInterfaceMethod = true;
+  			break;
+  		}
+  	}
+  	
+  	if (implementsInterfaceMethod)
+  	{
+  		break;
+  	}
+  }
+  
   int javaLine = realSb.toString().split("\\n").length+7;
 
   StringBuilder allCases = new StringBuilder();
@@ -220,10 +243,14 @@ class UmpleToJava {
     javaLine+=3;
   }
 
-  
+  String override =  (implementsInterfaceMethod) ? "@Override\n" : "";
   String scope = e.getIsInternal() || e.isAutoTransition() ? "private" : "public";
+  if (implementsInterfaceMethod)
+  {
+  	scope = "  " + scope;
+  }
   String eventOutput = allDeclarations.toString() + allCases.toString();#>>
-  <<= scope >> boolean <<#for (StateMachine sm : uClass.getStateMachines()){if((sm.isQueued() && e.getIsInternal() == false && e.isAutoTransition() == false && !e.isUnspecified()) || (sm.isPooled() && e.getIsInternal() == false && e.isAutoTransition() == false && !e.isUnspecified())){append(realSb,"_");}break;}#>><<=gen.translate("eventMethod",e)>>(<<= (e.getArgs()==null?"":e.getArgs())>><<#if(e.isUnspecified()){append(realSb,"String state, String event");}#>>)
+  <<= override >><<= scope >> boolean <<#for (StateMachine sm : uClass.getStateMachines()){if((sm.isQueued() && e.getIsInternal() == false && e.isAutoTransition() == false && !e.isUnspecified()) || (sm.isPooled() && e.getIsInternal() == false && e.isAutoTransition() == false && !e.isUnspecified())){append(realSb,"_");}break;}#>><<=gen.translate("eventMethod",e)>>(<<= (e.getArgs()==null?"":e.getArgs())>><<#if(e.isUnspecified()){append(realSb,"String state, String event");}#>>)
   {<<# if (customEventPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customEventPrefixCode,gen.translate("eventMethod",e));
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customEventPrefixCode, "    ")); } #>>
     boolean wasEventProcessed = false;

--- a/UmpleToPhp/UmpleTLTemplates/state_machine_Event.ump
+++ b/UmpleToPhp/UmpleTLTemplates/state_machine_Event.ump
@@ -3,7 +3,29 @@ class UmpleToPhp {
   StringBuffer allCases = new StringBuffer();
   StringBuffer allDeclarations = new StringBuffer();
   StringBuffer allArgs = new StringBuffer();
-
+  
+  // Issue 923 Fix: Prevent default implmentation of interface methods when a state machine implements them
+  boolean implementsInterfaceMethod = false;
+  for (UmpleInterface uInterface : uClass.getParentInterface())
+  {
+  	for (Method m : uInterface.getMethods())
+  	{
+  		Method eventMethod = new Method("",e.getName(),e.getType().toLowerCase(),false);
+  		eventMethod.setMethodParameters(e.getParams());
+  		if (m.compareWithTheMethod(eventMethod))
+  		{
+  			uClass.removeMethod(m);
+  			implementsInterfaceMethod = true;
+  			break;
+  		}
+  	}
+  	
+  	if (implementsInterfaceMethod)
+  	{
+  		break;
+  	}
+  }
+   
   boolean firstStateMachine = true;
   for(StateMachine sm : uClass.getStateMachines(e))
   {

--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -260,6 +260,12 @@ public class TemplateTest
     SampleFileWriter.destroy(pathToInput + "/client.rb");
     SampleFileWriter.destroy(pathToInput + "/Client.php");
     
+    // Tear down issue 923 tests
+    SampleFileWriter.destroy(pathToInput + "/java/FileLogger.java");
+    SampleFileWriter.destroy(pathToInput + "/java/Logger.java");
+    SampleFileWriter.destroy(pathToInput + "/php/NetworkNode.php");
+    SampleFileWriter.destroy(pathToInput + "/php/Router.php");
+    
    // destroying the object factory
   }
 

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineDoesNotImplementInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineDoesNotImplementInterface.java.txt
@@ -1,5 +1,5 @@
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
 
 
 
@@ -42,8 +42,7 @@ public class FileLogger implements Logger
     return status;
   }
 
-  @Override
-  public boolean connect()
+  public boolean attemptConnection()
   {
     boolean wasEventProcessed = false;
     
@@ -61,8 +60,7 @@ public class FileLogger implements Logger
     return wasEventProcessed;
   }
 
-  @Override
-  public boolean disconnect()
+  public boolean signalDisconnect()
   {
     boolean wasEventProcessed = false;
     
@@ -80,8 +78,7 @@ public class FileLogger implements Logger
     return wasEventProcessed;
   }
 
-  @Override
-  public boolean write(String String)
+  public boolean communicate(String message)
   {
     boolean wasEventProcessed = false;
     
@@ -106,6 +103,21 @@ public class FileLogger implements Logger
 
   public void delete()
   {}
+
+  @Override
+  public boolean connect(){
+          return false;
+  }
+
+  @Override
+  public boolean disconnect(){
+          return false;
+  }
+
+  @Override
+  public boolean write(String data){
+          return false;
+  }
 
 
   public String toString()

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump
@@ -1,0 +1,19 @@
+interface Logger {
+	boolean connect();
+	boolean disconnect();
+	boolean write(String data);
+}
+
+class FileLogger{
+	isA Logger;
+	internal fileName;
+	status{
+		disconnected{
+			attemptConnection -> connected;
+		}
+		connected{
+			signalDisconnect -> disconnected;
+			communicate(String message) -> connected;
+		}	
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.java.txt
@@ -81,7 +81,7 @@ public class FileLogger implements Logger
   }
 
   @Override
-  public boolean write(String String)
+  public boolean write(String data)
   {
     boolean wasEventProcessed = false;
     

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.java.txt
@@ -1,0 +1,114 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+
+
+
+public class FileLogger implements Logger
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //FileLogger Attributes
+  private String fileName;
+
+  //FileLogger State Machines
+  public enum Status { disconnected, connected }
+  private Status status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public FileLogger(String aFileName)
+  {
+    fileName = aFileName;
+    setStatus(Status.disconnected);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public String getStatusFullName()
+  {
+    String answer = status.toString();
+    return answer;
+  }
+
+  public Status getStatus()
+  {
+    return status;
+  }
+
+  public boolean connect()
+  {
+    boolean wasEventProcessed = false;
+    
+    Status aStatus = status;
+    switch (aStatus)
+    {
+      case disconnected:
+        setStatus(Status.connected);
+        wasEventProcessed = true;
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  public boolean disconnect()
+  {
+    boolean wasEventProcessed = false;
+    
+    Status aStatus = status;
+    switch (aStatus)
+    {
+      case connected:
+        setStatus(Status.disconnected);
+        wasEventProcessed = true;
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  public boolean write(String String)
+  {
+    boolean wasEventProcessed = false;
+    
+    Status aStatus = status;
+    switch (aStatus)
+    {
+      case connected:
+        setStatus(Status.connected);
+        wasEventProcessed = true;
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  private void setStatus(Status aStatus)
+  {
+    status = aStatus;
+  }
+
+  public void delete()
+  {}
+
+
+  public String toString()
+  {
+    String outputString = "";
+    return super.toString() + "["+ "]"
+     + outputString;
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.ump
@@ -1,7 +1,7 @@
 interface Logger {
 	boolean connect();
 	boolean disconnect();
-	boolean write(String Data);
+	boolean write(String data);
 }
 
 class FileLogger{
@@ -13,7 +13,7 @@ class FileLogger{
 		}
 		connected{
 			disconnect -> disconnected;
-			write(String) -> connected;
+			write(data) -> connected;
 		}	
 	}
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.ump
@@ -1,0 +1,19 @@
+interface Logger {
+	boolean connect();
+	boolean disconnect();
+	boolean write(String Data);
+}
+
+class FileLogger{
+	isA Logger;
+	internal fileName;
+	status{
+		disconnected{
+			connect -> connected;
+		}
+		connected{
+			disconnect -> disconnected;
+			write(String) -> connected;
+		}	
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsPartialInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsPartialInterface.java.txt
@@ -1,5 +1,5 @@
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
 
 
 
@@ -80,25 +80,6 @@ public class FileLogger implements Logger
     return wasEventProcessed;
   }
 
-  @Override
-  public boolean write(String String)
-  {
-    boolean wasEventProcessed = false;
-    
-    Status aStatus = status;
-    switch (aStatus)
-    {
-      case connected:
-        setStatus(Status.connected);
-        wasEventProcessed = true;
-        break;
-      default:
-        // Other states do respond to this event
-    }
-
-    return wasEventProcessed;
-  }
-
   private void setStatus(Status aStatus)
   {
     status = aStatus;
@@ -106,6 +87,11 @@ public class FileLogger implements Logger
 
   public void delete()
   {}
+
+  @Override
+  public boolean write(String data){
+          return false;
+  }
 
 
   public String toString()

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsPartialInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsPartialInterface.ump
@@ -1,0 +1,18 @@
+interface Logger {
+	boolean connect();
+	boolean disconnect();
+	boolean write(String data);
+}
+
+class FileLogger{
+	isA Logger;
+	internal fileName;
+	status{
+		disconnected{
+			connect -> connected;
+		}
+		connected{
+			disconnect -> disconnected;
+		}	
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -149,9 +149,23 @@ public class JavaClassTemplateTest extends ClassTemplateTest
   }
   
   @Test
-  public void stateMachineImplementsInterface(){
+  public void StateMachineImplementsInterface(){
       assertUmpleTemplateFor("java/ClassTemplateTest_StateMachineImplementsInterface.ump",
                              "java/ClassTemplateTest_StateMachineImplementsInterface.java.txt",
                              "FileLogger");
+  }
+  
+  @Test
+  public void StateMachineImplementsPartialInterface(){
+	  assertUmpleTemplateFor("java/ClassTemplateTest_StateMachineImplementsPartialInterface.ump",
+              				 "java/ClassTemplateTest_StateMachineImplementsPartialInterface.java.txt",
+              				 "FileLogger");
+  }
+  
+  @Test
+  public void StateMachineDoesNotImplementInterface(){
+	  assertUmpleTemplateFor("java/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump",
+				 			 "java/ClassTemplateTest_StateMachineDoesNotImplementInterface.java.txt",
+				 			 "FileLogger");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -147,5 +147,11 @@ public class JavaClassTemplateTest extends ClassTemplateTest
   public void immutableNotLazyAttributeConstructor(){
 	  assertUmpleTemplateFor("java/ImmutableNotLazyAttributeConstructor.ump","java/StudentImmutableNotLazyTest.java.txt","Student");
   }
-   
+  
+  @Test
+  public void stateMachineImplementsInterface(){
+      assertUmpleTemplateFor("java/ClassTemplateTest_StateMachineImplementsInterface.ump",
+                             "java/ClassTemplateTest_StateMachineImplementsInterface.java.txt",
+                             "FileLogger");
+  }
 }

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineDoesNotImplementInterface.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineDoesNotImplementInterface.php.txt
@@ -1,0 +1,102 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+
+class Router implements NetworkNode
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Router Attributes
+  private $ipAddress;
+
+  //Router State Machines
+  private static $StatusDisconnected = 1;
+  private static $StatusConnected = 2;
+  private $status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct($aIpAddress)
+  {
+    $this->ipAddress = $aIpAddress;
+    $this->setStatus(self::$StatusDisconnected);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getStatusFullName()
+  {
+    $answer = $this->getStatus();
+    return $answer;
+  }
+
+  public function getStatus()
+  {
+    if ($this->status == self::$StatusDisconnected) { return "StatusDisconnected"; }
+    elseif ($this->status == self::$StatusConnected) { return "StatusConnected"; }
+    return null;
+  }
+
+  public function createConnection()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusDisconnected)
+    {
+      $this->setStatus(self::$StatusConnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  public function disconnectRequest()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusConnected)
+    {
+      $this->setStatus(self::$StatusDisconnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  private function setStatus($aStatus)
+  {
+    $this->status = $aStatus;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+  public function connect()
+  {
+          return "";
+  }
+
+  public function disconnect()
+  {
+          return "";
+  }
+
+  public function errorDetected()
+  {
+          return "";
+  }
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump
@@ -1,0 +1,20 @@
+generate Php;
+
+interface NetworkNode {
+	boolean connect();
+	boolean disconnect();
+	boolean errorDetected();
+}
+
+class Router {
+	isA NetworkNode;
+	internal ipAddress;
+	status{
+		disconnected{
+			createConnection -> connected;
+		}
+		connected{
+			disconnectRequest -> disconnected;
+		}	
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsInterface.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsInterface.php.txt
@@ -1,0 +1,100 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+
+class Router implements NetworkNode
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Router Attributes
+  private $ipAddress;
+
+  //Router State Machines
+  private static $StatusDisconnected = 1;
+  private static $StatusConnected = 2;
+  private $status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct($aIpAddress)
+  {
+    $this->ipAddress = $aIpAddress;
+    $this->setStatus(self::$StatusDisconnected);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getStatusFullName()
+  {
+    $answer = $this->getStatus();
+    return $answer;
+  }
+
+  public function getStatus()
+  {
+    if ($this->status == self::$StatusDisconnected) { return "StatusDisconnected"; }
+    elseif ($this->status == self::$StatusConnected) { return "StatusConnected"; }
+    return null;
+  }
+
+  public function connect()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusDisconnected)
+    {
+      $this->setStatus(self::$StatusConnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  public function disconnect()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusConnected)
+    {
+      $this->setStatus(self::$StatusDisconnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  public function errorDetected()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusConnected)
+    {
+      $this->setStatus(self::$StatusDisconnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  private function setStatus($aStatus)
+  {
+    $this->status = $aStatus;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsInterface.ump
@@ -1,0 +1,21 @@
+generate Php;
+
+interface NetworkNode {
+	boolean connect();
+	boolean disconnect();
+	boolean errorDetected();
+}
+
+class Router {
+	isA NetworkNode;
+	internal ipAddress;
+	status{
+		disconnected{
+			connect -> connected;
+		}
+		connected{
+			disconnect -> disconnected;
+			errorDetected -> disconnected;
+		}	
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsPartialInterface.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsPartialInterface.php.txt
@@ -1,0 +1,92 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+
+class Router implements NetworkNode
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Router Attributes
+  private $ipAddress;
+
+  //Router State Machines
+  private static $StatusDisconnected = 1;
+  private static $StatusConnected = 2;
+  private $status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct($aIpAddress)
+  {
+    $this->ipAddress = $aIpAddress;
+    $this->setStatus(self::$StatusDisconnected);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getStatusFullName()
+  {
+    $answer = $this->getStatus();
+    return $answer;
+  }
+
+  public function getStatus()
+  {
+    if ($this->status == self::$StatusDisconnected) { return "StatusDisconnected"; }
+    elseif ($this->status == self::$StatusConnected) { return "StatusConnected"; }
+    return null;
+  }
+
+  public function connect()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusDisconnected)
+    {
+      $this->setStatus(self::$StatusConnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  public function disconnect()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusConnected)
+    {
+      $this->setStatus(self::$StatusDisconnected);
+      $wasEventProcessed = true;
+    }
+    return $wasEventProcessed;
+  }
+
+  private function setStatus($aStatus)
+  {
+    $this->status = $aStatus;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+  public function errorDetected()
+  {
+          return "";
+  }
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsPartialInterface.ump
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_StateMachineImplementsPartialInterface.ump
@@ -1,0 +1,20 @@
+generate Php;
+
+interface NetworkNode {
+	boolean connect();
+	boolean disconnect();
+	boolean errorDetected();
+}
+
+class Router {
+	isA NetworkNode;
+	internal ipAddress;
+	status{
+		disconnected{
+			connect -> connected;
+		}
+		connected{
+			disconnect -> disconnected;
+		}	
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/PhpClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/php/PhpClassTemplateTest.java
@@ -69,9 +69,31 @@ public class PhpClassTemplateTest extends ClassTemplateTest
 	  
     SampleFileWriter.assertFileContent(new File(pathToInput, languagePath + "/ClassTemplateTest_BuildOutputPath.ump.txt"), actual);
   }
+
   @Test 
   public void immutableNotLazyAttributeConstructor(){
 	  assertUmpleTemplateFor("php/ImmutableNotLazyAttributeConstructor.ump","php/StudentImmutableNotLazyTest.php.txt","Student");
+  }
+
+  @Test
+  public void StateMachineImplementsInterface(){
+    assertUmpleTemplateFor("php/ClassTemplateTest_StateMachineImplementsInterface.ump", 
+                           "php/ClassTemplateTest_StateMachineImplementsInterface.php.txt",
+                           "Router");
+  }
+
+  @Test
+  public void StateMachineImplementsPartialInterface(){
+    assertUmpleTemplateFor("php/ClassTemplateTest_StateMachineImplementsPartialInterface.ump", 
+                           "php/ClassTemplateTest_StateMachineImplementsPartialInterface.php.txt",
+                           "Router");
+  }
+
+  @Test
+  public void StateMachineDoesNotImplementInterface(){
+    assertUmpleTemplateFor("php/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump", 
+                           "php/ClassTemplateTest_StateMachineDoesNotImplementInterface.php.txt",
+                           "Router");
   }
 
 }


### PR DESCRIPTION
## Description

This PR fixes issue #923 by modifying the state_machine_Event.ump template for both Java and PHP generated code. This template now checks if an event implements an interface method. For Java, the "@Override" directive is placed on top of the event's method if it implements an interface method. On my Mac, the full build is successful.

## Tests

Added the following tests to "PhpClassTemplateTest.java" and "JavaClassTemplateTest.java" to check the generated PHP and Java code for when a state machine implements all, some, or none of the methods in an interface. 

StateMachineImplementsInterface   
Umple File: ClassTemplateTest_StateMachineImplementsInterface.ump  

StateMachineImplementsPartialInterface
Umple File: ClassTemplateTest_StateMachineImplementsPartialInterface.ump  

StateMachineDoesNotImplementInterface
Umple File: ClassTemplateTest_StateMachineDoesNotImplementInterface.ump  

For the PHP tests, none of the methods in the .ump files include parameters since issue #964 is still being fixed.  

