### PR TITLE
Adds a comment to the end of injections

### DIFF
--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -64,27 +64,35 @@ class GeneratorHelper
         String positionString = "";
         Position p = inject.getPosition();
         Position codeP = inject.getCodePosition();
+        String injectFooter = "";
+        String injectType = inject.getType();
         if (codeP != null) {
             positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+            if (injectType != null) {
+                injectFooter = "\n// END OF UMPLE " + injectType.toUpperCase() + " INJECTION";
+            }
         }
         else if (p != null) {
             positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+            if (injectType != null) {
+                injectFooter = "\n// END OF UMPLE " + injectType.toUpperCase() + " INJECTION";
+            }
         }
         if (asCode == null)
         {
           if(inject.getConstraintTree()!=null&&generator!=null)
           {
-            asCode = positionString + inject.getConstraintCode(generator);
+            asCode = positionString + inject.getConstraintCode(generator) + injectFooter;
           }
-          else asCode = positionString + inject.getCode();
+          else asCode = positionString + inject.getCode() + injectFooter;
         }
         else
         {
           if(inject.getConstraintTree()!=null&&generator!=null)
           {
-            asCode = StringFormatter.format("{0}\n{1}{2}",asCode,positionString,inject.getConstraintCode(generator));
+            asCode = StringFormatter.format("{0}\n{1}{2}{3}",asCode,positionString,inject.getConstraintCode(generator), injectFooter);
           }
-          else asCode = StringFormatter.format("{0}\n{1}{2}",asCode,positionString,inject.getCode());
+          else asCode = StringFormatter.format("{0}\n{1}{2}{3}",asCode,positionString,inject.getCode(), injectFooter);
         }
       }
     }

--- a/cruise.umple/src/util/SampleFileWriter_Code.ump
+++ b/cruise.umple/src/util/SampleFileWriter_Code.ump
@@ -186,13 +186,15 @@ class SampleFileWriter
         expectedLine = expectedReader.readLine();
         if (ignoreLineComments)
         {
-          // HACK: To deal with // line # comments
-          while (actualLine != null && actualLine.indexOf("// line") != -1)
+          // HACK: To deal with // line # comments and footer of inject statements
+          while (actualLine != null && (actualLine.indexOf("// line") != -1 || 
+                    actualLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")))
           { //Ignore the line, go to next
             actualLine = actualReader.readLine();
           }
           
-          while (expectedLine != null && expectedLine.indexOf("// line") != -1)
+          while (expectedLine != null && (expectedLine.indexOf("// line") != -1 ||
+                    expectedLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")))
           { 
         	  expectedLine = expectedReader.readLine();
           }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsBasic.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsBasic.java.txt
@@ -29,9 +29,11 @@ public class Student
   public String foo(int a){
     // line 17 "ClassTemplateTest_CodeInjectionsBasic.ump"
     System.out.println("Starting foo with argument: " + a);
+    // END OF UMPLE BEFORE INJECTION
     if(a < 0) {      
       // line 21 "ClassTemplateTest_CodeInjectionsBasic.ump"
       System.out.println("Returning from foo!");
+      // END OF UMPLE AFTER INJECTION
       return 0;
     }
 
@@ -39,11 +41,13 @@ public class Student
       if(i == a/4) {        
         // line 21 "ClassTemplateTest_CodeInjectionsBasic.ump"
         System.out.println("Returning from foo!");
+        // END OF UMPLE AFTER INJECTION
         return a;
       }
     }    
     // line 21 "ClassTemplateTest_CodeInjectionsBasic.ump"
     System.out.println("Returning from foo!");
+    // END OF UMPLE AFTER INJECTION
     return 4;
 
   }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsBasicOnOneLine.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsBasicOnOneLine.java.txt
@@ -29,9 +29,11 @@ public class Student
   public String foo(int a){
     // line 16 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
     System.out.println("Starting foo with argument: " + a);
+    // END OF UMPLE BEFORE INJECTION
     if(a < 0) {      
       // line 18 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
       System.out.println("Returning from foo!");
+      // END OF UMPLE AFTER INJECTION
       return 0;
     }
 
@@ -39,11 +41,13 @@ public class Student
       if(i == a/4) {        
         // line 18 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
         System.out.println("Returning from foo!");
+        // END OF UMPLE AFTER INJECTION
         return a;
       }
     }    
     // line 18 "ClassTemplateTest_CodeInjectionsBasicOnOneLine.ump"
     System.out.println("Returning from foo!");
+    // END OF UMPLE AFTER INJECTION
     return 4;
 
   }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersMulti.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_CodeInjectionsParametersMulti.java.txt
@@ -29,8 +29,10 @@ public class Student
   public String foo(int a){
     // line 26 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting foo...");
+    // END OF UMPLE BEFORE INJECTION
     // line 38 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting execution...");
+    // END OF UMPLE BEFORE INJECTION
     if(a < 0) {
       return 4;
     }
@@ -42,13 +44,16 @@ public class Student
   public String foo(int a, String b){
     // line 26 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting foo...");
+    // END OF UMPLE BEFORE INJECTION
     if(a > 0 && "".equals(b)) {      
       // line 30 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
       System.out.println("Returning from foo, a: " + a ", b: " + b);
+      // END OF UMPLE AFTER INJECTION
       return 3;
     }    
     // line 30 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Returning from foo, a: " + a ", b: " + b);
+    // END OF UMPLE AFTER INJECTION
     return 1;
   }
 
@@ -56,8 +61,10 @@ public class Student
   public String bar(){
     // line 34 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     // TODO: fix asap
+    // END OF UMPLE BEFORE INJECTION
     // line 38 "ClassTemplateTest_CodeInjectionsParametersMulti.ump"
     System.out.println("Starting execution...");
+    // END OF UMPLE BEFORE INJECTION
     int a = 4;
 
     if(a == 3) return 2;


### PR DESCRIPTION
## Description
This PR adds a comment at the end of all injected code so you can now tell where the injected code ends and the original function begins / resumes. This is necessary for my fix to issue 882 since we cannot find the original line without being able to differentiate between injected code and function code.

I also added a rule in the class that compares output for tests to ignore the new comment if the test requests it (before it would only ignore // line ## comments).

## Tests

Modifies a few of the existing tests that actually check comments, this both fixes failed tests while at the same time testing my changes.

Closes Issue #1143 

