### PR TITLE
Fixes parser failure due to variable named input; and fixes scripts t…

### DIFF
--- a/UmpleParser/src/GrammarParsing.ump
+++ b/UmpleParser/src/GrammarParsing.ump
@@ -309,7 +309,7 @@ class GrammarAnalyzer
   File file = null;
 
   //filename of the file to be parsed
-  input = null;
+  String input = null;
   
   //if a balanced rule is created, it needs to know if the current context is nospaces or not
   noSpaces = false;

--- a/dev-tools/bumple
+++ b/dev-tools/bumple
@@ -15,11 +15,15 @@ echo This should take 2-5 minutes. Do not interrupt.
 echo You should always have done 'git pull' before running this and resolved conflicts
 set logfile="/tmp/umplebuildlog$$.txt"
 ant -Dmyenv=$buildenv | tee $logfile
+
 grep -qi failed $logfile
-if ($status == 0) then
+set failedstatus=$status
+
+grep -qi 'Error ' $logfile
+if ($status == 0 || $failedstatus == 0) then
   echo "************************"
   echo Script bumple ended ABNORMALLY at $UMPLEROOT
-  echo The word FAILED was found in the above. Build was NOT SUCCESSFUL.
+  echo The word FAILED or ERROR was found in the above. Build was NOT SUCCESSFUL.
   echo Build log is at $logfile
   echo Test log can be opened in a web browser at $UMPLEROOT/dist/qa/index.php
 else

--- a/dev-tools/fbumple
+++ b/dev-tools/fbumple
@@ -15,11 +15,15 @@ echo This should take 1-2 minutes and does not run tests. Do not interrupt. Then
 echo You should always have done 'git pull' before running this and resolved conflicts
 set logfile="/tmp/umplebuildlog$$.txt"
 ant -Dmyenv=$buildenv first-build | tee $logfile
+
 grep -qi failed $logfile
-if ($status == 0) then
+set failedstatus=$status
+
+grep -qi 'Error ' $logfile
+if ($status == 0 || $failedstatus == 0) then
   echo "************************"
   echo Script fbumple ended ABNORMALLY at $UMPLEROOT
-  echo The word FAILED was found in the above. Build was NOT SUCCESSFUL.
+  echo The word FAILED or Error was found in the above. First Build was NOT SUCCESSFUL.
   echo Build log is at $logfile
 else
   rm $logfile


### PR DESCRIPTION
A recent change added a keyword 'input'. This caused a failure when compiling the compiler because there was a variable with this name. This fixes by giving that variable a type, allowing the parser to parse it. 

This also fixes the fbumple and bumple scripts to highlight errors not just parse failures. This error might have been detected faster had these changes been present.