### PR TITLE
Fixes 664 Clean wording in en.error and get rid of warning in build

### DIFF
--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -863,10 +863,6 @@ class MethodBody
   {
   return codeblock.getCode(lang);
   }
-  public void setExtraCode(String code)
-  {
-    codeblock.setCode(code);
-  }
   public void setExtraCode(String lang, String code)
   {
     codeblock.setCode(lang,code);

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -4,7 +4,7 @@
 # Use PageBeingDeveloped.html for new messages before manual pages are created
 
 0: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Generic Umple Error '{0}' ; 
-1: 4, "http://cruise.eecs.uottawa.ca/umple/W001SingletonWithNon-LazyAttribute.html", Lazy keyword missing from singleton class attribute '{0}' ; 
+1: 4, "http://cruise.eecs.uottawa.ca/umple/W001SingletonWithNon-LazyAttribute.html", Lazy keyword is needed on singleton class attribute '{0}' as the attribute cannot added at construction time ; 
 2: 4, "http://cruise.eecs.uottawa.ca/umple/W002SingletonWithRequiredObject.html", Association is referencing a singleton class with multiplicity 1 '{0}' ; 
 3: 4, "http://cruise.eecs.uottawa.ca/umple/W003RedundantLazyWithInitialization.html", The lazy keyword is redundant when the attribute is being initialized - in class '{0}' ;
 4: 1, "http://cruise.eecs.uottawa.ca/umple/E004InvalidMultiplicity.html", Invalid multiplicity '{0}' ; 
@@ -15,7 +15,7 @@
 9: 2, "http://cruise.eecs.uottawa.ca/umple/E009ReflexiveLowerBound.html", Reflexive association with multiplicity '{0}' has lower bound > 0 ; 
 10: 3, "http://cruise.eecs.uottawa.ca/umple/W010SingletonMultiplicityOver1.html", Singleton class '{0}' cannot have multiplicity greater than 1 ; 
 11: 1, "http://cruise.eecs.uottawa.ca/umple/E011ClassisSubclassOfSelf.html", {0} '{1}' cannot cyclically extend itself ; 
-12: 1, "http://cruise.eecs.uottawa.ca/umple/E012ClassIndirectlySubclassofSelf.html", {0} '{1}' cannot cyclically extend {0} '{2}'  ; 
+12: 1, "http://cruise.eecs.uottawa.ca/umple/E012ClassIndirectlySubclassofSelf.html", {0} '{1}' cannot cyclically extend {0} '{2}' ; 
 13: 2, "http://cruise.eecs.uottawa.ca/umple/E013NonImmutableAssociation.html", Class at directed end of immutable association must be an immutable class ;
 14: 3, "http://cruise.eecs.uottawa.ca/umple/E014ImmutableSubclassofMutable.html", Existing associations, state machines, or superclass for class '{0}' prevents class-level immutability ;
 15: 3, "http://cruise.eecs.uottawa.ca/umple/W015ImmutableClassStateMachine.html", Immutable class '{0}' may not contain state machines ;
@@ -25,7 +25,7 @@
 19: 2, "http://cruise.eecs.uottawa.ca/umple/E019DuplicateAssociation.html", There are multiple associations between class '{0}' and class '{1}'. Unique role names need to be added at '{0}' side to distinguish the different association ends in that class. ;
 20: 1, "http://cruise.eecs.uottawa.ca/umple/E020InterfaceAssociationNotOneWay.html", The class-interface association declared in '{0}' must have the '->' arrow ;
 
-21: 2, "http://cruise.eecs.uottawa.ca/umple/E021InvalidReflexiveAssociation.html", Reflexive association to class '{0}' must use a role name or else self ;
+21: 2, "http://cruise.eecs.uottawa.ca/umple/E021InvalidReflexiveAssociation.html", Reflexive association to class '{0}' must use a role name or else the keyword self ;
 22: 2, "http://cruise.eecs.uottawa.ca/umple/E022DuplicateAttribute.html", Class '{0}' has duplicate attribute name {1} ;
 23: 2, "http://cruise.eecs.uottawa.ca/umple/E023AttributeAssociationNameClash.html", Class '{0}' has attribute name {1} that duplicates an association name, or vice-versa ;
 24: 2, "http://cruise.eecs.uottawa.ca/umple/E024SortKeyNotofUmpleType.html", Sort key attribute '{0}' in class {1} must be of type Integer, Short, Long, Double, Float or String ;
@@ -39,19 +39,20 @@
 31: 4, "http://cruise.eecs.uottawa.ca/umple/W031NamespaceNotUsed.html", Declared namespace {0} was not used before declaring {1} ;
 32: 1, "http://cruise.eecs.uottawa.ca/umple/E032ReservedRoleName.html", The role name '{0}' has a conflict. Please don't use plural form of class name as a role name ;
 33: 3, "http://cruise.eecs.uottawa.ca/umple/W033MissingSuperclass.html", The indicated superclass {0} of class {1} does not exist and has been ignored. Declare {0} to be external if it is defined outside this Umple system ;
-34: 2, "http://cruise.eecs.uottawa.ca/umple/E034MultipleInheritance.html", Multiple inheritance not allowed in Umple so  code can be generated for languages that do not permit it. So class {0} cannot be a subclass of class {1} as well as other classes. Consider using multiple implementations of an interface ;
+34: 2, "http://cruise.eecs.uottawa.ca/umple/E034MultipleInheritance.html", Multiple inheritance not allowed in Umple so  code can be generated for languages that do not permit it. So class {0} cannot be a subclass of class {1} as well as other classes. Consider using multiple implementations of an interface or using traits ;
 35: 4, "http://cruise.eecs.uottawa.ca/umple/W035UninitializedConstant.html", 'const' variable '{0}' of type '{1}' was not initialized and its value was thus set to '{2}' ;
 36: 3, "http://cruise.eecs.uottawa.ca/umple/W036UnmanagedMultiplicity.html", The specific multiplicity bounds {0} cannot be managed by generated code, since this is a directed association ;
 37: 2, "http://cruise.eecs.uottawa.ca/umple/E037UninitializedConstantObject.html", 'const' variable '{0}' of type '{1}' was not initialized. Since '{1}' is not a built-in Umple data type no default value could be found. '{0}' must be initialized. ;
 38: 2, "http://cruise.eecs.uottawa.ca/umple/W9999FeatureUnderDevelopment.html", Attribute '{0}' has a name conflict with attribute auto generated by '{1}' variable '{2}';
-39: 3, "http://cruise.eecs.uottawa.ca/umple/W033MissingSuperclass.html", The interface {0} extends from an interface {1} that does not exist and has been ignored. Declare {1} to be external if it is defined outside this Umple system ;
-40: 2, "http://cruise.eecs.uottawa.ca/umple/E040SingletonHasSubclasses.html", Singleton class has private constructor and cannot be extended. So class {0} cannot be a subclass of singleton class {1}.;
-44: 3, "http://cruise.eecs.uottawa.ca/umple/W044AttributeDuplicatedinSuperclass.html", Class '{0}' has attribute name {1} that duplicates an attribute inherited from a superclass '{2}'. New definition is being disconsidered.;
+39: 3, "http://cruise.eecs.uottawa.ca/umple/W033MissingSuperclass.html", The interface {0} extends  an interface {1} that does not exist and has been ignored. Declare {1} to be external if it is defined outside this Umple system ;
+
+40: 2, "http://cruise.eecs.uottawa.ca/umple/E040SingletonHasSubclasses.html", Singleton classes have a private constructor and cannot be extended. So class {0} cannot be a subclass of singleton class {1} ;
+44: 3, "http://cruise.eecs.uottawa.ca/umple/W044AttributeDuplicatedinSuperclass.html", Class '{0}' has attribute name {1} that duplicates an attribute inherited from a superclass '{2}'. New definition is being disregarded ;
 45: 4, "http://cruise.eecs.uottawa.ca/umple/W045InitializedValueinKey.html", Attribute '{0}' in class '{1}' is in the key. Initializing it will result in all instances having this same value and being treated as equal ;
 46: 4, "http://cruise.eecs.uottawa.ca/umple/W046AttributeHasTemplateType.html", Attribute {0} in class {1} is declared using a collection template type {2}. Use a directed association (->) or multi-valued attribute([]) to follow proper modelling conventions ;
 47: 4, "http://cruise.eecs.uottawa.ca/umple/W047EmptyKeyStatement.html", Empty key statement in class {0} ;
-48: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute '{0}' in class '{1}' generates method '{2}' which is duplicate;
-49: 4, "http://cruise.eecs.uottawa.ca/umple/W049DuplicatedMethodName.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file. New definition at line {4} of '{5}' file is being disconsidered;
+48: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute '{0}' in class '{1}' generates method '{2}' which is a duplicate;
+49: 4, "http://cruise.eecs.uottawa.ca/umple/W049DuplicatedMethodName.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file. New definition at line {4} of '{5}' file is being disregarded;
 
 # State-Machine related messages
 50: 4, "http://cruise.eecs.uottawa.ca/umple/W050TargetStateNotFound.html", State '{0}' has not been declared, it is being treated as an new state ;
@@ -59,50 +60,51 @@
 52: 2, "http://cruise.eecs.uottawa.ca/umple/E052StateMachineNameClash.html", Association or attribute can not have same name as state machine '{0}' ;
 53: 2, "http://cruise.eecs.uottawa.ca/umple/E053NoConcurrencyAtTopLevel.html", State machine {0} has concurrent states, but concurrency is only allowed in nested substates or in 'active' blocks ;
 54: 4, "http://cruise.eecs.uottawa.ca/umple/W054DuplicateEvents.html", Transition {0} will be ignored due to a unguarded duplicate event;
-55: 4, "http://cruise.eecs.uottawa.ca/umple/W055DuplicateEventsWithinSubstates.html", Transition {0} in super-state will be ignored due to unguarded duplicate events in all sub-states;
-56: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Queued State machine {0} has no events to be queued;
-57: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Pooled State machine {0} has no events to be pooled;
-58: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} must have no queued state machine, pooled state machine, and regular state machine in the same class;
-59: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} must have no queued state machine and pooled state machine in the same class;
-60: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} must have no pooled state machine and regular state machine in the same class;
-61: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} must have no queued state machine and regular state machine in the same class;
-62: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", (unspecified) must not be used in combination with Pooled State machine {0} - it is treated such as other regular events - it is pooled;
-63: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", {0} is a reserved name for History or Deep History States;
-64: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state in a non existent state within state machine {0};
-65: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state at a state without substates within state machine {0};
-66: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Transition to '{0}' has multiple possible destinations. Please use dot notation to clarify what state the transition should go to. ;
+55: 4, "http://cruise.eecs.uottawa.ca/umple/W055DuplicateEventsWithinSubstates.html", Transition {0} in super-state will be ignored due to unguarded duplicate events in all sub-states ;
+56: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Queued State machine {0} has no events to be queued ;
+57: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Pooled State machine {0} has no events to be pooled ;
+58: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have queued state machine, pooled state machine, and regular state machine in the same class ;
+59: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have both queued state machine and pooled state machine in the same class ;
+60: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have both pooled state machine and regular state machine in the same class ;
+61: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have queued state machine and regular state machine in the same class ;
+62: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", (unspecified) must not be used in combination with Pooled State machine {0} - it is treated such as other regular events - it is pooled ;
+63: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", {0} is a reserved name for History or Deep History States ;
+64: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state in a non existent state within state machine {0} ;
+65: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state at a state without substates within state machine {0} ;
+66: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Transition to '{0}' has multiple possible destinations. Please use dot notation to clarify what state the transition should go to ;
 67: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html",  State '{0}' from StateMachine '{1}' is non-reachable. ;
-68: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Destiny state '{0}' of transition on line '{1}' has not been found. This transition is being disconsidered;
-69: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Auto-Transition to '{0}' on line '{1}' conflicts with a previous exisiting transition. This transition is being disconsidered;
-70: 4, "http://cruise.eecs.uottawa.ca/umple/W054DuplicateEvents.html", Guarded Transition {0} will be ignored due to a duplicate event with an equivalent guard;
-71: 4, "http://cruise.eecs.uottawa.ca/umple/W071DuplicateMethodDifferentType.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file, which returns a different type. New definition at line {4} of '{5}' file is being disconsidered;
-72: 4, "http://cruise.eecs.uottawa.ca/umple/W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}';
-73: 2, "http://cruise.eecs.uottawa.ca/umple/E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}'; 
-74: 2, "http://cruise.eecs.uottawa.ca/umple/E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' Final because it is a reserved keyword;
+68: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Destination state '{0}' of transition on line '{1}' has not been found. This transition is being disregarded ;
+69: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Auto-Transition to '{0}' on line '{1}' conflicts with a previous exisiting transition. This transition is being disregarded ;
+70: 4, "http://cruise.eecs.uottawa.ca/umple/W054DuplicateEvents.html", Guarded Transition {0} will be ignored due to a duplicate event with an equivalent guard ;
+
+71: 4, "http://cruise.eecs.uottawa.ca/umple/W071DuplicateMethodDifferentType.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file, which returns a different type. New definition at line {4} of '{5}' file is being disregarded ;
+72: 4, "http://cruise.eecs.uottawa.ca/umple/W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
+73: 2, "http://cruise.eecs.uottawa.ca/umple/E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
+74: 2, "http://cruise.eecs.uottawa.ca/umple/E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
 80: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", State '{0}' was not found in state machine '{1}'. Processed as if the state exists ;
 
 # Model Constraints' Error messages
-90: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute named {0} was not found in class {1}, as required in constraint. ;
-91: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute with type {0} was not found in class {1}, as required in constraint. ;
-92: 2, "http://cruise.eecs.uottawa.ca/umple/Page|| (tempMethod != null && tempMethod.isIsAbstract())BeingDeveloped.html", Class {0} was not found to be a subclass of class {1}, as required in constraint. ;
-93: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to be a superclass of class {1}, as required in constraint. ;
-94: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to have an association to class {1}, as required in constraint. ;
+90: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute named {0} was not found in class {1}, as required in constraint ;
+91: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute with type {0} was not found in class {1}, as required in constraint ;
+92: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to be a subclass of class {1}, as required in constraint ;
+93: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to be a superclass of class {1}, as required in constraint ;
+94: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to have an association to class {1}, as required in constraint ;
 
 # Enumeration Errors and Warnings
-95: 2, "http://cruise.eecs.uottawa.ca/umple/E095DuplicateEnumerations.html", Detected duplicate enumeration '{0}' on line '{1}';
-96: 2, "http://cruise.eecs.uottawa.ca/umple/E096EnumerationNameConflict.html", Enumeration name '{0}' on line '{1}' conflicts with model element on line '{2}';
-97: 2, "http://cruise.eecs.uottawa.ca/umple/E097EnumerationAndStateMachineConflict.html", Enumeration '{0}' on line '{1}' conflicts with state machine '{2}' in class '{3}';
-102: 4, "http://cruise.eecs.uottawa.ca/umple/W102EnumerationCausesMethodParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for method '{3}' on line '{4}' instead of class '{5}';
-103: 4, "http://cruise.eecs.uottawa.ca/umple/W103EnumerationCausesEventParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for event '{3}' in state machine '{4}' instead of class '{5}';
-104: 2, "http://cruise.eecs.uottawa.ca/umple/E104EnumerationInBidirectionalAssociation.html", Cannot use enumeration '{0}' on line '{1}' in bidirectional association on line '{2}' in class '{3}'; 
-105: 2, "http://cruise.eecs.uottawa.ca/umple/E105EnumerationInComposition.html", Cannot use enumeration '{0}' on line '{1}' in composition on line '{2}' in class '{3}'; 
-106: 4, "http://cruise.eecs.uottawa.ca/umple/W106EnumerationInUnidirectionalAssociation.html", Assuming enumeration '{0}' on line '{1}' is used in unidirectional association on line '{2}' instead of class '{3}'; 
+95: 2, "http://cruise.eecs.uottawa.ca/umple/E095DuplicateEnumerations.html", Detected duplicate enumeration '{0}' on line '{1}' ;
+96: 2, "http://cruise.eecs.uottawa.ca/umple/E096EnumerationNameConflict.html", Enumeration name '{0}' on line '{1}' conflicts with model element on line '{2}' ;
+97: 2, "http://cruise.eecs.uottawa.ca/umple/E097EnumerationAndStateMachineConflict.html", Enumeration '{0}' on line '{1}' conflicts with state machine '{2}' in class '{3}' ;
+102: 4, "http://cruise.eecs.uottawa.ca/umple/W102EnumerationCausesMethodParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for method '{3}' on line '{4}' instead of class '{5}' ;
+103: 4, "http://cruise.eecs.uottawa.ca/umple/W103EnumerationCausesEventParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for event '{3}' in state machine '{4}' instead of class '{5}' ;
+104: 2, "http://cruise.eecs.uottawa.ca/umple/E104EnumerationInBidirectionalAssociation.html", Cannot use enumeration '{0}' on line '{1}' in bidirectional association on line '{2}' in class '{3}' ;
+105: 2, "http://cruise.eecs.uottawa.ca/umple/E105EnumerationInComposition.html", Cannot use enumeration '{0}' on line '{1}' in composition on line '{2}' in class '{3}' ;
+106: 4, "http://cruise.eecs.uottawa.ca/umple/W106EnumerationInUnidirectionalAssociation.html", Assuming enumeration '{0}' on line '{1}' is used in unidirectional association on line '{2}' instead of class '{3}' ; 
 
 # Messages relating to format of identifiers.
-100: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Class name '{0}' must be alphanumeric and start with an alpha character, or _  ;
+100: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Class name '{0}' must be alphanumeric and start with an alpha character, or _ (underscore) ;
 101: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Class name '{0}' should start with a capital letter ;
 
-110: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Interface name '{0}' must be alphanumeric and start with an alpha character or _ ;
+110: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Interface name '{0}' must be alphanumeric and start with an alpha character or _ (underscore) ;
 111: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Interface name '{0}' should start with a capital letter ;
 112: 2, "http://cruise.eecs.uottawa.ca/umple/E112DuplicateConstantsinInterface.html", Interface '{0}' has duplicate constant name {1} ;
 
@@ -125,7 +127,7 @@
 
 180: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
 
-# Messages related to traits
+# Messages related to traits starting with 200
 200: 2, "http://cruise.eecs.uottawa.ca/umple/E200TraitIdentifierInvalid.html", The name of trait '{0}' must be alphanumeric and start with an alpha character, or _ . ;
 201: 4, "http://cruise.eecs.uottawa.ca/umple/W201TraitNameSyntax.html", The name of trait '{0}' should be started with a capital letter. ;
 202: 1, "http://cruise.eecs.uottawa.ca/umple/E202Traitnotdefined.html", The trait named '{0}' is not available. ;
@@ -171,12 +173,12 @@
 236: 1, "http://cruise.eecs.uottawa.ca/umple/E236TwoStateEntries.html", In the composition level of trait, the '{0}' activity/action in state '{1}', which comes from traits '{2}' and '{3}', results in a conflict.;
 237: 1, "http://cruise.eecs.uottawa.ca/umple/E237ComposingTwoStateEntries.html", In the modification level of trait '{0}', state '{1}' has already have another region with the name '{2}'.;
 
-# Messages related to MOTL
-301: 4,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Tracing of non-existent model entity  ;
+# Messages related to MOTL starting with 300
+301: 4,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Tracing of non-existent model entity ;
 302: 4,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Tracer not recognized - Console tracer is defaulted ;
 303: 1,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Parsing error: Incorrect attribute trace prefix '{0}' (Prefix can be set/get/both) ;
 
-# Messages relating to deprecated features
+# Messages relating to deprecated features starting with 901
 901: 4, "http://cruise.eecs.uottawa.ca/umple/W901DeprecatedKeywordConstant.html", Keyword "constant" deprecated, please use "const" ;
 
 # Messages relating to general parsing issues
@@ -202,14 +204,14 @@
 
 
 
-# Messages to be emitted when embedded code from another language is compiled and you are passing on the error
+# Messages to be emitted when embedded code from another language is compiled and you are passing on the error. These have not yet been activated.
 2001: 5, "http://cruise.eecs.uottawa.ca/umple/W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;
 2002: 5, "http://cruise.eecs.uottawa.ca/umple/W20xxErrorinEmbeddedCode.html", Error in C++ embedded in Umple: '{0}' ;
 
 # Warning messages related to distributed systems
 
 7002: 4, "http://cruise.eecs.uottawa.ca/umple/AssociationDistToNonDistributed.html", Distributed class '{0}' has an association with non-distributed class '{1}'. ;
-7001: 4, "http://cruise.eecs.uottawa.ca/umple/StaticAttributeExists.html", System is distributed but class '{0}' has a static attribute {1}. might result in multiple instances;
+7001: 4, "http://cruise.eecs.uottawa.ca/umple/StaticAttributeExists.html", System is distributed but class '{0}' has a static attribute {1}. This might result in multiple instances;
 7003: 4, "http://cruise.eecs.uottawa.ca/umple/DistributedWOAssociation.html", Distributed class '{0}' has no associations {1} It is better to define it as regular class if it is not called remotely;
 
 # Special testing messages for debugging


### PR DESCRIPTION
Fixes issue 664 residual comment about bad wording in en.error and removes warning 1009 that had been present in the build due to a method that duplicated a generated method (actually issue 664 reported a different warning that had already been removed)

This issue fixes the grammar in en.error in a number of places