### PR TITLE
fixing race that caused UmpleOnline sporadic errors displaying errors

### DIFF
--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -734,7 +734,7 @@ class PlaygroundMain
       }
       else {
         try {
-          client.sendToClient("ERROR!!"+errorToReport);
+          client.sendToClient("ERROR!!"+errorToReport+"!!ERROR");
         }
           catch (IOException e2) {
         }

--- a/umpleonline/scripts/UmpleServerTest.php
+++ b/umpleonline/scripts/UmpleServerTest.php
@@ -77,7 +77,7 @@
       $readMoreLines = FALSE;
     }
     else {
-      echo $output;
+      echo "[[[".$output."]]]\n";
     }
   }
   socket_close($theSocket);

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -618,12 +618,17 @@ function serverRun($commandLine,$rawcommand=null) {
     }
     else {
       if(substr($output,0,7) == "ERROR!!") {
-        // The following one line is for DEBUG, uncomment as appropriate
-        // saveFile("\n ERRORLOG* [[".substr($output,7)."]]\n","/tmp/UmpleOnlineLog.txt",'a');
+        $errorEnd = strpos($output, "!!ERROR");
+        $errorLength=$errorEnd-7;
+        $errorString = substr($output,7,$errorLength);
+        $output = substr($output,$errorLength+14); // cut out the error message.
 
-        savefile(substr($output,7),$errorfile);
+        // The following one line is for DEBUG, uncomment as appropriate
+        // saveFile("\n ERRORLOG* [[".$errorString."]] - other output [[".$output."]] ErrorEnd=".$errorEnd."\n","/tmp/UmpleOnlineLog.txt",'a');
+
+        savefile($errorString,$errorfile);
       }
-      else {
+      if(strlen($output)>0) {
         echo $output;
       }
     }


### PR DESCRIPTION
There was a race in the UmpleOnline server where sometimes a warning message was received at the same time as the generated code, and sometimes separately. It caused failure to display output on some code some of the time. This solves the problem.