### PR TITLE
Fix for issue 969 and issue 986

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -27,6 +27,12 @@ class UmpleToJava {
         String methodImplementationModifier = aMethod.getIsAbstract() ? " abstract" : "";
         String methodName = aMethod.getName();
         String methodType = aMethod.getType();
+		// Fix issue 969
+		if (!methodName.equals(uClass.getName()))
+		{
+			// If this is not a constructor, this method should return "void"
+			methodType = methodType.equals("") ? "void" : methodType;
+		}
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -48,21 +48,6 @@ class UmpleToJava {
         String isList="";
         String finalParams = "";        
         String finalParamsWithoutTypes = "";
-        if(methodName.equals("main")&&methodType.equals("void")&&methodModifier.contains("public")&&methodModifier.contains("static"))
-        {
-          String exceptionHandlerPackage = "";
-          if(mainMainClass!=null)
-          {
-            exceptionHandlerPackage = mainMainClass.getPackageName()+"."+mainMainClass.getName()+".";
-          }
-          else
-          {
-            mainMainClass = uClass;
-          }
-          properMethodBody = "    Thread.currentThread().setUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+
-                             "    Thread.setDefaultUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+properMethodBody;
-          uClass.setHasMainMethod(true);
-        }
         StringBuilder parameters = new StringBuilder();
         StringBuilder parametersWithoutTypes = new StringBuilder();
         if (aMethod.hasMethodParameters())
@@ -81,6 +66,22 @@ class UmpleToJava {
           finalParamsWithoutTypes = parametersWithoutTypes.toString().substring(0, parametersWithoutTypes.toString().length()-2);
         }
         
+		if(methodName.equals("main")&&methodType.equals("void")&&methodModifier.contains("public")&&methodModifier.contains("static")&&paramType.equals("String")&&isList.equals(" [] ")&&paramName.equals("args"))
+        {
+          String exceptionHandlerPackage = "";
+          if(mainMainClass!=null)
+          {
+            exceptionHandlerPackage = mainMainClass.getPackageName()+"."+mainMainClass.getName()+".";
+          }
+          else
+          {
+            mainMainClass = uClass;
+          }
+          properMethodBody = "    Thread.currentThread().setUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+
+                             "    Thread.setDefaultUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+properMethodBody;
+          uClass.setHasMainMethod(true);
+        }
+		
         if (aMethod.numberOfComments() > 0) { append(realSb, "\n\n  {0}", Comment.format("Method Javadoc",aMethod.getComments())); }
         
         append(realSb,"\n");

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2638,10 +2638,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       if (methodToken.is("methodName"))
       {
         aMethod.setName(methodToken.getValue());
-        if (methodToken.getValue().equals("main"))
-        {
-          uElement.setHasMainMethod(true);
-        }
       }
       if (methodToken.is("parameterList"))
       {

--- a/cruise.umple/src/util/SampleFileWriter_Code.ump
+++ b/cruise.umple/src/util/SampleFileWriter_Code.ump
@@ -196,18 +196,12 @@ class SampleFileWriter
         line++;
         
         // HACK: To deal with umple version issues
-        if (expectedLine != null && actualLine != null && expectedLine.indexOf("This code was generated using the UMPLE") == -1)
+        if (expectedLine != null && expectedLine.indexOf("This code was generated using the UMPLE") == -1)
         {
           Assert.assertEquals("Failed at:" + line,expectedLine,actualLine);  
         }
       } 
       while (expectedLine != null && actualLine != null);
-      
-      if ((expectedLine == null && actualLine != null) || expectedLine != null && actualLine == null) 
-      {
-    	  // Length mismatch between expected and actual
-    	  Assert.fail("Length mismatch between expected and actual at line " + line);
-      }
     }
     catch (Exception e)
     {

--- a/cruise.umple/src/util/SampleFileWriter_Code.ump
+++ b/cruise.umple/src/util/SampleFileWriter_Code.ump
@@ -196,12 +196,18 @@ class SampleFileWriter
         line++;
         
         // HACK: To deal with umple version issues
-        if (expectedLine != null && expectedLine.indexOf("This code was generated using the UMPLE") == -1)
+        if (expectedLine != null && actualLine != null && expectedLine.indexOf("This code was generated using the UMPLE") == -1)
         {
           Assert.assertEquals("Failed at:" + line,expectedLine,actualLine);  
         }
       } 
       while (expectedLine != null && actualLine != null);
+      
+      if ((expectedLine == null && actualLine != null) || expectedLine != null && actualLine == null) 
+      {
+    	  // Length mismatch between expected and actual
+    	  Assert.fail("Length mismatch between expected and actual at line " + line);
+      }
     }
     catch (Exception e)
     {

--- a/cruise.umple/test/cruise/umple/implementation/DistributedClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/DistributedClassTest.java
@@ -12,6 +12,7 @@ package cruise.umple.implementation;
 import org.junit.*;
 
 import cruise.umple.compiler.UmpleModel;
+import cruise.umple.compiler.java.JavaClassGenerator;
 import cruise.umple.util.SampleFileWriter;
 
 import java.io.File;
@@ -168,6 +169,16 @@ public class DistributedClassTest extends TemplateTest
 	      SampleFileWriter.assertPartialFileContent(expected, actual);
 	    }
 	  }
+	
+
+  @After
+  public void tearDown() {
+	/* Nullify mainMainClass. It's a static variable, if we don't do this the state will
+	 * affect the next set of JUnit tests that use mainMainClass.
+	 */
+	
+	JavaClassGenerator.mainMainClass = null;
+  }	
 	
   @Test
   public void TestDistributableDirectivesTest1()

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated.java.txt
@@ -24,8 +24,105 @@ public class Mentor
   public void delete()
   {}
 
-   public static   main(){
+   public static  void main(String [] args){
+    Thread.currentThread().setUncaughtExceptionHandler(new UmpleExceptionHandler());
+    Thread.setDefaultUncaughtExceptionHandler(new UmpleExceptionHandler());
     
   }
 
+  public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
+  {
+    public void uncaughtException(Thread t, Throwable e)
+    {
+      translate(e);
+      if(e.getCause()!=null)
+      {
+        translate(e.getCause());
+      }
+      e.printStackTrace();
+    }
+    public void translate(Throwable e)
+    {
+      java.util.List<StackTraceElement> result = new java.util.ArrayList<StackTraceElement>();
+      StackTraceElement[] elements = e.getStackTrace();
+      try
+      {
+        for(StackTraceElement element:elements)
+        {
+          String className = element.getClassName();
+          String methodName = element.getMethodName();
+          boolean methodFound = false;
+          int index = className.lastIndexOf('.')+1;
+          try {
+            java.lang.reflect.Method query = this.getClass().getMethod(className.substring(index)+"_"+methodName,new Class[]{});
+            UmpleSourceData sourceInformation = (UmpleSourceData)query.invoke(this,new Object[]{});
+            for(int i=0;i<sourceInformation.size();++i)
+            {
+              int distanceFromStart = element.getLineNumber()-sourceInformation.getJavaLine(i)-(("main".equals(methodName))?2:0);
+              if(distanceFromStart>=0&&distanceFromStart<=sourceInformation.getLength(i))
+              {
+                result.add(new StackTraceElement(element.getClassName(),element.getMethodName(),sourceInformation.getFileName(i),sourceInformation.getUmpleLine(i)+distanceFromStart));
+                methodFound = true;
+                break;
+              }
+            }
+          }
+          catch (Exception e2){}
+          if(!methodFound)
+          {
+            result.add(element);
+          }
+        }
+      }
+      catch (Exception e1)
+      {
+        e1.printStackTrace();
+      }
+      e.setStackTrace(result.toArray(new StackTraceElement[0]));
+    }
+  //The following methods Map Java lines back to their original Umple file / line    
+    public UmpleSourceData Mentor_main(){ return new UmpleSourceData().setFileNames("ClassTemplateTest_Generated.ump").setUmpleLines(5).setJavaLines(28).setLengths(3);}
+
+  }
+  public static class UmpleSourceData
+  {
+    String[] umpleFileNames;
+    Integer[] umpleLines;
+    Integer[] umpleJavaLines;
+    Integer[] umpleLengths;
+    
+    public UmpleSourceData(){
+    }
+    public String getFileName(int i){
+      return umpleFileNames[i];
+    }
+    public Integer getUmpleLine(int i){
+      return umpleLines[i];
+    }
+    public Integer getJavaLine(int i){
+      return umpleJavaLines[i];
+    }
+    public Integer getLength(int i){
+      return umpleLengths[i];
+    }
+    public UmpleSourceData setFileNames(String... filenames){
+      umpleFileNames = filenames;
+      return this;
+    }
+    public UmpleSourceData setUmpleLines(Integer... umplelines){
+      umpleLines = umplelines;
+      return this;
+    }
+    public UmpleSourceData setJavaLines(Integer... javalines){
+      umpleJavaLines = javalines;
+      return this;
+    }
+    public UmpleSourceData setLengths(Integer... lengths){
+      umpleLengths = lengths;
+      return this;
+    }
+    public int size(){
+      return umpleFileNames.length;
+    }
+  } 
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated2.java.txt
@@ -1,0 +1,31 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+package example;
+
+public class Mentor
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Mentor()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+   public void main(String [] args){
+    
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated2.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated2.ump
@@ -2,6 +2,6 @@ namespace example;
 
 class Mentor 
 {
-  public static main(String[] args)
+  public main(String[] args)
   {}
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.java.txt
@@ -1,5 +1,5 @@
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+/*This code was generated using the UMPLE ${last.version} modeling language!*/
 
 package example;
 
@@ -24,7 +24,7 @@ public class Mentor
   public void delete()
   {}
 
-   public void main(String [] args){
+   public static  void main(){
     
   }
 

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.java.txt
@@ -1,0 +1,31 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+package example;
+
+public class Mentor
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Mentor()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+   public void main(String [] args){
+    
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.ump
@@ -2,6 +2,6 @@ namespace example;
 
 class Mentor 
 {
-  public static main(String[] args)
+  public main(String[] args)
   {}
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated3.ump
@@ -2,6 +2,6 @@ namespace example;
 
 class Mentor 
 {
-  public main(String[] args)
+  public static void main()
   {}
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated4.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated4.java.txt
@@ -1,0 +1,133 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE ${last.version} modeling language!*/
+
+package example;
+
+public class Mentor
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Mentor()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+   public static  void main(String [] args){
+    Thread.currentThread().setUncaughtExceptionHandler(new UmpleExceptionHandler());
+    Thread.setDefaultUncaughtExceptionHandler(new UmpleExceptionHandler());
+    
+  }
+
+  public void foo(){
+    
+  }
+
+  public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
+  {
+    public void uncaughtException(Thread t, Throwable e)
+    {
+      translate(e);
+      if(e.getCause()!=null)
+      {
+        translate(e.getCause());
+      }
+      e.printStackTrace();
+    }
+    public void translate(Throwable e)
+    {
+      java.util.List<StackTraceElement> result = new java.util.ArrayList<StackTraceElement>();
+      StackTraceElement[] elements = e.getStackTrace();
+      try
+      {
+        for(StackTraceElement element:elements)
+        {
+          String className = element.getClassName();
+          String methodName = element.getMethodName();
+          boolean methodFound = false;
+          int index = className.lastIndexOf('.')+1;
+          try {
+            java.lang.reflect.Method query = this.getClass().getMethod(className.substring(index)+"_"+methodName,new Class[]{});
+            UmpleSourceData sourceInformation = (UmpleSourceData)query.invoke(this,new Object[]{});
+            for(int i=0;i<sourceInformation.size();++i)
+            {
+              int distanceFromStart = element.getLineNumber()-sourceInformation.getJavaLine(i)-(("main".equals(methodName))?2:0);
+              if(distanceFromStart>=0&&distanceFromStart<=sourceInformation.getLength(i))
+              {
+                result.add(new StackTraceElement(element.getClassName(),element.getMethodName(),sourceInformation.getFileName(i),sourceInformation.getUmpleLine(i)+distanceFromStart));
+                methodFound = true;
+                break;
+              }
+            }
+          }
+          catch (Exception e2){}
+          if(!methodFound)
+          {
+            result.add(element);
+          }
+        }
+      }
+      catch (Exception e1)
+      {
+        e1.printStackTrace();
+      }
+      e.setStackTrace(result.toArray(new StackTraceElement[0]));
+    }
+  //The following methods Map Java lines back to their original Umple file / line    
+    public UmpleSourceData Mentor_foo(){ return new UmpleSourceData().setFileNames("ClassTemplateTest_Generated4.ump").setUmpleLines(9).setJavaLines(35).setLengths(3);}
+    public UmpleSourceData Mentor_main(){ return new UmpleSourceData().setFileNames("ClassTemplateTest_Generated4.ump").setUmpleLines(5).setJavaLines(28).setLengths(3);}
+
+  }
+  public static class UmpleSourceData
+  {
+    String[] umpleFileNames;
+    Integer[] umpleLines;
+    Integer[] umpleJavaLines;
+    Integer[] umpleLengths;
+    
+    public UmpleSourceData(){
+    }
+    public String getFileName(int i){
+      return umpleFileNames[i];
+    }
+    public Integer getUmpleLine(int i){
+      return umpleLines[i];
+    }
+    public Integer getJavaLine(int i){
+      return umpleJavaLines[i];
+    }
+    public Integer getLength(int i){
+      return umpleLengths[i];
+    }
+    public UmpleSourceData setFileNames(String... filenames){
+      umpleFileNames = filenames;
+      return this;
+    }
+    public UmpleSourceData setUmpleLines(Integer... umplelines){
+      umpleLines = umplelines;
+      return this;
+    }
+    public UmpleSourceData setJavaLines(Integer... javalines){
+      umpleJavaLines = javalines;
+      return this;
+    }
+    public UmpleSourceData setLengths(Integer... lengths){
+      umpleLengths = lengths;
+      return this;
+    }
+    public int size(){
+      return umpleFileNames.length;
+    }
+  } 
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated4.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated4.ump
@@ -1,0 +1,11 @@
+namespace example;
+
+class Mentor 
+{
+  public static void main(String[] args)
+  {}
+  
+  void foo()
+  {
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -128,6 +128,7 @@ public class JavaClassTemplateTest extends ClassTemplateTest
     assertUmpleTemplateFor("java/ClassTemplateTest_Java.ump","java/ClassTemplateTest_Java.java.txt","Mentor");
   }
   
+  // Tests fix for issue 969 and 986
   @Test
   public void Generated()
   {
@@ -140,6 +141,9 @@ public class JavaClassTemplateTest extends ClassTemplateTest
      *  when a function matches the "public static void main(String[] args)" format exactly.
      */
     assertUmpleTemplateFor("java/ClassTemplateTest_Generated2.ump","java/ClassTemplateTest_Generated2.java.txt","Mentor");
+    assertUmpleTemplateFor("java/ClassTemplateTest_Generated3.ump","java/ClassTemplateTest_Generated3.java.txt","Mentor");
+    
+    // Check that void is not added twice if the user explicitly includes it in the .ump file
     assertUmpleTemplateFor("java/ClassTemplateTest_Generated3.ump","java/ClassTemplateTest_Generated3.java.txt","Mentor");
 
     

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -131,7 +131,18 @@ public class JavaClassTemplateTest extends ClassTemplateTest
   @Test
   public void Generated()
   {
+	/* Test that "void" is added to a non-constructor method with no specified return type, 
+	 * and that the correct threading code is generated when "public static void main(String[] args)" is specified
+	 */
     assertUmpleTemplateFor("java/ClassTemplateTest_Generated.ump","java/ClassTemplateTest_Generated.java.txt","Mentor");
+    /*
+     *  Check that a "main" function (in the Java sense) is only detected (and accompanying threading code generated)
+     *  when a function matches the "public static void main(String[] args)" format exactly.
+     */
+    assertUmpleTemplateFor("java/ClassTemplateTest_Generated2.ump","java/ClassTemplateTest_Generated2.java.txt","Mentor");
+    assertUmpleTemplateFor("java/ClassTemplateTest_Generated3.ump","java/ClassTemplateTest_Generated3.java.txt","Mentor");
+
+    
   }
   
   @Test

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
@@ -39,6 +39,8 @@ import cruise.umple.compiler.java.JavaClassGenerator;
 import cruise.umple.parser.analysis.RuleBasedParser;
 import cruise.umple.test.harness.compiler.JavaInternalCompiler;
 import cruise.umple.test.harness.compiler.interfaces.ICompiler;
+import cruise.umple.test.harness.resource.TemplateGeneratedOutput;
+
 import cruise.umple.util.SampleFileWriter;
 
 import org.junit.Assert;


### PR DESCRIPTION
## Description

Fixes the "Not having return types for methods" issue ([969](https://github.com/umple/umple/issues/969)) for Java and Php (not for C++, I've created a [seperate issue](https://github.com/umple/umple/issues/989) for the C++ guys).

As part of the investigating 969, I uncovered issues relating to the generation of "main" methods and associated threading code in Java (the investigation formed its own issue, ([986](https://github.com/umple/umple/issues/986))). Essentially, the test to determine if a method was a Java main method wasn't rigorous enough. This has been fixed and the threading code is generating properly now (i.e. only if `public static (void) main(String[] args)` is present)

Additionally, I looked into why the threading code being generated for a Java main method wasn't consistent from run to run. The problem was that a JUnit test wasn't cleaning up after itself, and has also been fixed. 



## Tests

Several tests have been added (and a few existing tests have been modified) to fully verify the correctness of the generated `main` methods and associated threading code, as well as to verify that `void` is being added to Java methods that don't specify a return type.

`Closes #969, #968`