### PR TITLE
Minor fix to ensure compiler can compile under Java 9

### DIFF
--- a/cruise.umple/test/cruise/umple/compiler/RuleInstanceTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/RuleInstanceTest.java
@@ -140,7 +140,7 @@ public class RuleInstanceTest
     Assert.assertEquals(RulePart.Type.Variable,part.getType());
   }
   
-  @Test(expected=ArrayIndexOutOfBoundsException.class)
+  @Test(expected=IndexOutOfBoundsException.class)
   public void getRulePart_invalid_tooLow()
   {
     RuleInstance instance = new RuleInstance(parser);


### PR DESCRIPTION
This PR fixes a single test that fails when building is done in Java 9, which was released in September. With this fix, Umple can be built in either Java 8 or Java 9. I tested in Java 9 to verify that Umple-generated code is fine in Java 9 (for other users) and found that the build failed on one test case.

Basically the situation is that ArrayList in Java 9 now throws IndexOutOfBoundsException instead of ArrayIndexOutOfBoundsException

Since the latter is a subclass of the former, the failing test is set to use expect the former.

We will continue to do CI builds with Java 8 for now, but this sets the stage for conversion when we need to. Umple has normally waited about 4-6 months before making the change (i.e. until someone expresses a desire to use new features.

This PR does not get rid of some new deprecation warnings that are raised in Java 9. That would have to be done later.