### PR TITLE
Fixes issue 1026

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/equals.ump
+++ b/UmpleToJava/UmpleTLTemplates/equals.ump
@@ -11,18 +11,19 @@ class UmpleToJava {
     AssociationVariable as = uClass.getAssociationVariable(memberId);
     if (av != null)
     {
-      String avString = av.getIsDerived()?(gen.translate("getMethod",av)+"()"):gen.translate("attributeOne",av);
+      String avString = gen.translate("getMethod",av)+"()";
       if (!av.isImmutable() || av.getIsLazy()) canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("attributeCanSet",av)));
       if (av.getIsList())
       {
-        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",gen.translate("attributeMany",av)));
+        String avStringMany = gen.translate("getManyMethod",av) + "()";
+        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",avStringMany));
         checks.append(StringFormatter.format("    {\n"));
         checks.append(StringFormatter.format("      return false;\n"));
         checks.append(StringFormatter.format("    }\n\n"));
-        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",gen.translate("attributeMany",av)));
+        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",avStringMany));
         checks.append(StringFormatter.format("    {\n"));
-        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",av),gen.translate("attributeMany",av)));
-        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",av),gen.translate("attributeMany",av)));
+        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",av),avStringMany));
+        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",av),avStringMany));
         checks.append(StringFormatter.format("      if (me == null && them != null)\n"));
         checks.append(StringFormatter.format("      {\n"));
         checks.append(StringFormatter.format("       return false;\n"));
@@ -55,18 +56,18 @@ class UmpleToJava {
     }
     else if (as != null)
     {
-      String asString = gen.translate("attributeOne",as);
       canSet.append(StringFormatter.format("    {0} = false;\n",gen.translate("associationCanSet",as)));
       if (as.isMany())
       {
-        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",gen.translate("associationMany",as)));
+        String asString = gen.translate("getManyMethod",as) + "()";
+        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",asString));
         checks.append(StringFormatter.format("    {\n"));
         checks.append(StringFormatter.format("      return false;\n"));
         checks.append(StringFormatter.format("    }\n\n"));
-        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",gen.translate("attributeMany",as)));
+        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",asString));
         checks.append(StringFormatter.format("    {\n"));
-        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",as),gen.translate("associationMany",as)));
-        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",as),gen.translate("associationMany",as)));
+        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",as),asString));
+        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",as),asString));
         checks.append(StringFormatter.format("      if (me == null && them != null)\n"));
         checks.append(StringFormatter.format("      {\n"));
         checks.append(StringFormatter.format("       return false;\n"));
@@ -79,6 +80,7 @@ class UmpleToJava {
       }
       else
       {
+        String asString = gen.translate("getMethod",as) + "()";
         checks.append(StringFormatter.format("    if ({0} == null && compareTo.{0} != null)\n",asString));
         checks.append(StringFormatter.format("    {\n"));
         checks.append(StringFormatter.format("      return false;\n"));
@@ -93,7 +95,7 @@ class UmpleToJava {
     
     if (av != null)
     {
-      String avString = av.getIsDerived()?(gen.translate("getMethod",av)+"()"):gen.translate("attributeOne",av);
+      String avString = gen.translate("getMethod",av)+"()";
       if ("Integer".equals(av.getType()) && !av.getIsList())
       {
         hash.append(StringFormatter.format("    cachedHashCode = cachedHashCode * 23 + {0};\n",avString));
@@ -108,8 +110,8 @@ class UmpleToJava {
       }
       else
       {
-        String attributeType = av.getIsList() ? "attributeMany" : av.getIsDerived()?"getMethod":"attributeOne";
-        String typeString = gen.translate(attributeType,av)+(av.getIsDerived()?"()":"");
+        String attributeType = av.getIsList() ? "getManyMethod" : "getMethod";
+        String typeString = gen.translate(attributeType,av) + "()";
         hash.append(StringFormatter.format("    if ({0} != null)\n",typeString));
         hash.append(StringFormatter.format("    {\n"));
         hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23 + {0}.hashCode();\n",typeString));
@@ -123,10 +125,11 @@ class UmpleToJava {
     }
     else if (as != null)
     {
-      String attributeType = as.isOne() ? "attributeOne" : "attributeMany";
-      hash.append(StringFormatter.format("    if ({0} != null)\n",gen.translate(attributeType,as)));
+      String attributeType = as.isOne() ? "getMethod" : "getManyMethod";
+      String typeString = gen.translate(attributeType, as) + "()";
+      hash.append(StringFormatter.format("    if ({0} != null)\n",typeString));
       hash.append(StringFormatter.format("    {\n"));
-      hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23 + {0}.hashCode();\n",gen.translate(attributeType,as)));
+      hash.append(StringFormatter.format("      cachedHashCode = cachedHashCode * 23 + {0}.hashCode();\n",typeString));
       hash.append(StringFormatter.format("    }\n"));
       hash.append(StringFormatter.format("    else\n"));
       hash.append(StringFormatter.format("    {\n"));

--- a/UmpleToJava/UmpleTLTemplates/equals.ump
+++ b/UmpleToJava/UmpleTLTemplates/equals.ump
@@ -16,14 +16,14 @@ class UmpleToJava {
       if (av.getIsList())
       {
         String avStringMany = gen.translate("getManyMethod",av) + "()";
-        checks.append(StringFormatter.format("    if ({0}.size() != compareTo.{0}.size())\n",avStringMany));
+        checks.append(StringFormatter.format("    if ({0}.length != compareTo.{0}.length)\n",avStringMany));
         checks.append(StringFormatter.format("    {\n"));
         checks.append(StringFormatter.format("      return false;\n"));
         checks.append(StringFormatter.format("    }\n\n"));
-        checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",avStringMany));
+        checks.append(StringFormatter.format("    for (int i=0; i<{0}.length; i++)\n",avStringMany));
         checks.append(StringFormatter.format("    {\n"));
-        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",av),avStringMany));
-        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",av),avStringMany));
+        checks.append(StringFormatter.format("      {0} me = {1}[i];\n",gen.translate("typeMany",av),avStringMany));
+        checks.append(StringFormatter.format("      {0} them = compareTo.{1}[i];\n",gen.translate("typeMany",av),avStringMany));
         checks.append(StringFormatter.format("      if (me == null && them != null)\n"));
         checks.append(StringFormatter.format("      {\n"));
         checks.append(StringFormatter.format("       return false;\n"));
@@ -66,8 +66,8 @@ class UmpleToJava {
         checks.append(StringFormatter.format("    }\n\n"));
         checks.append(StringFormatter.format("    for (int i=0; i<{0}.size(); i++)\n",asString));
         checks.append(StringFormatter.format("    {\n"));
-        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("type",as),asString));
-        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("type",as),asString));
+        checks.append(StringFormatter.format("      {0} me = {1}.get(i);\n",gen.translate("typeMany",as),asString));
+        checks.append(StringFormatter.format("      {0} them = compareTo.{1}.get(i);\n",gen.translate("typeMany",as),asString));
         checks.append(StringFormatter.format("      if (me == null && them != null)\n"));
         checks.append(StringFormatter.format("      {\n"));
         checks.append(StringFormatter.format("       return false;\n"));

--- a/cruise.umple/test/cruise/umple/compiler/AssociationEndTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/AssociationEndTest.java
@@ -283,14 +283,14 @@ public class AssociationEndTest
   }   
   
   @Test
-  public void equals_checkAllData_nullNoLongerSameAsEmpty()
+  public void equals_checkAllData_nullNowSameAsEmpty()
   {
     AssociationEnd end,compareTo;
 
     end = new AssociationEnd(null,null,null,null,createMultiplicity(1,2));
     compareTo = new AssociationEnd("","","","",createMultiplicity(1,2));
-    Assert.assertEquals(false,end.equals(compareTo));
-    Assert.assertEquals(false,compareTo.equals(end));
+    Assert.assertEquals(true,end.equals(compareTo));
+    Assert.assertEquals(true,compareTo.equals(end));
     Assert.assertEquals(true,end.equals(end));
   }   
   

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_AlreadyImmutable.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_AlreadyImmutable.java.txt
@@ -79,26 +79,26 @@ public class Student
 
     Student compareTo = (Student)obj;
   
-    if (intId != compareTo.intId)
+    if (getIntId() != compareTo.getIntId())
     {
       return false;
     }
 
-    if (doubleId != compareTo.doubleId)
+    if (getDoubleId() != compareTo.getDoubleId())
     {
       return false;
     }
 
-    if (booleanId != compareTo.booleanId)
+    if (getBooleanId() != compareTo.getBooleanId())
     {
       return false;
     }
 
-    if (stringId == null && compareTo.stringId != null)
+    if (getStringId() == null && compareTo.getStringId() != null)
     {
       return false;
     }
-    else if (stringId != null && !stringId.equals(compareTo.stringId))
+    else if (getStringId() != null && !getStringId().equals(compareTo.getStringId()))
     {
       return false;
     }
@@ -113,15 +113,15 @@ public class Student
       return cachedHashCode;
     }
     cachedHashCode = 17;
-    cachedHashCode = cachedHashCode * 23 + intId;
+    cachedHashCode = cachedHashCode * 23 + getIntId();
 
-    cachedHashCode = cachedHashCode * 23 + (new Double(doubleId)).hashCode();
+    cachedHashCode = cachedHashCode * 23 + (new Double(getDoubleId())).hashCode();
 
-    cachedHashCode = cachedHashCode * 23 + (booleanId ? 1 : 0);
+    cachedHashCode = cachedHashCode * 23 + (getBooleanId() ? 1 : 0);
 
-    if (stringId != null)
+    if (getStringId() != null)
     {
-      cachedHashCode = cachedHashCode * 23 + stringId.hashCode();
+      cachedHashCode = cachedHashCode * 23 + getStringId().hashCode();
     }
     else
     {

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Associations.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Associations.java.txt
@@ -191,24 +191,24 @@ public class Mentor
 
     Mentor compareTo = (Mentor)obj;
   
-    if (main == null && compareTo.main != null)
+    if (getMain() == null && compareTo.getMain() != null)
     {
       return false;
     }
-    else if (main != null && !main.equals(compareTo.main))
-    {
-      return false;
-    }
-
-    if (secondaries.size() != compareTo.secondaries.size())
+    else if (getMain() != null && !getMain().equals(compareTo.getMain()))
     {
       return false;
     }
 
-    for (int i=0; i<secondaries.size(); i++)
+    if (getSecondaries().size() != compareTo.getSecondaries().size())
     {
-      Course me = secondaries.get(i);
-      Course them = compareTo.secondaries.get(i);
+      return false;
+    }
+
+    for (int i=0; i<getSecondaries().size(); i++)
+    {
+      Course me = getSecondaries().get(i);
+      Course them = compareTo.getSecondaries().get(i);
       if (me == null && them != null)
       {
        return false;
@@ -229,17 +229,17 @@ public class Mentor
       return cachedHashCode;
     }
     cachedHashCode = 17;
-    if (main != null)
+    if (getMain() != null)
     {
-      cachedHashCode = cachedHashCode * 23 + main.hashCode();
+      cachedHashCode = cachedHashCode * 23 + getMain().hashCode();
     }
     else
     {
       cachedHashCode = cachedHashCode * 23;
     }
-    if (secondaries != null)
+    if (getSecondaries() != null)
     {
-      cachedHashCode = cachedHashCode * 23 + secondaries.hashCode();
+      cachedHashCode = cachedHashCode * 23 + getSecondaries().hashCode();
     }
     else
     {

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
@@ -163,39 +163,39 @@ public class Student
 
     Student compareTo = (Student)obj;
   
-    if (intId != compareTo.intId)
+    if (getIntId() != compareTo.getIntId())
     {
       return false;
     }
 
-    if (doubleId != compareTo.doubleId)
+    if (getDoubleId() != compareTo.getDoubleId())
     {
       return false;
     }
 
-    if (booleanId != compareTo.booleanId)
+    if (getBooleanId() != compareTo.getBooleanId())
     {
       return false;
     }
 
-    if (stringId == null && compareTo.stringId != null)
+    if (getStringId() == null && compareTo.getStringId() != null)
     {
       return false;
     }
-    else if (stringId != null && !stringId.equals(compareTo.stringId))
-    {
-      return false;
-    }
-
-    if (stringListIds.size() != compareTo.stringListIds.size())
+    else if (getStringId() != null && !getStringId().equals(compareTo.getStringId()))
     {
       return false;
     }
 
-    for (int i=0; i<stringListIds.size(); i++)
+    if (getStringListIds().size() != compareTo.getStringListIds().size())
     {
-      String me = stringListIds.get(i);
-      String them = compareTo.stringListIds.get(i);
+      return false;
+    }
+
+    for (int i=0; i<getStringListIds().size(); i++)
+    {
+      String me = getStringListIds().get(i);
+      String them = compareTo.getStringListIds().get(i);
       if (me == null && them != null)
       {
        return false;
@@ -216,24 +216,24 @@ public class Student
       return cachedHashCode;
     }
     cachedHashCode = 17;
-    cachedHashCode = cachedHashCode * 23 + intId;
+    cachedHashCode = cachedHashCode * 23 + getIntId();
 
-    cachedHashCode = cachedHashCode * 23 + (new Double(doubleId)).hashCode();
+    cachedHashCode = cachedHashCode * 23 + (new Double(getDoubleId())).hashCode();
 
-    cachedHashCode = cachedHashCode * 23 + (booleanId ? 1 : 0);
+    cachedHashCode = cachedHashCode * 23 + (getBooleanId() ? 1 : 0);
 
-    if (stringId != null)
+    if (getStringId() != null)
     {
-      cachedHashCode = cachedHashCode * 23 + stringId.hashCode();
+      cachedHashCode = cachedHashCode * 23 + getStringId().hashCode();
     }
     else
     {
       cachedHashCode = cachedHashCode * 23;
     }
 
-    if (stringListIds != null)
+    if (getStringListIds() != null)
     {
-      cachedHashCode = cachedHashCode * 23 + stringListIds.hashCode();
+      cachedHashCode = cachedHashCode * 23 + getStringListIds().hashCode();
     }
     else
     {

--- a/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/EqualsTest_Attributes.java.txt
@@ -187,15 +187,15 @@ public class Student
       return false;
     }
 
-    if (getStringListIds().size() != compareTo.getStringListIds().size())
+    if (getStringListIds().length != compareTo.getStringListIds().length)
     {
       return false;
     }
 
-    for (int i=0; i<getStringListIds().size(); i++)
+    for (int i=0; i<getStringListIds().length; i++)
     {
-      String me = getStringListIds().get(i);
-      String them = compareTo.getStringListIds().get(i);
+      String me = getStringListIds()[i];
+      String them = compareTo.getStringListIds()[i];
       if (me == null && them != null)
       {
        return false;

--- a/cruise.umple/test/cruise/umple/implementation/java/InheritedKeys.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/InheritedKeys.java.txt
@@ -5,12 +5,12 @@
 
     Bar compareTo = (Bar)obj;
   
-    if (a != compareTo.a)
+    if (getA() != compareTo.getA())
     {
       return false;
     }
 
-    if (b != compareTo.b)
+    if (getB() != compareTo.getB())
     {
       return false;
     }
@@ -25,9 +25,9 @@
       return cachedHashCode;
     }
     cachedHashCode = 17;
-    cachedHashCode = cachedHashCode * 23 + a;
+    cachedHashCode = cachedHashCode * 23 + getA();
 
-    cachedHashCode = cachedHashCode * 23 + b;
+    cachedHashCode = cachedHashCode * 23 + getB();
 
     canSetA = false;
     canSetB = false;

--- a/testbed/src/TestHarnessAssociations.ump
+++ b/testbed/src/TestHarnessAssociations.ump
@@ -703,8 +703,8 @@ class AssociatedClassWithKey {
 }
 
 class AssociationClass {
-  1 -- 1 AssociatedClassWithKey;
-  key {AssociatedClassWithKey};
+  1 -- 1 AssociatedClassWithKey associatedClassWithKey;
+  key {associatedClassWithKey};
 }
 
 class AssociationClassManyKeys {

--- a/testbed/src/TestHarnessAssociations.ump
+++ b/testbed/src/TestHarnessAssociations.ump
@@ -697,17 +697,17 @@ class Seating {
   lazy seat;
 }
 
-class SomeAssociatedClassWithKey {
+class AssociatedClassWithKey {
   Integer id;
   key {id};
 }
 
-class SomeAssociationClass {
-  1 -- 1 SomeAssociatedClassWithKey;
-  key {SomeAssociatedClassWithKey};
+class AssociationClass {
+  1 -- 1 AssociatedClassWithKey;
+  key {AssociatedClassWithKey};
 }
 
-class SomeAssociationClassMany {
-  * -- * SomeAssociatedClassWithKey;
-  key {SomeAssociatedClassWithKey};
+class AssociationClassManyKeys {
+  * -- * AssociatedClassWithKey associatedClasses;
+  key {associatedClasses};
 }

--- a/testbed/src/TestHarnessAssociations.ump
+++ b/testbed/src/TestHarnessAssociations.ump
@@ -697,4 +697,17 @@ class Seating {
   lazy seat;
 }
 
+class SomeAssociatedClassWithKey {
+  Integer id;
+  key {id};
+}
 
+class SomeAssociationClass {
+  1 -- 1 SomeAssociatedClassWithKey;
+  key {SomeAssociatedClassWithKey};
+}
+
+class SomeAssociationClassMany {
+  * -- * SomeAssociatedClassWithKey;
+  key {SomeAssociatedClassWithKey};
+}

--- a/testbed/src/TestHarnessAttributes.ump
+++ b/testbed/src/TestHarnessAttributes.ump
@@ -74,10 +74,22 @@ class ManyAttribute
   Integer[] works;
 }
 
+class ManyStringAttributes
+{
+  String[] worksString;
+}
+
 class ManyKeys
 {
   isA ManyAttribute;
   key {works};
+}
+
+class ManKeysStringAndInt
+{
+  isA ManyStringAttributes;
+  Integer id;
+  key {worksString, id}
 }
 
 class TypeInference

--- a/testbed/src/TestHarnessAttributes.ump
+++ b/testbed/src/TestHarnessAttributes.ump
@@ -1,4 +1,3 @@
-
 namespace cruise.attributes.test;
 
 // Ignore warnings about lack of initialization of constants and setting to default
@@ -59,9 +58,26 @@ class DoorG
   Double doubleWithF = 1.4;    	
 }
 
+class DoorH
+{
+  id;
+}
+
+class DoorI
+{
+  isA DoorH;
+  key {id};
+}
+
 class ManyAttribute
 {
   Integer[] works;
+}
+
+class ManyKeys
+{
+  isA ManyAttribute;
+  key {works};
 }
 
 class TypeInference

--- a/testbed/test/cruise/associations/InheritedTest.java
+++ b/testbed/test/cruise/associations/InheritedTest.java
@@ -1,0 +1,35 @@
+package cruise.associations;
+
+import org.junit.*;
+import java.sql.*;
+
+public class InheritedTest
+{
+ @Test 
+  public void InheritedAssociationKey() {
+	  SomeAssociationClass someclass = new SomeAssociationClass(1);
+	  SomeAssociationClass someclass2 = new SomeAssociationClass(1);
+	  
+	  Assert.assertEquals(true, someclass.equals(someclass2));
+  }
+ 
+ @Test
+ public void InheritedAssociationManyKeys() {
+	 SomeAssociatedClassWithKey someAssociatedClass = new SomeAssociatedClassWithKey(1);
+	 SomeAssociatedClassWithKey someAssociatedClass2 = new SomeAssociatedClassWithKey(2);
+	 SomeAssociatedClassWithKey someAssociatedClass3 = new SomeAssociatedClassWithKey(3);
+	 
+	 SomeAssociationClassMany someclass = new SomeAssociationClassMany();
+	 SomeAssociationClassMany someclass2 = new SomeAssociationClassMany();
+	 
+	 someclass.addSomeAssociatedClassWithKey(someAssociatedClass);
+	 someclass.addSomeAssociatedClassWithKey(someAssociatedClass2);
+	 someclass.addSomeAssociatedClassWithKey(someAssociatedClass3);
+	 
+	 someclass2.addSomeAssociatedClassWithKey(someAssociatedClass);
+	 someclass2.addSomeAssociatedClassWithKey(someAssociatedClass2);
+	 someclass2.addSomeAssociatedClassWithKey(someAssociatedClass3);
+	 
+	 Assert.assertEquals(true, someclass.equals(someclass2));
+ }
+}

--- a/testbed/test/cruise/associations/InheritedTest.java
+++ b/testbed/test/cruise/associations/InheritedTest.java
@@ -7,29 +7,35 @@ public class InheritedTest
 {
  @Test 
   public void InheritedAssociationKey() {
-	  SomeAssociationClass someclass = new SomeAssociationClass(1);
-	  SomeAssociationClass someclass2 = new SomeAssociationClass(1);
+	  AssociationClass someclass = new AssociationClass(1);
+	  AssociationClass someclass2 = new AssociationClass(1);
 	  
 	  Assert.assertEquals(true, someclass.equals(someclass2));
   }
  
  @Test
  public void InheritedAssociationManyKeys() {
-	 SomeAssociatedClassWithKey someAssociatedClass = new SomeAssociatedClassWithKey(1);
-	 SomeAssociatedClassWithKey someAssociatedClass2 = new SomeAssociatedClassWithKey(2);
-	 SomeAssociatedClassWithKey someAssociatedClass3 = new SomeAssociatedClassWithKey(3);
+	 AssociatedClassWithKey someAssociatedClass = new AssociatedClassWithKey(1);
+	 AssociatedClassWithKey someAssociatedClass2 = new AssociatedClassWithKey(2);
+	 AssociatedClassWithKey someAssociatedClass3 = new AssociatedClassWithKey(3);
+	 AssociatedClassWithKey someAssociatedClass4 = new AssociatedClassWithKey(4);
 	 
-	 SomeAssociationClassMany someclass = new SomeAssociationClassMany();
-	 SomeAssociationClassMany someclass2 = new SomeAssociationClassMany();
+	 AssociationClassManyKeys someclass = new AssociationClassManyKeys();
+	 AssociationClassManyKeys someclass2 = new AssociationClassManyKeys();
 	 
-	 someclass.addSomeAssociatedClassWithKey(someAssociatedClass);
-	 someclass.addSomeAssociatedClassWithKey(someAssociatedClass2);
-	 someclass.addSomeAssociatedClassWithKey(someAssociatedClass3);
+	 someclass.addAssociatedClass(someAssociatedClass);
+	 someclass.addAssociatedClass(someAssociatedClass2);
+	 someclass.addAssociatedClass(someAssociatedClass3);
 	 
-	 someclass2.addSomeAssociatedClassWithKey(someAssociatedClass);
-	 someclass2.addSomeAssociatedClassWithKey(someAssociatedClass2);
-	 someclass2.addSomeAssociatedClassWithKey(someAssociatedClass3);
+	 someclass2.addAssociatedClass(someAssociatedClass);
+	 someclass2.addAssociatedClass(someAssociatedClass2);
+	 someclass2.addAssociatedClass(someAssociatedClass3);
 	 
 	 Assert.assertEquals(true, someclass.equals(someclass2));
+	 
+	 someclass.addAssociatedClass(someAssociatedClass4);
+	 
+	 Assert.assertEquals(false, someclass.equals(someclass2));
+	 Assert.assertEquals(false, someclass2.equals(someclass));
  }
 }

--- a/testbed/test/cruise/attributes/test/InheritedTest.java
+++ b/testbed/test/cruise/attributes/test/InheritedTest.java
@@ -28,4 +28,23 @@ public class InheritedTest
 	  
 	  Assert.assertEquals(true, manykeys.equals(manykeys2));
   }
+  
+  @Test
+  public void MultipleKeysTest() {
+	  ManKeysStringAndInt class1 = new ManKeysStringAndInt(1);
+	  ManKeysStringAndInt class2 = new ManKeysStringAndInt(1);
+	  
+	  class1.addWorksString("1");
+	  class1.addWorksString("2");
+	  
+	  class2.addWorksString("1");
+	  class2.addWorksString("2");
+	  
+	  Assert.assertEquals(true, class1.equals(class2));
+	  	  
+	  class2.addWorksString("3");
+	  
+	  Assert.assertEquals(false, class1.equals(class2));
+	  Assert.assertEquals(false, class2.equals(class1));
+  }
 }

--- a/testbed/test/cruise/attributes/test/InheritedTest.java
+++ b/testbed/test/cruise/attributes/test/InheritedTest.java
@@ -1,0 +1,31 @@
+package cruise.attributes.test;
+
+import org.junit.*;
+import java.sql.*;
+
+public class InheritedTest
+{
+
+  @Test 
+  public void InheritedKey()
+  {
+    DoorI door = new DoorI("1");
+    DoorI door2 = new DoorI("1");
+    
+    Assert.assertEquals(true, door.equals(door2)); 
+    Assert.assertEquals("1",door.getId());
+  }
+  
+  @Test
+  public void InheritedManyKeys()
+  {
+	  ManyKeys manykeys = new ManyKeys();
+	  manykeys.addWork(new Integer(1));
+	  manykeys.addWork(new Integer(2));
+	  ManyKeys manykeys2 = new ManyKeys();
+	  manykeys2.addWork(new Integer(1));
+	  manykeys2.addWork(new Integer(2));
+	  
+	  Assert.assertEquals(true, manykeys.equals(manykeys2));
+  }
+}


### PR DESCRIPTION
The equals() and hash() functions for keys within a class now exclusively call get methods
This prevents the issue of trying to access private inherited members directly while also keeping a consistent format

https://github.com/umple/umple/issues/1026

**IMPORTANT**: By submitting a patch, you agree that your work will be licensed under the [license](https://github.com/umple/umple/blob/master/LICENSE.md) used by the project.

If your pull request does not pass CI, it will **not** be merged (unless *heavily* justified). 

## Description

Applies a fix to issue 1026

## Tests

Had to change existing tests since they were expecting java code to be produced which directly accesses member variables (we now only call the gettters). All other tests passed and those that were modified now pass as well.

Closes #1026  
Closes #1089 
