### PR TITLE
Fix for issue 947

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/toString_declare.ump
+++ b/UmpleToJava/UmpleTLTemplates/toString_declare.ump
@@ -3,7 +3,7 @@ class UmpleToJava {
 
   public String toString()
   {
-    String outputString = "";<<#
+    <<#
 	  String customToStringPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before","toString"));
 	  String customToStringPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after","toString"));
 	  if (customToStringPrefixCode != null) 
@@ -87,7 +87,6 @@ class UmpleToJava {
 	      ret += " + System.getProperties().getProperty(\"line.separator\") +\n            ";
 	      ret += "\"  \" + " +  "\""+reflexiveNames.get(m)+" = \"+("+reflexive.get(m)+"!=null?Integer.toHexString(System.identityHashCode("+reflexive.get(m)+")):\"null\")";
 	  }
-	  ret += "\n     + outputString";
 	  append(realSb,"\n    return {0};", ret);
 	  #>>
   }!>>

--- a/cruise.umple/test/cruise/umple/compiler/FLoatGenerator.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/FLoatGenerator.java.txt
@@ -123,7 +123,6 @@ public class FLoatGenerator
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "x" + ":" + getX()+ "," +
             "y" + ":" + getY()+ "," +
@@ -131,7 +130,6 @@ public class FLoatGenerator
             "b" + ":" + getB()+ "," +
             "c" + ":" + getC()+ "," +
             "rho" + ":" + getRho()+ "," +
-            "theta" + ":" + getTheta()+ "]"
-     + outputString;
+            "theta" + ":" + getTheta()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/compiler/RangeX.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/RangeX.java.txt
@@ -60,10 +60,8 @@ public class RangeX
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "start" + ":" + getStart()+ "," +
-            "end" + ":" + getEnd()+ "]"
-     + outputString;
+            "end" + ":" + getEnd()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
@@ -205,13 +205,11 @@ public class RegularFlight
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "flightNumber" + ":" + getFlightNumber()+ "," +
             "flightNumber3" + ":" + getFlightNumber3()+ "," +
             "flightNumber4" + ":" + getFlightNumber4()+ "," +
             "lala" + ":" + getLala()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "time" + "=" + (getTime() != null ? !getTime().equals(this)  ? getTime().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "time" + "=" + (getTime() != null ? !getTime().equals(this)  ? getTime().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Mentor.java.txt
@@ -164,10 +164,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "studentsPriority" + "=" + (getStudentsPriority() != null ? !getStudentsPriority().equals(this)  ? getStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "studentsPriority" + "=" + (getStudentsPriority() != null ? !getStudentsPriority().equals(this)  ? getStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationBothSidesSorted_Student.java.txt
@@ -164,10 +164,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentorsPriority" + "=" + (getMentorsPriority() != null ? !getMentorsPriority().equals(this)  ? getMentorsPriority().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "mentorsPriority" + "=" + (getMentorsPriority() != null ? !getMentorsPriority().equals(this)  ? getMentorsPriority().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Mentor.java.txt
@@ -164,10 +164,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "myStudentsPriority" + "=" + (getMyStudentsPriority() != null ? !getMyStudentsPriority().equals(this)  ? getMyStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "myStudentsPriority" + "=" + (getMyStudentsPriority() != null ? !getMyStudentsPriority().equals(this)  ? getMyStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationSortedWithNameSpace_Student.java.txt
@@ -164,10 +164,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "ProfsPriority" + "=" + (getProfsPriority() != null ? !getProfsPriority().equals(this)  ? getProfsPriority().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "ProfsPriority" + "=" + (getProfsPriority() != null ? !getProfsPriority().equals(this)  ? getProfsPriority().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Mentor.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Mentor.java.txt
@@ -149,9 +149,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "studentsPriority" + "=" + (getStudentsPriority() != null ? !getStudentsPriority().equals(this)  ? getStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "studentsPriority" + "=" + (getStudentsPriority() != null ? !getStudentsPriority().equals(this)  ? getStudentsPriority().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Student.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/AssociationTestSorted_Student.java.txt
@@ -169,9 +169,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "id" + ":" + getId()+ "]"
-     + outputString;
+            "id" + ":" + getId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint1.java.txt
@@ -52,9 +52,7 @@ public class student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "age" + ":" + getAge()+ "]"
-     + outputString;
+            "age" + ":" + getAge()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint3.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint3.java.txt
@@ -73,10 +73,8 @@ public class Client
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "minAge" + ":" + getMinAge()+ "," +
-            "age" + ":" + getAge()+ "]"
-     + outputString;
+            "age" + ":" + getAge()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint4.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint4.java.txt
@@ -55,9 +55,7 @@ public class student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "age" + ":" + getAge()+ "]"
-     + outputString;
+            "age" + ":" + getAge()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint5.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint5.java.txt
@@ -70,10 +70,8 @@ public class student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
-            "weight" + ":" + getWeight()+ "]"
-     + outputString;
+            "weight" + ":" + getWeight()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint6.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint6.java.txt
@@ -70,10 +70,8 @@ public class student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
-            "weight" + ":" + getWeight()+ "]"
-     + outputString;
+            "weight" + ":" + getWeight()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint7.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint7.java.txt
@@ -67,10 +67,8 @@ public class student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
-            "weight" + ":" + getWeight()+ "]"
-     + outputString;
+            "weight" + ":" + getWeight()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint8.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicConstraint8.java.txt
@@ -67,10 +67,8 @@ public class student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "age" + ":" + getAge()+ "," +
-            "weight" + ":" + getWeight()+ "]"
-     + outputString;
+            "weight" + ":" + getWeight()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicPostcondition1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicPostcondition1.java.txt
@@ -59,9 +59,7 @@ public class Client
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "minAge" + ":" + getMinAge()+ "]"
-     + outputString;
+            "minAge" + ":" + getMinAge()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/BasicPrecondition1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/BasicPrecondition1.java.txt
@@ -59,9 +59,7 @@ public class Client
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "minAge" + ":" + getMinAge()+ "]"
-     + outputString;
+            "minAge" + ":" + getMinAge()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassInheritance.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassInheritance.java.txt
@@ -160,9 +160,7 @@ public class Teacher extends Person
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "position" + ":" + getPosition()+ "]"
-     + outputString;
+            "position" + ":" + getPosition()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationAttributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationAttributes.java.txt
@@ -45,9 +45,7 @@ public class Token
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "p" + "=" + (getP() != null ? !getP().equals(this)  ? getP().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "p" + "=" + (getP() != null ? !getP().equals(this)  ? getP().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationClassTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AssociationClassTest.java.txt
@@ -114,11 +114,9 @@ public class Registration
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "grade" + ":" + getGrade()+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null") + System.getProperties().getProperty("line.separator") +
-            "  " + "courseSection = "+(getCourseSection()!=null?Integer.toHexString(System.identityHashCode(getCourseSection())):"null")
-     + outputString;
+            "  " + "courseSection = "+(getCourseSection()!=null?Integer.toHexString(System.identityHashCode(getCourseSection())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeComments.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeComments.java.txt
@@ -55,9 +55,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "c" + ":" + getC()+ "]"
-     + outputString;
+            "c" + ":" + getC()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeInlineComment.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeInlineComment.java.txt
@@ -48,9 +48,7 @@ public class Foo
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "bar" + ":" + getBar()+ "]"
-     + outputString;
+            "bar" + ":" + getBar()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeMultilineComment.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AttributeMultilineComment.java.txt
@@ -48,9 +48,7 @@ public class Foo
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
@@ -383,7 +383,6 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "x" + ":" + getX()+ "," +
             "str" + ":" + getStr()+ "," +
@@ -403,7 +402,6 @@ public class Mentor
             "  " + "tt" + "=" + (getTt() != null ? !getTt().equals(this)  ? getTt().toString().replaceAll("  ","    ") : "this" : "null") + System.getProperties().getProperty("line.separator") +
             "  " + "u" + "=" + (getU() != null ? !getU().equals(this)  ? getU().toString().replaceAll("  ","    ") : "this" : "null") + System.getProperties().getProperty("line.separator") +
             "  " + "v" + "=" + (getV() != null ? !getV().equals(this)  ? getV().toString().replaceAll("  ","    ") : "this" : "null") + System.getProperties().getProperty("line.separator") +
-            "  " + "w" + "=" + (getW() != null ? !getW().equals(this)  ? getW().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "w" + "=" + (getW() != null ? !getW().equals(this)  ? getW().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_BuildOutputPath.ump.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_BuildOutputPath.ump.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_EmptyStringAttr.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_EmptyStringAttr.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "grade" + ":" + getGrade()+ "]"
-     + outputString;
+            "grade" + ":" + getGrade()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes.java.txt
@@ -65,10 +65,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "capacity" + ":" + getCapacity()+ "]"
-     + outputString;
+            "capacity" + ":" + getCapacity()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes1.java.txt
@@ -50,9 +50,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "id" + ":" + getId()+ "]"
-     + outputString;
+            "id" + ":" + getId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes2.java.txt
@@ -82,11 +82,9 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "capacity" + ":" + getCapacity()+ "," +
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes3.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_FixmlAttributes3.java.txt
@@ -84,11 +84,9 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "capacity" + ":" + getCapacity()+ "," +
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import.java.txt
@@ -124,10 +124,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")
-     + outputString;
+            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Import2.java.txt
@@ -349,9 +349,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_IsA2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_IsA2.java.txt
@@ -48,9 +48,7 @@ public class SubMentor2 extends Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "subName" + ":" + getSubName()+ "]"
-     + outputString;
+            "subName" + ":" + getSubName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributeOnImmutableClass.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributeOnImmutableClass.java.txt
@@ -59,10 +59,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
-            "studentNumber" + ":" + getStudentNumber()+ "]"
-     + outputString;
+            "studentNumber" + ":" + getStudentNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributesOnSingleton.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_LazyAttributesOnSingleton.java.txt
@@ -89,11 +89,9 @@ public class Application
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "version" + ":" + getVersion()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "id" + "=" + (getId() != null ? !getId().equals(this)  ? getId().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "id" + "=" + (getId() != null ? !getId().equals(this)  ? getId().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_ListAttributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_ListAttributes.java.txt
@@ -77,8 +77,6 @@ public class Token
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_MultipleAttributeComments.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_MultipleAttributeComments.java.txt
@@ -104,12 +104,10 @@ public class Foo
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "testAttribute1" + ":" + getTestAttribute1()+ "," +
             "testAttribute2" + ":" + getTestAttribute2()+ "," +
             "testAttribute3" + ":" + getTestAttribute3()+ "," +
-            "testAttribute4" + ":" + getTestAttribute4()+ "]"
-     + outputString;
+            "testAttribute4" + ":" + getTestAttribute4()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineDoesNotImplementInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineDoesNotImplementInterface.java.txt
@@ -122,8 +122,6 @@ public class FileLogger implements Logger
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsInterface.java.txt
@@ -110,8 +110,6 @@ public class FileLogger implements Logger
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsPartialInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_StateMachineImplementsPartialInterface.java.txt
@@ -96,8 +96,6 @@ public class FileLogger implements Logger
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI5.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI5.java.txt
@@ -222,10 +222,8 @@ public class MicrowaveImpl implements IMicrowaveImpl
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "x" + ":" + getX()+ "," +
-            "f" + ":" + getF()+ "]"
-     + outputString;
+            "f" + ":" + getF()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI5_parent.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI5_parent.java.txt
@@ -220,9 +220,7 @@ public class ClientImpl implements IClientImpl
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "id" + ":" + getId()+ "]"
-     + outputString;
+            "id" + ":" + getId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods.java.txt
@@ -411,12 +411,10 @@ public class MicrowaveImpl implements IMicrowaveImpl, Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "lightOn" + ":" + getLightOn()+ "," +
             "powerTubeOn" + ":" + getPowerTubeOn()+ "," +
             "isDoorOpened" + ":" + getIsDoorOpened()+ "," +
-            "isButtonPressed" + ":" + getIsButtonPressed()+ "]"
-     + outputString;
+            "isButtonPressed" + ":" + getIsButtonPressed()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods2.java.txt
@@ -395,12 +395,10 @@ public class MicrowaveImpl extends CCImpl implements IMicrowaveImpl, Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "lightOn" + ":" + getLightOn()+ "," +
             "powerTubeOn" + ":" + getPowerTubeOn()+ "," +
             "isDoorOpened" + ":" + getIsDoorOpened()+ "," +
-            "isButtonPressed" + ":" + getIsButtonPressed()+ "]"
-     + outputString;
+            "isButtonPressed" + ":" + getIsButtonPressed()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_ProxyPattern_Microwave.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_ProxyPattern_Microwave.java.txt
@@ -196,10 +196,8 @@ public class MicrowaveImpl extends Client
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "x" + ":" + getX()+ "," +
-            "f" + ":" + getF()+ "]"
-     + outputString;
+            "f" + ":" + getF()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
@@ -222,14 +222,12 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "name" + ":" + getName()+ "," +
             "type" + ":" + getType()+ "," +
             "funName" + ":" + getFunName()+ "," +
             "injBool" + ":" + getInjBool()+ "," +
-            "dInjBool" + ":" + getDInjBool()+ "]"
-     + outputString;
+            "dInjBool" + ":" + getDInjBool()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionWildCardTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionWildCardTest.java.txt
@@ -62,10 +62,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "firstName" + ":" + getFirstName()+ "," +
-            "lastName" + ":" + getLastName()+ "]"
-     + outputString;
+            "lastName" + ":" + getLastName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/DateConstraint1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/DateConstraint1.java.txt
@@ -71,10 +71,8 @@ public class X
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+ "]" + System.getProperties().getProperty("line.separator") +
             "  " + "d" + "=" + (getD() != null ? !getD().equals(this)  ? getD().toString().replaceAll("  ","    ") : "this" : "null") + System.getProperties().getProperty("line.separator") +
-            "  " + "e" + "=" + (getE() != null ? !getE().equals(this)  ? getE().toString().replaceAll("  ","    ") : "this" : "null")
-     + outputString;
+            "  " + "e" + "=" + (getE() != null ? !getE().equals(this)  ? getE().toString().replaceAll("  ","    ") : "this" : "null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_AlreadyImmutable.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_AlreadyImmutable.java.txt
@@ -138,12 +138,10 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "stringId" + ":" + getStringId()+ "," +
             "booleanId" + ":" + getBooleanId()+ "," +
             "doubleId" + ":" + getDoubleId()+ "," +
-            "intId" + ":" + getIntId()+ "]"
-     + outputString;
+            "intId" + ":" + getIntId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
@@ -254,12 +254,10 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "stringId" + ":" + getStringId()+ "," +
             "booleanId" + ":" + getBooleanId()+ "," +
             "doubleId" + ":" + getDoubleId()+ "," +
-            "intId" + ":" + getIntId()+ "]"
-     + outputString;
+            "intId" + ":" + getIntId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/Float.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Float.java.txt
@@ -60,10 +60,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "f1" + ":" + getF1()+ "," +
-            "f2" + ":" + getF2()+ "]"
-     + outputString;
+            "f2" + ":" + getF2()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMNTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMNTest.java.txt
@@ -117,9 +117,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMStarTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalMStarTest.java.txt
@@ -112,9 +112,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalManyTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalManyTest.java.txt
@@ -112,9 +112,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalNTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalNTest.java.txt
@@ -122,9 +122,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOneTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOneTest.java.txt
@@ -66,10 +66,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalNTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalNTest.java.txt
@@ -117,9 +117,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalOneTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalOptionalOneTest.java.txt
@@ -66,10 +66,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalTests_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ImmutableUnidirectionalTests_Unaware.java.txt
@@ -37,9 +37,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association.java.txt
@@ -238,9 +238,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMNTest_Association2.java.txt
@@ -238,9 +238,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MN.java.txt
@@ -228,9 +228,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToMStarTest_MStar.java.txt
@@ -238,9 +238,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_MN.java.txt
@@ -211,9 +211,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToNTest_N.java.txt
@@ -238,9 +238,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_MN.java.txt
@@ -186,9 +186,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MNToOptionalNTest_OptionalN.java.txt
@@ -190,9 +190,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association.java.txt
@@ -228,9 +228,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToMStarTest_Association2.java.txt
@@ -228,9 +228,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_MStar.java.txt
@@ -186,9 +186,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/MStarToOptionalNTest_OptionalN.java.txt
@@ -221,9 +221,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_MN.java.txt
@@ -176,9 +176,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMNTest_Many.java.txt
@@ -236,9 +236,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_MStar.java.txt
@@ -176,9 +176,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToMStarTest_Many.java.txt
@@ -226,9 +226,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association.java.txt
@@ -169,9 +169,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToManyTest_Association2.java.txt
@@ -169,9 +169,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_Many.java.txt
@@ -209,9 +209,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToNTest_N.java.txt
@@ -176,9 +176,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_Many.java.txt
@@ -220,9 +220,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ManyToOptionalNTest_OptionalN.java.txt
@@ -169,9 +169,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_MStar.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_MStar.java.txt
@@ -211,9 +211,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToMStarTest_N.java.txt
@@ -228,9 +228,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association.java.txt
@@ -211,9 +211,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToNTest_Association2.java.txt
@@ -211,9 +211,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_N.java.txt
@@ -186,9 +186,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/NToOptionalNTest_OptionalN.java.txt
@@ -163,9 +163,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_MN.java.txt
@@ -93,10 +93,8 @@ public class Pupil
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMNTest_One.java.txt
@@ -194,9 +194,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_Many.java.txt
@@ -92,10 +92,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToMandatoryManyTest_One.java.txt
@@ -178,9 +178,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_Many.java.txt
@@ -81,10 +81,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToManyTest_One.java.txt
@@ -158,9 +158,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_N.java.txt
@@ -93,10 +93,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToNTest_One.java.txt
@@ -167,9 +167,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association.java.txt
@@ -87,11 +87,9 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "id" + ":" + getId()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")
-     + outputString;
+            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOneTest_Association2.java.txt
@@ -87,11 +87,9 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_One.java.txt
@@ -175,9 +175,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_OptionalN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalNTest_OptionalN.java.txt
@@ -93,10 +93,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Driver.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Driver.java.txt
@@ -93,10 +93,8 @@ public class MyDriver
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mySubordinate = "+(getMySubordinate()!=null?Integer.toHexString(System.identityHashCode(getMySubordinate())):"null")
-     + outputString;
+            "  " + "mySubordinate = "+(getMySubordinate()!=null?Integer.toHexString(System.identityHashCode(getMySubordinate())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Subordinate.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OneToOptionalOneTest_Subordinate.java.txt
@@ -93,10 +93,8 @@ public class MySubordinate
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "myDriver = "+(getMyDriver()!=null?Integer.toHexString(System.identityHashCode(getMyDriver())):"null")
-     + outputString;
+            "  " + "myDriver = "+(getMyDriver()!=null?Integer.toHexString(System.identityHashCode(getMyDriver())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association.java.txt
@@ -179,9 +179,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalNToOptionalNTest_Association2.java.txt
@@ -179,9 +179,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_MN.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_MN.java.txt
@@ -73,10 +73,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMNTest_One.java.txt
@@ -236,9 +236,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_Many.java.txt
@@ -123,10 +123,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToMStarTest_One.java.txt
@@ -227,9 +227,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_Many.java.txt
@@ -83,10 +83,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToManyTest_One.java.txt
@@ -156,9 +156,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_Many.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_Many.java.txt
@@ -64,10 +64,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToNTest_One.java.txt
@@ -158,9 +158,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_N.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_N.java.txt
@@ -88,10 +88,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null")
-     + outputString;
+            "  " + "mentor = "+(getMentor()!=null?Integer.toHexString(System.identityHashCode(getMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/OptionalOneToOptionalNTest_One.java.txt
@@ -166,9 +166,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OneSymmetric.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OneSymmetric.java.txt
@@ -87,11 +87,9 @@ public class OneSymmetric
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
             "number" + ":" + getNumber()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "friend = "+(getFriend()!=null?Integer.toHexString(System.identityHashCode(getFriend())):"null")
-     + outputString;
+            "  " + "friend = "+(getFriend()!=null?Integer.toHexString(System.identityHashCode(getFriend())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneAsymmetric.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneAsymmetric.java.txt
@@ -146,9 +146,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneSymmetric.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ReflexiveAssociationTest_OptionalOneSymmetric.java.txt
@@ -97,10 +97,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "superMentor = "+(getSuperMentor()!=null?Integer.toHexString(System.identityHashCode(getSuperMentor())):"null")
-     + outputString;
+            "  " + "superMentor = "+(getSuperMentor()!=null?Integer.toHexString(System.identityHashCode(getSuperMentor())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_One.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_One.java.txt
@@ -156,9 +156,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_Singleton.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/SingletonToOneTest_Singleton.java.txt
@@ -92,10 +92,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")
-     + outputString;
+            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/StudentImmutableNotLazyTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/StudentImmutableNotLazyTest.java.txt
@@ -57,10 +57,8 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "number" + ":" + getNumber()+ "," +
-            "number2" + ":" + getNumber2()+ "]"
-     + outputString;
+            "number2" + ":" + getNumber2()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Aware.java.txt
@@ -183,9 +183,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMNTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Aware.java.txt
@@ -175,9 +175,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalMStarTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Aware.java.txt
@@ -139,9 +139,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalManyTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Aware.java.txt
@@ -126,9 +126,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalNTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Aware.java.txt
@@ -70,10 +70,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")
-     + outputString;
+            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOneTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Aware.java.txt
@@ -171,9 +171,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalNTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Aware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Aware.java.txt
@@ -69,10 +69,8 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null")
-     + outputString;
+            "  " + "student = "+(getStudent()!=null?Integer.toHexString(System.identityHashCode(getStudent())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Unaware.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/UnidirectionalOptionalOneTest_Unaware.java.txt
@@ -45,9 +45,7 @@ public class Student
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "number" + ":" + getNumber()+ "]"
-     + outputString;
+            "number" + ":" + getNumber()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/javaRubyPHPConstraint.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/javaRubyPHPConstraint.java.txt
@@ -71,10 +71,8 @@ public class Range
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "start" + ":" + getStart()+ "," +
-            "end" + ":" + getEnd()+ "]"
-     + outputString;
+            "end" + ":" + getEnd()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/phpJavaRubyConstraint.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/phpJavaRubyConstraint.java.txt
@@ -71,10 +71,8 @@ public class Range
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "start" + ":" + getStart()+ "," +
-            "end" + ":" + getEnd()+ "]"
-     + outputString;
+            "end" + ":" + getEnd()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CodeBlock_and_Expression/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CodeBlock_and_Expression/Java/TemplateTest.java.txt
@@ -84,9 +84,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CommentBlock/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_CommentBlock/Java/TemplateTest.java.txt
@@ -79,9 +79,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_referToSharedTemplateDefinition/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_referToSharedTemplateDefinition/Java/TemplateTest.java.txt
@@ -80,9 +80,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_many_templateDefinitions/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_many_templateDefinitions/Java/TemplateTest.java.txt
@@ -80,9 +80,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_parameters/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Emit_with_parameters/Java/TemplateTest.java.txt
@@ -80,9 +80,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_ExactSpace_methods/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_ExactSpace_methods/Java/TemplateTest.java.txt
@@ -100,9 +100,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Expressions/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Expressions/Java/TemplateTest.java.txt
@@ -113,11 +113,9 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "string1" + ":" + getString1()+ "," +
-            "string2" + ":" + getString2()+ "]"
-     + outputString;
+            "string2" + ":" + getString2()+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Nested_reference_templates/Java/ClassGenerator.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_Nested_reference_templates/Java/ClassGenerator.java.txt
@@ -113,9 +113,7 @@ public class ClassGenerator
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/HelperTemplate.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/HelperTemplate.java.txt
@@ -103,8 +103,6 @@ public class HelperTemplate
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_SingletonEmit/Java/TemplateTest.java.txt
@@ -78,9 +78,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_complex_Generation/Java/HtmlNode.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_complex_Generation/Java/HtmlNode.java.txt
@@ -310,11 +310,9 @@ public class HtmlNode
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "tag" + ":" + getTag()+ "," +
-            "content" + ":" + getContent()+ "]"
-     + outputString;
+            "content" + ":" + getContent()+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleCodeBlock/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleCodeBlock/Java/TemplateTest.java.txt
@@ -77,9 +77,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleTest/Java/TemplateTest.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/umpleTL/resources/UmpleTL_simpleTest/Java/TemplateTest.java.txt
@@ -76,9 +76,7 @@ public class TemplateTest
 
   public String toString()
   {
-    String outputString = "";
-    return super.toString() + "["+ "]"
-     + outputString;
+    return super.toString() + "["+ "]";
   }
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/activeObject.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/activeObject.java.txt
@@ -300,9 +300,7 @@ public class Lamp
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "log" + ":" + getLog()+ "]"
-     + outputString;
+            "log" + ":" + getLog()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments.java.txt
@@ -143,9 +143,7 @@ public class LightFixture
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventWithArguments_1.java.txt
@@ -143,9 +143,7 @@ public class LightFixture
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/exitActionSelfTransition.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/exitActionSelfTransition.java.txt
@@ -132,9 +132,7 @@ public class A
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "result" + ":" + getResult()+ "]"
-     + outputString;
+            "result" + ":" + getResult()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNameBothAttributeAndMethod.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNameBothAttributeAndMethod.java.txt
@@ -105,9 +105,7 @@ public class A
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "repeatCheck" + ":" + getRepeatCheck()+ "]"
-     + outputString;
+            "repeatCheck" + ":" + getRepeatCheck()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNameBothAttributeAndMethod2.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNameBothAttributeAndMethod2.java.txt
@@ -105,9 +105,7 @@ public class A
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "repeatCheck" + ":" + getRepeatCheck()+ "]"
-     + outputString;
+            "repeatCheck" + ":" + getRepeatCheck()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNameBothAttributeAndMethod3.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNameBothAttributeAndMethod3.java.txt
@@ -105,9 +105,7 @@ public class A
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "repeatCheck" + ":" + getRepeatCheck()+ "]"
-     + outputString;
+            "repeatCheck" + ":" + getRepeatCheck()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardSpacing.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardSpacing.java.txt
@@ -93,9 +93,7 @@ public class Garage
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "entranceClear" + ":" + getEntranceClear()+ "]"
-     + outputString;
+            "entranceClear" + ":" + getEntranceClear()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEvent.java.txt
@@ -94,9 +94,7 @@ public class LightFixture
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEventWithDefaultNoGuard.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleGuardsSameEventWithDefaultNoGuard.java.txt
@@ -96,9 +96,7 @@ public class LightFixture
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/nestedStateMachineExtendedByClass.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/nestedStateMachineExtendedByClass.java.txt
@@ -436,10 +436,8 @@ public class Animal extends ThingInWorld
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "isAlive" + ":" + getIsAlive()+ "]" + System.getProperties().getProperty("line.separator") +
-            "  " + "world = "+(getWorld()!=null?Integer.toHexString(System.identityHashCode(getWorld())):"null")
-     + outputString;
+            "  " + "world = "+(getWorld()!=null?Integer.toHexString(System.identityHashCode(getWorld())):"null");
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/nestedStateMachineExtendedByMultipleClasses.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/nestedStateMachineExtendedByMultipleClasses.java.txt
@@ -199,9 +199,7 @@ public class Animal
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "isAlive" + ":" + getIsAlive()+ "]"
-     + outputString;
+            "isAlive" + ":" + getIsAlive()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/oneGuard.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/oneGuard.java.txt
@@ -88,9 +88,7 @@ public class LightFixture
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents.java.txt
@@ -324,9 +324,7 @@ public class Mentor implements Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]"
-     + outputString;
+            "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
@@ -276,9 +276,7 @@ public class LightFixture implements Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents.java.txt
@@ -297,9 +297,7 @@ public class Mentor implements Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]"
-     + outputString;
+            "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
@@ -248,9 +248,7 @@ public class LightFixture implements Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
@@ -249,9 +249,7 @@ public class LightFixture implements Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "brightness" + ":" + getBrightness()+ "]"
-     + outputString;
+            "brightness" + ":" + getBrightness()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/stateMachineWithStringComparisonGuard.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/stateMachineWithStringComparisonGuard.java.txt
@@ -100,9 +100,7 @@ public class stateMachineWithStringComparisonGuard
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "cmdString" + ":" + getCmdString()+ "]"
-     + outputString;
+            "cmdString" + ":" + getCmdString()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testMultipleQSMs.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testMultipleQSMs.java.txt
@@ -350,9 +350,7 @@ public class X implements Runnable
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "ev" + ":" + getEv()+ "]"
-     + outputString;
+            "ev" + ":" + getEv()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/timedEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/timedEvent.java.txt
@@ -197,9 +197,7 @@ public class Mentor
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]"
-     + outputString;
+            "howLongUntilOk" + ":" + getHowLongUntilOk()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceBiAssocManyToManyRoleCondition.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceBiAssocManyToManyRoleCondition.java.txt
@@ -190,9 +190,7 @@ public class Company
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceCaseAttrStm.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceCaseAttrStm.java.txt
@@ -202,10 +202,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
-            "id" + ":" + getId()+ "]"
-     + outputString;
+            "id" + ":" + getId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbEvent.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbPostfix.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbPostfix.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbState.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceLightBulbState.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeAfter.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeAfter.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeOccurences.java.txt
@@ -73,10 +73,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributePeriod.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributePeriod.java.txt
@@ -107,10 +107,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord4.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeRecord4.java.txt
@@ -75,11 +75,9 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "contact" + ":" + getContact()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeUntil.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceMultipleAttributeUntil.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeOccurences.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord1.java.txt
@@ -59,10 +59,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord4.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/TraceSingleAttributeRecord4.java.txt
@@ -74,11 +74,9 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "contact" + ":" + getContact()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/tmp.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/Console/tmp.java.txt
@@ -64,10 +64,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceBiAssocManyToManyRoleCondition.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceBiAssocManyToManyRoleCondition.java.txt
@@ -190,9 +190,7 @@ public class Company
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceCaseAttrStm.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceCaseAttrStm.java.txt
@@ -202,10 +202,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
-            "id" + ":" + getId()+ "]"
-     + outputString;
+            "id" + ":" + getId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbEvent.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbPostfix.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbPostfix.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbState.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceLightBulbState.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeAfter.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeAfter.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeOccurences.java.txt
@@ -73,10 +73,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributePeriod.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributePeriod.java.txt
@@ -107,10 +107,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord4.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeRecord4.java.txt
@@ -75,11 +75,9 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "contact" + ":" + getContact()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeUntil.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceMultipleAttributeUntil.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeOccurences.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord1.java.txt
@@ -59,10 +59,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord4.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/TraceSingleAttributeRecord4.java.txt
@@ -74,11 +74,9 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "contact" + ":" + getContact()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/File/tmp.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/File/tmp.java.txt
@@ -64,10 +64,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceBiAssocManyToManyRoleCondition.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceBiAssocManyToManyRoleCondition.java.txt
@@ -190,9 +190,7 @@ public class Company
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceCaseAttrStm.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceCaseAttrStm.java.txt
@@ -202,10 +202,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "name" + ":" + getName()+ "," +
-            "id" + ":" + getId()+ "]"
-     + outputString;
+            "id" + ":" + getId()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbEvent.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbEvent.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbPostfix.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbPostfix.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbState.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceLightBulbState.java.txt
@@ -100,9 +100,7 @@ public class LightBulb
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
-            "v" + ":" + getV()+ "]"
-     + outputString;
+            "v" + ":" + getV()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeAfter.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeAfter.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeOccurences.java.txt
@@ -73,10 +73,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributePeriod.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributePeriod.java.txt
@@ -107,10 +107,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord4.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeRecord4.java.txt
@@ -75,11 +75,9 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "contact" + ":" + getContact()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeUntil.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceMultipleAttributeUntil.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeOccurences.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeOccurences.java.txt
@@ -75,10 +75,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord1.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord1.java.txt
@@ -59,10 +59,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord4.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/TraceSingleAttributeRecord4.java.txt
@@ -74,11 +74,9 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
             "contact" + ":" + getContact()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }

--- a/cruise.umple/test/cruise/umple/tracer/implementation/java/String/tmp.java.txt
+++ b/cruise.umple/test/cruise/umple/tracer/implementation/java/String/tmp.java.txt
@@ -64,10 +64,8 @@ public class Tracer
 
   public String toString()
   {
-    String outputString = "";
     return super.toString() + "["+
             "id" + ":" + getId()+ "," +
-            "name" + ":" + getName()+ "]"
-     + outputString;
+            "name" + ":" + getName()+ "]";
   }
 }


### PR DESCRIPTION
## Description
-Removed unused string `outputString` as well as all references to `outputString` from the automatically generated `toString()` Java function (see toString_declare.UmpleToJava/UmpleTLTemplates/toString_declare.ump).

-Removed references to `outputString` in several test files.

The references were found and replaced using regular expressions. See http://stackoverflow.com/questions/41930546/cleaning-up-formatting-after-deletion-using-regex/41930787#41930787 for details.

I checked that in each test file included in this pull request that three lines were removed and one line was added. I also did a quick visual check in the Github UI that nothing unexpected was removed.

## Tests

I removed references to `outputString` in over 200 existing test files, these test files will now test for the correct behaviour of the modified `toString` method.

`Closes #947`

