### PR TITLE
Fixes some manual pages that had syntax errors, and makes build fail …

### DIFF
--- a/build/reference/5202UmplificationTooling.txt
+++ b/build/reference/5202UmplificationTooling.txt
@@ -12,7 +12,7 @@ The <b> Umplificator </b> is a reverse engineering tool for the incremental auto
 <li><b>Eclipse</b>: To use the Umplificator with Eclipse, you need to load the the Umplificator plugin (cruise.umplificator.eclipse.X.X.X.jar). This can be obtained from our <a href="http:/dl.umple.org">downloads site</a>. </li>
 <br />
 
-<li><b>Command-line based compiler</b>: You can use the Umplificator from the command line.  Simply download the latest officially released version of the <a href=""http:/dl.umple.org"> umplificator jar</a>, and run it as "java -jar umplificator.jar *.java". </li>
+<li><b>Command-line based compiler</b>: You can use the Umplificator from the command line.  Simply download the latest officially released version of the <a href="http:/dl.umple.org"> umplificator jar</a>, and run it as "java -jar umplificator.jar *.java". </li>
 Note that it is also possible to umplify files with extension ".ump". 
 </ul>
 

--- a/build/reference/9142TypeIsAccessSpecifier.txt
+++ b/build/reference/9142TypeIsAccessSpecifier.txt
@@ -18,9 +18,9 @@ All attributes are public by default, and other Umple constructs can be used to 
 
 @@example
 @@source manualexamples/W142TypeIsAccessSpecifierCorrect.ump
-@endexample
+@@endexample
 
 @@example
 @@source manualexamples/W142TypeIsAccessSpecifierExplicit.ump
-@endexample
+@@endexample
 

--- a/cruise.umple/src/Documenter.ump
+++ b/cruise.umple/src/Documenter.ump
@@ -24,6 +24,7 @@ class Documenter
   inputPath;
   outputPath;
   String[] messages;
+  Boolean seriousProblem = false;
   
   1 -> 0..1 ContentParser parser;
 }

--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -38,6 +38,7 @@ class DocumenterMain
     {
       println(message);
     }
+    System.exit(doc.isSeriousProblem() ? -1 : 0);
   }
    
   private static void println(String output)
@@ -57,6 +58,7 @@ class Documenter
     if (!inputDirectory.exists())
     {
       addMessage("Unknown directory: " + getInputPath());
+      setSeriousProblem(true);
       return false;
     }
 
@@ -79,6 +81,7 @@ class Documenter
     else
     {
       addMessage("Unable to analyze files in " + getInputPath());
+      setSeriousProblem(true);
       return false;
     }
   }
@@ -158,6 +161,7 @@ class Documenter
         if (htmlOutput.length() == 0)
         {
           addMessage("Failed on: " + content.getTitle());
+          setSeriousProblem(true);
           return false;
         }
         
@@ -247,7 +251,8 @@ class Documenter
       {
         if (!getParser().parse("content", SampleFileWriter.readContent(aFile)+" @@Filename "+aFile.getName()).getWasSuccess())
         {
-          addMessage("Unable to parse "+ getParser().getParseResult().getPosition() +": " + aFile.getName() );
+          addMessage("Unable to parse manual source page at line "+ getParser().getParseResult().getPosition() +": " + aFile.getName() );
+          setSeriousProblem(true);
         }
       }
     }

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -476,6 +476,13 @@ class PlaygroundMain
 
   Boolean isServer=false;
   int commandsRun = 0;
+  int logCommandsRun = 0;
+  int sourceCommandsRun = 0;
+  int editClassCommandsRun = 0;
+  int generateJsonCommandsRun = 0;
+  int generateJsonMixedCommandsRun = 0;
+  int addClassCommandsRun = 0;
+  
   static String[] previousCommand = new String[1];
   static String[] lastCommand = new String[1];
   static String[] currentCommand = new String[1];
@@ -557,6 +564,16 @@ class PlaygroundMain
     lastCommand = currentCommand;
     lastIP = currentIP;
     currentCommand = args;
+    
+    if(currentCommand[0].equals("-log")) logCommandsRun++;
+    else if(currentCommand[0].equals("-source"))  sourceCommandsRun++;
+    else if(currentCommand[0].equals("-editClass"))  editClassCommandsRun++;
+    else if(currentCommand[0].equals("-generate")
+      && currentCommand[1].equals("Json") )  generateJsonCommandsRun++;
+    else if(currentCommand[0].equals("-generate")
+      && currentCommand[1].equals("JsonMized"))  generateJsonMixedCommandsRun++;
+    else if(currentCommand[0].equals("-addClass"))  addClassCommandsRun++;
+    
     if(client != null) {
       currentIP = client.getInetAddress();
     }
@@ -580,20 +597,33 @@ class PlaygroundMain
       returnCommandResult("<action> <deltaCode> <filename>\n", client);  
       return;
     }
-    
+
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy MMM dd HH:mm:ss");    
     if ("-version".equals(args[0])) {
-      returnCommandResult("Version: " + UmpleModel.VERSION_NUMBER+"\n", client);
+      returnCommandResult("Version: " + UmpleModel.VERSION_NUMBER
+        + " Compiled: "+sdf.format(CompileDate.getClassBuildTime())
+        +"\n", client);
       return;
     }    
 
     if ("-log".equals(args[0])) {
       if(isServer) {
           long uptime = ManagementFactory.getRuntimeMXBean().getUptime();
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy MMM dd HH:mm:ss");
           Date startDate = new Date(System.currentTimeMillis()-uptime);
           
+          returnCommandResult("UmpleOnline Log recorded: "
+            +sdf.format(System.currentTimeMillis()) +"\n\n", client);
+          
           returnCommandResult("Number of commands run since start: "
-            +commandsRun+"  (pace "+String.format("%.1f", 3600000.0*commandsRun/uptime)+"/h)\n\n", client);          
+            +commandsRun+"  (pace "+String.format("%.1f", 3600000.0*commandsRun/uptime)+"/h)\n", client);          
+          returnCommandResult(
+              "  log: " +logCommandsRun
+              +"  source: " +sourceCommandsRun
+              +"  editClass: " +editClassCommandsRun
+              +"  addClass: " +addClassCommandsRun
+              +"  g Json: " +generateJsonCommandsRun
+              +"  g JsonMixed: " +generateJsonMixedCommandsRun
+              +"\n\n", client);          
           
           returnCommandResult("JVM uptime: "
             +uptime/1000+"s  "+String.format("%.3f",uptime/60000/1440.0)+"days  restarted "+
@@ -614,7 +644,9 @@ class PlaygroundMain
 
           returnCommandResult("Port: "+getPort()+"\n\n", client);
           
-          returnCommandResult("Version: " + UmpleModel.VERSION_NUMBER+"\n\n", client);
+          returnCommandResult("Version: " + UmpleModel.VERSION_NUMBER
+            + " Jar file date updated: "+sdf.format(CompileDate.getClassBuildTime())
+            +"\n\n", client);
 
           if(lastIP != null) {
             returnCommandResult("Last command      from "
@@ -871,4 +903,46 @@ class PlaygroundMain
 
 use Compiler.ump;
 use ArgumentTokenizer.ump;
+
+class CompileDate {
+  depend java.net.URISyntaxException;
+  depend java.util.Date;
+  depend java.util.jar.JarFile;
+  depend java.util.zip.ZipFile;
+  depend java.io.IOException;
+  depend java.io.File;
+  depend java.util.zip.ZipEntry;
+  depend java.net.URL;
+  
+  // From https://stackoverflow.com/questions/3336392/java-print-time-of-last-compilation
+
+  public static Date getClassBuildTime() {
+    Date d = null;
+    Class<?> currentClass = new Object() {}.getClass().getEnclosingClass();
+    URL resource = currentClass.getResource(currentClass.getSimpleName() + ".class");
+    if (resource != null) {
+        if (resource.getProtocol().equals("file")) {
+            try {
+                d = new Date(new File(resource.toURI()).lastModified());
+            } catch (URISyntaxException ignored) { }
+        } else if (resource.getProtocol().equals("jar")) {
+            String path = resource.getPath();
+            d = new Date( new File(path.substring(5, path.indexOf("!"))).lastModified() );    
+        } else if (resource.getProtocol().equals("zip")) {
+            String path = resource.getPath();
+            File jarFileOnDisk = new File(path.substring(0, path.indexOf("!")));
+            //long jfodLastModifiedLong = jarFileOnDisk.lastModified ();
+            //Date jfodLasModifiedDate = new Date(jfodLastModifiedLong);
+            try(JarFile jf = new JarFile (jarFileOnDisk)) {
+                ZipEntry ze = jf.getEntry (path.substring(path.indexOf("!") + 2));//Skip the ! and the /
+                long zeTimeLong = ze.getTime ();
+                Date zeTimeDate = new Date(zeTimeLong);
+                d = zeTimeDate;
+            } catch (IOException|RuntimeException ignored) { }
+        }
+    }
+    return d;
+}
+
+}
 


### PR DESCRIPTION
There were two longstanding manual pages that were not published due to syntax errors. Messages in the build log were being printed, but ignored.

This PR returns -1 from the manual builder if there are syntax errors, and fixes the existing syntax errors, which were caused by improper XML in one case and a missing '@' in another case.

Also there is some expansion to logging.