### PR TITLE
Split the UmpleOnline Dockerfile to save space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,20 +54,22 @@ script:
 
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.
   - if [ "$HAVE_DOCKER" ]; then
-        $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline;
+        $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline &&
+        docker build -t "umple/umpleonline-base:local"
+                     -f ../umpleonline/Dockerfile-base ../umpleonline &&
         docker build -t "umple/umpleonline:$TRAVIS_COMMIT" ../umpleonline;
     fi
 
 after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
-        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-        DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT";
-        docker push "$DOCKER_IMAGE_NAME";
+        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
+        DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
+        docker push "$DOCKER_IMAGE_NAME" &&
         if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
+            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
             docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
         elif [ "$TRAVIS_BRANCH" = 'master' ]; then
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest";
+            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
             docker push "umple/umpleonline:latest";
         elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
             echo 'The branch name is "latest", not pushing branch tag';
@@ -76,6 +78,10 @@ after_success:
         else
             docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
             docker push "umple/umpleonline:$TRAVIS_BRANCH";
+        fi &&
+        if [ "$TRAVIS_TAG" ]; then
+            docker tag "umple/umpleonline-base:local" "umple/umpleonline-base:latest" &&
+            docker push "umple/umpleonline-base:latest";
         fi
     fi
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -1,12 +1,6 @@
-FROM nginx:1.13.5-alpine
-
-MAINTAINER Umple umple-help@googlegroups.com
-
-# give php its own user and install UmpleOnline's dependencies
-RUN adduser -D -H -h /var/cache/php -s /sbin/nologin -G nginx php && \
-    apk add --no-cache openjdk8 python py-pip graphviz zip \
-		       php7 php7-fpm php7-sockets && \
-    pip install supervisor==3.3.3
+FROM umple/umpleonline-base:latest
+# To save 200MB on image size, all our dependencies are in a separate
+# slow-changing base image
 
 # make sure supervisord, nginx and php-fpm are configured
 COPY docker_config/supervisord.conf /etc/supervisord.conf

--- a/umpleonline/Dockerfile-base
+++ b/umpleonline/Dockerfile-base
@@ -1,0 +1,10 @@
+FROM nginx:1.13.5-alpine
+
+MAINTAINER Umple umple-help@googlegroups.com
+
+# give php its own user and install UmpleOnline's dependencies
+RUN adduser -D -H -h /var/cache/php -s /sbin/nologin -G nginx php && \
+    apk add --no-cache openjdk8 python py-pip graphviz zip \
+		       php7 php7-fpm php7-sockets && \
+    pip install supervisor==3.3.3
+


### PR DESCRIPTION
## Description

The header of the Dockerfile that installs all the dependencies is now
split out into an image called umpleonline-base. It should not need to
change much and saves 200MB from the full UmpleOnline image size.

The Travis build has been altered to base its Dockerfile on that image, and
rebuild it on tag builds.

## Tests

As with other build system modifications, all tests are live.

The Dockerfiles have been tested independently, hopefully the tag build logic works.

Closes #1121 