### PR TITLE
Telling Appveyor not to run ErrorOut tests

### DIFF
--- a/build/_appveyor.xml
+++ b/build/_appveyor.xml
@@ -15,6 +15,7 @@
   <property name="ivyResolveLogLevel" value="default" />
   <property name="junit" value="*Test"/> 
   <property name="rake_cmd" value="rake.bat"/>  
+  <property name="excludeCompilerErrorOutput" value="true"/>  
 
   <property name="online" value="true" />
    


### PR DESCRIPTION
Earlier in the day we asked cc not to compile certain tests. It turns out Appveyor has problems with them too. For now will run them just on local builds and Travis.