### PR TITLE
Fixes #1160 wrongly instantiating abstract class

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOne.ump
@@ -1,9 +1,10 @@
 class UmpleToJava {
-    association_AddManyToOne <<!<</*association_AddManyToOne*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddManyToOne <<!  /* Code from template association_AddManyToOne */
+<</*association_AddManyToOne*/>>
+<<# if(!(av.getRelatedAssociation().getUmpleClass().getIsAbstract())) {#>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
-  }
+  }<<#}#>>
 
   public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {

--- a/cruise.umple/src/util/SampleFileWriter_Code.ump
+++ b/cruise.umple/src/util/SampleFileWriter_Code.ump
@@ -115,6 +115,12 @@ class SampleFileWriter
         { //Ignore the line, go to next
           actualLine = readLine(actualReader);
         }
+
+        // Deal with Code from template
+        while (actualLine != null && actualLine.indexOf("/* Code from template") != -1)
+        { //Ignore the line, go to next
+          actualLine = readLine(actualReader);
+        }        
         
         line++;
         
@@ -174,6 +180,7 @@ class SampleFileWriter
   
   public static void assertFileContent(BufferedReader expectedReader, BufferedReader actualReader, boolean ignoreLineComments)
   {
+    Boolean skippedActualLineDifference;
     try
     {
       String expectedLine = null;
@@ -184,20 +191,27 @@ class SampleFileWriter
       {
         actualLine = actualReader.readLine();
         expectedLine = expectedReader.readLine();
+        skippedActualLineDifference = false;
         if (ignoreLineComments)
         {
-          // HACK: To deal with // line # comments and footer of inject statements
-          while (actualLine != null && (actualLine.indexOf("// line") != -1 || 
+          // Skip past elements that may change in updated code but are not important differences
+          while (actualLine != null && (actualLine.indexOf("// line") != -1 ||
+                    actualLine.indexOf("/* Code from template") != -1 ||
                     actualLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")))
-          { //Ignore the line, go to next
+          { //Ignore the line, go to next - line found has unimportant difference
             actualLine = actualReader.readLine();
+            skippedActualLineDifference = true;
           }
           
           while (expectedLine != null && (expectedLine.indexOf("// line") != -1 ||
+                    expectedLine.indexOf("/* Code from template") != -1 ||  
+                    (skippedActualLineDifference == true && expectedLine.trim().isEmpty()) ||      
                     expectedLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")))
           { 
         	  expectedLine = expectedReader.readLine();
+        	  skippedActualLineDifference = false; // Only skip one blank
           }
+             
         } 
         
         line++;

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest.java
@@ -378,6 +378,16 @@ public class ClassTemplateTest extends TemplateTest
 		  assertUmpleTemplateFor("ClassTemplateTest_AbstractClassInheritance.ump",languagePath + "/ClassTemplateTest_AbstractClassInheritance."+languagePath+".txt","Teacher");
 	  }
   }
+
+@Test
+  public void AbstractClassAvoidingInstantiation()
+  {
+	  if (languagePath.equals("java"))
+	  {
+		  assertUmpleTemplateFor("ClassTemplateTest_AbstractClassAvoidingInstantiation.ump",languagePath + "/ClassTemplateTest_AbstractClassAvoidingInstantiation."+languagePath+".txt","Teacher");
+	  }
+  }
+
   
 @Ignore @Test
   public void LazyAttributeOnImmutableClass()

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_AbstractClassAvoidingInstantiation.ump
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_AbstractClassAvoidingInstantiation.ump
@@ -1,0 +1,5 @@
+class Teacher {
+  1 -- 0..* Person myStudents;
+}
+
+class Person {  abstract; }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassAvoidingInstantiation.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassAvoidingInstantiation.java.txt
@@ -1,0 +1,139 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+
+import java.util.*;
+
+// line 2 "model.ump"
+public class Teacher
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Teacher Associations
+  private List<Person> myStudents;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Teacher()
+  {
+    myStudents = new ArrayList<Person>();
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public Person getMyStudent(int index)
+  {
+    Person aMyStudent = myStudents.get(index);
+    return aMyStudent;
+  }
+
+  public List<Person> getMyStudents()
+  {
+    List<Person> newMyStudents = Collections.unmodifiableList(myStudents);
+    return newMyStudents;
+  }
+
+  public int numberOfMyStudents()
+  {
+    int number = myStudents.size();
+    return number;
+  }
+
+  public boolean hasMyStudents()
+  {
+    boolean has = myStudents.size() > 0;
+    return has;
+  }
+
+  public int indexOfMyStudent(Person aMyStudent)
+  {
+    int index = myStudents.indexOf(aMyStudent);
+    return index;
+  }
+
+  public static int minimumNumberOfMyStudents()
+  {
+    return 0;
+  }
+  /* Code from template association_AddManyToOne */
+
+
+  public boolean addMyStudent(Person aMyStudent)
+  {
+    boolean wasAdded = false;
+    if (myStudents.contains(aMyStudent)) { return false; }
+    Teacher existingTeacher = aMyStudent.getTeacher();
+    boolean isNewTeacher = existingTeacher != null && !this.equals(existingTeacher);
+    if (isNewTeacher)
+    {
+      aMyStudent.setTeacher(this);
+    }
+    else
+    {
+      myStudents.add(aMyStudent);
+    }
+    wasAdded = true;
+    return wasAdded;
+  }
+
+  public boolean removeMyStudent(Person aMyStudent)
+  {
+    boolean wasRemoved = false;
+    //Unable to remove aMyStudent, as it must always have a teacher
+    if (!this.equals(aMyStudent.getTeacher()))
+    {
+      myStudents.remove(aMyStudent);
+      wasRemoved = true;
+    }
+    return wasRemoved;
+  }
+
+  public boolean addMyStudentAt(Person aMyStudent, int index)
+  {  
+    boolean wasAdded = false;
+    if(addMyStudent(aMyStudent))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > numberOfMyStudents()) { index = numberOfMyStudents() - 1; }
+      myStudents.remove(aMyStudent);
+      myStudents.add(index, aMyStudent);
+      wasAdded = true;
+    }
+    return wasAdded;
+  }
+
+  public boolean addOrMoveMyStudentAt(Person aMyStudent, int index)
+  {
+    boolean wasAdded = false;
+    if(myStudents.contains(aMyStudent))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > numberOfMyStudents()) { index = numberOfMyStudents() - 1; }
+      myStudents.remove(aMyStudent);
+      myStudents.add(index, aMyStudent);
+      wasAdded = true;
+    } 
+    else 
+    {
+      wasAdded = addMyStudentAt(aMyStudent, index);
+    }
+    return wasAdded;
+  }
+
+  public void delete()
+  {
+    for(int i=myStudents.size(); i > 0; i--)
+    {
+      Person aMyStudent = myStudents.get(i - 1);
+      aMyStudent.delete();
+    }
+  }
+
+}


### PR DESCRIPTION
This PR fixes issue #1160 .. it ensures that an instantiate method is not created in a case of many-1 associations involving an abstract class on the 1 side. A test is included.

It also injects the name of the template into the generated code; this will be extremely useful for future debugging of templates. The name of the template was always being injected into the compiler code that does the generation, but not into the final target code. This was a mistake made long, long ago when there had been a request do this. A consequence of this change is that there are some minor adjustments to SampleFileWriter that is used to compare expected and generated code, so as to ignore the presence/absence of these templates. This PR just makes this change for the one template that is being edited anyway. See issue #1186 for a proposal to expand this to all other templates.