### PR TITLE
Refactoring many templates so their name appears in generated code as…

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddImmutableUnidirectionalMany <<!<</*association_AddImmutableUnidirectionalMany*/>>
-  private boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddImmutableUnidirectionalMany <<!  /* Code from template association_AddImmutableUnidirectionalMany */
+<</*association_AddImmutableUnidirectionalMany*/>>  private boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddImmutableUnidirectionalMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddImmutableUnidirectionalMany_relatedSpecialization <<!<</*association_AddImmutableUnidirectionalMany_relatedSpecialization*/>>
-  private boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddImmutableUnidirectionalMany_relatedSpecialization <<!  /* Code from template association_AddImmutableUnidirectionalMany_relatedSpecialization */
+<</*association_AddImmutableUnidirectionalMany_relatedSpecialization*/>>  private boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddIndexControlFunctions <<!<</*association_AddIndexControlFunctions*/>>
-  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  association_AddIndexControlFunctions <<!  /* Code from template association_AddIndexControlFunctions */
+<</*association_AddIndexControlFunctions*/>>  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
   {  
     boolean wasAdded = false;
     if(<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>))

--- a/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddIndexControlFunctions_relatedSpecialization <<!<</*association_AddIndexControlFunctions_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  association_AddIndexControlFunctions_relatedSpecialization <<!  /* Code from template association_AddIndexControlFunctions_relatedSpecialization */
+<</*association_AddIndexControlFunctions_relatedSpecialization*/>>  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
   {  
     boolean wasAdded = false;
     if(<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>))

--- a/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddIndexControlFunctions_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddIndexControlFunctions_specialization <<!<</*association_AddIndexControlFunctions_specialization*/>>
-  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
+  association_AddIndexControlFunctions_specialization <<!  /* Code from template association_AddIndexControlFunctions_specialization */
+<</*association_AddIndexControlFunctions_specialization*/>>  public boolean <<=gen.translate("addAtMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, int index)
   {  
     boolean wasAdded = false;
     if(<<=gen.translate("addMethod",av)>>(<<=gen.translate("parameterOne",av)>>))

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToMany <<!<</*association_AddMNToMany*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMNToMany <<!  /* Code from template association_AddMNToMany */
+<</*association_AddMNToMany*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToMany_relatedSpecialization <<!<</*association_AddMNToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMNToMany_relatedSpecialization <<!  /* Code from template association_AddMNToMany_relatedSpecialization */
+<</*association_AddMNToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToMany_specialization <<!<</*association_AddMNToMany_specialization*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMNToMany_specialization <<!  /* Code from template association_AddMNToMany_specialization */
+<</*association_AddMNToMany_specialization*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customRemovePrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToOnlyOne <<!<</*association_AddMNToOnlyOne*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddMNToOnlyOne <<!  /* Code from template association_AddMNToOnlyOne */
+<</*association_AddMNToOnlyOne*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
     {

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToOnlyOne_relatedSpecialization <<!<</*association_AddMNToOnlyOne_relatedSpecialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddMNToOnlyOne_relatedSpecialization <<!  /* Code from template association_AddMNToOnlyOne_relatedSpecialization */
+<</*association_AddMNToOnlyOne_relatedSpecialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
     {

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOnlyOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToOnlyOne_specialization <<!<</*association_AddMNToOnlyOne_specialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddMNToOnlyOne_specialization <<!  /* Code from template association_AddMNToOnlyOne_specialization */
+<</*association_AddMNToOnlyOne_specialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
     {

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToOptionalOne <<!<</*association_AddMNToOptionalOne*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMNToOptionalOne <<!  /* Code from template association_AddMNToOptionalOne */
+<</*association_AddMNToOptionalOne*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToOptionalOne_relatedSpecialization <<!<</*association_AddMNToOptionalOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMNToOptionalOne_relatedSpecialization <<!  /* Code from template association_AddMNToOptionalOne_relatedSpecialization */
+<</*association_AddMNToOptionalOne_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMNToOptionalOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMNToOptionalOne_specialization <<!<</*association_AddMNToOptionalOne_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMNToOptionalOne_specialization <<!  /* Code from template association_AddMNToOptionalOne_specialization */
+<</*association_AddMNToOptionalOne_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMStarToMany <<!<</*association_AddMStarToMany*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMStarToMany <<!  /* Code from template association_AddMStarToMany */
+<</*association_AddMStarToMany*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMStarToMany_relatedSpecialization <<!<</*association_AddMStarToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMStarToMany_relatedSpecialization <<!  /* Code from template association_AddMStarToMany_relatedSpecialization */
+<</*association_AddMStarToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customRemovePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customRemovePrefixCode,gen.translate("removeMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMStarToMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMStarToMany_specialization <<!<</*association_AddMStarToMany_specialization*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMStarToMany_specialization <<!  /* Code from template association_AddMStarToMany_specialization */
+<</*association_AddMStarToMany_specialization*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customRemovePrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMandatoryManyToOne <<!<</*association_AddMandatoryManyToOne*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddMandatoryManyToOne <<!  /* Code from template association_AddMandatoryManyToOne */
+<</*association_AddMandatoryManyToOne*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     <<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> = new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
 (traceItemAssocAdd!=null?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")

--- a/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMandatoryManyToOne_relatedSpecialization <<!<</*association_AddMandatoryManyToOne_relatedSpecialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddMandatoryManyToOne_relatedSpecialization <<!  /* Code from template association_AddMandatoryManyToOne_relatedSpecialization */
+<</*association_AddMandatoryManyToOne_relatedSpecialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     <<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>> = new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);<<#for( TraceItem traceItemAssocAdd : traceItemAssocAdds )#>><<= 
 (traceItemAssocAdd!=null?"\n"+traceItemAssocAdd.trace(gen, av,"as_a", uClass,gen.translate("numberOfMethod",av)+"()"):"")

--- a/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddMandatoryManyToOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddMandatoryManyToOne_specialization <<!<</*association_AddMandatoryManyToOne_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddMandatoryManyToOne_specialization <<!  /* Code from template association_AddMandatoryManyToOne_specialization */
+<</*association_AddMandatoryManyToOne_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToManyMethod <<!<</*association_AddManyToManyMethod*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddManyToManyMethod <<!  /* Code from template association_AddManyToManyMethod */
+<</*association_AddManyToManyMethod*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToManyMethod_relatedSpecialization <<!<</*association_AddManyToManyMethod_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddManyToManyMethod_relatedSpecialization <<!  /* Code from template association_AddManyToManyMethod_relatedSpecialization */
+<</*association_AddManyToManyMethod_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToManyMethod_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToManyMethod_specialization <<!<</*association_AddManyToManyMethod_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddManyToManyMethod_specialization <<!  /* Code from template association_AddManyToManyMethod_specialization */
+<</*association_AddManyToManyMethod_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null && av.getMultiplicity().getUpperBound() == 1) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToOne_relatedSpecialization <<!<</*association_AddManyToOne_relatedSpecialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddManyToOne_relatedSpecialization <<!  /* Code from template association_AddManyToOne_relatedSpecialization */
+<</*association_AddManyToOne_relatedSpecialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);
   }

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToOne_specialization <<!<</*association_AddManyToOne_specialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddManyToOne_specialization <<!  /* Code from template association_AddManyToOne_specialization */
+<</*association_AddManyToOne_specialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     // need to keep this because of the type differences between sub & super classes
     return new <<=gen.translate("type",av)>>(<<=gen.translate("callerArgumentsExcept",relatedAssociation)>>);

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToOptionalOne <<!<</*association_AddManyToOptionalOne*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddManyToOptionalOne <<!  /* Code from template association_AddManyToOptionalOne */
+<</*association_AddManyToOptionalOne*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToOptionalOne_relatedSpecialization <<!<</*association_AddManyToOptionalOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddManyToOptionalOne_relatedSpecialization <<!  /* Code from template association_AddManyToOptionalOne_relatedSpecialization */
+<</*association_AddManyToOptionalOne_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddManyToOptionalOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddManyToOptionalOne_specialization <<!<</*association_AddManyToOptionalOne_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddManyToOptionalOne_specialization <<!  /* Code from template association_AddManyToOptionalOne_specialization */
+<</*association_AddManyToOptionalOne_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddOptionalNToOne <<!<</*association_AddOptionalNToOne*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddOptionalNToOne <<!  /* Code from template association_AddOptionalNToOne */
+<</*association_AddOptionalNToOne*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>())
     {

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddOptionalNToOne_relatedSpecialization <<!<</*association_AddOptionalNToOne_relatedSpecialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddOptionalNToOne_relatedSpecialization <<!  /* Code from template association_AddOptionalNToOne_relatedSpecialization */
+<</*association_AddOptionalNToOne_relatedSpecialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
     {

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddOptionalNToOne_specialization <<!<</*association_AddOptionalNToOne_specialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
+  association_AddOptionalNToOne_specialization <<!  /* Code from template association_AddOptionalNToOne_specialization */
+<</*association_AddOptionalNToOne_specialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("addMethod",av)>>(<<=gen.translate("methodArgumentsExcept",relatedAssociation)>>)
   {
     if (<<=gen.translate("numberOfMethod",av)>>() >= <<=gen.translate("maximumNumberOfMethod",av)>>_<<=gen.translate("type",av)>>())
     {

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddOptionalNToOptionalOne <<!<</*association_AddOptionalNToOptionalOne*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddOptionalNToOptionalOne <<!  /* Code from template association_AddOptionalNToOptionalOne */
+<</*association_AddOptionalNToOptionalOne*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddOptionalNToOptionalOne_relatedSpecialization <<!<</*association_AddOptionalNToOptionalOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddOptionalNToOptionalOne_relatedSpecialization <<!  /* Code from template association_AddOptionalNToOptionalOne_relatedSpecialization */
+<</*association_AddOptionalNToOptionalOne_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddOptionalNToOptionalOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddOptionalNToOptionalOne_specialization <<!<</*association_AddOptionalNToOptionalOne_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddOptionalNToOptionalOne_specialization <<!  /* Code from template association_AddOptionalNToOptionalOne_specialization */
+<</*association_AddOptionalNToOptionalOne_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMN <<!<</*association_AddUnidirectionalMN*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMN <<!  /* Code from template association_AddUnidirectionalMN */
+<</*association_AddUnidirectionalMN*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMN_relatedSpecialization <<!<</*association_AddUnidirectionalMN_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMN_relatedSpecialization <<!  /* Code from template association_AddUnidirectionalMN_relatedSpecialization */
+<</*association_AddUnidirectionalMN_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMN_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMN_specialization <<!<</*association_AddUnidirectionalMN_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMN_specialization <<!  /* Code from template association_AddUnidirectionalMN_specialization */
+<</*association_AddUnidirectionalMN_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMStar <<!<</*association_AddUnidirectionalMStar*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMStar <<!  /* Code from template association_AddUnidirectionalMStar */
+<</*association_AddUnidirectionalMStar*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMStar_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMStar_relatedSpecialization <<!<</*association_AddUnidirectionalMStar_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMStar_relatedSpecialization <<!  /* Code from template association_AddUnidirectionalMStar_relatedSpecialization */
+<</*association_AddUnidirectionalMStar_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMany <<!<</*association_AddUnidirectionalMany*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMany <<!  /* Code from template association_AddUnidirectionalMany */
+<</*association_AddUnidirectionalMany*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMany_relatedSpecialization <<!<</*association_AddUnidirectionalMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMany_relatedSpecialization <<!  /* Code from template association_AddUnidirectionalMany_relatedSpecialization */
+<</*association_AddUnidirectionalMany_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalMany_specialization <<!<</*association_AddUnidirectionalMany_specialization*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalMany_specialization <<!  /* Code from template association_AddUnidirectionalMany_specialization */
+<</*association_AddUnidirectionalMany_specialization*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalOptionalN <<!<</*association_AddUnidirectionalOptionalN*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalOptionalN <<!  /* Code from template association_AddUnidirectionalOptionalN */
+<</*association_AddUnidirectionalOptionalN*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalOptionalN_relatedSpecialization <<!<</*association_AddUnidirectionalOptionalN_relatedSpecialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalOptionalN_relatedSpecialization <<!  /* Code from template association_AddUnidirectionalOptionalN_relatedSpecialization */
+<</*association_AddUnidirectionalOptionalN_relatedSpecialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_AddUnidirectionalOptionalN_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_AddUnidirectionalOptionalN_specialization <<!<</*association_AddUnidirectionalOptionalN_specialization*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_AddUnidirectionalOptionalN_specialization <<!  /* Code from template association_AddUnidirectionalOptionalN_specialization */
+<</*association_AddUnidirectionalOptionalN_specialization*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { #>>

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetMany <<!<</*association_GetMany*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>(int index)
+  association_GetMany <<!  /* Code from template association_GetMany */
+<</*association_GetMany*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>(int index)
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>><<# for( TraceItem traceItem : traceItems ) #>><<= 

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany_clear.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany_clear.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetMany_clear <<!<</*association_GetMany_clear*/>>
-  protected void clear_<<=gen.translate("associationMany",av)>>()
+  association_GetMany_clear <<!  /* Code from template association_GetMany_clear */
+<</*association_GetMany_clear*/>>  protected void clear_<<=gen.translate("associationMany",av)>>()
   {
     <<=gen.translate("associationMany",av)>>.clear();
   }

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetMany_relatedSpecialization <<!<</*association_GetMany_relatedSpecialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>(int index)
+  association_GetMany_relatedSpecialization <<!  /* Code from template association_GetMany_relatedSpecialization */
+<</*association_GetMany_relatedSpecialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>(int index)
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>><<# for( TraceItem traceItem : traceItems ) #>><<= 

--- a/UmpleToJava/UmpleTLTemplates/association_GetMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetMany_specialization <<!<</*association_GetMany_specialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>(int index)
+  association_GetMany_specialization <<!  /* Code from template association_GetMany_specialization */
+<</*association_GetMany_specialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_<<=gen.translate("type",av)>>(int index)
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>><<# for( TraceItem traceItem : traceItems ) #>><<= 

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetOne <<!<</*association_GetOne*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>()
+  association_GetOne <<!  /* Code from template association_GetOne */
+<</*association_GetOne*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne_clear.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne_clear.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetOne_clear <<!<</*association_GetOne_clear*/>>
-  protected void clear_<<=gen.translate("associationOne",av)>>()
+  association_GetOne_clear <<!  /* Code from template association_GetOne_clear */
+<</*association_GetOne_clear*/>>  protected void clear_<<=gen.translate("associationOne",av)>>()
   {
     <<=gen.translate("associationOne",av)>> = null;
   }

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetOne_relatedSpecialization <<!<</*association_GetOne_relatedSpecialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()
+  association_GetOne_relatedSpecialization <<!  /* Code from template association_GetOne_relatedSpecialization */
+<</*association_GetOne_relatedSpecialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_GetOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetOne_specialization <<!<</*association_GetOne_specialization*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()
+  association_GetOne_specialization <<!  /* Code from template association_GetOne_specialization */
+<</*association_GetOne_specialization*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getMethod",av)>>_One<<=gen.translate("type",av)>>()
   {
     <<# if (customGetPrefixCode != null && mulChangedToOne) { #>>
     <<=gen.translate("type",av)>> <<=gen.translate("associationOne",av)>> = <<#if (relReqSuperCode) { #>>(<<=gen.translate("type",av)>>)<<# } #>>super.<<=gen.translate("getMethod",av)>>(0);%>

--- a/UmpleToJava/UmpleTLTemplates/association_GetPrivate.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_GetPrivate.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_GetPrivate <<!<</*association_GetPrivate*/>>
-  private void <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterOne",av)>>)
+  association_GetPrivate <<!  /* Code from template association_GetPrivate */
+<</*association_GetPrivate*/>>  private void <<=gen.relatedTranslate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>, <<=gen.relatedTranslate("type",av)>> <<=gen.relatedTranslate("parameterOne",av)>>)
   {
     try
     {

--- a/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_IsNumberOfValidMethod <<!<</*association_IsNumberOfValidMethod*/>>
-  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>()
+  association_IsNumberOfValidMethod <<!  /* Code from template association_IsNumberOfValidMethod */
+<</*association_IsNumberOfValidMethod*/>>  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>()
   {
     <<# if (customIsNumberOfValidPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPrefixCode,gen.translate("isNumberOfValidMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_IsNumberOfValidMethod_relatedSpecialization <<!<</*association_IsNumberOfValidMethod_relatedSpecialization*/>>
-  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>_<<=gen.translate("type",av)>>()
+  association_IsNumberOfValidMethod_relatedSpecialization <<!  /* Code from template association_IsNumberOfValidMethod_relatedSpecialization */
+<</*association_IsNumberOfValidMethod_relatedSpecialization*/>>  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>_<<=gen.translate("type",av)>>()
   {
     <<# if (customIsNumberOfValidPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPrefixCode,gen.translate("isNumberOfValidMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_IsNumberOfValidMethod_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_IsNumberOfValidMethod_specialization <<!<</*association_IsNumberOfValidMethod_specialization*/>>
-  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>_<<=gen.translate("type",av)>>()
+  association_IsNumberOfValidMethod_specialization <<!  /* Code from template association_IsNumberOfValidMethod_specialization */
+<</*association_IsNumberOfValidMethod_specialization*/>>  public boolean <<=gen.translate("isNumberOfValidMethod",av)>>_<<=gen.translate("type",av)>>()
   {
     <<# if (customIsNumberOfValidPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customIsNumberOfValidPrefixCode,gen.translate("isNumberOfValidMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customIsNumberOfValidPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/association_RemoveMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RemoveMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_RemoveMany <<!<</*association_RemoveMany*/>>
-  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_RemoveMany <<!  /* Code from template association_RemoveMany */
+<</*association_RemoveMany*/>>  public boolean <<=gen.translate("removeMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasRemoved = false;<<#for( TraceItem traceItemAssocRemove : traceItemAssocRemoves )#>><<=
     (traceItemAssocRemove!=null&&traceItemAssocRemove.getIsPre()?"\n"+traceItemAssocRemove.trace(gen, av,"as_r", uClass,gen.translate("numberOfMethod",av)+"()"):"")

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetMNToMany <<!<</*association_SetMNToMany*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetMNToMany <<!  /* Code from template association_SetMNToMany */
+<</*association_SetMNToMany*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetMNToMany_relatedSpecialization <<!<</*association_SetMNToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetMNToMany_relatedSpecialization <<!  /* Code from template association_SetMNToMany_relatedSpecialization */
+<</*association_SetMNToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetMNToMany_specialization <<!<</*association_SetMNToMany_specialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetMNToMany_specialization <<!  /* Code from template association_SetMNToMany_specialization */
+<</*association_SetMNToMany_specialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetMStarToMany <<!<</*association_SetMStarToMany*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetMStarToMany <<!  /* Code from template association_SetMStarToMany */
+<</*association_SetMStarToMany*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetMStarToMany_relatedSpecialization <<!<</*association_SetMStarToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetMStarToMany_relatedSpecialization <<!  /* Code from template association_SetMStarToMany_relatedSpecialization */
+<</*association_SetMStarToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMStarToMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetMStarToMany_specialization <<!<</*association_SetMStarToMany_specialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetMStarToMany_specialization <<!  /* Code from template association_SetMStarToMany_specialization */
+<</*association_SetMStarToMany_specialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne.ump
@@ -2,8 +2,8 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetNToOptionalOne <<!<</*association_SetNToOptionalOne*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetNToOptionalOne <<!  /* Code from template association_SetNToOptionalOne */
+<</*association_SetNToOptionalOne*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_relatedSpecialization.ump
@@ -2,8 +2,8 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetNToOptionalOne_relatedSpecialization <<!<</*association_SetNToOptionalOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetNToOptionalOne_relatedSpecialization <<!  /* Code from template association_SetNToOptionalOne_relatedSpecialization */
+<</*association_SetNToOptionalOne_relatedSpecialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetNToOptionalOne_specialization.ump
@@ -2,8 +2,8 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetNToOptionalOne_specialization <<!<</*association_SetNToOptionalOne_specialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetNToOptionalOne_specialization <<!  /* Code from template association_SetNToOptionalOne_specialization */
+<</*association_SetNToOptionalOne_specialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToAtMostN <<!<</*association_SetOneToAtMostN*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToAtMostN <<!  /* Code from template association_SetOneToAtMostN */
+<</*association_SetOneToAtMostN*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToAtMostN_relatedSpecialization <<!<</*association_SetOneToAtMostN_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToAtMostN_relatedSpecialization <<!  /* Code from template association_SetOneToAtMostN_relatedSpecialization */
+<</*association_SetOneToAtMostN_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToAtMostN_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToAtMostN_specialization <<!<</*association_SetOneToAtMostN_specialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToAtMostN_specialization <<!  /* Code from template association_SetOneToAtMostN_specialization */
+<</*association_SetOneToAtMostN_specialization*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToMandatoryMany <<!<</*association_SetOneToMandatoryMany*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToMandatoryMany <<!  /* Code from template association_SetOneToMandatoryMany */
+<</*association_SetOneToMandatoryMany*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToMandatoryMany_relatedSpecialization <<!<</*association_SetOneToMandatoryMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToMandatoryMany_relatedSpecialization <<!  /* Code from template association_SetOneToMandatoryMany_relatedSpecialization */
+<</*association_SetOneToMandatoryMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMandatoryMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToMandatoryMany_specialization <<!<</*association_SetOneToMandatoryMany_specialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToMandatoryMany_specialization <<!  /* Code from template association_SetOneToMandatoryMany_specialization */
+<</*association_SetOneToMandatoryMany_specialization*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToMany <<!<</*association_SetOneToMany*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToMany <<!  /* Code from template association_SetOneToMany */
+<</*association_SetOneToMany*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToManyAssociationClass <<!<</*association_SetOneToManyAssociationClass*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToManyAssociationClass <<!  /* Code from template association_SetOneToManyAssociationClass */
+<</*association_SetOneToManyAssociationClass*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToManyAssociationClass_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToManyAssociationClass_relatedSpecialization <<!<</*association_SetOneToManyAssociationClass_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToManyAssociationClass_relatedSpecialization <<!  /* Code from template association_SetOneToManyAssociationClass_relatedSpecialization */
+<</*association_SetOneToManyAssociationClass_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToMany_relatedSpecialization <<!<</*association_SetOneToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToMany_relatedSpecialization <<!  /* Code from template association_SetOneToMany_relatedSpecialization */
+<</*association_SetOneToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToMany_specialization <<!<</*association_SetOneToMany_specialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToMany_specialization <<!  /* Code from template association_SetOneToMany_specialization */
+<</*association_SetOneToMany_specialization*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<=gen.translate("type",av)>> <<=gen.translate("associationOne",av)>> = <<=gen.translate("getMethod",av)>><<# if (mulChangedToOne) { #>>_One<<=gen.translate("type",av)>><<# } #>>();

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToOptionalN <<!<</*association_SetOneToOptionalN*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToOptionalN <<!  /* Code from template association_SetOneToOptionalN */
+<</*association_SetOneToOptionalN*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalN_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToOptionalN_relatedSpecialization <<!<</*association_SetOneToOptionalN_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOneToOptionalN_relatedSpecialization <<!  /* Code from template association_SetOneToOptionalN_relatedSpecialization */
+<</*association_SetOneToOptionalN_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av));

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToOptionalOne <<!<</*association_SetOneToOptionalOne*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOneToOptionalOne <<!  /* Code from template association_SetOneToOptionalOne */
+<</*association_SetOneToOptionalOne*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_relatedSpecialization.ump
@@ -2,8 +2,8 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetOneToOptionalOne_relatedSpecialization <<!<</*association_SetOneToOptionalOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOneToOptionalOne_relatedSpecialization <<!  /* Code from template association_SetOneToOptionalOne_relatedSpecialization */
+<</*association_SetOneToOptionalOne_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOneToOptionalOne_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOneToOptionalOne_specialization <<!<</*association_SetOneToOptionalOne_specialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOneToOptionalOne_specialization <<!  /* Code from template association_SetOneToOptionalOne_specialization */
+<</*association_SetOneToOptionalOne_specialization*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalNToMany <<!<</*association_SetOptionalNToMany*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetOptionalNToMany <<!  /* Code from template association_SetOptionalNToMany */
+<</*association_SetOptionalNToMany*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalNToMany_relatedSpecialization <<!<</*association_SetOptionalNToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetOptionalNToMany_relatedSpecialization <<!  /* Code from template association_SetOptionalNToMany_relatedSpecialization */
+<</*association_SetOptionalNToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalNToMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalNToMany_specialization <<!<</*association_SetOptionalNToMany_specialization*/>>
-  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
+  association_SetOptionalNToMany_specialization <<!  /* Code from template association_SetOptionalNToMany_specialization */
+<</*association_SetOptionalNToMany_specialization*/>>  public boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetManyPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetManyPrefixCode,gen.translate("setManyMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToMandatoryMany <<!<</*association_SetOptionalOneToMandatoryMany*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToMandatoryMany <<!  /* Code from template association_SetOptionalOneToMandatoryMany */
+<</*association_SetOptionalOneToMandatoryMany*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     //
     // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToMandatoryMany_relatedSpecialization <<!<</*association_SetOptionalOneToMandatoryMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToMandatoryMany_relatedSpecialization <<!  /* Code from template association_SetOptionalOneToMandatoryMany_relatedSpecialization */
+<</*association_SetOptionalOneToMandatoryMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     //
     // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMandatoryMany_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToMandatoryMany_specialization <<!<</*association_SetOptionalOneToMandatoryMany_specialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToMandatoryMany_specialization <<!  /* Code from template association_SetOptionalOneToMandatoryMany_specialization */
+<</*association_SetOptionalOneToMandatoryMany_specialization*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     //
     // This source of this source generation is association_SetOptionalOneToMandatoryMany.jet

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToMany <<!<</*association_SetOptionalOneToMany*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToMany <<!  /* Code from template association_SetOptionalOneToMany */
+<</*association_SetOptionalOneToMany*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToMany_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToMany_relatedSpecialization <<!<</*association_SetOptionalOneToMany_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToMany_relatedSpecialization <<!  /* Code from template association_SetOptionalOneToMany_relatedSpecialization */
+<</*association_SetOptionalOneToMany_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToOne <<!<</*association_SetOptionalOneToOne*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOptionalOneToOne <<!  /* Code from template association_SetOptionalOneToOne */
+<</*association_SetOptionalOneToOne*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOne_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToOne_relatedSpecialization <<!<</*association_SetOptionalOneToOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOptionalOneToOne_relatedSpecialization <<!  /* Code from template association_SetOptionalOneToOne_relatedSpecialization */
+<</*association_SetOptionalOneToOne_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToOptionalN <<!<</*association_SetOptionalOneToOptionalN*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToOptionalN <<!  /* Code from template association_SetOptionalOneToOptionalN */
+<</*association_SetOptionalOneToOptionalN*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_relatedSpecialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToOptionalN_relatedSpecialization <<!<</*association_SetOptionalOneToOptionalN_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToOptionalN_relatedSpecialization <<!  /* Code from template association_SetOptionalOneToOptionalN_relatedSpecialization */
+<</*association_SetOptionalOneToOptionalN_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalN_specialization.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToOptionalN_specialization <<!<</*association_SetOptionalOneToOptionalN_specialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  association_SetOptionalOneToOptionalN_specialization <<!  /* Code from template association_SetOptionalOneToOptionalN_specialization */
+<</*association_SetOptionalOneToOptionalN_specialization*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    association_SetOptionalOneToOptionalOne <<!<</*association_SetOptionalOneToOptionalOne*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOptionalOneToOptionalOne <<!  /* Code from template association_SetOptionalOneToOptionalOne */
+<</*association_SetOptionalOneToOptionalOne*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetOptionalOneToOptionalOne_relatedSpecialization.ump
@@ -2,8 +2,8 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetOptionalOneToOptionalOne_relatedSpecialization <<!<</*association_SetOptionalOneToOptionalOne_relatedSpecialization*/>>
-  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
+  association_SetOptionalOneToOptionalOne_relatedSpecialization <<!  /* Code from template association_SetOptionalOneToOptionalOne_relatedSpecialization */
+<</*association_SetOptionalOneToOptionalOne_relatedSpecialization*/>>  public boolean <<=gen.translate("setMethod",av)>>_<<=gen.translate("type",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetCodeInjection.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_GetCodeInjection <<!<</*attribute_GetCodeInjection*/>>
-  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  attribute_GetCodeInjection <<!  /* Code from template attribute_GetCodeInjection */
+<</*attribute_GetCodeInjection*/>>  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDefaulted.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDefaulted.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_GetDefaulted <<!<</*attribute_GetDefaulted*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
+  attribute_GetDefaulted <<!  /* Code from template attribute_GetDefaulted */
+<</*attribute_GetDefaulted*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
   {
     <<# if (customGetDefaultPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetDefaultPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDefaultedCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDefaultedCodeInjection.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_GetDefaultedCodeInjection <<!<</*attribute_GetDefaultedCodeInjection*/>>
-  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
+  attribute_GetDefaultedCodeInjection <<!  /* Code from template attribute_GetDefaultedCodeInjection */
+<</*attribute_GetDefaultedCodeInjection*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
   {
     <<# if (customGetDefaultPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getDefaultMethod",av)); 
       append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetDefaultPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_GetMany <<!<</*attribute_GetMany*/>>
-  public <<=gen.translate("typeMany",av)>> <<=gen.translate("getMethod",av)>>(int index)
+  attribute_GetMany <<!  /* Code from template attribute_GetMany */
+<</*attribute_GetMany*/>>  public <<=gen.translate("typeMany",av)>> <<=gen.translate("getMethod",av)>>(int index)
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av));
      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetUnique.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetUnique.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_GetUnique <<!<</*attribute_GetUnique*/>>
-  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  attribute_GetUnique <<!  /* Code from template attribute_GetUnique */
+<</*attribute_GetUnique*/>>  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
   {
     <<# if (customGetUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePrefixCode,gen.translate("getUniqueMethod",av));
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetUniquePrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetUniqueCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetUniqueCodeInjection.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_GetUniqueCodeInjection <<!<</*attribute_GetUniqueCodeInjection*/>>
-  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  attribute_GetUniqueCodeInjection <<!  /* Code from template attribute_GetUniqueCodeInjection */
+<</*attribute_GetUniqueCodeInjection*/>>  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
   {
     <<# if (customGetUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePrefixCode,gen.translate("getUniqueMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetUniquePrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_HasUnique.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_HasUnique.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_HasUnique <<!<</*attribute_HasUnique*/>>
-  public static boolean <<=gen.translate("hasUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  attribute_HasUnique <<!  /* Code from template attribute_HasUnique */
+<</*attribute_HasUnique*/>>  public static boolean <<=gen.translate("hasUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
   {
     <<# if (customHasUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasUniquePrefixCode,gen.translate("hasUniqueMethod",av));
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasUniquePrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_HasUniqueCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_HasUniqueCodeInjection.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_HasUniqueCodeInjection <<!<</*attribute_HasUniqueCodeInjection*/>>
-  public static boolean <<=gen.translate("hasUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  attribute_HasUniqueCodeInjection <<!  /* Code from template attribute_HasUniqueCodeInjection */
+<</*attribute_HasUniqueCodeInjection*/>>  public static boolean <<=gen.translate("hasUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
   {
     <<# if (customHasUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customHasUniquePrefixCode,gen.translate("hasUniqueMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customHasUniquePrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBoolean.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBoolean.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_IsBoolean <<!<</*attribute_IsBoolean*/>>
-  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  attribute_IsBoolean <<!  /* Code from template attribute_IsBoolean */
+<</*attribute_IsBoolean*/>>  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjection.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_IsBooleanCodeInjection <<!<</*attribute_IsBooleanCodeInjection*/>>
-  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  attribute_IsBooleanCodeInjection <<!  /* Code from template attribute_IsBooleanCodeInjection */
+<</*attribute_IsBooleanCodeInjection*/>>  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjectionDerived.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanCodeInjectionDerived.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_IsBooleanCodeInjectionDerived <<!<</*attribute_IsBooleanCodeInjectionDerived*/>>
-  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  attribute_IsBooleanCodeInjectionDerived <<!  /* Code from template attribute_IsBooleanCodeInjectionDerived */
+<</*attribute_IsBooleanCodeInjectionDerived*/>>  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanDerived.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_IsBooleanDerived.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_IsBooleanDerived <<!<</*attribute_IsBooleanDerived*/>>
-  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
+  attribute_IsBooleanDerived <<!  /* Code from template attribute_IsBooleanDerived */
+<</*attribute_IsBooleanDerived*/>>  public <<=gen.translate("type",av)>> <<= gen.translate("isMethod",av) >>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("isMethod",av)); 
     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_SetDefaulted <<!<</*attribute_SetDefaulted*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  attribute_SetDefaulted <<!  /* Code from template attribute_SetDefaulted */
+<</*attribute_SetDefaulted*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetDefaulted_subclass.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_SetDefaulted_subclass <<!<</*attribute_SetDefaulted_subclass*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  attribute_SetDefaulted_subclass <<!  /* Code from template attribute_SetDefaulted_subclass */
+<</*attribute_SetDefaulted_subclass*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { 

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetImmutable.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetImmutable.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_SetImmutable <<!<</*attribute_SetImmutable*/>>
-  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  attribute_SetImmutable <<!  /* Code from template attribute_SetImmutable */
+<</*attribute_SetImmutable*/>>  public boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetMany.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_SetMany <<!<</*attribute_SetMany*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
+  attribute_SetMany <<!  /* Code from template attribute_SetMany */
+<</*attribute_SetMany*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customAddPrefixCode,gen.translate("addMethod",av)); 

--- a/UmpleToJava/UmpleTLTemplates/attribute_SetMany_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_SetMany_subclass.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_SetMany_subclass <<!<</*attribute_SetMany_subclass*/>>
-  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
+  attribute_SetMany_subclass <<!  /* Code from template attribute_SetMany_subclass */
+<</*attribute_SetMany_subclass*/>>  public boolean <<=gen.translate("addMethod",av)>>(<<=gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasAdded = false;
     <<# if (customAddPrefixCode != null) {

--- a/UmpleToJava/UmpleTLTemplates/attribute_Set_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set_subclass.ump
@@ -1,6 +1,6 @@
 class UmpleToJava {
-    attribute_Set_subclass <<!<</*attribute_Set_subclass*/>>
-  public boolean <<= gen.translate("setMethod",av) >>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
+  attribute_Set_subclass <<!  /* Code from template attribute_Set_subclass */
+<</*attribute_Set_subclass*/>>  public boolean <<= gen.translate("setMethod",av) >>(<<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>>)
   {
     boolean wasSet = false;
     <<# if (customSetPrefixCode != null) {

--- a/build/_template.xml
+++ b/build/_template.xml
@@ -122,7 +122,7 @@
         <isreachable property="access.maven" 
                      host="http://repo1.maven.org" />
         <isreachable property="access.umple" 
-                     host="http://cruise.eecs.uottawa.ca" />
+                     host="http://cruise.eecs.uottawa.ca/index.shtml" />
         <isreachable property="access.github" 
                      host="https://github.com" />
       </parallel>


### PR DESCRIPTION
This refactors many of the templates in
UmpleToJava/UmpleTLTemplates/ so that the name of the template appears in generated Java code. This will help people reporting bugs to let the compiler development team know which template is causing the problem and will greatly facilitate debugging. It is a pre-requisite for fixing #1160 properly.

This adds comments such as the following at the point where the template is being applied.
```
/* Code from template association_AddIndexControlFunctions_specialization */
```
This will appear in generated code and in generated javadoc of the compiler.

Note that this is a first refactor affecting all templates for associations and attributes that 1) start with a method to be output ; b) don't have any UmpleTL condition <<#; 3) Don't fail any tests that use non-standard testing asserts (Most template tests use an assert that is silent when the above comments unexpectedly appear).

PR #1187 had already made this refactor for UmpleToJava/UmpleTLTemplates/association_AddManyToOne.ump