### PR TITLE
Fix 1128 jmcmanus

### DIFF
--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -57,31 +57,43 @@ class GeneratorHelper
   public static String toCode(List<CodeInjection> allCodeInjections)
   {
     String asCode = null;
-    String positionString = "";
     if (allCodeInjections != null)
     {
       for (CodeInjection inject : allCodeInjections)
       {
         if (asCode == null)
         {
+          String positionString = "";
+          Position p = inject.getPosition();
+          Position codeP = inject.getCodePosition();
+          if (codeP != null) {
+              positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+          }
+          else if (p != null) {
+              positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+          }
           if(inject.getConstraintTree()!=null&&generator!=null)
           {
-            asCode = inject.getConstraintCode(generator);
+            asCode = positionString + inject.getConstraintCode(generator);
           }
-          else asCode = inject.getCode();
-           
-          Position p = inject.getPosition();
-	      if (p != null) {
-	          positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
-	      }
+          else asCode = positionString + inject.getCode();
         }
         else
         {
+          String positionString = "";
+          Position p = inject.getPosition();
+          Position codeP = inject.getCodePosition();
+          if (codeP != null) {
+              positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+          }
+          else if (p != null) {
+              positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+          }
           if(inject.getConstraintTree()!=null&&generator!=null)
           {
-            asCode = StringFormatter.format("{0}\n{1}",asCode,inject.getConstraintCode(generator));
+            asCode = StringFormatter.format("{0}\n{1}{2}",asCode,positionString,inject.getConstraintCode(generator));
           }
-          else asCode = StringFormatter.format("{0}\n{1}",asCode,inject.getCode());
+          else asCode = StringFormatter.format("{0}\n{1}{2}",asCode,positionString,inject.getCode());
         }
       }
     }
@@ -89,7 +101,7 @@ class GeneratorHelper
     {
       return null;
     }
-    return positionString + asCode;
+    return asCode;
   }  
 
   public static String doIndent(String code, String indents)

--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -61,17 +61,17 @@ class GeneratorHelper
     {
       for (CodeInjection inject : allCodeInjections)
       {
+        String positionString = "";
+        Position p = inject.getPosition();
+        Position codeP = inject.getCodePosition();
+        if (codeP != null) {
+            positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+        }
+        else if (p != null) {
+            positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+        }
         if (asCode == null)
         {
-          String positionString = "";
-          Position p = inject.getPosition();
-          Position codeP = inject.getCodePosition();
-          if (codeP != null) {
-              positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
-          }
-          else if (p != null) {
-              positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
-          }
           if(inject.getConstraintTree()!=null&&generator!=null)
           {
             asCode = positionString + inject.getConstraintCode(generator);
@@ -80,15 +80,6 @@ class GeneratorHelper
         }
         else
         {
-          String positionString = "";
-          Position p = inject.getPosition();
-          Position codeP = inject.getCodePosition();
-          if (codeP != null) {
-              positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
-          }
-          else if (p != null) {
-              positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
-          }
           if(inject.getConstraintTree()!=null&&generator!=null)
           {
             asCode = StringFormatter.format("{0}\n{1}{2}",asCode,positionString,inject.getConstraintCode(generator));

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -467,6 +467,7 @@ class CodeInjection
   * -> 1 UmpleClassifier;
   1 -> 0..1 ConstraintTree;
   lazy Position position;
+  lazy Position codePosition;
   Boolean isInternal = false;
 }
 

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3445,12 +3445,17 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         if(langs.size()==0)
         {
           cb.setCode(sub.getValue());
+          injection.setCodePosition(sub.getPosition());
         }
         else
         {
           for(String lang:langs)
             {
-            cb.setCode(lang,sub.getValue());
+                cb.setCode(lang,sub.getValue());
+                if("Java".equals(lang))
+                {
+                  injection.setCodePosition(sub.getPosition());
+                }
             }
         }
         langs.clear();      

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump
@@ -1,0 +1,19 @@
+class Student {
+  String foo(int a) {
+    if(a < 0) {
+      return 0;
+    }
+
+    for(int i = 0; i < a; i++) {
+      if(i == a/4) {
+        return a;
+      }
+    }
+
+    return 4;
+  }
+
+  before custom foo { System.out.println("Starting foo with argument: " + a);  }
+
+  after all foo { System.out.println("Returning from foo!");  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsBasicOnOneLine.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsBasicOnOneLine.java.txt
@@ -3,7 +3,7 @@
 
 
 
-// line 1 "ClassTemplateTest_CodeInjectionsBasic.ump"
+// line 1 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
 public class Student
 {
 
@@ -25,24 +25,24 @@ public class Student
   public void delete()
   {}
 
-  // line 3 "ClassTemplateTest_CodeInjectionsBasic.ump"
+  // line 3 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
   public String foo(int a){
-    // line 17 "ClassTemplateTest_CodeInjectionsBasic.ump"
+    // line 16 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
     System.out.println("Starting foo with argument: " + a);
     if(a < 0) {      
-      // line 21 "ClassTemplateTest_CodeInjectionsBasic.ump"
+      // line 18 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
       System.out.println("Returning from foo!");
       return 0;
     }
 
     for(int i = 0; i < a; i++) {
       if(i == a/4) {        
-        // line 21 "ClassTemplateTest_CodeInjectionsBasic.ump"
+        // line 18 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
         System.out.println("Returning from foo!");
         return a;
       }
     }    
-    // line 21 "ClassTemplateTest_CodeInjectionsBasic.ump"
+    // line 18 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
     System.out.println("Returning from foo!");
     return 4;
 

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersMulti.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersMulti.java.txt
@@ -3,6 +3,7 @@
 
 
 
+// line 1 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
 public class Student
 {
 
@@ -24,8 +25,11 @@ public class Student
   public void delete()
   {}
 
+  // line 3 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
   public String foo(int a){
+    // line 26 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting foo...");
+    // line 38 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting execution...");
     if(a < 0) {
       return 4;
@@ -34,18 +38,25 @@ public class Student
     return 3;
   }
 
+  // line 11 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
   public String foo(int a, String b){
+    // line 26 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting foo...");
     if(a > 0 && "".equals(b)) {      
+      // line 30 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
       System.out.println("Returning from foo, a: " + a ", b: " + b);
       return 3;
     }    
+    // line 30 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Returning from foo, a: " + a ", b: " + b);
     return 1;
   }
 
+  // line 18 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
   public String bar(){
+    // line 34 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     // TODO: fix asap
+    // line 38 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting execution...");
     int a = 4;
 

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -76,7 +76,13 @@ public class JavaClassTemplateTest extends ClassTemplateTest
   @Test
   public void ClassCodeInjections_Basic()
   {
-    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsBasic.ump", languagePath + "/ClassTemplateTest_CodeInjectionsBasic." + languagePath + ".txt", "Student");
+    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsBasic.ump", languagePath + "/ClassTemplateTest_CodeInjectionsBasic." + languagePath + ".txt", "Student", true, false);
+  }
+  
+  @Test
+  public void ClassCodeInjections_BasicOnOneLine()
+  {
+    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump", languagePath + "/ClassTemplateTest_CodeInjectionsBasicOnOneLine." + languagePath + ".txt", "Student", true, false);
   }
 
   @Test
@@ -111,7 +117,7 @@ public class JavaClassTemplateTest extends ClassTemplateTest
   @Test
   public void ClassCodeInjections_ParametersMulti()
   {
-    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsParametersMulti.ump", languagePath + "/ClassTemplateTest_CodeInjectionsParametersMulti." + languagePath + ".txt", "Student");
+    assertUmpleTemplateFor("ClassTemplateTest_CodeInjectionsParametersMulti.ump", languagePath + "/ClassTemplateTest_CodeInjectionsParametersMulti." + languagePath + ".txt", "Student", true, false);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes the issues where code injection does not output the correct line number in the:
"// line \#\# "file""
The line number previously pointed to the line where the before/after statement was declared, not where the code begins like in normal user defined methods. 

It also fixes an issue where only one of the above comments is generated when there are multiple before and/or multiple after statements for a single function.

## Tests
Modified a couple of existing code injection tests to now check for correct line number comments.
Added an additional test to verify that this works for files that aren't well formatted (before/after statement and code is on the same line).

Closes Issue #1128 

