### PR TITLE
Removed check for input parameter name

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -66,7 +66,8 @@ class UmpleToJava {
           finalParamsWithoutTypes = parametersWithoutTypes.toString().substring(0, parametersWithoutTypes.toString().length()-2);
         }
         
-		if(methodName.equals("main")&&methodType.equals("void")&&methodModifier.contains("public")&&methodModifier.contains("static")&&paramType.equals("String")&&isList.equals(" [] ")&&paramName.equals("args"))
+        if(methodName.equals("main")&&methodType.equals("void")&&methodModifier.contains("public")&&methodModifier.contains("static")
+          &&paramType.equals("String")&&isList.equals(" [] "))
         {
           String exceptionHandlerPackage = "";
           if(mainMainClass!=null)


### PR DESCRIPTION
## Description

Removing the argument name component of the check that determines if a user-added function is a main function or not.

