### PR TITLE
Fixes 1159: Nested class inheritance

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -240,7 +240,9 @@ class Constant
   //Issue 322 - by default set internal to false
   Boolean isInternal = false;
   
-  class UniqueIdentifier { }
+  // Commented out to prevent conflict with extending UmpleVariable
+  // Previously, this extends would be overwritten, but Issue 1159 changes it to cause error 34
+  // class UniqueIdentifier { }
 }
 
 /*

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -228,10 +228,29 @@ class UmpleInternalParser
     else if (token.is("classDefinition"))
     {
       UmpleClass childClass = analyzeClass(token);
-      boolean wasSet = childClass.setExtendsClass(aClass);
-      if (!wasSet)
-      {
-        setFailedPosition(token.getPosition(), 16, childClass.getName(), aClass.getName());
+      Token p = token.getParentToken();
+      for (Token t: p.getSubTokens()) {
+        if (t.getValue() == aClass.getName()) {
+          if (aClass.getName() == childClass.getName()) {
+            setFailedPosition(token.getPosition(),11,"Class",childClass.getName());
+          }
+          if (unlinkedExtends.get(childClass) == null) {
+            List<String> extend = new ArrayList<>();
+            extend.add(aClass.getName());
+            unlinkedExtends.put(childClass, extend);
+          } else {
+            setFailedPosition(token.getPosition(),34,childClass.getName(),aClass.getName());
+            break;
+          }
+          if (unlinkedExtendsTokens.get(childClass) == null) {
+            List<Token> extendToken = new ArrayList<>();
+            extendToken.add(t);
+            unlinkedExtendsTokens.put(childClass, extendToken);
+          } else {
+            setFailedPosition(token.getPosition(),34,childClass.getName(),aClass.getName());
+            break;
+          }
+        }
       }
     }
     else if (token.is("constantDeclaration"))
@@ -1100,7 +1119,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         setFailedPosition(classToken.getPosition(), 0, "Unable to make class abstract!");
       }
     }
-
     addExtendsTo(classToken, aClass, unlinkedExtends, unlinkedExtendsTokens);
     
     // If the "singleton" keyword is parsed, make the Umple class a singleton.

--- a/cruise.umple/test/cruise/umple/compiler/007_singleton_extended2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/007_singleton_extended2.ump
@@ -9,10 +9,7 @@ class Airplane
   singleton;
 }
 
-class Fighters 
+class F16
 {
-  class F16
-  {
-    isA Airplane;
-  }
+  isA Airplane;
 }

--- a/cruise.umple/test/cruise/umple/compiler/022_propagateImmutabilityToAllRelationships.ump
+++ b/cruise.umple/test/cruise/umple/compiler/022_propagateImmutabilityToAllRelationships.ump
@@ -32,14 +32,11 @@ class URLMS
   {
     int quantity;
       
-    class Equipment
-    {
     String type;
-    }
 
     class Supply
     {
-    String type;
+    String supplyType;
     }
   }
 

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance1.ump
@@ -1,0 +1,5 @@
+class Hospital {
+class Hospital {
+
+}
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance2.ump
@@ -1,0 +1,6 @@
+class X {
+    class Y {
+        class X {
+        }
+    }
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance3.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance3.ump
@@ -1,0 +1,5 @@
+class X {
+    isA Y;
+    class Y {
+    }
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance4.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance4.ump
@@ -1,0 +1,5 @@
+class X {
+    class Y {
+    }
+    isA Y;
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance5.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance5.ump
@@ -1,0 +1,6 @@
+class X {
+    class Y {
+        class Y {
+        }
+    }
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance6.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassCyclicInheritance6.ump
@@ -1,0 +1,8 @@
+class Y {
+    class X {
+        class Y {
+            class X {
+            }
+        }
+    }
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassMultipleInheritance1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassMultipleInheritance1.ump
@@ -1,0 +1,10 @@
+class TopHat{
+  class Question{
+    boolean status;
+  }
+
+  class HomeworkQuestion{
+    isA Question;
+    Date dueDate;
+  }
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassMultipleInheritance2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassMultipleInheritance2.ump
@@ -1,0 +1,8 @@
+class Z {
+    class X {
+        class Y {
+            class X {
+            }
+        }
+    }
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_nestedClassMultipleInheritance3.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_nestedClassMultipleInheritance3.ump
@@ -1,0 +1,8 @@
+class X {
+    class Y {
+        isA Z;
+    }
+}
+
+class Z {
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -422,6 +422,25 @@ public class UmpleParserTest
     Assert.assertEquals(false,model.getUmpleClass("E").getIsAbstract());
   }
 
+  //Issue 1159
+  @Test
+  public void nestedClassCyclicInheritance() {
+    assertFailedParse("422_nestedClassCyclicInheritance1.ump",11);
+    assertFailedParse("422_nestedClassCyclicInheritance2.ump",12);
+    assertFailedParse("422_nestedClassCyclicInheritance3.ump",12);
+    assertFailedParse("422_nestedClassCyclicInheritance4.ump",12);
+    assertFailedParse("422_nestedClassCyclicInheritance5.ump",11);
+    assertFailedParse("422_nestedClassCyclicInheritance6.ump",12);
+  }
+
+  //Issue 1159
+  @Test
+  public void nestedClassMultipleInheritance() {
+    assertFailedParse("422_nestedClassMultipleInheritance1.ump",34);
+    assertFailedParse("422_nestedClassMultipleInheritance2.ump",34);
+    assertFailedParse("422_nestedClassMultipleInheritance3.ump",34);
+  }
+ 
   @Test
   public void abstractInterfaceExtends()
   {
@@ -2981,7 +3000,7 @@ public class UmpleParserTest
     assertHasWarningsParse("142_typeIsAccessSpecifierProtected.ump", 142);
     assertHasWarningsParse("142_typeIsAccessSpecifierPrivate.ump", 142);
   }
- 
+  
   public boolean parse(String filename)
   {
     //String input = SampleFileWriter.readContent(new File(pathToInput, filename));


### PR DESCRIPTION
## Pull request title
Fixes 1159: Nested class inheritance

## Pull request description
Changed handling of nested class definitions to allow cyclic and multiple inheritance to be properly detected alongside "isA" inheritance.

## Pull request content
Commented out nested class UniqueIdentifier in class Constant in Umple.ump. Previously this inheritance would be overridden by a later inheritance from UmpleVariable.

Added logic to UmpleInternalParser_CodeClass.ump to have nested inheritance to be handled in the same way as 'isA' inheritance.

Altered tests 007_singleton_extended2.ump and 007_singleton_extended2.ump as they used nested inheritance in an illegal way.

Added test files 422_nestedClassCyclicInheritance1.ump, 422_nestedClassCyclicInheritance2.ump, 422_nestedClassCyclicInheritance3.ump, 422_nestedClassCyclicInheritance4.ump, 422_nestedClassCyclicInheritance5.ump, 422_nestedClassCyclicInheritance6.ump, 422_nestedClassMultipleInheritance1.ump, 422_nestedClassMultipleInheritance2.ump, and 422_nestedClassMultipleInheritance3.ump.

Added tests for above files to UmpleParserTest.java