### PR TITLE
Make compiler.php check that languageStyle is set

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -73,7 +73,8 @@ else if (isset($_REQUEST["umpleCode"]))
     $suboptions = $suboptions . " -s " . $langparts[$i];
   }
   
-  $languageStyle = $_REQUEST["languageStyle"];
+  $languageStyle = isset($_REQUEST["languageStyle"])?
+    $_REQUEST["languageStyle"] : false;
   $outputErr = isset($_REQUEST["error"])?$_REQUEST["error"]:false;
   $uigu = False;
 


### PR DESCRIPTION
This avoids a benign warning when languageStyle is not provided in the query string to
compiler.php. Behaviour should otherwise be unchanged.

Closes #1087 

# Testing

I've tested it manually - the warning is gone now.