### PR TITLE
Warn when a type looks like an access specifier

### DIFF
--- a/build/reference/9142TypeIsAccessSpecifier.txt
+++ b/build/reference/9142TypeIsAccessSpecifier.txt
@@ -1,0 +1,26 @@
+W142 Type is access specifier
+Errors and Warnings
+noreferences
+
+@@description
+
+<h2>Umple warning when a type looks like it was meant as a Java access specifier</h2>
+
+<p>
+Umple does not directly support Java-style access specifiers.
+All attributes are public by default, and other Umple constructs can be used to control how attributes can be used.
+</p>
+
+
+@@example
+@@source manualexamples/W142TypeIsAccessSpecifierAmbiguous.ump
+@@endexample
+
+@@example
+@@source manualexamples/W142TypeIsAccessSpecifierCorrect.ump
+@endexample
+
+@@example
+@@source manualexamples/W142TypeIsAccessSpecifierExplicit.ump
+@endexample
+

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3959,6 +3959,14 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         return;
       }
     }
+
+    if(type != null)
+    {
+      if("public".equals(type) || "private".equals(type) || "protected".equals(type))
+      {
+	setFailedPosition(attributeToken.getPosition(), 142, type);
+      }
+    }
         
     if(type != null && value != null)
     {

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -115,6 +115,7 @@
 
 140: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Attribute type name '{0}' must be alphanumeric, starting with a letter ;
 141: 4, "http://cruise.eecs.uottawa.ca/umple/W141ValueTypeMismatch.html", Mismatch between type '{0}' and value {1} ;
+142: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute '{0}' has a type of {public|private|protected}. This looks like an access specifier and is likely an error. In Umple attributes are private by default, and are Strings if no type is specified. ;
 
 150: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", State machine name '{0}' must be alphanumeric and start with a letter ;
 152: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", State name '{0}' must be alphanumeric and start with a letter ;

--- a/cruise.umple/test/cruise/umple/compiler/142_typeIsAccessSpecifierPrivate.ump
+++ b/cruise.umple/test/cruise/umple/compiler/142_typeIsAccessSpecifierPrivate.ump
@@ -1,0 +1,3 @@
+class Foo{
+  private x;
+}

--- a/cruise.umple/test/cruise/umple/compiler/142_typeIsAccessSpecifierProtected.ump
+++ b/cruise.umple/test/cruise/umple/compiler/142_typeIsAccessSpecifierProtected.ump
@@ -1,0 +1,3 @@
+class Foo{
+  protected x;
+}

--- a/cruise.umple/test/cruise/umple/compiler/142_typeIsAccessSpecifierPublic.ump
+++ b/cruise.umple/test/cruise/umple/compiler/142_typeIsAccessSpecifierPublic.ump
@@ -1,0 +1,3 @@
+class Foo{
+  public x;
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2919,6 +2919,14 @@ public class UmpleParserTest
   assertHasWarningsParse("058_enumerationInUnidirectionalAssoc2.ump", 106);
   assertHasNoWarningsParse("058_enumerationInUnidirectionalAssoc3.ump");
  }
+
+  //Issue 211
+  @Test
+  public void typeIsAccessSpecifier() {
+    assertHasWarningsParse("142_typeIsAccessSpecifierPublic.ump", 142);
+    assertHasWarningsParse("142_typeIsAccessSpecifierProtected.ump", 142);
+    assertHasWarningsParse("142_typeIsAccessSpecifierPrivate.ump", 142);
+  }
  
   public boolean parse(String filename)
   {

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierAmbiguous.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierAmbiguous.ump
@@ -1,0 +1,7 @@
+// This case is probably an error - Umple will consider "x" to have type "public"
+class X {
+  public x;
+}
+
+//$?[End_of_model]$?
+// @@@skipcompile - the resulting code will not compile

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierCorrect.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierCorrect.ump
@@ -1,0 +1,6 @@
+// This is equivalent, attributes have public access by default
+class X {
+  x;
+}
+
+//$?[End_of_model]$?

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierExplicit.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierExplicit.ump
@@ -1,0 +1,7 @@
+// If you want to bypass Umple and directly include the attribute in the generated code, write the full declaration.
+// The generated code will include the attribute verbatim.
+class X {
+  public String x;
+}
+
+//$?[End_of_model]$?


### PR DESCRIPTION
- Add warning 142 which is triggered when an attribute type is "public", "private" or
"protected"
- This helps point out user errors when trying to write e.g "public x;"

Closes #211 

## Tests

Tests have been added to UmpleParserTest.