### PR TITLE
Fixes #1192, Delete a.rb after build

### DIFF
--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -230,6 +230,7 @@ public class TemplateTest
     
     SampleFileWriter.destroy(pathToInput + "/A.java");
     SampleFileWriter.destroy(pathToInput + "/A.php");
+    SampleFileWriter.destroy(pathToInput + "/a.rb");
     
     SampleFileWriter.destroy(pathToInput + "/stateMachineWithNegativeNumberGuard.java");
     SampleFileWriter.destroy(pathToInput + "/stateMachineWithNegativeNumberGuard.php");


### PR DESCRIPTION
## Delete a.rb after build

Fixes #1192 

## Pull request description

A previous commit created a test which generated a file "a.rb" but never deleted it after the test was complete. This change cleans up the file.
