### PR TITLE
Fix the issue that the removing association in JJs might not work correctly

### DIFF
--- a/cruise.umple/src/sync/DeleteAssociationAction_Code.ump
+++ b/cruise.umple/src/sync/DeleteAssociationAction_Code.ump
@@ -125,7 +125,14 @@ class DeleteAssociationAction
           firstRole = firstRole == null? "" : ":" + firstRole; 
           secondRole = secondRole == null? "" : ":" + secondRole;
           
-          currentName = firstClassName + firstRole + "__" + secondClassName + secondRole;
+          if (firstClassName.compareTo(secondClassName) <= 0)
+          {
+            currentName = firstClassName + firstRole + "__" + secondClassName + secondRole;
+          }
+          else
+          {
+            currentName = secondClassName + secondRole + "__" + firstClassName + firstRole;
+          }
           
           if (currentName.equals(associationName))
           {

--- a/cruise.umple/src/sync/DeleteAssociationAction_Code.ump
+++ b/cruise.umple/src/sync/DeleteAssociationAction_Code.ump
@@ -125,14 +125,7 @@ class DeleteAssociationAction
           firstRole = firstRole == null? "" : ":" + firstRole; 
           secondRole = secondRole == null? "" : ":" + secondRole;
           
-          if (firstClassName.compareTo(secondClassName) <= 0)
-          {
-            currentName = firstClassName + firstRole + "__" + secondClassName + secondRole;
-          }
-          else
-          {
-            currentName = secondClassName + secondRole + "__" + firstClassName + firstRole;
-          }
+          currentName = firstClassName + firstRole + "__" + secondClassName + secondRole;
           
           if (currentName.equals(associationName))
           {

--- a/umpleonline/scripts/jjs/jjs_parse.js
+++ b/umpleonline/scripts/jjs/jjs_parse.js
@@ -814,6 +814,16 @@ var JJSdiagram = {
 		jjsJsonOne.position.width = jjsJsonOne.size.width;
 		jjsJsonTwo.position.height = jjsJsonTwo.size.height;
 		jjsJsonTwo.position.width = jjsJsonTwo.size.width;
+		var nameOne = "";
+		var nameTwo = "";
+
+		if (jjsJsonOne.name[0] <= jjsJsonTwo.name[0]){
+			nameOne = jjsJsonOne.name[0];
+			nameTwo = jjsJsonTwo.name[0];
+		}else {
+			nameOne = jjsJsonTwo.name[0];
+			nameTwo = jjsJsonOne.name[0];
+		}
 		var actionCodeObj = {
 			"classOnePosition": jjsJsonOne.position,
 			"classTwoPosition": jjsJsonTwo.position,
@@ -831,7 +841,7 @@ var JJSdiagram = {
 			},
 			"multiplicityOne": "*",
 			"multiplicityTwo": "*",
-			"name": jjsJsonOne.name[0] + "__" + jjsJsonTwo.name[0],
+			"name": nameOne + "__" + nameTwo,
 			"roleOne": "",
 			"roleTwo": "",
 			"isSymmetricReflexive": "false",
@@ -865,7 +875,7 @@ var JJSdiagram = {
 				console.log('JJSdiagram.makeUmpleCodeFromAssociation: action type error.');
 				break;
 		}
-
+		
 		DiagramEdit.updateUmpleText({
 			actionCode: actionCode,
 			codeChange: true


### PR DESCRIPTION


## Description

This commit fix the problem mentioned in issue #1125.

 However, I am not really sure if there is such a need to do this class name check and set current association name end by using dictionary order of the class names. From my perspective, class names do not really matter, we always remove the association if there is such a subtoken in side a class definition. 

This check will raise the risk of failing to pick up association definition in umple code under cases like #1125 .
