### PR TITLE
Fixes issue #1193, inner enumerations referencing in java 

### DIFF
--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -1480,7 +1480,24 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
         UmpleClass classToRemove = getModel().getUmpleClass(getType(assVar.getRelatedAssociation()));
         GeneratedClass generatedClassToRemove = classToRemove.getGeneratedClass();
         String parameterNameToRemove = StringFormatter.format("{0} {1}", translate("type",assVar), translate("parameterOne",assVar));
-        return StringFormatter.replaceParameter(generatedClassToRemove.getLookup("constructorSignature"), parameterNameToRemove, ""); 
+
+        String classToRemoveConstructorString = StringFormatter.replaceParameter(generatedClassToRemove.getLookup("constructorSignature"), parameterNameToRemove, "");
+        String [] arrayOfConstructorParameters = classToRemoveConstructorString.split(",");
+        for(String constructorParameter : arrayOfConstructorParameters)
+        {
+          String tempConstructorParameter = constructorParameter.trim();
+             if (tempConstructorParameter.length() < 1)
+              continue;
+            String parameterType = tempConstructorParameter.substring(0,tempConstructorParameter.indexOf(" "));
+
+            if (classToRemove.hasEnum(parameterType))
+            {
+              classToRemoveConstructorString = classToRemoveConstructorString.replaceAll("\\b"+parameterType+"\\b", classToRemove.getName()+"."+parameterType);
+            }
+          
+        }
+        return classToRemoveConstructorString;
+
       }
       else if ("callerArgumentsForMandatory".equals(keyName))
       {

--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -51,6 +51,7 @@ public class TemplateTest
 
     SampleFileWriter.destroy(pathToInput + "/example");
     SampleFileWriter.destroy(pathToInput + "/java/example");
+    SampleFileWriter.destroy(pathToInput + "/java/enumerations");
     SampleFileWriter.destroy(pathToInput + "/IX.php");
     SampleFileWriter.destroy(pathToInput + "/ISomething.java");
     SampleFileWriter.destroy(pathToInput + "/Token.java");

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -267,7 +267,14 @@ public class JavaClassTemplateTest extends ClassTemplateTest
         "java/TestUmpleEnumerations_8.java.txt",
         "A");
   }
-  
+  @Test
+  public void TestUmpleEnumerations_innerQualified(){
+    assertUmpleTemplateFor("java/TestUmpleEnumerations_innerQualified_1.ump",
+        "java/TestUmpleEnumerations_innerQualified_1.java.txt",
+        "Driver");
+  }
+
+
   @Test
   public void CascadeDelete()
   {

--- a/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.java.txt
@@ -63,9 +63,9 @@ public class Driver
     return 0;
   }
   /* Code from template association_AddManyToOne */
-  public DriverSchedule addDriverSchedule(DriverSchedule.Shift aShift)
+  public DriverSchedule addDriverSchedule(DriverSchedule.Shift aShift, DriverSchedule.Status aStatus)
   {
-    return new DriverSchedule(aShift, this);
+    return new DriverSchedule(aShift, aStatus, this);
   }
 
   public boolean addDriverSchedule(DriverSchedule aDriverSchedule)

--- a/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.java.txt
@@ -1,0 +1,142 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+package enumerations;
+import java.util.*;
+
+
+public class Driver
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Driver Associations
+  private List<DriverSchedule> driverSchedules;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Driver()
+  {
+    driverSchedules = new ArrayList<DriverSchedule>();
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+  /* Code from template association_GetMany */
+  public DriverSchedule getDriverSchedule(int index)
+  {
+    DriverSchedule aDriverSchedule = driverSchedules.get(index);
+    return aDriverSchedule;
+  }
+
+  public List<DriverSchedule> getDriverSchedules()
+  {
+    List<DriverSchedule> newDriverSchedules = Collections.unmodifiableList(driverSchedules);
+    return newDriverSchedules;
+  }
+
+  public int numberOfDriverSchedules()
+  {
+    int number = driverSchedules.size();
+    return number;
+  }
+
+  public boolean hasDriverSchedules()
+  {
+    boolean has = driverSchedules.size() > 0;
+    return has;
+  }
+
+  public int indexOfDriverSchedule(DriverSchedule aDriverSchedule)
+  {
+    int index = driverSchedules.indexOf(aDriverSchedule);
+    return index;
+  }
+  /* Code from template association_MinimumNumberOfMethod */
+  public static int minimumNumberOfDriverSchedules()
+  {
+    return 0;
+  }
+  /* Code from template association_AddManyToOne */
+  public DriverSchedule addDriverSchedule(DriverSchedule.Shift aShift)
+  {
+    return new DriverSchedule(aShift, this);
+  }
+
+  public boolean addDriverSchedule(DriverSchedule aDriverSchedule)
+  {
+    boolean wasAdded = false;
+    if (driverSchedules.contains(aDriverSchedule)) { return false; }
+    Driver existingDriver = aDriverSchedule.getDriver();
+    boolean isNewDriver = existingDriver != null && !this.equals(existingDriver);
+    if (isNewDriver)
+    {
+      aDriverSchedule.setDriver(this);
+    }
+    else
+    {
+      driverSchedules.add(aDriverSchedule);
+    }
+    wasAdded = true;
+    return wasAdded;
+  }
+
+  public boolean removeDriverSchedule(DriverSchedule aDriverSchedule)
+  {
+    boolean wasRemoved = false;
+    //Unable to remove aDriverSchedule, as it must always have a driver
+    if (!this.equals(aDriverSchedule.getDriver()))
+    {
+      driverSchedules.remove(aDriverSchedule);
+      wasRemoved = true;
+    }
+    return wasRemoved;
+  }
+  /* Code from template association_AddIndexControlFunctions */
+  public boolean addDriverScheduleAt(DriverSchedule aDriverSchedule, int index)
+  {  
+    boolean wasAdded = false;
+    if(addDriverSchedule(aDriverSchedule))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > numberOfDriverSchedules()) { index = numberOfDriverSchedules() - 1; }
+      driverSchedules.remove(aDriverSchedule);
+      driverSchedules.add(index, aDriverSchedule);
+      wasAdded = true;
+    }
+    return wasAdded;
+  }
+
+  public boolean addOrMoveDriverScheduleAt(DriverSchedule aDriverSchedule, int index)
+  {
+    boolean wasAdded = false;
+    if(driverSchedules.contains(aDriverSchedule))
+    {
+      if(index < 0 ) { index = 0; }
+      if(index > numberOfDriverSchedules()) { index = numberOfDriverSchedules() - 1; }
+      driverSchedules.remove(aDriverSchedule);
+      driverSchedules.add(index, aDriverSchedule);
+      wasAdded = true;
+    } 
+    else 
+    {
+      wasAdded = addDriverScheduleAt(aDriverSchedule, index);
+    }
+    return wasAdded;
+  }
+
+  public void delete()
+  {
+    for(int i=driverSchedules.size(); i > 0; i--)
+    {
+      DriverSchedule aDriverSchedule = driverSchedules.get(i - 1);
+      aDriverSchedule.delete();
+    }
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.ump
@@ -1,0 +1,10 @@
+namespace enumerations;
+
+class Driver {
+}
+
+class DriverSchedule {
+  enum Shift { Morning, Afternoon, Night }
+  Shift shift;
+  * -- 1 Driver driver;
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_innerQualified_1.ump
@@ -5,6 +5,8 @@ class Driver {
 
 class DriverSchedule {
   enum Shift { Morning, Afternoon, Night }
+  enum Status {ACTIVE, INACTIVE}
   Shift shift;
+  Status status;
   * -- 1 Driver driver;
 }


### PR DESCRIPTION
This allows java inner enums to be referenced as qualified classes in one-to-many associations. Example of the bug is described in the issue #1193.   

