### PR TITLE
fix the joint.js fetch incorrect index of attribute/methods & offset of flying shape

### DIFF
--- a/umpleonline/scripts/jjs/jjs_parse.js
+++ b/umpleonline/scripts/jjs/jjs_parse.js
@@ -212,8 +212,8 @@ var JJSdiagram = {
 						el: jQuery('#flyPaper'),
 						model: flyGraph,
 						interactive: false,
-						width: 150,
-						height: 80
+						width: 89,
+						height: 54
 					}),
 
 					//create the class template
@@ -223,24 +223,18 @@ var JJSdiagram = {
 						name: ['NewClass' + JJSdiagram.newClassIndex],
 						attributes: [],
 						methods: []
-					}),
-
-					pos = { x: e.clientX, y: e.clientY },
-					offset = {
-						x: x - pos.x,
-						y: y - pos.y
-					};
+					});
 
 				flyShape.position(0, 0);
 				flyGraph.addCell(flyShape);
 				jQuery("#flyPaper").offset({
-					left: e.pageX - offset.x,
-					top: e.pageY - offset.y
+					left: e.pageX,
+					top: e.pageY
 				});
 				jQuery('body').on('mousemove.fly', function (e) {
 					jQuery("#flyPaper").offset({
-						left: e.pageX - offset.x,
-						top: e.pageY - offset.y
+						left: e.pageX,
+						top: e.pageY
 					});
 				});
 				jQuery('body').on('mouseup.fly', function (e) {
@@ -250,10 +244,10 @@ var JJSdiagram = {
 					// Dropped over paper
 					if (x > target.left && x < target.left + JJSdiagram.paper.$el.width() && y > target.top && y < target.top + JJSdiagram.paper.$el.height()) {
 						var s = flyShape.clone();
-						s.position(x - target.left - offset.x, y - target.top - offset.y);
+						s.position(x - target.left, y - target.top );
 						JJSdiagram.paper.model.addCell(s);
+						var cell = JJSdiagram.paper.model.getCell(s.id);
 						JJSdiagram.makeUmpleCodeFromClass('addNewClass', JJSdiagram.getCurrentObject(JJSdiagram.paper.model.toJSON(), s.id));
-
 					}
 					$(EvenTarget).removeClass("selected");
 					jQuery('body').off('mousemove.fly').off('mouseup.fly');

--- a/umpleonline/scripts/jjs/joint.shapes.umpleuml.js
+++ b/umpleonline/scripts/jjs/joint.shapes.umpleuml.js
@@ -524,18 +524,22 @@ joint.shapes.umpleuml.ClassView = joint.dia.ElementView.extend({
         this.$box.css({
             width: bbox.width,
             height: bbox.height,
-            left: bbox.x+100,
-            top: bbox.y+50,
+            left: bbox.x,
+            top: bbox.y,
             transform: 'rotate(' + (this.model.get('angle') || 0) + 'deg)'
         });
 
         var widthScale = bbox.width/100;
         var heightScale = bbox.height/60;
 
+        //Dynamically set scale and translate of joint.js shape
         var jointShape = jQuery("#" + this.id);
+        var xTranslate = bbox.x - 100;
+        var yTranslate = bbox.y - 50;
         if (jointShape.children().size() > 0){
 			var rectScale = jQuery(jointShape.children().children());
 			rectScale.attr({"transform": "scale("+ widthScale + "," + heightScale +")"})
+			jointShape.attr({"transform": "translate("+ xTranslate + "," + yTranslate +")"})
         }
 
     }

--- a/umpleonline/scripts/jjs/joint.shapes.umpleuml.js
+++ b/umpleonline/scripts/jjs/joint.shapes.umpleuml.js
@@ -246,7 +246,7 @@ joint.shapes.umpleuml.ClassView = joint.dia.ElementView.extend({
 
                 JJSdiagram.makeUmpleCodeFromClass('addAttribute', this.model.toJSON(), jQuery(e.target).data('attributeIndex'));
             }else if (e.target.value !== ""){
-            	var attributeIndex = jQuery('div.attributInput').index(jQuery(e.target).parent());
+            	var attributeIndex = this.$box.find('div.attributInput').index(jQuery(e.target).parent());
             	var oldName = this.model.get('attributes')[attributeIndex];
             	oldName = oldName.split(":")[0].substr(2);
 				var attrs = this.model.get('attributes');
@@ -278,7 +278,7 @@ joint.shapes.umpleuml.ClassView = joint.dia.ElementView.extend({
             e.target.readOnly = true;
 
             if (this.$box.find('.classMethods input:last').val()) {
-                var tempIndex = this.$box.find('.classMethods input:last').data('methodIndex') + 1;
+                var tempIndex = this.$box.find('div.methodInput').index(jQuery(e.target).parent());
                 this.addMethodBox(tempIndex);
                 this.addListeners();
 
@@ -301,7 +301,7 @@ joint.shapes.umpleuml.ClassView = joint.dia.ElementView.extend({
          * delete attributes icon clicked
          */
         this.$box.find('.attributInput .deleteAttr').off('click').on('click', _.bind(function (e) {
-            var attIndex = jQuery('div.attributInput').index(jQuery(e.target).parent());
+            var attIndex = this.$box.find('div.attributInput').index(jQuery(e.target).parent());
             var attValue = jQuery(e.target.parentNode.children[0]).val();
             //value is empty, do nothing 
             //value is not empty, delete the attribute from model and update box
@@ -383,7 +383,7 @@ joint.shapes.umpleuml.ClassView = joint.dia.ElementView.extend({
 
 		//methods delete icon clicked
         this.$box.find('.methodInput .deleteMet').off('click').on('click', _.bind(function (e) {
-            var metIndex = jQuery(e.target.parentNode.children[0]).data('methodIndex');
+            var metIndex = this.$box.find('div.methodInput').index(jQuery(e.target).parent());
             var metValue = jQuery(e.target.parentNode.children[0]).val();
             //value is empty, do nothing 
             //value is not empty, delete the attribute from model and update box


### PR DESCRIPTION
## Description

This PR fix a problem when multiple classes exist, joint.js query wrong attributes & method index. This PR also fix the problem that there is an offset applied to joint.js paper which results in, when editing classes the flying "class" shape is not under the cursor.

