### PR TITLE
Remainder of refactoring that can be done to output comment in genera…

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_MaximumNumberOfMethod <<!<</*association_MaximumNumberOfMethod*/>><<#
+  association_MaximumNumberOfMethod <<!  /* Code from template association_MaximumNumberOfMethod */<</*association_MaximumNumberOfMethod*/>><<#
     String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
 
     String customMaximumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("maximumNumberOfMethod",av)));

--- a/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_MaximumNumberOfMethod_relatedSpecialization <<!<</*association_MaximumNumberOfMethod_relatedSpecialization*/>><<#
+  association_MaximumNumberOfMethod_relatedSpecialization <<!  /* Code from template association_MaximumNumberOfMethod_relatedSpecialization */<</*association_MaximumNumberOfMethod_relatedSpecialization*/>><<#
     String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
 
     String customMaximumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("maximumNumberOfMethod",av)));

--- a/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MaximumNumberOfMethod_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_MaximumNumberOfMethod_specialization <<!<</*association_MaximumNumberOfMethod_specialization*/>><<#
+  association_MaximumNumberOfMethod_specialization <<!  /* Code from template association_MaximumNumberOfMethod_specialization */<</*association_MaximumNumberOfMethod_specialization*/>><<#
     String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
 
     String customMaximumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("maximumNumberOfMethod",av)));

--- a/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_MinimumNumberOfMethod <<!<</*association_MinimumNumberOfMethod*/>><<#
+  association_MinimumNumberOfMethod <<!  /* Code from template association_MinimumNumberOfMethod */<</*association_MinimumNumberOfMethod*/>><<#
     String customMinimumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("minimumNumberOfMethod",av)));
     String customMinimumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("minimumNumberOfMethod",av)));
     #>>

--- a/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_MinimumNumberOfMethod_relatedSpecialization <<!<</*association_MinimumNumberOfMethod_relatedSpecialization*/>><<#
+  association_MinimumNumberOfMethod_relatedSpecialization <<!  /* Code from template association_MinimumNumberOfMethod_relatedSpecialization */<</*association_MinimumNumberOfMethod_relatedSpecialization*/>><<#
     String customMinimumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("minimumNumberOfMethod",av)));
     String customMinimumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("minimumNumberOfMethod",av)));
     #>>

--- a/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_MinimumNumberOfMethod_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_MinimumNumberOfMethod_specialization <<!<</*association_MinimumNumberOfMethod_specialization*/>><<#
+  association_MinimumNumberOfMethod_specialization <<!  /* Code from template association_MinimumNumberOfMethod_specialization */<</*association_MinimumNumberOfMethod_specialization*/>><<#
     String customMinimumNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("minimumNumberOfMethod",av)));
     String customMinimumNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("minimumNumberOfMethod",av)));
     #>>

--- a/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_RequiredNumberOfMethod <<!<</*association_RequiredNumberOfMethod*/>><<#
+  association_RequiredNumberOfMethod <<!  /* Code from template association_RequiredNumberOfMethod */<</*association_RequiredNumberOfMethod*/>><<#
     String customRequiredNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("requiredNumberOfMethod",av)));
     String customRequiredNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("requiredNumberOfMethod",av)));
 #>>

--- a/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_RequiredNumberOfMethod_relatedSpecialization <<!<</*association_RequiredNumberOfMethod_relatedSpecialization*/>><<#
+  association_RequiredNumberOfMethod_relatedSpecialization <<!  /* Code from template association_RequiredNumberOfMethod_relatedSpecialization */<</*association_RequiredNumberOfMethod_relatedSpecialization*/>><<#
     String customRequiredNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("requiredNumberOfMethod",av)));
     String customRequiredNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("requiredNumberOfMethod",av)));
 #>>

--- a/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_RequiredNumberOfMethod_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_RequiredNumberOfMethod_specialization <<!<</*association_RequiredNumberOfMethod_specialization*/>><<#
+  association_RequiredNumberOfMethod_specialization <<!  /* Code from template association_RequiredNumberOfMethod_specialization */<</*association_RequiredNumberOfMethod_specialization*/>><<#
     String customRequiredNumberOfPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("requiredNumberOfMethod",av)));
     String customRequiredNumberOfPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("requiredNumberOfMethod",av)));
 #>>

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne.ump
@@ -2,7 +2,7 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetMNToOptionalOne <<!<</*association_SetMNToOptionalOne*/>><<#
+  association_SetMNToOptionalOne <<!  /* Code from template association_SetMNToOptionalOne */<</*association_SetMNToOptionalOne*/>><<#
   String existingToNewMap = StringFormatter.format("{0}ToNew{1}", relatedAssociation.getName(), av.getUpperCaseName());
   String orCheckMaxBound = av.isStar() ? "" : StringFormatter.format(" || {0}.length > {1}()", gen.translate("parameterMany",av), gen.translate("maximumNumberOfMethod",av));
 #>>

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_relatedSpecialization.ump
@@ -2,7 +2,7 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetMNToOptionalOne_relatedSpecialization <<!<</*association_SetMNToOptionalOne_relatedSpecialization*/>><<#
+  association_SetMNToOptionalOne_relatedSpecialization <<!  /* Code from template association_SetMNToOptionalOne_relatedSpecialization */<</*association_SetMNToOptionalOne_relatedSpecialization*/>><<#
   String existingToNewMap = StringFormatter.format("{0}ToNew{1}", relatedAssociation.getName(), av.getUpperCaseName());
   String orCheckMaxBound = av.isStar() ? "" : StringFormatter.format(" || {0}.length > {1}{2}{3}()", gen.translate("parameterMany",av), gen.translate("maximumNumberOfMethod",av), "_", gen.translate("type",av));
 #>>

--- a/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetMNToOptionalOne_specialization.ump
@@ -2,7 +2,7 @@ use association_GetPrivate.ump;
 
 
 class UmpleToJava {
-    association_SetMNToOptionalOne_specialization <<!<</*association_SetMNToOptionalOne_specialization*/>><<#
+  association_SetMNToOptionalOne_specialization <<!  /* Code from template association_SetMNToOptionalOne_specialization */<</*association_SetMNToOptionalOne_specialization*/>><<#
   String existingToNewMap = StringFormatter.format("{0}ToNew{1}", relatedAssociation.getName(), av.getUpperCaseName());
   String orCheckMaxBound = av.isStar() ? "" : StringFormatter.format(" || {0}.length > {1}{2}{3}()", gen.translate("parameterMany",av), gen.translate("maximumNumberOfMethod",av), "_", gen.translate("type",av));
 #>>

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMN <<!<</*association_SetUnidirectionalMN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMN <<!  /* Code from template association_SetUnidirectionalMN */<</*association_SetUnidirectionalMN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMN_relatedSpecialization <<!<</*association_SetUnidirectionalMN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMN_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalMN_relatedSpecialization */<</*association_SetUnidirectionalMN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMN_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMN_specialization <<!<</*association_SetUnidirectionalMN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMN_specialization <<!  /* Code from template association_SetUnidirectionalMN_specialization */<</*association_SetUnidirectionalMN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMStar <<!<</*association_SetUnidirectionalMStar*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMStar <<!  /* Code from template association_SetUnidirectionalMStar */<</*association_SetUnidirectionalMStar*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMStar_relatedSpecialization <<!<</*association_SetUnidirectionalMStar_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMStar_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalMStar_relatedSpecialization */<</*association_SetUnidirectionalMStar_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMStar_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMStar_specialization <<!<</*association_SetUnidirectionalMStar_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMStar_specialization <<!  /* Code from template association_SetUnidirectionalMStar_specialization */<</*association_SetUnidirectionalMStar_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMany <<!<</*association_SetUnidirectionalMany*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMany <<!  /* Code from template association_SetUnidirectionalMany */<</*association_SetUnidirectionalMany*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMany_relatedSpecialization <<!<</*association_SetUnidirectionalMany_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMany_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalMany_relatedSpecialization */<</*association_SetUnidirectionalMany_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalMany_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalMany_specialization <<!<</*association_SetUnidirectionalMany_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalMany_specialization <<!  /* Code from template association_SetUnidirectionalMany_specialization */<</*association_SetUnidirectionalMany_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalN <<!<</*association_SetUnidirectionalN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalN <<!  /* Code from template association_SetUnidirectionalN */<</*association_SetUnidirectionalN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalN_relatedSpecialization <<!<</*association_SetUnidirectionalN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalN_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalN_relatedSpecialization */<</*association_SetUnidirectionalN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalN_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalN_specialization <<!<</*association_SetUnidirectionalN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalN_specialization <<!  /* Code from template association_SetUnidirectionalN_specialization */<</*association_SetUnidirectionalN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOne <<!<</*association_SetUnidirectionalOne*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOne <<!  /* Code from template association_SetUnidirectionalOne */<</*association_SetUnidirectionalOne*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOne_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOne_relatedSpecialization <<!<</*association_SetUnidirectionalOne_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOne_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalOne_relatedSpecialization */<</*association_SetUnidirectionalOne_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOptionalN <<!<</*association_SetUnidirectionalOptionalN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOptionalN <<!  /* Code from template association_SetUnidirectionalOptionalN */<</*association_SetUnidirectionalOptionalN*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOptionalN_relatedSpecialization <<!<</*association_SetUnidirectionalOptionalN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOptionalN_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalOptionalN_relatedSpecialization */<</*association_SetUnidirectionalOptionalN_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_specialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalN_specialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOptionalN_specialization <<!<</*association_SetUnidirectionalOptionalN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOptionalN_specialization <<!  /* Code from template association_SetUnidirectionalOptionalN_specialization */<</*association_SetUnidirectionalOptionalN_specialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setManyMethod",av)>>(<<=gen.translate("type",av)>>... <<=gen.translate("parameterMany",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOptionalOne <<!<</*association_SetUnidirectionalOptionalOne*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOptionalOne <<!  /* Code from template association_SetUnidirectionalOptionalOne */<</*association_SetUnidirectionalOptionalOne*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne_relatedSpecialization.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_SetUnidirectionalOptionalOne_relatedSpecialization.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    association_SetUnidirectionalOptionalOne_relatedSpecialization <<!<</*association_SetUnidirectionalOptionalOne_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
+  association_SetUnidirectionalOptionalOne_relatedSpecialization <<!  /* Code from template association_SetUnidirectionalOptionalOne_relatedSpecialization */<</*association_SetUnidirectionalOptionalOne_relatedSpecialization*/>><<# String accessModifier = (av.isImmutable()) ? "private" : "public"; #>>
   <<= accessModifier >> boolean <<=gen.translate("setMethod",av)>>(<<=gen.translate("type",av)>> <<=gen.translate("parameterNew",av)>>)
   {
     boolean wasSet = false;

--- a/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqCommonCode.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqCommonCode.ump
@@ -45,7 +45,7 @@ use association_Sort.ump;
 
 
 class UmpleToJava {
-    association_set_specialization_reqCommonCode <<!<</*association_set_specialization_reqCommonCode*/>><<#
+  association_set_specialization_reqCommonCode <<!  /* Code from template association_set_specialization_reqCommonCode */<</*association_set_specialization_reqCommonCode*/>><<#
 
     String customIsNumberOfValidPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("isNumberOfValidMethod",av)));
     String customIsNumberOfValidPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("isNumberOfValidMethod",av)));

--- a/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqSuperCode.ump
+++ b/UmpleToJava/UmpleTLTemplates/association_set_specialization_reqSuperCode.ump
@@ -36,7 +36,7 @@ use specializationSkip.ump;
 
 
 class UmpleToJava {
-    association_set_specialization_reqSuperCode <<!<</*association_set_specialization_reqSuperCode*/>><<#
+  association_set_specialization_reqSuperCode <<!  /* Code from template association_set_specialization_reqSuperCode */<</*association_set_specialization_reqSuperCode*/>><<#
 	String customIsNumberOfValidPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("isNumberOfValidMethod",av)));
     String customIsNumberOfValidPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("isNumberOfValidMethod",av)));
     

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDerivedCodeInjection.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDerivedCodeInjection.ump
@@ -1,5 +1,5 @@
 class UmpleToJava {
-    attribute_GetDerivedCodeInjection <<!<</*attribute_GetDerivedCodeInjection*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  attribute_GetDerivedCodeInjection <<!  /* Code from template attribute_GetDerivedCodeInjection */<</*attribute_GetDerivedCodeInjection*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
   public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
   {
     <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 


### PR DESCRIPTION
This is a followup on PR #1209. Code generation templates are being adjusted so they emit the template name into the generated code, to facilitate debugging. The refactoring was split into two parts to make things simple. This group involves templates that don't start with a method, but with logic (i.e. <<#)

This is a prerequisite for #1160 

It contributes to fixing #1186. That issue calls for doing the refactoring all all the templates. However, that will be much more work, since changing the templates that have not been changed in this PR or #1209 break a lot of tests in tricky ways. This PR means that most of the associations and attributes templates are now covered, although not deletion methods nor constructors. State machine templates are not covered yet.