### PR TITLE
Improving version number sequencing by putting commit count before hash

### DIFF
--- a/build/_versionNew.xml
+++ b/build/_versionNew.xml
@@ -36,7 +36,7 @@
       </not>
     </condition>  
 
-    <property name="umple.version" value="${base.version}-${git.revision}-${git.commitnum}" />
+    <property name="umple.version" value="${base.version}.${git.commitnum}.${git.revision}" />
     <echo message="Current Version: ${umple.version}" />
   
 </project>


### PR DESCRIPTION
Prior to this PR,  releases are 1.zz.y-xxxxxx-rrrr
After this PR releases are 1.xx.y.rrrr.xxxxxx
where
  1 will likely remain constant for a long time
  zz is the major release now 27 and increments a few times a year
  y is the minor release, usually 0, sometimes 1 or 2
  xxxxxx is the git has prefix to identify the commit
  rrrr is the commit count (continually increasing).

This PR ensure that from now on sorting numerically will result in the correct time-order. This will help us set up proper archiving at http://dist.umple.org for use by Ivy and Maven, as per issue #653 
Note the period separators instead of the hyphen separators
As before, builds not done on a git repo will substitute x for the commit and commit count