### PR TITLE
Add Umple User Manual entry for Final States

### DIFF
--- a/build/reference/3001basicStateMachines.txt
+++ b/build/reference/3001basicStateMachines.txt
@@ -27,6 +27,7 @@ Details of each state can include:
   </ul>
 <li>Entry actions, exit actions and do activities. <a href="StateMachineActionsandDoActivities.html">See the separate manual page</a>.
 <li>Nested states. <a href="NestedStateMachines.html">See the separate manual page.</a> You can nest state machines to arbitrary levels of depth.
+<li>Final states. <a href="FinalStates.html">See the separate manual page</a>.
 </ul>
 </p>
 

--- a/build/reference/3005FinalStates.txt
+++ b/build/reference/3005FinalStates.txt
@@ -1,0 +1,30 @@
+Final States
+State Machines
+noreferences
+
+@@description
+
+<p>      
+In Umple, there are two ways to define final states.
+</p>
+
+<p>
+The first way is to use the "Final" keyword. This automatically defines a final state for the top-level state machine. Once the state machine is in this state, it is considered to be complete, and it is terminated. The "Final" keyword can be used as shown in the example below. Note, if a user defines a state named "Final", error <a href="E074UserDefinedStateCannotBeNamedFinal.html">E074 User Defined State Cannot be Named Final</a> will be thrown.
+</p>
+
+<p>
+The second way is to use the "final" keyword. Using this keyword allows users to define final states as shown below. In the case of concurrent state machines, all state machines within the same concurrent region must be in their final states before the enclosing region is considered to be complete. In the case of non-concurrent state machines, as soon as a final state is entered, the state machine is considered to be complete.
+<p>
+
+@@example
+@@source manualexamples/FinalStateKeywordExample.ump &diagramtype=state
+@@endexample
+
+@@example
+@@source manualexamples/RegionFinal_ConcurrentExample.ump &diagramtype=state
+@@endexample
+
+
+@@example
+@@source manualexamples/RegionFinal_NonConcurrentExample.ump &diagramtype=state
+@@endexample

--- a/umpleonline/ump/manualexamples/FinalStateKeywordExample.ump
+++ b/umpleonline/ump/manualexamples/FinalStateKeywordExample.ump
@@ -1,0 +1,13 @@
+// Using the keyword "Final" automatically defines the 
+// final state for the top-level state machine "sm"
+
+class X {
+  sm {
+    s1 {
+      goToS2 -> s2;
+    }
+    s2 {
+      goToFinal -> Final;
+    }
+  }
+}

--- a/umpleonline/ump/manualexamples/RegionFinal_ConcurrentExample.ump
+++ b/umpleonline/ump/manualexamples/RegionFinal_ConcurrentExample.ump
@@ -1,0 +1,30 @@
+// "s1" is an orthogonal region, and it is considered to be complete when
+// all of the concurrent state machines are in their final states
+// (i.e. s2 is in state "s4", s5 is in state "s7", and s8 is in state "s10")
+
+class X {
+  sm {
+    s1 {
+      s2 {
+        s3 {
+         goToS4 -> s4;
+        }
+        final s4 { }
+      }
+      ||
+      s5 { 
+        s6 {
+          goToS7 -> s7;
+        }
+        final s7 { }
+      }
+      ||
+      s8 {
+        s9 {
+          goToS10 -> s10;
+        }
+        final s10 { }
+      }
+    }
+  }
+}

--- a/umpleonline/ump/manualexamples/RegionFinal_NonConcurrentExample.ump
+++ b/umpleonline/ump/manualexamples/RegionFinal_NonConcurrentExample.ump
@@ -1,0 +1,18 @@
+// "sm" will be considered as complete when
+// it is in either state "s3" or "s5"
+
+class X {
+  sm {
+    s1 {
+      s2 {
+        goToS3 -> s3;
+        goToS4 -> s4;
+      }
+      final s3 { }
+    }
+    s4 {
+      goToS5 -> s5;
+      final s5 { }
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR addresses #1035 by adding an entry for "Final States" in the Umple User Manual. It also includes examples.

Closes #1035 


