### PR TITLE
Implement issue 1123

### DIFF
--- a/umpleonline/404.shtml
+++ b/umpleonline/404.shtml
@@ -1,0 +1,83 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <!--#include virtual="files/inclcommonhead.html" -->
+
+  <title>CRuiSE Server - Page not Found - Error 404</title>
+</head>
+
+<body>
+
+  <!--#include virtual="files/incltopuottawabanner.html" -->
+
+  <!-- The following is the main table, split horizontally into
+       a menu and the primary content -->
+  <table border="0" cellpadding="0" cellspacing="0" width="780">
+    <tbody>
+
+      <!-- The following specifies the part of the left bar menu
+           to highlight as current -->
+      <!--#set var="page" value="cruise" -->
+
+      <!-- The following includes the top row with the uottawa
+           banner, plus the leftmost columns of the main row
+           including the left menu -->
+      <!--#include virtual="files/inclleftmenu.shtml" -->
+
+        <!-- Page Content Area table cell: -->
+        <td id="content">
+
+<h1>A page you requested was not found</h1>
+
+<p>A page you requested was not found. If you came to this page via clicking on a
+link or from a search engine, please report the information at the bottom to <a href="mailto:tcl@eecs.uottawa.c">tcl@eecs.uottawa.ca</a></p>
+
+<br/>&nbsp;<br/>
+
+<h2>Models 2015 Conference</h2>
+
+<p>If you are looking for a page related to the Models 2015 conference, please go to <a href="http://www.modelsconference.org">http://www.modelsconference.org</a>
+
+<br/>&nbsp;<br/>
+
+<h2>Umple</h2>
+
+<p>If this was an UmpleOnline request to
+display a model, it might be that the page has expired; temporary models are
+kept for about a day unless they are saved as a bookmarkable URL.</p>
+
+<p>For more information about Umple <a href="/umple">see the Umple home
+page</a> or the <a href="/umple/GettingStarted.html">Umple user
+manual</a>.</p>
+
+<br/>&nbsp;<br/>
+
+<p>For other information about the CRuiSE group, see one of the links on
+the left.</p>
+
+<p>For debugging purposes, here is some data to report</p>
+      
+<ul>
+  <li>Request URI =  <!--#echo var="request_uri" -->
+  <li>Referrer=  <!--#echo var="http_referrer" -->
+  <li>Document root =  <!--#echo var="document_root" -->
+  <li>Document URI =  <!--#echo var="document_uri" -->
+  <li>Forwarded =  <!--#echo var="forwarded" -->
+  <li>From =  <!--#echo var="from" -->
+  <li>Gateway_interface =  <!--#echo var="gateway_interface" -->
+  <li>Document name =  <!--#echo var="document_name" -->
+</ul>
+
+
+&nbsp;<br>
+
+
+
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>

--- a/umpleonline/bookmark.php
+++ b/umpleonline/bookmark.php
@@ -13,8 +13,8 @@ $tempModelId = $_REQUEST["model"];
 // The following creates a random numbered directory in ump
 // the result is ump/{dir}/model.ump
 date_default_timezone_set('UTC');
-$savedModelData = $dataStore->createData(date("ymd"));
-$tempModelData = $dataStore->readData($tempModelId);
+$savedModelData = dataStore()->createData(date("ymd"));
+$tempModelData = dataStore()->openData($tempModelId);
 
 $saveModelId = $savedModelData->getName();
 
@@ -22,25 +22,25 @@ $saveModelId = $savedModelData->getName();
 // and has just created a model.ump file, then this is an error.
 // It is also an error if an attempt is made to later on bookmark some
 // file that has long since been deleted
-if (!$saveModel->hasData('model.ump'))
+if (!$tempModelData || !$tempModelData->hasData('model.ump'))
 {
   header('HTTP/1.0 404 Not Found');
-  readfile('../404.shtml');
-  if(substr($tempModelId,0,3) == "tmp") {
-    $saveModelData->delete();
+  readfile(rootDir().'/404.shtml');
+  if(substr($tempModelId,0,3) == "tmp" && $tempModelData) {
+    $tempModelData->delete();
   }
-  $tempModelData->delete();
+  $savedModelData->delete();
   exit();
 }
 
-if (!is_file("ump/{$tempModelId}/model.ump.erroroutput"))
+if (!$tempModelData->hasData('model.ump.erroroutput'))
 {
   header('HTTP/1.0 412 Precondition Failed');
   echo "<html><head><title>Javascript Off</title></head><body><p>You cannot make a bookmarked page when JavaScript is turned off. Please turn it on.</p></body></html>";
   if(substr($tempModelId,0,3) == "tmp") {
     $tempModelData->delete();
   }
-  $saveModelData->delete();
+  $savedModelData->delete();
   exit();
 }
 

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -36,14 +36,14 @@ if (isset($_REQUEST["save"]))
     {
       $filename = basename($_REQUEST['filename']);
       $modelId = dirname($_REQUEST['filename']);
-      $dataHandle = $dataStore->readData($modelId);
+      $dataHandle = dataStore()->openData($modelId);
       $dataHandle->writeData($filename, $input);
     }
     else
     {
       // this makes no sense, but mimic old behaviour for now
       $filename = 'model.ump';
-      $dataHandle = $dataStore->createData();
+      $dataHandle = dataStore()->createData();
       $dataHandle->writeData($filename, $input);
     }
     $workDir = $handleData->getWorkDir();
@@ -66,10 +66,9 @@ else if (isset($_REQUEST["load"]))
 {
   // extract the model ID and filename from the old-style path
   $filename = basename($_REQUEST["filename"]);
-  $modelId = dirname($_REQUEST["filename"]);
-  $dataHandle = $dataStore->readData($modelId);
+  $modelId = basename(dirname($_REQUEST["filename"]));
+  $dataHandle = dataStore()->openData($modelId);
   $outputUmple = $dataHandle->readData($filename);
-  $outputUmple = readTemporaryFile($filename);
   echo $outputUmple;
 }
 else if (isset($_REQUEST["action"]))
@@ -426,7 +425,7 @@ else if (isset($_REQUEST["umpleCode"]))
 }  // end request has umpleCode
 else if (isset($_REQUEST["exampleCode"]))
 {
-  $filename = $rootDir."/ump/" . $_REQUEST["exampleCode"];
+  $filename = rootDir()."/ump/" . $_REQUEST["exampleCode"];
   $outputUmple = readTemporaryFile($filename);
   echo $outputUmple;
 }

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -320,7 +320,7 @@ else if (isset($_REQUEST["umpleCode"]))
        $javadocdir = $workDir->makePermalink('javadoc/');
        $javadoczip = $workDir->makePermalink('javadocFromUmple.zip');
        $html = "<a href=\"{$javadoczip}\">Download the following as a zip file</a>&nbsp;{$errhtml}
-      <iframe width=100% height=1000 src=\"" . $javadocdir . "/javadoc/\">This browser does not
+      <iframe width=100% height=1000 src=\"" . $javadocdir . "\">This browser does not
       support iframes, so the javadoc cannot be displayed</iframe> 
      ";
        echo $html;

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -43,55 +43,67 @@ putenv("PATH=$PATH");
 $rootDir = dirname(__DIR__);
 
 class ReadOnlyDataHandle{
-	function __construct($root){
-		$this->root = $root;
-	}
-	function hasData($name){
-		return file_exists($this->root.'/'.$name);
-	}
-	function acquireWrite(){
-		$result = new DataHandle($this->root);
-		$this->root = NULL;
-		return $result;
-	}
+    function __construct($root){
+        $this->root = $root;
+    }
+    function getName(){
+        return basename($this->root);
+    }
+    function hasData($name){
+        return file_exists($this->root.'/'.$name);
+    }
+    function readData($name){
+        return file_get_contents($this->root.'/'.$name);
+    }
+    function acquireWrite(){
+        $result = new DataHandle($this->root);
+        $this->root = NULL;
+        return $result;
+    }
 }
 
 class DataHandle extends ReadOnlyDataHandle{
-	function __construct($root){
-		$this->root = $root;
-	}
-	function delete(){
-		recursiveDelete($this->root);
-		$this->root = NULL;
-	}
-	function getWorkDir(){
-		return new WorkDir($this->root);
-	}
-	function cloneFrom($other){
-		copy($other->root.'/model.ump', $this->root.'/model.ump');
-	}
+    function __construct($root){
+        $this->root = $root;
+    }
+    function delete(){
+        recursiveDelete($this->root);
+        $this->root = NULL;
+    }
+    function writeData($name, $data){
+        return file_put_contents($this->root.'/'.$name, $data);
+    }
+    function getWorkDir(){
+        return new WorkDir($this->root);
+    }
+    function cloneFrom($other){
+        copy($other->root.'/model.ump', $this->root.'/model.ump');
+    }
 }
 
 class WorkDir{
-	function __construct($root){
-		$this->root = $root;
-	}
-	function getPath(){
-		return $this->root;
-	}
-	function makePermalink($path){
-    	// assumes the server root is umpleonline/
-    	$localpath = $this->root.'/'.$path;
-    	$serverpath = substr($localpath, strrpos($localpath, 'umpleonline'));
-    	return $serverpath;
-	}
+    function __construct($root){
+        $this->root = $root;
+    }
+    function getPath(){
+        return $this->root;
+    }
+    function saveModel(){
+        // no-op when using the file system
+    }
+    function makePermalink($path){
+        // assumes the server root is umpleonline/
+        $localpath = $this->root.'/'.$path;
+        $serverpath = substr($localpath, strrpos($localpath, 'umpleonline'));
+        return $serverpath;
+    }
 }
 
 class DataStore{
-	function __contruct($root){
-		$this->root = $rootDir.'/'.$root;
-	}
-	function createData($prefix = NULL){		
+    function __contruct($root){
+        $this->root = $rootDir.'/'.$root;
+    }
+    function createData($prefix = 'tmp'){
         while(true)
         {
             $id = rand(0,999999);
@@ -102,22 +114,34 @@ class DataStore{
                 return new DataHandle($dirname);
             }
         }
-	}
-	function openData($name){
-		if(file_exists($this->root.'/'.$name)){
-			return new DataHandle($this->root.'/'.$name);
-		}else{
-			return NULL;
-		}
-	}
+    }
+    function openData($name){
+        if(file_exists($this->root.'/'.$name)){
+            return new DataHandle($this->root.'/'.$name);
+        }else{
+            return NULL;
+        }
+    }
+    function openDataReadOnly($name){
+        if(file_exists($this->root.'/'.$name)){
+            return new ReadOnlyDataHandle($this->root.'/'.$name);
+        }else{
+            return NULL;
+        }
+    }
 }
 
 $dataStore = new DataStore('ump');
 
+// converts an example filename to a full path
+function getExamplePath($example){
+    return $rootDir.'/ump/'.$example;
+}
+
 $uiguDir="";
 
 function getUIGUDir() {
-	return $uiguDir;
+    return $uiguDir;
 }
 
 if (php_uname('s') == "Darwin") {
@@ -145,7 +169,7 @@ function generateMenu($buttonSuffix)
             <option id=\"gencpp\" value=\"cpp:RTCpp\">C++ Code</option>
             <option id=\"genruby\" value=\"ruby:Ruby\">Ruby Code</option>
             <option id=\"genalloy\" value=\"alloy:Alloy\">Alloy Model</option>
-	    <option id=\"gennusmv\" value=\"nusmv:NuSMV\">NuSMV Model</option>
+        <option id=\"gennusmv\" value=\"nusmv:NuSMV\">NuSMV Model</option>
             <option value=\"xml:Ecore\">Ecore</option>
             <option value=\"java:TextUml\">TextUml</option>
             <option value=\"xml:Scxml\">Scxml (Experimental)</option>
@@ -174,20 +198,8 @@ function generateMenu($buttonSuffix)
    echo $generatemenu;
 }
 
-function saveFile($input, $filename = null, $openmode = 'w')
+function saveFile($input, $filename, $openmode = 'w')
 {
-  if ($filename == null)
-  {
-    if (!isset($_REQUEST["filename"]))
-    {
-      $filename = nextFilename();
-    }
-    else
-    {
-      $filename = $_REQUEST["filename"];
-    }
-  }
-
   $fh = fopen($filename, $openmode);
   if($fh === false) {
     if(strpos($filename,"UmpleOnlineLog.txt") === FALSE) {
@@ -229,25 +241,10 @@ function readTemporaryFile($filename)
   return $contents;
 }
 
-function isBookmark($filename)
+function isBookmark($dataHandle)
 {
-  $modelId = extractModelId($filename);
-  return substr($modelId,0,3) != "tmp";
-}
-
-function extractModelId($filename)
-{
-  if ($filename == null)
-  {
-    return "";
-  }
-  else
-  {
-    $index = strpos($filename,"/model.ump");
-    $prefix = substr($filename,0,$index);
-    if(!strpos($prefix,"/")) return $prefix;
-    return substr(strrchr($prefix,"/"),1);
-  }
+    $modelId = $dataHandle->getName();
+    return substr($modelId,0,3) != "tmp";
 }
 
 // delete everything stored in a directory
@@ -288,115 +285,99 @@ function ensureFullPath($relativeFilename)
   return $filename;
 }
 
+function getOrCreateDataHandle(){
+    if(isset($_REQUEST['filename'])){
+        $modelId = dirname($_REQUEST['filename']);
+        $filename= basename($_REQUEST['filename']);
+        $dataHandle = $dataStore->readData($modelId);
+        if($dataHandle){
+            return array($filename, $dataHandle);
+        }
+    }else{
+        $filename = 'model.ump';
+    }
+    $dataHandle = $dataStore->createData();
+    return array($filename, $dataHandle);
+}
+
 function extractFilename()
 {
-  // If the argument is model=X, then load that saved tmp or bookmarked model
-  if (isset($_REQUEST["model"]))
-  {
-    $filename = "../ump/". $_REQUEST["model"] ."/model.ump";
-    if (!file_exists("ump/" . $filename)) {
-      $destfile = nextFilename("ump");
-      $filename = "../" . $destfile;
-
-      file_put_contents($destfile, "// Saved URL ending in " . $_REQUEST["model"] . " cannot be found");
-    }
-    else  // file does exist
+    // If the argument is model=X, then load that saved tmp or bookmarked model
+    if (isset($_REQUEST["model"]))
     {
-      // Check if there is a password lock on the model
-      if (file_exists("ump/" . $_REQUEST["model"] ."/readonlylock.txt"))
-      {
-        // TODO: Open the read only file and check if the
-        // There is an argument with a matching overwrite key
-        // For now, just ensure that the saved URL can only
-        // be overwritten if the argument &overwrite=yes is supplied
-        if (!$_REQUEST["overwrite"] == "yes") {
-          $readOnly = true;
-          $fileToCopy = "ump/" . $filename;
-          $destfile = nextFilename("ump");
-          $filename = "../" . $destfile;
-          copy($fileToCopy, $destfile);
+        $dataHandle = $dataStore->openData($_REQUEST['model']);
+        // if the model does not exist, create one containing an error message
+        if(!$dataHandle){
+            $dataHandle = $dataStore->createData();
+            $dataHandle->writeData('model.ump', "// Saved URL ending in " . $_REQUEST["model"] . " cannot be found");
+        }else{
+            if($dataHandle->hasData('readonlylock.txt')){
+                // TODO: Open the read only file and check if the
+                // There is an argument with a matching overwrite key
+                // For now, just ensure that the saved URL can only
+                // be overwritten if the argument &overwrite=yes is supplied
+                if (!$_REQUEST["overwrite"] == "yes") {
+                    $readOnly = true;
+                    $dataHandleCopy = $dataStore->createData();
+                    $dataHandleCopy->cloneFrom($dataHandle);
+                    $dataHandle = $dataHandleCopy;
+                }
+            }
         }
-      }
     }
-  }
-  // If the argument is example=X then copy the example and open it
-  elseif (isset($_REQUEST['example']) && $_REQUEST["example"] != "")
-  {
-    $fileToCopy = "ump/".htmlspecialchars($_REQUEST['example']).".ump";
-    if (!file_exists($fileToCopy))
+    // If the argument is example=X then copy the example and open it
+    elseif (isset($_REQUEST['example']) && $_REQUEST["example"] != "")
     {
-       $fileToCopy = "ump/NullExample.ump";
+        $fileToCopy = getExamplePath(htmlspecialchars($_REQUEST['example']).'.ump');
+        if(!file_exists($fileToCopy)){
+            $fileToCopy = getExamplePath('NullExample.ump');
+        }
+        $dataHandle = $dataStore->createData();
+        $workDir = $dataHandle->getWorkDir();
+        copy($fileToCopy, $workDir->getPath().'/model.ump');
+        $workDir->saveModel();
     }
-    $destfile = nextFilename("ump");
-    $filename = "../" . $destfile;
-
-    copy($fileToCopy, $destfile);
-  }
-  elseif (isset($_REQUEST['text']) && $_REQUEST["text"] != "")
-  {
-    $destfile = nextFilename("ump");
-    $filename = "../" . $destfile;
-
-    file_put_contents($destfile, urldecode($_REQUEST["text"]));
-  }
-  // Starting from scratch; so simply create a blank model
-  elseif (!isset($_REQUEST['filename']) || $_REQUEST["filename"] == "")
-  {
-    $filename = "../" . nextFilename("ump");
-  }
-
-  // The only other option is that there is a filename option
-  else
-  {
-    $destfile = nextFilename("ump");
-    $filename = "../" . $destfile;
-
-    if(!substr($_REQUEST["filename"],-4)==".ump") {
-       file_put_contents($destfile, "// URL in filename argument must end in .ump and the initial http:// must be omitted");
+    elseif (isset($_REQUEST['text']) && $_REQUEST["text"] != "")
+    {
+        $dataHandle = $dataStore->createData();
+        $dataHandle->writeData('model.ump', urldecode(urldecode($_REQUEST["text"]));
     }
+    // Starting from scratch; so simply create a blank model
+    elseif (!isset($_REQUEST['filename']) || $_REQUEST["filename"] == "")
+    {
+        $dataHandle = $dataStore->createData();
+    }
+
+    // The only other option is that there is a filename option
     else
     {
-      file_put_contents($destfile, file_get_contents("http://" . $_REQUEST["filename"]));
-      if(substr($http_response_header[0],-2)!="OK") {
-         // try https
-        file_put_contents($destfile, file_get_contents("https://" . $_REQUEST["filename"]));
-        if(substr($http_response_header[0],-2)!="OK") {         
-          file_put_contents($destfile, "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"]);
+        $dataHandle = $dataStore->createData();
+        if(!substr($_REQUEST["filename"],-4)==".ump") {
+            $dataToWrite = "// URL in filename argument must end in .ump and the initial http:// must be omitted";
         }
-      }
+        else
+        {
+            $dataToWrite = file_get_contents("http://" . $_REQUEST["filename"]);
+            if(substr($http_response_header[0],-2)!="OK") {
+                // try https
+                $dataToWrite = file_get_contents("https://" . $_REQUEST["filename"]);
+                if(substr($http_response_header[0],-2)!="OK") {         
+                    $dataToWrite = "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"];
+                }
+            }
+        }
+        $dataHandle->writeData('model.ump', $dataToWrite);
     }
-  }
-  return $filename;
+    return $dataHandle;
 }
 
-function getFilenameId($filename)
+function showYumlImage($dataHandle)
 {
-  return substr($filename,7,strlen($filename) - strlen("../ump/") - strlen("/model.ump"));
-}
-
-// This will create your umple file, as well as the directory used for the uigu
-function nextFilename($basedir = "../ump", $prefix = "tmp")
-{
-  while(true)
-  {
-    $id = rand(0,999999);
-    $dirname = "{$basedir}/{$prefix}{$id}";
-    $filename = "{$dirname}/model.ump";
-
-    if (!file_exists($dirname))
-    {
-
-      mkdir($dirname);
-      return $filename;
-    }
-  }
-}
-
-function showYumlImage($filename)
-{
+  $workDir = $dataHandle->getWorkDir();
+  $filename = $workDir->getPath().'/model.ump';
   $yuml = executeCommand("java -jar umplesync.jar -generate Yuml {$filename}");
 
-	$title = "View As YUML Image";
+    $title = "View As YUML Image";
   $icon = "yuml.png";
   ?>
   <head>
@@ -406,24 +387,24 @@ function showYumlImage($filename)
 
   <body>
   <img id="diagram" />
-	<textarea id="source" style="display:none">
-	<?php echo $yuml; ?>
-	</textarea>
+    <textarea id="source" style="display:none">
+    <?php echo $yuml; ?>
+    </textarea>
 
         <!-- empty or /scruffy -->
-	<input id="diagramType" type="hidden" value="" />
+    <input id="diagramType" type="hidden" value="" />
 
-	<script type="text/javascript" charset="utf-8">
-	  var source = document.getElementById("source");
-	  var diagramType = document.getElementById("diagramType").value;
-	  var diagram = document.getElementById("diagram");
-	  diagram.src = "http://yuml.me/diagram"+ diagramType +"/class/" + source.value;
-	</script>
+    <script type="text/javascript" charset="utf-8">
+      var source = document.getElementById("source");
+      var diagramType = document.getElementById("diagramType").value;
+      var diagram = document.getElementById("diagram");
+      diagram.src = "http://yuml.me/diagram"+ diagramType +"/class/" + source.value;
+    </script>
   </body>
   <?php
 }
 
-function showUserInterface($filename)
+function showUserInterface($dataname, $dataHandle)
 {
   $title = "Generate User Interface";
   $icon = "uigu.png";
@@ -437,53 +418,53 @@ function showUserInterface($filename)
   </html>
   <?php
     // adding a default namespace if namespace doesn't exist
-	$content = file_get_contents($filename);
-	$namespace_location=strpos($content, 'namespace');
-	if ($namespace_location===false) {
-		file_put_contents($filename,"namespace uigu;\n" . $content);
-	}
-
-	$tempDir=dirname($filename);
-	$umpDir=dirname($tempDir);
-	if (file_exists("$tempDir/files"))
+    $content = $dataHandle->readData($dataname);
+    $namespace_location=strpos($content, 'namespace');
+    if ($namespace_location===false) {
+        $dataHandle->writeData($dataname, "namespace uigu;\n" . $content);
+    }
+    $dataWorkDir = $dataHandle->workDir();
+    $tempDir=$dataWorkDir->getPath();
+    $umpDir=dirname($tempDir);
+    if (file_exists("$tempDir/files"))
       emptyDir("$tempDir/files");
-	else
-	  mkdir("$tempDir/files");
-	rcopy("JSFProvider/files", "$tempDir/files");
-	copy("JSFProvider/build.xml", "$tempDir/build.xml");
+    else
+      mkdir("$tempDir/files");
+    rcopy("JSFProvider/files", "$tempDir/files");
+    copy("JSFProvider/build.xml", "$tempDir/build.xml");
 
     chdir($tempDir);
 
-	$output = executeCommand("ant -DxmlFile=../../scripts/JSFProvider/UmpleProject.xml -DumpleFile=model.ump -DoutputFolder=TempApp -DprojectName=umpleUIGU");
+    $output = executeCommand("ant -DxmlFile={$rootDir}/scripts/JSFProvider/UmpleProject.xml -DumpleFile=model.ump -DoutputFolder=TempApp -DprojectName=umpleUIGU");
 
-	$didCompile = strpos($output,"BUILD SUCCESSFUL") > 0;
+    $didCompile = strpos($output,"BUILD SUCCESSFUL") > 0;
     if ($didCompile){
-		if (!file_exists("TempProj"))
-			mkdir("TempProj");
-		copy("umpleUIGU.war", "TempProj/umpleUIGU.war");
-		chdir("TempProj");
-		executeCommand("jar xf umpleUIGU.war");
-		unlink('umpleUIGU.war');
-		//echo getcwd();
-		$umpDir=dirname($tempDir);
-		$tmp=basename($tempDir);
-		chdir("../../uigu");
-		$uiguDir=getAvailableUIGUDirectory();
-		//echo $uiguDir;
-		emptyDir($uiguDir);
-		//echo "$tempDir/TempProj";
-		chdir("..");
-		rcopy($tmp."/TempProj", $umpDir."/uigu/".$uiguDir);
+        if (!file_exists("TempProj"))
+            mkdir("TempProj");
+        copy("umpleUIGU.war", "TempProj/umpleUIGU.war");
+        chdir("TempProj");
+        executeCommand("jar xf umpleUIGU.war");
+        unlink('umpleUIGU.war');
+        //echo getcwd();
+        $umpDir=dirname($tempDir);
+        $tmp=basename($tempDir);
+        chdir($rootDir."/uigu");
+        $uiguDir=getAvailableUIGUDirectory();
+        //echo $uiguDir;
+        emptyDir($uiguDir);
+        //echo "$tempDir/TempProj";
+        chdir($rootDir);
+        rcopy($tmp."/TempProj", $umpDir."/uigu/".$uiguDir);
 
-		chdir($tmp);
+        chdir($tmp);
 
-		$gh=fopen("uigudir.txt", 'w');
-		fwrite($gh, $uiguDir);
-		fclose($gh);
+        $gh=fopen("uigudir.txt", 'w');
+        fwrite($gh, $uiguDir);
+        fclose($gh);
 
-		$fh=fopen("index.html", 'w') or die("Failed to create/open file!");
+        $fh=fopen("index.html", 'w') or die("Failed to create/open file!");
 
-		$before = <<< _BEFORE
+        $before = <<< _BEFORE
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -499,38 +480,39 @@ $after = <<< _AFTER
 </body>
 </html>
 _AFTER;
-		fwrite($fh, $after);
-		fclose($fh);
+        fwrite($fh, $after);
+        fclose($fh);
     }
     else{
-	  $errorFilename = "{$filename}.erroroutput";
-	  $fh = fopen($errorFilename, 'w') or die("can't open file");
+      $errorFilename = "{$filename}.erroroutput";
+      $fh = fopen($errorFilename, 'w') or die("can't open file");
       $stringData = "<h2> An error occurred while interpreting your Umple code. Please review it and try again. </h2>";
       fwrite($fh, $stringData);
       $stringData = "<pre>{$output}</pre>";
       fwrite($fh, $stringData);
       fclose($fh);
     }
+    return $dataWorkDir;
 }
 
 function getAvailableUIGUDirectory()
 {
-	$files = array();
-	if ($handle = opendir(".")) {
-		while (false !== ($file = readdir($handle))) {
-			if (strstr($file, "uigu")) {
-				$files[filemtime($file)] = $file;
-			}
-		}
-		closedir($handle);
+    $files = array();
+    if ($handle = opendir(".")) {
+        while (false !== ($file = readdir($handle))) {
+            if (strstr($file, "uigu")) {
+                $files[filemtime($file)] = $file;
+            }
+        }
+        closedir($handle);
 
-		// sort
-		ksort($files);
-		// find the oldest modification
-		$reallyOldModified = reset($files);
-	 	return $reallyOldModified;
-	}
-	return '';
+        // sort
+        ksort($files);
+        // find the oldest modification
+        $reallyOldModified = reset($files);
+        return $reallyOldModified;
+    }
+    return '';
 }
 
 function showUmlImage($json)
@@ -600,9 +582,9 @@ function handleUmpleTextChange()
   
   $rawActionCode = $_REQUEST["actionCode"];
   if(!is_null($rawActionCode)){
-	  //Escape all the double quotes
-	  $rawActionCode = trim(str_replace("\"","\\\"",$rawActionCode));
-	}
+      //Escape all the double quotes
+      $rawActionCode = trim(str_replace("\"","\\\"",$rawActionCode));
+    }
 
   //Windows versus Linux PHP issues
   $actionCode = $GLOBALS["OS"] == "Windows" ? json_encode($_REQUEST["actionCode"]) : "\"" . $_REQUEST["actionCode"] . "\"";
@@ -610,17 +592,21 @@ function handleUmpleTextChange()
   $actionCode = str_replace(">","\>",$actionCode);
 
   if(!is_null($actionCode)){
-	  //Escape all the double quotes
-	  $actionCode = str_replace("\"","\\\"",$actionCode);
-	  //Trim for any un-standard characters
-	  $actionCode = trim($actionCode);
-	  //Trim for escaped doubles quotes in the beginning and end of the actionCode string
-	  $actionCode = trim($actionCode, "\\\"");
+      //Escape all the double quotes
+      $actionCode = str_replace("\"","\\\"",$actionCode);
+      //Trim for any un-standard characters
+      $actionCode = trim($actionCode);
+      //Trim for escaped doubles quotes in the beginning and end of the actionCode string
+      $actionCode = trim($actionCode, "\\\"");
   }
 
-  $filename = saveFile($input);
+  list($dataname, $dataHandle) = getOrCreateDataHandle();
+  $dataHandle->writeData($dataname, $input);
+  $workDir = $dataHandle->getWorkDir();
+  $filename = $workDir->getPath().'/'.$dataname;
+
   $umpleOutput = executeCommand("java -jar umplesync.jar -{$action} \"{$actionCode}\" {$filename}", "-{$action} \"{$rawActionCode}\" {$filename}");
-  saveFile($umpleOutput,$filename);
+  $handleData->writeData($dataname, $umpleOutput);
   echo $umpleOutput;
   return;
 }
@@ -775,7 +761,7 @@ function cleanupOldFiles()
 function rrmdir($dir) {
     foreach(glob($dir . '/*') as $file) {
         if(is_dir($file))
-			rrmdir($file);
+            rrmdir($file);
         else
             unlink($file);
     }
@@ -785,8 +771,8 @@ function rrmdir($dir) {
 function rcopy($src, $dst) {
   //if (file_exists($dst)) rrmdir($dst);
   if (is_dir($src)) {
-	if (!file_exists($dst))
-    	mkdir($dst);
+    if (!file_exists($dst))
+        mkdir($dst);
     $files = scandir($src);
     foreach ($files as $file)
     if ($file != "." && $file != "..") rcopy("$src/$file", "$dst/$file");
@@ -795,24 +781,24 @@ function rcopy($src, $dst) {
 }
 
 function emptyDir($dir) {
-	$handle=opendir($dir);
+    $handle=opendir($dir);
 
-	while (($fl = readdir($handle))!==false) {
-		$file="$dir/$fl";
-		if (!is_dir($file))
-			unlink($file);
-		else {
-			if ($fl != "." && $fl != "..") {
-				$files = scandir($file);
-				if (count($files) <= 2)
-					rmdir($file);
-				else {
-					emptyDir($file);
-					rmdir($file);
-				}
-			}
-		}
-	}
+    while (($fl = readdir($handle))!==false) {
+        $file="$dir/$fl";
+        if (!is_dir($file))
+            unlink($file);
+        else {
+            if ($fl != "." && $fl != "..") {
+                $files = scandir($file);
+                if (count($files) <= 2)
+                    rmdir($file);
+                else {
+                    emptyDir($file);
+                    rmdir($file);
+                }
+            }
+        }
+    }
 
-	closedir($handle);
+    closedir($handle);
 }

--- a/umpleonline/scripts/compiler_vml.php
+++ b/umpleonline/scripts/compiler_vml.php
@@ -81,7 +81,7 @@ else if (isset($_REQUEST["vmlCode"]))
 }
 else if (isset($_REQUEST["exampleCode"]))
 {
-  $filename = $rootDir."/ump/" . $_REQUEST["exampleCode"];
+  $filename = rootDir()."/ump/" . $_REQUEST["exampleCode"];
   $outputUmple = readTemporaryFile($filename);
   echo $outputUmple;
 }

--- a/umpleonline/scripts/compiler_vml.php
+++ b/umpleonline/scripts/compiler_vml.php
@@ -5,7 +5,9 @@ require_once("compiler_config.php");
 if (isset($_REQUEST["save"]))
 {
   $input = $_REQUEST["vmlCode"];
-  $filename = saveFile($input);
+  list($dataname, $dataHandle) = getOrCreateDataHandle();
+  $dataHandle->writeData($dataname, $input);
+  $filename = '../ump/'.$dataHandle->getName().'/'.$dataname;
   echo $filename;
 }
 else if (isset($_REQUEST["vmlCode"]))
@@ -13,7 +15,12 @@ else if (isset($_REQUEST["vmlCode"]))
   $input = $_REQUEST["vmlCode"];
   $language = $_REQUEST["language"];
   
-  $filename = saveFile($input);
+  list($dataname, $dataHandle) = getOrCreateDataHandle();
+  $dataHandle->writeData($dataname, $input);
+  $workDir = $dataHandle->getWorkDir();
+  
+  $filename = $workDir->getPath().'/'.$dataname;
+  
   $outputFilename = "{$filename}.output";
   
   $command = "java -jar vml.jar $outputFilename $filename";
@@ -74,7 +81,7 @@ else if (isset($_REQUEST["vmlCode"]))
 }
 else if (isset($_REQUEST["exampleCode"]))
 {
-  $filename = "../ump/" . $_REQUEST["exampleCode"];
+  $filename = $rootDir."/ump/" . $_REQUEST["exampleCode"];
   $outputUmple = readTemporaryFile($filename);
   echo $outputUmple;
 }

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -8,7 +8,7 @@ require_once ("scripts/compiler_config.php");
 cleanupOldFiles();
 
 if (isset($_REQUEST["model"])) {
-  $dataHandle = $dataStore->readData($_REQUEST['model']);
+  $dataHandle = dataStore()->openData($_REQUEST['model']);
   if (!dataHandle) {
     header('HTTP/1.0 404 Not Found');
     readfile('../404.shtml');
@@ -140,9 +140,9 @@ $output = $dataHandle->readData('model.ump');
     <span id="linetext">Line=<input size=2 id="linenum" value=1 onChange="Action.setCaretPosition(value);"></input>&nbsp; &nbsp;</span> 
   
     <?php if (isBookmark($dataHandle)) { ?>
-      <a id="topBookmarkable" href="umple.php?model=<?php echo dataHandle->getName() ?>">Changes at this URL are saved</a>
+      <a id="topBookmarkable" href="umple.php?model=<?php echo $dataHandle->getName() ?>">Changes at this URL are saved</a>
     <?php } else { ?>
-      <a id="topBookmarkable" href="bookmark.php?model=<?php echo dataHandle->getName() ?>">Create Bookmarkable URL</a>
+      <a id="topBookmarkable" href="bookmark.php?model=<?php echo $dataHandle->getName() ?>">Create Bookmarkable URL</a>
     <?php } ?>
     
     <span id="restorecode" >&nbsp; &nbsp; <a href="#"> Restore Saved State</a></span>

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -8,9 +8,8 @@ require_once ("scripts/compiler_config.php");
 cleanupOldFiles();
 
 if (isset($_REQUEST["model"])) {
-  if (!is_file("ump/".$_REQUEST["model"]."/model.ump")) {
-  
-  
+  $dataHandle = $dataStore->readData($_REQUEST['model']);
+  if (!dataHandle) {
     header('HTTP/1.0 404 Not Found');
     readfile('../404.shtml');
     exit();
@@ -51,7 +50,7 @@ if (isset($_REQUEST['example']) && $_REQUEST["example"] != "") {
   }
 }
 
-$filename = extractFilename();
+$dataHandle = extractFilename();
 
 // Core options after ? and between &. One of the first four is allowed
 
@@ -99,7 +98,7 @@ if (isset($_REQUEST['generateDefault']) && $_REQUEST["generateDefault"] != "") {
   $generateDefault="#gen".$_REQUEST['generateDefault'];
 }
 
-$output = readTemporaryFile("ump/" . $filename);
+$output = $dataHandle->readData('model.ump');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -134,16 +133,16 @@ $output = readTemporaryFile("ump/" . $filename);
     </pre>
   </noscript> 
           
-  <input id="filename" type="hidden" value="<?php echo $filename ?>" />
+  <input id="filename" type="hidden" value="<?php echo '../ump/'.$dataHandle->getName().'/model.ump' ?>" />
   <input id="advancedMode" type="hidden" value="0" />
 
   <div id="topLine" class="bookmarkableUrl">
     <span id="linetext">Line=<input size=2 id="linenum" value=1 onChange="Action.setCaretPosition(value);"></input>&nbsp; &nbsp;</span> 
   
-    <?php if (isBookmark($filename)) { ?>
-      <a id="topBookmarkable" href="umple.php?model=<?php echo extractModelId($filename) ?>">Changes at this URL are saved</a>
+    <?php if (isBookmark($dataHandle)) { ?>
+      <a id="topBookmarkable" href="umple.php?model=<?php echo dataHandle->getName() ?>">Changes at this URL are saved</a>
     <?php } else { ?>
-      <a id="topBookmarkable" href="bookmark.php?model=<?php echo extractModelId($filename) ?>">Create Bookmarkable URL</a>
+      <a id="topBookmarkable" href="bookmark.php?model=<?php echo dataHandle->getName() ?>">Create Bookmarkable URL</a>
     <?php } ?>
     
     <span id="restorecode" >&nbsp; &nbsp; <a href="#"> Restore Saved State</a></span>
@@ -170,16 +169,16 @@ $output = readTemporaryFile("ump/" . $filename);
         <div class="section">
           <ul class="first">
             <li class="subtitle">SAVE</li>
-            <?php if (isBookmark($filename)) { ?>
+            <?php if (isBookmark($dataHandle)) { ?>
             <li id="ttSaveBookmark">
               <div id="menuBookmarkable" class="bookmarkableUrl">
-                <a href="umple.php?model=<?php echo extractModelId($filename) ?>">Bookmark Model</a>
+                <a href="umple.php?model=<?php echo $dataHandle->getName() ?>">Bookmark Model</a>
               </div>
             </li>
             <?php } else { ?>
             <li id="ttSaveModel"> 
               <div id="menuBookmarkable" class="bookmarkableUrl">
-                <a href="bookmark.php?model=<?php echo extractModelId($filename) ?>">Save Model</a>
+                <a href="bookmark.php?model=<?php echo $dataHandle->getName() ?>">Save Model</a>
               </div>
             </li>
             <?php } ?>

--- a/umpleonline/vml.php
+++ b/umpleonline/vml.php
@@ -1,8 +1,8 @@
 <?php
 require_once ("scripts/compiler_config.php");
 cleanupOldFiles();
-$filename = extractFilename();
-$output = readTemporaryFile($filename);
+$dataHandle = $dataStore->createData();
+$output = $dataHandle->readData('model.ump');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -29,7 +29,7 @@ $output = readTemporaryFile($filename);
     </tr>
   </table>
 
-<input id="filename" type="hidden" value="<?php echo $filename ?>" />
+<input id="filename" type="hidden" value="<?php echo '../ump/'.$dataHandle->getName().'/model.ump' ?>" />
 
 <table id="container" class="container">
 <tr>

--- a/umpleonline/vml.php
+++ b/umpleonline/vml.php
@@ -1,7 +1,7 @@
 <?php
 require_once ("scripts/compiler_config.php");
 cleanupOldFiles();
-$dataHandle = $dataStore->createData();
+$dataHandle = dataStore()->createData();
 $output = $dataHandle->readData('model.ump');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
## Description

This PR is a full refactor of UmpleOnline's data storage. It implements the interface described here: [https://github.com/umple/umple/wiki/Refactoring-UmpleOnline's-storage-backend](https://github.com/umple/umple/wiki/Refactoring-UmpleOnline's-storage-backend).

All functionality should remain unchanged, the only difference should be the code structure.

What the structural changes give us:
- code now makes no assumptions about having a persistent working directory, requesting one explicitly when needed. This means if we were to change the storage backend we would know when the code expects a working folder and would be able to provide one.
- any PHP code must explicitly request access to any data it needs. This allows putting in place various concurrency control constructs as and when needed.
- any generated data that will be presented to the browser via hrefs will go through an API that abstracts away how we ensure they persist. This becomes a significant issue if we try to scale UmpleOnline past 1 server due to load balancing, but the hooks provided here should make implementing any support for that manageable.

Notable exception to the feature freeze: passing arbitrary paths using the filename query parameter will no longer work as internally UmpleOnline now knows/cares more about where things go. The filename parameters look the same, but are simply parsed for their model ID file name. 

## Tests

As per usual with UmpleOnline all testing is manual. Testing is currently incomplete, merging is not recommended. All HTTP endpoints related to the file store will need testing.

Parts tested so far:
- Basic code editing
- Some very simple bookmarking scenarios
- Compilation to Java
- Downloading the compiled Java artifacts