### PR TITLE
This PR add a feature which allows having default types for template parameters

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
@@ -800,6 +800,7 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
 	if (inUmpleClassifier instanceof UmpleTrait) {type = "trait";} 
 	for (GeneralTemplateParameter gtParameter : model.getUmpleTrait(inGeneralTPAppliedByName.getInheritanceName()).getGeneralTemplateParameters()){
 		String bindingValue= inGeneralTPAppliedByName.getParameterMapping().get(gtParameter.getName());
+		if (bindingValue==null && gtParameter.getDefaultValue()!=null) continue;
 		if (bindingValue.equals("Integer") | bindingValue.equals("Float") | bindingValue.equals("String")| bindingValue.equals("Double")| bindingValue.equals("Date")| bindingValue.equals("Time")){
 			if (gtParameter.numberOfInterfacesAndClass()>0){
 				getParseResult().addErrorMessage( new ErrorMessage( 221, inUmpleClassifier.getPosition(0),bindingValue, gtParameter.getName(),inGeneralTPAppliedByName.getInheritanceName(),type,inUmpleClassifier.getName()) ); 
@@ -884,7 +885,7 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
  	 for (Method method : inTrait.getMethods()) {
     	 if (! method.isIsAbstract()){ 
     	 	 Method newMethod = new Method(method);
-    	 	 ApplyTypeParametersToMethod(newMethod,inGTPApplied);
+    	 	 ApplyTypeParametersToMethod(newMethod,inGTPApplied,inTrait);
     	 	 newMethod.getMethodBody().getCodeblock().ApplyTypeParameters(inGTPApplied);
  			 methods.add(newMethod);
 	 	 }
@@ -894,7 +895,7 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
      for (UmpleTrait uTrait : inTrait.getExtendsTraits()) {
        GeneralTPApplied newGTParameter = inTrait.getGeneralTPAppliedByName(uTrait.getName())!=null ? new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName())) : null;
        if (newGTParameter!=null){
-         ApplyTypeParametersToTypeParameters(newGTParameter, inGTPApplied);       
+         ApplyTypeParametersToTypeParameters(newGTParameter, inGTPApplied,inTrait);       
      	   checkClassSupportTraitsInterfaces(newGTParameter,inTrait);
      	 }
  		   if ( ! getParseResult().getWasSuccess() ) return traitMethods;
@@ -911,45 +912,46 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
  //----------------------------------------------------------------------------   
  //---------------------------------Start--------------------------------------    
 
-  private void ApplyTypeParametersToTypeParameters(GeneralTPApplied newGTPA, GeneralTPApplied currentGTPA) {
-  	 if (currentGTPA == null) return;
-	 for (String strType : currentGTPA.getParameterMapping().keySet()){
-			for(String key : newGTPA.getParameterMapping().keySet()){
-				if (newGTPA.getParameterMapping().get(key).equals(strType)){
-					newGTPA.getParameterMapping().put(key, currentGTPA.getParameterMapping().get(strType));
-				}
-			}
-		}
+  private void ApplyTypeParametersToTypeParameters(GeneralTPApplied newGTPA, GeneralTPApplied currentGTPA, UmpleTrait inTrait) {
+    if (currentGTPA == null && inTrait.getGeneralTemplateParameters().size()==0) return;
+    for (GeneralTemplateParameter gtp : inTrait.getGeneralTemplateParameters()){
+      String newName = (currentGTPA!=null && currentGTPA.getParameterMapping().containsKey(gtp.getName())) ? currentGTPA.getParameterMapping().get(gtp.getName()) : gtp.getDefaultValue();
+      for(Map.Entry<String,String> entry : newGTPA.getParameterMapping().entrySet()){
+        if (entry.getValue().equals(gtp.getName()) ){
+          entry.setValue(newName);
+        }
+      }
+    }
   } 
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------    
-  private void ApplyTypeParametersToMethod(Method newMethod, GeneralTPApplied inGeneralTPApplied) {
-  	if (inGeneralTPApplied == null) return;
-	for (String strType : inGeneralTPApplied.getParameterMapping().keySet()) {
-		String newName = inGeneralTPApplied.getParameterMapping().get(strType);
-		if (newMethod.getType().equals(strType)){
-			newMethod.setType(newName);
-		}
-		for (int i = 0; i < newMethod.numberOfMethodParameters(); i++) {
-            if(newMethod.getMethodParameter(i).getType().equals(strType)){
-            	newMethod.getMethodParameter(i).setType(newName);
-            }
-	    }
-	}
+  private void ApplyTypeParametersToMethod(Method newMethod, GeneralTPApplied inGeneralTPApplied, UmpleTrait inTrait){
+     if (inGeneralTPApplied == null && inTrait.getGeneralTemplateParameters().size()==0) return;
+     for (GeneralTemplateParameter gtp : inTrait.getGeneralTemplateParameters()){
+       String newName = (inGeneralTPApplied!=null && inGeneralTPApplied.getParameterMapping().containsKey(gtp.getName())) ? inGeneralTPApplied.getParameterMapping().get(gtp.getName()) : gtp.getDefaultValue();
+       if (newMethod.getType().equals(gtp.getName())){
+         newMethod.setType(newName);
+       }
+       for (int i = 0; i < newMethod.numberOfMethodParameters(); i++) {
+         if(newMethod.getMethodParameter(i).getType().equals(gtp.getName())){
+           newMethod.getMethodParameter(i).setType(newName);
+         }
+       }
+     }
   }
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start-------------------------------------- 
-	private void ApplyTypeParametersToAttribute(Attribute newAttribute,	GeneralTPApplied inGTPApplied) {
-	    if (inGTPApplied == null) return;
-		for (String strType : inGTPApplied.getParameterMapping().keySet()) {
-			String newName = inGTPApplied.getParameterMapping().get(strType);
-			if (newAttribute.getType().equals(strType)){
-				newAttribute.setType(newName);
-			}
-		}	
-	}
+  private void ApplyTypeParametersToAttribute(Attribute newAttribute, GeneralTPApplied inGTPApplied, UmpleTrait inTrait){
+    if (inGTPApplied == null && inTrait.getGeneralTemplateParameters().size()==0) return;
+    for (GeneralTemplateParameter gtp : inTrait.getGeneralTemplateParameters()){
+      String newName = (inGTPApplied!=null && inGTPApplied.getParameterMapping().containsKey(gtp.getName())) ? inGTPApplied.getParameterMapping().get(gtp.getName()) : gtp.getDefaultValue();
+      if (newAttribute.getType().equals(gtp.getName())){
+        newAttribute.setType(newName);
+      }
+    }
+  }
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start-------------------------------------- 
@@ -1045,7 +1047,7 @@ private void ApplyTypeParametersToAssociation(AssociationVariable inAssociationV
     	return;
     }
     for (GeneralTemplateParameter gtp : localTrait.getGeneralTemplateParameters()) {
-	    if (! inGeneralTPApplied.getParameterMapping().containsKey(gtp.getName())){
+	    if (! inGeneralTPApplied.getParameterMapping().containsKey(gtp.getName()) && gtp.getDefaultValue().equals("") ){
 	 	   getParseResult().addErrorMessage(new ErrorMessage(219,inGeneralTPApplied.getPositions(),gtp.getName(),localTrait.getName())); 
 	 	   return;
 	    }
@@ -1218,47 +1220,45 @@ private void ApplyTypeParametersToAssociation(AssociationVariable inAssociationV
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------	 
   private void checkTypeParametersAvailability() {
-	for (UmpleClass uClass : getModel().getUmpleClasses()) {
-		for (UmpleTrait uTrait : uClass.getExtendsTraits()) {
-			if (uTrait.numberOfGeneralTemplateParameters()>0){
-				boolean find = false;
-				for (GeneralTPApplied gTPApplied : uClass.getGeneralTPApplieds()) {
-					if(gTPApplied.getInheritanceName().equals(uTrait.getName())){
-						find = true;
-					}
-				}
-				if (!find){
-					getParseResult().addErrorMessage( new ErrorMessage( 219, uClass.getPosition(0), uTrait.getGeneralTemplateParameter(0).getName(), uTrait.getName() ) ); 
-				 	return;
-				}
-			}
-		}   	
-    	for (GeneralTPApplied gTPApplied : uClass.getGeneralTPApplieds()) {
-			
-			checkTypeParameterAvailability(gTPApplied);
-		}
-	}
-	for (UmpleTrait uTrait : getModel().getUmpleTraits()) {
-		for (UmpleTrait inTrait : uTrait.getExtendsTraits()) {
-			if (inTrait.numberOfGeneralTemplateParameters()>0){
-				boolean find = false;
-				for (GeneralTPApplied gTPApplied : uTrait.getGeneralTPApplieds()) {
-					if(gTPApplied.getInheritanceName().equals(inTrait.getName())){
-						find = true;
-					}
-				}
-				if (!find){
-					getParseResult().addErrorMessage( new ErrorMessage( 219, uTrait.getPosition(0), inTrait.getGeneralTemplateParameter(0).getName(), inTrait.getName() ) ); 
-				 	return;
-				}
-			}
-		} 
-		
-		for (GeneralTPApplied gTPApplied : uTrait.getGeneralTPApplieds()) {
-			checkTypeParameterAvailability(gTPApplied);
-		}
-	}
- }
+    for (UmpleClass uClass : getModel().getUmpleClasses()) {
+      for (UmpleTrait uTrait : uClass.getExtendsTraits()) {
+        checkTypeParametersValid(uClass, uTrait);
+      }     
+      for (GeneralTPApplied gTPApplied : uClass.getGeneralTPApplieds()) {
+        checkTypeParameterAvailability(gTPApplied);
+      }
+    }
+    for (UmpleTrait uTrait : getModel().getUmpleTraits()) {
+      for (UmpleTrait inTrait : uTrait.getExtendsTraits()) {
+        checkTypeParametersValid(uTrait, inTrait);
+      } 
+      for (GeneralTPApplied gTPApplied : uTrait.getGeneralTPApplieds()) {
+        checkTypeParameterAvailability(gTPApplied);
+      }
+    }
+  }
+//---------------------------------end----------------------------------------
+//----------------------------------------------------------------------------   
+//---------------------------------Start--------------------------------------
+  private void checkTypeParametersValid(UmpleClassifier inUmpleClassifier, UmpleTrait uTrait) {
+    if (uTrait.numberOfGeneralTemplateParameters()>0){
+      boolean requireGTPApplied = false;
+      for (GeneralTemplateParameter gtp :uTrait.getGeneralTemplateParameters()){
+        if (gtp.getDefaultValue().equals("")) requireGTPApplied = true;
+      }     
+      if (requireGTPApplied){
+        boolean find = false;
+        List<GeneralTPApplied> gtpApplied = (inUmpleClassifier instanceof UmpleClass) ? ((UmpleClass)inUmpleClassifier).getGeneralTPApplieds() : ((UmpleTrait)inUmpleClassifier).getGeneralTPApplieds();
+        for (GeneralTPApplied gTPApplied : gtpApplied) {
+          if(gTPApplied.getInheritanceName().equals(uTrait.getName()))  find = true; 
+        }
+        if (!find){
+          getParseResult().addErrorMessage( new ErrorMessage( 219, inUmpleClassifier.getPosition(0), uTrait.getGeneralTemplateParameter(0).getName(), uTrait.getName() ) ); 
+          return;
+        }
+      }
+    }
+  }
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------	
@@ -1346,13 +1346,13 @@ private void recursiveCheckRequiredInterfaces(UmpleClass inClass,	UmpleTrait inT
 	  if ( !getParseResult().getWasSuccess() ) return; 
 	  for (UmpleTrait uTrait : inTrait.getExtendsTraits()) {
       GeneralTPApplied newGeneralTPApplied =inTrait.getGeneralTPAppliedByName(uTrait.getName())!=null ? new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName())) : null;
-      if (newGeneralTPApplied!=null)  ApplyTypeParametersToTypeParameters(newGeneralTPApplied,inGeneralTPApplied);
+      if (newGeneralTPApplied!=null)  ApplyTypeParametersToTypeParameters(newGeneralTPApplied,inGeneralTPApplied,inTrait);
       recursiveCheckRequiredMethods(inClass,uTrait,newGeneralTPApplied);
     }
 	  for (Method uMethod : inTrait.getMethods() ) {
 		  if (uMethod.isIsAbstract()) {
 			  Method newMethod = new Method(uMethod);
-			  ApplyTypeParametersToMethod(newMethod,inGeneralTPApplied);
+			  ApplyTypeParametersToMethod(newMethod,inGeneralTPApplied,inTrait);
 			  if(inClass.isIsAbstract()){
 				  newMethod.getComment(2).setText(newMethod.getComment(2).getText()+"'"+inClass.getName()+"' ");
 				  newMethod.setSource(Method.Source.fTrait);
@@ -1386,7 +1386,10 @@ private void recursiveCheckRequiredInterfaces(UmpleClass inClass,	UmpleTrait inT
 			   for (int i =1;i<subToken.numberOfSubTokens(); i++){
 				   if(subToken.getSubToken(i).is("tInterface")){
 					   gtParameter.addInterfacesAndClass(subToken.getSubToken(i).getValue());
-				   }
+				   } else if(subToken.getSubToken(i).is("defaultType")){
+             //This code will be executed once. A parameter has always a default value;
+             gtParameter.setDefaultValue(subToken.getSubToken(i).getValue());
+           }
 			   }
 			   aTrait.addGeneralTemplateParameter(gtParameter);
 		   }
@@ -1656,12 +1659,18 @@ private Map<UmpleTrait, List<Attribute>> gatherAttributes(UmpleTrait inTrait, Ge
 	 List<Attribute> attributes = new ArrayList<Attribute>();	  
 	 for (Attribute attribute : inTrait.getAttributes()) {
 		 Attribute newAttribute = new Attribute(attribute);
-	 	 ApplyTypeParametersToAttribute(newAttribute,inGTPApplied);
+	 	 ApplyTypeParametersToAttribute(newAttribute,inGTPApplied,inTrait);
 		 attributes.add(newAttribute);
 	 }
     traitAttributes.put(inTrait,attributes);
     //----------------------------------------------------------------------------------------
     for (UmpleTrait uTrait : inTrait.getExtendsTraits()) {
+      GeneralTPApplied newGTParameter = inTrait.getGeneralTPAppliedByName(uTrait.getName())!=null ? new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName())) : null;
+      if (newGTParameter!=null){
+         ApplyTypeParametersToTypeParameters(newGTParameter, inGTPApplied,inTrait);       
+         checkClassSupportTraitsInterfaces(newGTParameter,inTrait);
+      }
+      if ( ! getParseResult().getWasSuccess() ) return traitAttributes;
     	tempTraitAttributes = gatherAttributes(uTrait,getNewGeneralTPAppliedWithP2P(inTrait,uTrait,inGTPApplied));   	 
    	 	if ( ! getParseResult().getWasSuccess() ) return traitAttributes;
    	 	if (CheckAttComeFromTraitsIsAvaialbleInOtherTraits(traitAttributes, tempTraitAttributes)) return traitAttributes;
@@ -1689,7 +1698,7 @@ private Map<UmpleTrait, List<AssociationVariable>> gatherAssociations(UmpleTrait
      for (UmpleTrait uTrait : inTrait.getExtendsTraits()) {
        GeneralTPApplied newGTParameter = inTrait.getGeneralTPAppliedByName(uTrait.getName())!=null ? new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName())) : null;     
        if (newGTParameter!=null){
-         ApplyTypeParametersToTypeParameters(newGTParameter, inGTPApplied);       
+         ApplyTypeParametersToTypeParameters(newGTParameter, inGTPApplied,inTrait);       
     	   tempTraitAssociationVariables = gatherAssociations(uTrait,newGTParameter,inClass);   
     	 }	 
     	 if ( ! getParseResult().getWasSuccess() ) return traitAssociationVariables;
@@ -1787,8 +1796,8 @@ private boolean CheckAttComeFromTraitsIsAvaialbleInOtherTraits(	Map<UmpleTrait, 
 	 	GeneralTPApplied newGeneralTPApplied = null;
 	 	if (inTrait.getGeneralTPAppliedByName(uTrait.getName()) !=null) {
 	 		newGeneralTPApplied = new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName()));
-     		ApplyTypeParametersToTypeParameters(newGeneralTPApplied,inGTPApplied);
-    	 }
+      ApplyTypeParametersToTypeParameters(newGeneralTPApplied,inGTPApplied,inTrait);
+    }
 		return newGeneralTPApplied;
 	}
 //---------------------------------end----------------------------------------

--- a/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
@@ -744,14 +744,14 @@ class UmpleInternalParser
           if (getParseResult().getWasSuccess()) copyMethodsFromTraitToClass(uClass);
           if (getParseResult().getWasSuccess()) copyAssociationsFromTraitToClass(uClass);
           if (getParseResult().getWasSuccess()) copyStateMachinesFromTraiToClass(uClass);
-  				if (getParseResult().getWasSuccess()) {
-  				  for (UmpleTrait uTrait : uClass.getExtendsTraits()) {
-  				    recursiveApplyTraits(uClass,uTrait);
-  				    if ( ! getParseResult().getWasSuccess() ) return;  
-  				  }  
-  				}
+          if (getParseResult().getWasSuccess()) {
+            for (UmpleTrait uTrait : uClass.getExtendsTraits()) {
+              recursiveApplyTraits(uClass,uTrait);
+              if ( ! getParseResult().getWasSuccess() ) return;  
+            }  
+          }
         }
-  		}
+      }
       if (getParseResult().getWasSuccess()) checkAllRequiredMethodsAndInterfaces();
     }	
   }
@@ -801,7 +801,7 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
 	for (GeneralTemplateParameter gtParameter : model.getUmpleTrait(inGeneralTPAppliedByName.getInheritanceName()).getGeneralTemplateParameters()){
 		String bindingValue= inGeneralTPAppliedByName.getParameterMapping().get(gtParameter.getName());
 		if (bindingValue==null && gtParameter.getDefaultValue()!=null) continue;
-		if (bindingValue.equals("Integer") | bindingValue.equals("Float") | bindingValue.equals("String")| bindingValue.equals("Double")| bindingValue.equals("Date")| bindingValue.equals("Time")){
+		if (bindingValue.equals("Boolean")| bindingValue.equals("Integer") | bindingValue.equals("Float") | bindingValue.equals("String")| bindingValue.equals("Double")| bindingValue.equals("Date")| bindingValue.equals("Time")){
 			if (gtParameter.numberOfInterfacesAndClass()>0){
 				getParseResult().addErrorMessage( new ErrorMessage( 221, inUmpleClassifier.getPosition(0),bindingValue, gtParameter.getName(),inGeneralTPAppliedByName.getInheritanceName(),type,inUmpleClassifier.getName()) ); 
 			 	return;	
@@ -886,7 +886,7 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
     	 if (! method.isIsAbstract()){ 
     	 	 Method newMethod = new Method(method);
     	 	 ApplyTypeParametersToMethod(newMethod,inGTPApplied,inTrait);
-    	 	 newMethod.getMethodBody().getCodeblock().ApplyTypeParameters(inGTPApplied);
+    	 	 newMethod.getMethodBody().getCodeblock().ApplyTypeParameters(inGTPApplied,inTrait);
  			 methods.add(newMethod);
 	 	 }
 	 }
@@ -955,58 +955,59 @@ private void checkClassSupportTraitsInterfaces(	GeneralTPApplied inGeneralTPAppl
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start-------------------------------------- 
-private void ApplyTypeParametersToAssociation(AssociationVariable inAssociationVariable, GeneralTPApplied inGeneralTPApplied,UmpleClass inClass, UmpleTrait inTrait) {  
-  String rawLName = "";
-  String lName="";
-  String rawRName = "";
-  String rName = "";
-  UmpleClass relatedClass=null;
-  UmpleInterface relatedInterface = null; 
-  boolean bidirectional = inAssociationVariable.getRelatedAssociation().getIsNavigable();
-  if (inGeneralTPApplied != null) {
-	 	for (String strType : inGeneralTPApplied.getParameterMapping().keySet()) {
-			String newName = inGeneralTPApplied.getParameterMapping().get(strType);
-			if (inAssociationVariable.getType().equals(strType)){
-		        //----------------------------------------------------------------
-		        if (inAssociationVariable.getName().length()==0){
-			        rawRName = StringFormatter.toCamelCase(newName);
-			        rName = inAssociationVariable.getMultiplicity().isMany() ? model.getGlossary().getPlural(rawRName) : rawRName;        	
-		        } else{
-			        rawRName = StringFormatter.toCamelCase(inAssociationVariable.getName());
-			        rName = inAssociationVariable.getMultiplicity().isMany() ? model.getGlossary().getPlural(rawRName) : rawRName;        		        	
-		        }
-				relatedClass = getModel().getUmpleClass(newName);
-				if (bidirectional && relatedClass==null){
-					setFailedPosition(inTrait.getPosition(0), 213, "trait "+inTrait.getName());
-					return;
-				}
-		        if (inAssociationVariable.getRelatedAssociation().getName().length()==0){
-					rawLName = StringFormatter.toCamelCase(inClass.getName());
-			        lName = inAssociationVariable.getRelatedAssociation().getMultiplicity().isMany() ? model.getGlossary().getPlural(rawLName) : rawLName;	
-		        } else {
-		        	rawLName = StringFormatter.toCamelCase(inAssociationVariable.getRelatedAssociation().getName());
-			        lName = inAssociationVariable.getRelatedAssociation().getMultiplicity().isMany() ? model.getGlossary().getPlural(rawLName) : rawLName;
-		        }
-		        addAssociation(lName,rName, inAssociationVariable,inClass,relatedClass);
-		        return;
-		        //----------------------------------------------------------------		    
-			}
-		}	
-	}
-  rName = inAssociationVariable.getName();
-  relatedClass = getModel().getUmpleClass(inAssociationVariable.getType());
-  if (relatedClass==null){
-	relatedInterface = getModel().getUmpleInterface(inAssociationVariable.getType());
-	if (bidirectional){
-		setFailedPosition(inTrait.getPosition(0), 213, "trait "+inTrait.getName());
-		return;
-	} else {
-		relatedClass = new UmpleClass(relatedInterface.getName());	
-	}
+  private void ApplyTypeParametersToAssociation(AssociationVariable inAssociationVariable, GeneralTPApplied inGeneralTPApplied,UmpleClass inClass, UmpleTrait inTrait) {  
+    
+    String rawLName = "";
+    String lName="";
+    String rawRName = "";
+    String rName = "";
+    UmpleClass relatedClass=null;
+    UmpleInterface relatedInterface = null; 
+    boolean bidirectional = inAssociationVariable.getRelatedAssociation().getIsNavigable();
+    if (inGeneralTPApplied != null || inTrait.getGeneralTemplateParameters().size()>0) {
+      for (GeneralTemplateParameter gtp : inTrait.getGeneralTemplateParameters()){
+        String newName = (inGeneralTPApplied!=null && inGeneralTPApplied.getParameterMapping().containsKey(gtp.getName())) ? inGeneralTPApplied.getParameterMapping().get(gtp.getName()) : gtp.getDefaultValue();
+        if (inAssociationVariable.getType().equals(gtp.getName())){
+              //----------------------------------------------------------------
+              if (inAssociationVariable.getName().length()==0){
+                rawRName = StringFormatter.toCamelCase(newName);
+                rName = inAssociationVariable.getMultiplicity().isMany() ? model.getGlossary().getPlural(rawRName) : rawRName;          
+              } else{
+                rawRName = StringFormatter.toCamelCase(inAssociationVariable.getName());
+                rName = inAssociationVariable.getMultiplicity().isMany() ? model.getGlossary().getPlural(rawRName) : rawRName;                      
+              }
+          relatedClass = getModel().getUmpleClass(newName);
+          if (bidirectional && relatedClass==null){
+            setFailedPosition(inTrait.getPosition(0), 213, "trait "+inTrait.getName());
+            return;
+          }
+              if (inAssociationVariable.getRelatedAssociation().getName().length()==0){
+            rawLName = StringFormatter.toCamelCase(inClass.getName());
+                lName = inAssociationVariable.getRelatedAssociation().getMultiplicity().isMany() ? model.getGlossary().getPlural(rawLName) : rawLName;  
+              } else {
+                rawLName = StringFormatter.toCamelCase(inAssociationVariable.getRelatedAssociation().getName());
+                lName = inAssociationVariable.getRelatedAssociation().getMultiplicity().isMany() ? model.getGlossary().getPlural(rawLName) : rawLName;
+              }
+              addAssociation(lName,rName, inAssociationVariable,inClass,relatedClass);
+              return;
+              //----------------------------------------------------------------        
+        }
+      }
+    }
+    rName = inAssociationVariable.getName();
+    relatedClass = getModel().getUmpleClass(inAssociationVariable.getType());
+    if (relatedClass==null){
+  	relatedInterface = getModel().getUmpleInterface(inAssociationVariable.getType());
+  	if (bidirectional){
+  		setFailedPosition(inTrait.getPosition(0), 213, "trait "+inTrait.getName());
+  		return;
+  	} else {
+  		relatedClass = new UmpleClass(relatedInterface.getName());	
+  	}
+    }
+    lName=inAssociationVariable.getRelatedAssociation().getName();
+    addAssociation(lName,rName, inAssociationVariable,inClass,relatedClass);
   }
-  lName=inAssociationVariable.getRelatedAssociation().getName();
-  addAssociation(lName,rName, inAssociationVariable,inClass,relatedClass);
-}
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start-------------------------------------- 
@@ -1243,8 +1244,12 @@ private void ApplyTypeParametersToAssociation(AssociationVariable inAssociationV
   private void checkTypeParametersValid(UmpleClassifier inUmpleClassifier, UmpleTrait uTrait) {
     if (uTrait.numberOfGeneralTemplateParameters()>0){
       boolean requireGTPApplied = false;
+       String requiredTPName = "";
       for (GeneralTemplateParameter gtp :uTrait.getGeneralTemplateParameters()){
-        if (gtp.getDefaultValue().equals("")) requireGTPApplied = true;
+        if (gtp.getDefaultValue().equals("")){
+          requireGTPApplied = true;
+          requiredTPName = gtp.getName();
+        }
       }     
       if (requireGTPApplied){
         boolean find = false;
@@ -1253,7 +1258,7 @@ private void ApplyTypeParametersToAssociation(AssociationVariable inAssociationV
           if(gTPApplied.getInheritanceName().equals(uTrait.getName()))  find = true; 
         }
         if (!find){
-          getParseResult().addErrorMessage( new ErrorMessage( 219, inUmpleClassifier.getPosition(0), uTrait.getGeneralTemplateParameter(0).getName(), uTrait.getName() ) ); 
+          getParseResult().addErrorMessage( new ErrorMessage( 219, inUmpleClassifier.getPosition(0),requiredTPName , uTrait.getName() ) ); 
           return;
         }
       }
@@ -1792,14 +1797,14 @@ private boolean CheckAttComeFromTraitsIsAvaialbleInOtherTraits(	Map<UmpleTrait, 
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------
-	private GeneralTPApplied getNewGeneralTPAppliedWithP2P(UmpleTrait inTrait, UmpleTrait uTrait,GeneralTPApplied inGTPApplied) {
-	 	GeneralTPApplied newGeneralTPApplied = null;
-	 	if (inTrait.getGeneralTPAppliedByName(uTrait.getName()) !=null) {
-	 		newGeneralTPApplied = new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName()));
+  private GeneralTPApplied getNewGeneralTPAppliedWithP2P(UmpleTrait inTrait, UmpleTrait uTrait,GeneralTPApplied inGTPApplied) {
+    GeneralTPApplied newGeneralTPApplied = null;
+    if (inTrait.getGeneralTPAppliedByName(uTrait.getName()) !=null) {  
+      newGeneralTPApplied = new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName()));
       ApplyTypeParametersToTypeParameters(newGeneralTPApplied,inGTPApplied,inTrait);
     }
-		return newGeneralTPApplied;
-	}
+    return newGeneralTPApplied;
+  }
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------

--- a/cruise.umple/src/UmpleInternalParser_CodeTrait_StateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTrait_StateMachine.ump
@@ -83,7 +83,13 @@ class UmpleInternalParser
   	 * Go through the included traits.
   	 */
   	for (UmpleTrait uTrait : inTrait.getExtendsTraits()) {
-  		tempTraitStateMachine = gatherStateMachinesFromTrait(uTrait,inTrait.getGeneralTPAppliedByName(uTrait.getName()),inClass);	 
+	    GeneralTPApplied newGTParameter = inTrait.getGeneralTPAppliedByName(uTrait.getName())!=null ? new GeneralTPApplied(inTrait.getGeneralTPAppliedByName(uTrait.getName())) : null;
+      if (newGTParameter!=null){
+        ApplyTypeParametersToTypeParameters(newGTParameter, inGTPApplied,inTrait);       
+         checkClassSupportTraitsInterfaces(newGTParameter,inTrait);
+       }
+      if ( ! getParseResult().getWasSuccess() ) return traitStateMachine; 
+  		tempTraitStateMachine = gatherStateMachinesFromTrait(uTrait,getNewGeneralTPAppliedWithP2P(inTrait,uTrait,inGTPApplied),inClass);	 
   		if ( ! getParseResult().getWasSuccess() ) return traitStateMachine;
   		if (!CheckSMFromTraitIsNotAvaialbleInOtherTraits(traitStateMachine,tempTraitStateMachine,inTrait)) return traitStateMachine;
   		AddStateMachineMapToAnother(traitStateMachine,tempTraitStateMachine);
@@ -116,7 +122,7 @@ class UmpleInternalParser
 		for(Map.Entry<UmpleTrait, List<StateMachine>> entry : traitStateMachine2.entrySet()){
 			List<StateMachine> mustBeRemoved =  new ArrayList<StateMachine>();	
 			for (StateMachine sMachine : entry.getValue()) {
-		  	 	StateMachine stTemp = CompeletlyAllyTypeParametersToStateMachines(sMachine,inGTPApplied);
+		  	 	StateMachine stTemp = CompeletlyAllyTypeParametersToStateMachines(sMachine,inGTPApplied,inTrait);
 		  		if (stTemp==null) mustBeRemoved.add(sMachine);
 		  	}
 			for(StateMachine sm : mustBeRemoved)	traitStateMachine2.get(entry.getKey()).remove(sm);
@@ -425,12 +431,12 @@ class UmpleInternalParser
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------  
-	private StateMachine CompeletlyAllyTypeParametersToStateMachines(StateMachine inSMachine, GeneralTPApplied inGTPApplied) {
+	private StateMachine CompeletlyAllyTypeParametersToStateMachines(StateMachine inSMachine, GeneralTPApplied inGTPApplied, UmpleTrait inTrait) {
 		StateMachine stTemp = ApplyRemoveAndInclude(inSMachine,inGTPApplied);
 		if (stTemp!=null) stTemp = ApplyTypeParametersToStateMachine(inSMachine,inGTPApplied);		
 		if (stTemp!=null)	{
-			ApplyTypeParametersToEventsOfStateMachines(stTemp, inGTPApplied);
-			ApplyTypeParametersToActionCodesOfStateMachines(stTemp, inGTPApplied);
+			ApplyTypeParametersToEventsOfStateMachines(stTemp, inGTPApplied,inTrait);
+			ApplyTypeParametersToActionCodesOfStateMachines(stTemp, inGTPApplied,inTrait);
 		}	
 		return stTemp;
 	}
@@ -754,29 +760,29 @@ class UmpleInternalParser
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start-------------------------------------- 
- private void ApplyTypeParametersToEventsOfStateMachines(StateMachine inStateMachine, GeneralTPApplied inGeneralTPApplied){
-   if (inGeneralTPApplied == null) return;
-   for (String strType : inGeneralTPApplied.getParameterMapping().keySet()) {
-     String newName = inGeneralTPApplied.getParameterMapping().get(strType);
-     for(Event e : inStateMachine.getAllEvents()){
-       for(MethodParameter p : e.getParams()){
-         if (p.getType().equals(strType)){
-           p.setType(newName);
-         }
-       }
-     }
-   }
- }
+  private void ApplyTypeParametersToEventsOfStateMachines(StateMachine inStateMachine, GeneralTPApplied inGeneralTPApplied, UmpleTrait inTrait){
+    if (inGeneralTPApplied == null && inTrait.getGeneralTemplateParameters().size()==0) return;
+    for (GeneralTemplateParameter gtp : inTrait.getGeneralTemplateParameters()){
+      String newName = (inGeneralTPApplied!=null && inGeneralTPApplied.getParameterMapping().containsKey(gtp.getName())) ? inGeneralTPApplied.getParameterMapping().get(gtp.getName()) : gtp.getDefaultValue();
+      for(Event e : inStateMachine.getAllEvents()){
+         for(MethodParameter p : e.getParams()){
+           if (p.getType().equals(gtp.getName())){
+             p.setType(newName);
+          }
+        }
+      }
+    }
+  }
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------  
-  private void ApplyTypeParametersToActionCodesOfStateMachines(StateMachine inStateMachine, GeneralTPApplied inGeneralTPApplied){
-   if (inGeneralTPApplied == null) return;
-   for (Transition transition : inStateMachine.getAllTransitions()){
+  private void ApplyTypeParametersToActionCodesOfStateMachines(StateMachine inStateMachine, GeneralTPApplied inGeneralTPApplied,UmpleTrait inTrait){
+    if (inGeneralTPApplied == null && inTrait.getGeneralTemplateParameters().size()==0) return;
+    for (Transition transition : inStateMachine.getAllTransitions()){
     if (transition.getAction()!=null )
-      transition.getAction().getCodeblock().ApplyTypeParameters(inGeneralTPApplied);
-   }
- }  
+      transition.getAction().getCodeblock().ApplyTypeParameters(inGeneralTPApplied,inTrait);
+    }
+  }  
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------   
 //---------------------------------Start--------------------------------------  

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -915,41 +915,48 @@ class CodeBlock
   /*
    * @author Vahdat
    */
-  public void ApplyTypeParameters(GeneralTPApplied inGeneralTPApplied){
-	   if (inGeneralTPApplied == null) return;
-	   Integer start=0,end=0;
-	   boolean inProcess = false;
-	   String internalCode = "";
-	   for (String language : codes.keySet()) {
-		   String code = codes.get(language);
-		   start=0;
-		   end=0;
-		   inProcess = false;
-		   internalCode = "";
-		   for (int i=0;i<code.length();i++) {
-		  		if (code.charAt(i)=='#' &&!inProcess){
-		  			inProcess=true;
-		  			start = i;
-		  			continue;
-		  		}
-		  		if (code.charAt(i)=='#' && inProcess){
-		  			inProcess=false;
-		  			end=i;
-		  			String strTemp = code.substring(start+1, end);
-		  			if (inGeneralTPApplied.getParameterMapping().containsKey(strTemp)){
-		  				internalCode = internalCode+inGeneralTPApplied.getParameterMapping().get(strTemp);
-		  				continue;
-		  			} else {
-		  				internalCode = internalCode+"#"+strTemp;
-		  			}
-
-		  		}
-		  		if (!inProcess){
-		  			internalCode = internalCode+code.charAt(i);
-		  		}
-			}
-		   codes.put(language, internalCode);
-	   }
+  public void ApplyTypeParameters(GeneralTPApplied inGeneralTPApplied, UmpleTrait inTrait){
+    if (inGeneralTPApplied == null && inTrait.numberOfGeneralTemplateParameters()==0) return;
+    Integer start=0,end=0;
+    boolean inProcess = false;
+    String internalCode = "";
+    for (String language : codes.keySet()) {
+      String code = codes.get(language);
+      start=0;
+      end=0;
+      inProcess = false;
+      internalCode = "";
+      for (int i=0;i<code.length();i++) {
+        if (code.charAt(i)=='#' &&!inProcess){
+          inProcess=true;
+          start = i;
+          continue;
+        }
+        if (code.charAt(i)=='#' && inProcess){
+        inProcess=false;
+        end=i;
+        String strTemp = code.substring(start+1, end);
+        Boolean replaced = false;
+        for(GeneralTemplateParameter gtp : inTrait.getGeneralTemplateParameters()){
+          if (strTemp.equals(gtp.getName())){
+            String newName = (inGeneralTPApplied!=null && inGeneralTPApplied.getParameterMapping().containsKey(gtp.getName())) ? inGeneralTPApplied.getParameterMapping().get(gtp.getName()) : gtp.getDefaultValue();
+            internalCode = internalCode+newName;
+            replaced = true;
+            break;
+          }
+        }
+        if (!replaced) {
+          internalCode = internalCode+"#"+strTemp;
+        } else{
+          continue;
+        }
+      }
+      if (!inProcess){
+        internalCode = internalCode+code.charAt(i);
+      }
+    }
+    codes.put(language, internalCode);
+   }
   }
   
   /*
@@ -4061,13 +4068,28 @@ class GeneralTPApplied {
 //----------------------------------------------------------------------------
 //---------------------------------Start--------------------------------------
 	public GeneralTPApplied(GeneralTPApplied another) {
-	  if (another == null) return;
-	  this.parameterMapping = new HashMap<String, String>(another.parameterMapping);
-	  this.inheritanceName = another.inheritanceName;
-	  methodTemplateSignatures = new ArrayList<MethodTemplateSignature>();
-	  for (MethodTemplateSignature mtSignature : another.getMethodTemplateSignatures()) {
-		  methodTemplateSignatures.add(new MethodTemplateSignature(mtSignature));
-	  }
+    if (another == null) return;
+    this.parameterMapping = new HashMap<String, String>(another.parameterMapping);
+    this.inheritanceName = another.inheritanceName;
+    
+    
+    stateMachineModifiers = new ArrayList<StateMachineModifier>();
+    parameters = new ArrayList<String>();
+    for (String str : another.getParameters()){
+      parameters.add(str);
+    }  
+    methodTemplateSignatures = new ArrayList<MethodTemplateSignature>();
+    for (MethodTemplateSignature mtSignature : another.getMethodTemplateSignatures()) {
+      methodTemplateSignatures.add(new MethodTemplateSignature(mtSignature));
+    }
+    methodTemplateSignatures = new ArrayList<MethodTemplateSignature>();
+    for (MethodTemplateSignature mtSignature : another.getMethodTemplateSignatures()){
+      methodTemplateSignatures.add(mtSignature);
+    }
+    stateMachineTemplateSignatures = new ArrayList<StateMachineTemplateSignature>();
+    for (StateMachineTemplateSignature smSignature : another.getStateMachineTemplateSignatures()){
+      stateMachineTemplateSignatures.add(smSignature);
+    }
   }
 //---------------------------------end----------------------------------------
 //----------------------------------------------------------------------------

--- a/cruise.umple/src/Umple_Code_Trait.ump
+++ b/cruise.umple/src/Umple_Code_Trait.ump
@@ -325,6 +325,15 @@ class UmpleTrait {
 		}
 		return -1;
 	}
+	
+	public GeneralTemplateParameter getGeneralTemplateParameterByName(String name) {
+    for (int i = 0; i<numberOfGeneralTemplateParameters();i++) {
+      if(getGeneralTemplateParameter(i).getName().equals(name)) {
+        return getGeneralTemplateParameter(i);
+      }
+    }
+    return null;
+  }
 //--------------------------------------------------------------------------------------
 //------------------------------------end-----------------------------------------------
   

--- a/cruise.umple/src/umple_traits.grammar
+++ b/cruise.umple/src/umple_traits.grammar
@@ -1,7 +1,7 @@
 traitDefinition : trait [name] [[traitParameters]]? { [[traitContent]]* }
 traitContent- : [[requiredModelElements]] | [[comment]] | [[traitDefinition]] | [[trace]] | [[position]] | [[displayColor]] | [[abstract]] | [[keyDefinition]] | [[softwarePattern]] | [[depend]] | [[symmetricReflexiveAssociation]] | [[attribute]] | [[stateMachine]] | [[inlineAssociation]] | [[concreteMethodDeclaration]] | [[abstractMethodDeclaration]] | [[constantDeclaration]] | [[invariant]] | ; | [[exception]] | [[extraCode]]
 traitParameters : < [[traitFullParameters]] ( , [[traitFullParameters]] )* >
-traitFullParameters : [~parameter] ([[traitParametersInterface]])?
+traitFullParameters : [~parameter] ([[traitParametersInterface]])? ( = [~defaultType] )?
 traitParametersInterface- : isA [~tInterface]( & [~tInterface])*
 requiredModelElements : require ([[requiredState]] | [[requiredEvent]])
 requiredState : [smName] ;

--- a/cruise.umple/test/cruise/umple/compiler/UmpleTraitTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleTraitTest.java
@@ -2754,6 +2754,46 @@ public class UmpleTraitTest {
 
 	}
 
+	
+	@Test
+	public void InterfaceForTemplates007() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0076.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"String");
+	}
+	
+	@Test
+	public void InterfaceForTemplates008() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0077.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"Integer");
+	}	
+	
+	@Test
+	public void InterfaceForTemplates009() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0078.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"Integer");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(1).getType(),"Boolean");
+	}
+	
+	@Test
+	public void InterfaceForTemplates010() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0079.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"Integer");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(1).getType(),"String");
+	}
+	
+	@Test
+	public void InterfaceForTemplates011() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0080.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"String");
+	}
+	
+	@Test
+	public void InterfaceForTemplates012() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0081.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"Integer");
+	}
+	
+	
 	@Test
 	public void RequiredInterfaces001() {
 		String code = "class A{isA T;isA I;} interface I{} interface II{} trait T{isA I;isA II;}";

--- a/cruise.umple/test/cruise/umple/compiler/UmpleTraitTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleTraitTest.java
@@ -2793,6 +2793,66 @@ public class UmpleTraitTest {
 		Assert.assertEquals(model.getUmpleClass("A").getAttribute(0).getType(),"Integer");
 	}
 	
+	@Test
+	public void InterfaceForTemplates013() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0082.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getMethod(0).getMethodParameter(0).getType(),"String");
+		Assert.assertEquals(model.getUmpleClass("A").getMethod(0).getMethodParameter(1).getType(),"Integer");
+	}
+	
+	@Test
+	public void InterfaceForTemplates014() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0083.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getMethod(0).getMethodParameter(0).getType(),"String");
+	}
+	
+	@Test
+	public void InterfaceForTemplates015() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0084.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getMethod(0).getMethodParameter(0).getType(),"Integer");
+	}
+	
+	@Test
+	public void InterfaceForTemplates016() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0085.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAssociation(0).getEnd(1).getClassName(),"C");
+	}	
+	
+	@Test
+	public void InterfaceForTemplates017() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0086.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getAssociation(0).getEnd(1).getClassName(),"C");
+	}	
+
+	@Test
+	public void InterfaceForTemplates018() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0087.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getStateMachine(0).getState(0).getTransition(0).getEvent().getParam(0).getType(),"String");
+	}	
+	
+	@Test
+	public void InterfaceForTemplates019() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0088.ump");
+		Assert.assertEquals(model.getUmpleClass("A").getStateMachine(0).getState(0).getTransition(0).getEvent().getParam(0).getType(),"String");
+	}
+	
+	@Test
+	public void InterfaceForTemplates020() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0089.ump");
+		Assert.assertTrue(model.getUmpleClass("A").getStateMachine(0).getState(0).getTransition(0).getAction().getActionCode().contains("String a;"));
+	}
+	
+	@Test
+	public void InterfaceForTemplates021() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0090.ump");
+		Assert.assertTrue(model.getUmpleClass("A").getStateMachine(0).getState(0).getTransition(0).getAction().getActionCode().contains("String a;"));
+	}
+	
+	@Test
+	public void InterfaceForTemplates022() {
+		UmpleModel model = getRunModelByFilename("trait_test_data_0091.ump");
+		Assert.assertTrue(model.getUmpleClass("A").getStateMachine(0).getState(0).getTransition(0).getAction().getActionCode().contains("Integer a;"));
+	}
 	
 	@Test
 	public void RequiredInterfaces001() {
@@ -2801,7 +2861,7 @@ public class UmpleTraitTest {
 		Assert.assertEquals(2, model.getUmpleTrait(0).numberOfRequiredInterfaces());
 
 	}
-
+	
 	@Test
 	public void RequiredInterfaces002() {
 		String code = "class A{isA T;} interface I{} trait T{isA I;}";

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0076.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0076.ump
@@ -1,0 +1,6 @@
+class A{
+  isA T;
+}
+trait T<TP = String>{
+  TP att;
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0077.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0077.ump
@@ -1,0 +1,6 @@
+class A{
+  isA T<TP = Integer>;
+}
+trait T<TP = String>{
+  TP att;
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0078.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0078.ump
@@ -1,0 +1,7 @@
+class A{
+  isA T<TP = Integer>;
+}
+trait T<TP = String,TP2 = Boolean>{
+  TP att;
+  TP2 att2;
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0079.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0079.ump
@@ -1,0 +1,7 @@
+class A{
+  isA T<TP = Integer,TP2=String>;
+}
+trait T<TP = String,TP2 = Boolean>{
+  TP att;
+  TP2 att2;
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0080.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0080.ump
@@ -1,0 +1,11 @@
+class A{
+  
+  isA T;
+}
+
+trait T<TP = String, TP2=Integer>{
+  isA T2;
+}
+trait T2<TP = String>{
+  TP[] x;
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0081.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0081.ump
@@ -1,0 +1,11 @@
+class A{
+  
+  isA T;
+}
+
+trait T<TP = String, TP2=Integer>{
+  isA T2<TP=TP2>;
+}
+trait T2<TP = String>{
+  TP[] x;
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0082.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0082.ump
@@ -1,0 +1,9 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String, TP2=Integer>{
+  void getData(TP d1, TP2 d2){
+    //
+  } 
+}

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0083.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0083.ump
@@ -1,0 +1,13 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String, TP2=Integer>{
+  isA T2;
+}
+trait T2<TP=String>{
+  void getData(TP d1){
+    //
+  } 
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0084.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0084.ump
@@ -1,0 +1,13 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String, TP2=Integer>{
+  isA T2<TP=TP2>;
+}
+trait T2<TP=String>{
+  void getData(TP d1){
+    //
+  } 
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0085.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0085.ump
@@ -1,0 +1,12 @@
+class A{
+  isA T;
+}
+
+trait T<TP = C>{
+  0..1 -> * TP; 
+}
+
+class B{}
+class C{}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0086.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0086.ump
@@ -1,0 +1,14 @@
+class A{
+  isA T;
+}
+
+trait T<TP = C>{
+  isA T2<TP=TP>;
+}
+trait T2<TP>{
+  0..1 -> * TP; 
+}
+class B{}
+class C{}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0087.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0087.ump
@@ -1,0 +1,15 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String>{
+  sm{
+    s1{
+      e2(TP p) -> s2;
+    }
+    s2{
+      
+    }
+  }
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0088.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0088.ump
@@ -1,0 +1,18 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String>{
+  isA T2<TP=TP>;
+}
+trait T2<TP>{
+    sm{
+    s1{
+      e2(TP p) -> s2;
+    }
+    s2{
+      
+    }
+  }
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0089.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0089.ump
@@ -1,0 +1,15 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String>{
+  sm{
+    s1{
+      e2(TP p) -> /{#TP# a;} s2;
+    }
+    s2{
+      
+    }
+  }
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0090.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0090.ump
@@ -1,0 +1,18 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String>{
+  isA T2<TP=TP>;
+}
+trait T2<TP = Integer>{
+  sm{
+    s1{
+      e2(TP p) -> /{#TP# a;} s2;
+    }
+    s2{
+      
+    }
+  }
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0091.ump
+++ b/cruise.umple/test/cruise/umple/compiler/trait/test/resources/trait_test_data_0091.ump
@@ -1,0 +1,18 @@
+class A{
+  isA T;
+}
+
+trait T<TP = String>{
+  isA T2;
+}
+trait T2<TP = Integer>{
+  sm{
+    s1{
+      e2(TP p) -> /{#TP# a;} s2;
+    }
+    s2{
+      
+    }
+  }
+}
+


### PR DESCRIPTION
Thanks to @ahmedvc for reminding me about this feature.
Now, we can define default binding types for template parameters in Traits and if there is not binding value for them, the default types will be considered.