### PR TITLE
Umple release 1.26

### DIFF
--- a/build/umpleversion.last.txt
+++ b/build/umpleversion.last.txt
@@ -1,1 +1,1 @@
-version : 1.25.0-963d2bd
+version : 1.26.0-b05b57321

--- a/build/umpleversion.txt
+++ b/build/umpleversion.txt
@@ -1,1 +1,1 @@
-version : 1.25.0
+version : 1.26.0


### PR DESCRIPTION
Umple release 1.26. Includes all changes siince 1.26; this includes in particular work from the January to APril UCOSP team, updates to formal methods generation and Traits.