### PR TITLE
Fixes 1181: Multiple Inheritance in Different Class Blocks

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -528,6 +528,11 @@ class UmpleClassifier
   1 -> 0..* Constant;
   1 -> 0..* ModelConstraint;
   * -> 0..1 Token extendsToken;
+  
+  // Methods to distinguishe the subclass types
+  boolean isUmpleClass() {return false;}
+  boolean isUmpleInterface() {return false;}
+  boolean isUmpleTrait() {return false;}
 }
 
 /*
@@ -545,6 +550,8 @@ class UmpleInterface
 
   before setPackageName { if (aPackageName == null) { return false; } }
   before addDepend { if (depends.contains(aDepend)) { return false; } }
+
+  boolean isUmpleInterface() {return true;}
 }
 
 /*
@@ -629,6 +636,8 @@ class UmpleClass
   before setExtendsClass { if (!enforceImmutabilityInheritanceRules(aExtendsClass)) { return false; } }
 
   before addStateMachine { if (isImmutable()) { return false; } }
+
+  boolean isUmpleClass() {return true;}
 }
 
 
@@ -706,6 +715,7 @@ class UmpleTrait {
 
   before addStateMachine { if (isImmutable()) { return false; } }
 
+  boolean isUmpleTrait() {return true;}
 }
 
 //This class is used to specify parameters for traits.

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1206,7 +1206,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       }
     }
   	//Checks list of extends tokens to prevent multiple class inheritance
-    if(numberOfExtendsClass(extendsTokenList) > 1)
+    if(numberOfExtendsClass(unlinkedExtendsTokens.get(aClassifier)) > 1)
 	{
 	  Token t = extendsTokenList.get(0);    	
 	  getParseResult().addErrorMessage(new ErrorMessage(34,t.getPosition(),aClassifier.getName(),t.getValue()));
@@ -1216,13 +1216,17 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 	//Returns the number of umple class in extends list (extList)
   private int numberOfExtendsClass(List<Token> extList)
   {
-	int counter = 0;
-	for(Token t : extList)
-	{	
-	  if(isAnUmpleClass(t.getValue("extendsName")))
-    counter++;
-	}
-	return counter;
+    if (extList == null) {
+      return 0;
+    }
+    Set<String> tokenSet = new HashSet<>();
+    for(Token t : extList)
+    {	
+      if(isAnUmpleClass(t.getValue("extendsName"))) {
+        tokenSet.add(t.getValue("extendsName"));
+      }
+    }
+	return tokenSet.size();
   }
 
   //This method checks if an umple element with name "name" is an umple class

--- a/cruise.umple/test/cruise/umple/compiler/422_multipleClassBlockInheritance1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_multipleClassBlockInheritance1.ump
@@ -1,0 +1,11 @@
+class A {}
+class B {}
+
+class C {
+  isA A;
+}
+
+class C {
+  isA B;
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/422_multipleClassBlockInheritance2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_multipleClassBlockInheritance2.ump
@@ -1,0 +1,10 @@
+class A {}
+
+class C {
+  isA A;
+}
+
+class C {
+  isA A;
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -440,6 +440,13 @@ public class UmpleParserTest
     assertFailedParse("422_nestedClassMultipleInheritance2.ump",34);
     assertFailedParse("422_nestedClassMultipleInheritance3.ump",34);
   }
+  
+  //Issue 1181
+  @Test
+  public void multipleClassBlockInheritance() {
+    assertFailedParse("422_multipleClassBlockInheritance1.ump",34);
+    assertSimpleParse("422_multipleClassBlockInheritance2.ump");
+  }
  
   @Test
   public void abstractInterfaceExtends()


### PR DESCRIPTION
## Pull request title
Fixes 1181: Multiple Inheritance in Different Class Blocks

## Pull request description
Previously, when using multiple class blocks for the same class, having an "isA" statement in each block pointing to different superclasses would not cause an error. This how the check for multiple inheritance is run so that "isA" statements from other class blocks will be detected.

## Pull request content
Umple.ump: Added methods to determine if the current UmpleClassifier is an UmpleClass, UmpleInterface, or UmpleTrait.
UmpleInternalParser_CodeClass.ump: Changed check for repeated inheritance to be run on entire list of extends, instead of just on those added in the current class block. Also changed it to not report the same class being extended multiple times.
422_multipleClassBlockInheritance1.ump, 422_multipleClassBlockInheritance2.ump, UmpleParserTest.java: Test cases