### PR TITLE
Fixes file path formatting

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -4314,8 +4314,8 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       }
 
       CodeBlock cb = new CodeBlock();
-      String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename() + "\"", "Java"));
-      String otherComment = ("// line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename() + "\"", "Java"));
+      String rubyComment = ("# line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename(), "Java") + "\"");
+      String otherComment = ("// line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename(), "Java") + "\"");
 
       cb.setCode(otherComment);
       cb.setCode("Ruby", rubyComment);
@@ -4340,7 +4340,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename() + "\"", "Java"));
+      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename(), "Java") + "\"");
       aClass.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1006, sub.getValue("name"));
     }
@@ -4355,7 +4355,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         }
       }
       extraCode += "\n  {\n    "+sub.getValue("innerstuff")+"\n  }";
-      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename() + "\"", "Java"));
+      aClass.appendExtraCode("// line " + exception.getPosition().getLineNumber() + " \"" + aClass.getRelativePath( exception.getPosition().getFilename(), "Java") + "\"");
       aClass.appendExtraCode("  "+extraCode+"\n");
       setFailedPosition(sub.getPosition(), 1008, sub.getValue("name"));
     }

--- a/testbed/test/cruise/compiler/CompilerErrorUtil.java
+++ b/testbed/test/cruise/compiler/CompilerErrorUtil.java
@@ -12,9 +12,9 @@ import java.io.BufferedReader;
 public class CompilerErrorUtil
 {
 	static String UMPLE_ROOT = "../";
-	static String SOURCE_FOLDER = UMPLE_ROOT + "testbed/test/cruise/compiler/src/";
-	static String EXPECTED_FOLDER = UMPLE_ROOT + "testbed/test/cruise/compiler/expected/";
-	static String UMPLE_JAR = UMPLE_ROOT + "dist/umple.jar";
+	static String SOURCE_FOLDER = (UMPLE_ROOT + "testbed/test/cruise/compiler/src/").replaceAll("/", File.separator);
+	static String EXPECTED_FOLDER = (UMPLE_ROOT + "testbed/test/cruise/compiler/expected/").replaceAll("/", File.separator);
+	static String UMPLE_JAR = (UMPLE_ROOT + "dist/umple.jar").replaceAll("/", File.separator);
 	
 	public static void AssertCompileError(String umpleFile, String expectedOutputFile) {
 		// Construct a sub-process to build the umple file and compile the resulting Java

--- a/testbed/test/cruise/runtime/RuntimeErrorUtil.java
+++ b/testbed/test/cruise/runtime/RuntimeErrorUtil.java
@@ -14,8 +14,8 @@ import java.io.BufferedReader;
 public class RuntimeErrorUtil
 {
 	static String UMPLE_ROOT = "../";
-	static String SOURCE_FOLDER = UMPLE_ROOT + "testbed/bin/";
-	static String EXPECTED_FOLDER = UMPLE_ROOT + "testbed/test/cruise/runtime/expected/";
+	static String SOURCE_FOLDER = (UMPLE_ROOT + "testbed/bin/").replaceAll("/", File.separator);
+	static String EXPECTED_FOLDER = (UMPLE_ROOT + "testbed/test/cruise/runtime/expected/").replaceAll("/", File.separator);
 	static String PACKAGE_NAME = "cruise.runtime.";
 
 	public static void AssertRuntimeError(String javaClass, String expectedOutputFile) {


### PR DESCRIPTION
## Description

Replaces some linux file separators with the system separator

Fixes a typo where the quotes that go around a filename in the // line comments was put inside of the getRelativePath function

