### PR TITLE
Fixing preferred PhP pattern to be 7.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ init:
 
 - cmd: gem update --system
 - ps: cinst ant 2>&1 | Out-Null
-- ps: cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+- ps: cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern 7.1 | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
 
 install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ init:
 
 - cmd: gem update --system
 - ps: cinst ant 2>&1 | Out-Null
-- ps: cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern 7.1 | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+- ps: choco install php
 
 install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.26.0-build-{build}
+version: 1.26.0-{build}-{branch}
 
 clone_depth: 5
 
@@ -14,6 +14,12 @@ init:
 
 - cmd: gem update --system
 - ps: cinst ant 2>&1 | Out-Null
+# These next three are being installed separately as they are php dependents
+# and were failing to install along with php
+- ps: choco install kb3035131
+- ps: choco install kb2919442
+- os: choco install kb2999226
+# install the latest php
 - ps: choco install php
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ init:
 
 install:
 
-- ps: $env:Path="C:\Ruby21\bin;C:/tools/ruby22/bin;C:\Program Files (x86)\Java\jdk1.8.0\bin;$($env:Path);C:\tools\php;C:\ProgramData\chocolatey\lib\ant"
+- ps: $env:Path="C:\Ruby21\bin;C:/tools/ruby22/bin;C:\Program Files (x86)\Java\jdk1.8.0\bin;$($env:Path);C:\tools\php71;C:\tools\php;C:\ProgramData\chocolatey\lib\ant"
 
 - ps: ant -version
 - ps: pushd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ version: 1.26.0-{build}-{branch}
 
 clone_depth: 5
 
+platform:
+  - x64
+
 cache:
 
 - C:\Users\appveyor\.ant -> appveyor.yml
@@ -16,7 +19,7 @@ init:
 - ps: cinst ant 2>&1 | Out-Null
 
 # install the latest php (dependencies kb2919442 kb3035131 kb2999226 were failing )
-- ps: choco install php --ignore-depdendencies
+- ps: choco install php --ignore-dependencies
 
 install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,11 +36,11 @@ install:
 
 - ps: popd
 
-- ps: php.exe --version
-- ps: ruby.exe -v
-- cmd: java.exe -version # using ps causes it to fail because it prints to sterr
-- ps: ant -version
-- ps: rake.bat -V
+- cmd: php --version
+- cmd: ruby -v
+- cmd: java -version # using ps causes it to fail because it prints to sterr
+- cmd: ant -version
+- cmd: rake -V
 
 build_script:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,9 @@ init:
 
 - cmd: gem update --system
 - ps: cinst ant 2>&1 | Out-Null
-# These next three are being installed separately as they are php dependents
-# and were failing to install along with php
-- ps: choco install kb2919442
-- ps: choco install kb3035131
-- os: choco install kb2999226
-# install the latest php
-- ps: choco install php
+
+# install the latest php (dependencies kb2919442 kb3035131 kb2999226 were failing )
+- ps: choco install php --ignore-depdendencies
 
 install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ init:
 - ps: cinst ant 2>&1 | Out-Null
 # These next three are being installed separately as they are php dependents
 # and were failing to install along with php
-- ps: choco install kb3035131
 - ps: choco install kb2919442
+- ps: choco install kb3035131
 - os: choco install kb2999226
 # install the latest php
 - ps: choco install php

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,9 @@ init:
 - cmd: gem update --system
 - ps: cinst ant 2>&1 | Out-Null
 
+# install some dependencies needed by php
+- ps: choco install chocolatey-core.extension --ignore-dependencies
+
 # install the latest php (dependencies kb2919442 kb3035131 kb2999226 were failing )
 - ps: choco install php --ignore-dependencies
 


### PR DESCRIPTION
Some code for selecting the version of PhP in the Appveyor.yml had a bug. This should fix