### PR TITLE
Fixes #412 adds UmpleOnline buttons and deals with broken Yuml

### DIFF
--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -654,10 +654,18 @@ class PlaygroundMain
             hn=java.net.InetAddress.getLocalHost().getCanonicalHostName();
           }
           catch (Exception e) {}
-          
-          returnCommandResult("UmpleOnline Log recorded: "
+         
+          returnCommandResult("UmpleOnline Log         recorded "
             +sdf.format(System.currentTimeMillis()) 
             +"  at "+hn+"\n\n", client);
+          
+          returnCommandResult("JVM up: "
+            +uptime/1000+"s  "+String.format("%.3f",uptime/60000/1440.0)+"d   restart "+
+            sdf.format(startDate)+"\n\n", client);
+
+          returnCommandResult("Version: " + UmpleModel.VERSION_NUMBER
+            + " Jar "+sdf.format(CompileDate.getClassBuildTime())
+            +"\n\n", client);
           
           cpDiffCmds = commandsRun - checkpoint2CommandsRun;
           cpDiffTime = System.currentTimeMillis()-checkpoint2Time;
@@ -680,10 +688,6 @@ class PlaygroundMain
               +"  GvState: " +generateGvStateDiagramCommandsRun
               +"  JsonMixed: " +generateJsonMixedCommandsRun
               +"\n\n", client);          
-          
-          returnCommandResult("JVM uptime: "
-            +uptime/1000+"s  "+String.format("%.3f",uptime/60000/1440.0)+"days  restarted "+
-            sdf.format(startDate)+"\n\n", client);
 
           returnCommandResult("Number of clients queued: "
             +getClientConnections().length+"\n\n", client);
@@ -703,10 +707,6 @@ class PlaygroundMain
           returnCommandResult("Port: "+getPort()+"  Process:"
               +ManagementFactory.getRuntimeMXBean().getName().split("@")[0]
               +"\n\n", client);
-          
-          returnCommandResult("Version: " + UmpleModel.VERSION_NUMBER
-            + " Jar file date updated: "+sdf.format(CompileDate.getClassBuildTime())
-            +"\n\n", client);
 
           if(lastIP != null) {
             returnCommandResult("Last command      from "

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -387,13 +387,12 @@ else if (isset($_REQUEST["umpleCode"]))
       exec("rm -rf " . $thedir . "/yuml.txt");
       $command = "cp " . $thedir . "/model.ump.output " . $thedir .  "/yuml.txt";
       exec($command);
+      $command = "python yuml.py -i " . $thedir . "/yuml.txt -o " . $thedir .  "/yuml.png -s plain ";   
+      $res = shell_exec($command . " 2>&1");           
       $yumllink = $workDir->makePermalink('yuml.txt');
-      $html = "<a href=\"$yumllink\">Download the Yuml text for the following</a>&nbsp;{$errhtml}";
-      if ($sourceCode != "null") {
-        $html = $html . "
-          <iframe width=100% height=500 src=\"http://yuml.me/diagram/class/" . $sourceCode . "\">This browser does not
-          support iframes, so the diagram cannot be displayed</iframe> ";
-      }
+      $imglink = $workDir->makePermalink('yuml.png');
+      $html = "<a href=\"$yumllink\">Download the Yuml text for the following</a>&nbsp;<br/>
+      <img src=\"$imglink\"\>";
       echo $html;
     } // end yuml diagram  
 

--- a/umpleonline/scripts/yuml.py
+++ b/umpleonline/scripts/yuml.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+
+from optparse import OptionParser
+import urllib2, urllib
+import codecs
+import os, sys
+import time
+
+class Request():
+    opts = None
+    body = u""
+    out = None
+    
+    API_BASE = u"http://yuml.me/diagram"
+    
+    
+    def log(self, msg):
+        if self.opts.v:
+            print u"[yuml]", msg
+        else:
+            return
+    
+    def loadbody(self):
+        f = self.opts.infile
+        self.log(u'Loading from %s' % ('stdin' if f == '-' else f))
+        if f == '-':
+            self.body = sys.stdin.readlines()
+        elif os.path.exists(f):
+            self.body = [x.strip() for x in codecs.open(f, 'r', 'utf-8').readlines()]
+        else:
+            raise IOError(u"File %s not found" % f)
+    
+    def prepout(self):
+        self.out = open(self.opts.outfile, 'w')
+    
+    def run(self):
+        start = time.time()
+        
+        if not self.body:
+            self.loadbody()
+        
+        if not self.out:
+            self.prepout()
+        
+        opts = self.opts.style + (";scale:" + str(self.opts.scale) if self.opts.scale else '')
+        url = u"%s/%s/%s/%s.%s" % (self.API_BASE, opts, self.opts.type, urllib.quote(u', '.join(self.body).encode('utf8')), self.opts.fmt)
+        
+        self.log(u'Requesting %s' % url)
+        
+        response = urllib2.urlopen(url).read()
+        self.out.write(response)
+        
+        self.log(u'Done after %f seconds' % (time.time() - start))
+
+if __name__ == '__main__':
+    parser = OptionParser(usage="%prog [-i FILE] -o FILE", version="%prog 0.1")
+    parser.add_option("-i", "--in", dest="infile", help="read yuml from FILE instead of stdin", metavar="FILE", default="-")
+    parser.add_option("-o", "--out", dest="outfile", help="store output in FILE", metavar="FILE")
+    parser.add_option("-f", "--format", dest="fmt", help="force format FMT", metavar="FMT", default="png", choices=['png', 'pdf', 'jpg'])
+    parser.add_option("-t", "--type", dest="type", help="draw a TYPE diagram", metavar="TYPE", default="class", choices=['class', 'activity', 'usecase'])
+    parser.add_option("-s", "--style", dest="style", help="use style STY", metavar="STY", default="scruffy", choices=['scruffy', 'boring', 'plain'])
+    parser.add_option("--scale", dest="scale", help="scale output to percentage", metavar="PERCENT", type="int")
+    parser.add_option("-v", "--verbose", dest="v", help="print some debug info", action="store_true", default=False)
+
+    (options, args) = parser.parse_args()
+    
+    r = Request()
+    r.opts = options
+    r.run()

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -107,6 +107,57 @@ $output = $dataHandle->readData('model.ump');
   <script src="scripts/_load.js" type="text/javascript"></script>
   <title>UmpleOnline: Generate Java, C++, PHP, Alloy, NuSMV or Ruby code from Umple</title>
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" /> 
+  <style>
+  .button2 {
+   border-top: 1px solid #d3bc8f;
+   line-height: 2;
+   background: #d8a695;
+   background: -webkit-gradient(linear, left top, left bottom, from(#e5bcae), to(#d8a695));
+   background: -webkit-linear-gradient(top, #e5bcae, #d8a695);
+   background: -moz-linear-gradient(top, #e5bcae, #d8a695);
+   background: -ms-linear-gradient(top, #e5bcae, #d8a695);
+   background: -o-linear-gradient(top, #e5bcae, #d8a695);
+   padding: 2px 5px;
+   -webkit-border-radius: 6px;
+   -moz-border-radius: 6px;
+   border-radius: 6px;
+   -webkit-box-shadow: rgba(0,0,0,1) 0 1px 0;
+   -moz-box-shadow: rgba(0,0,0,1) 0 1px 0;
+   box-shadow: rgba(0,0,0,1) 0 1px 0;
+   text-shadow: rgba(0,0,0,.4) 0 1px 0;
+   color: white;
+   font-size: 14px;
+   font-family: 'Lucida Grande', Helvetica, Arial, Sans-Serif;
+   text-decoration: none;
+   vertical-align: middle;
+   }
+.button2:hover {
+   border-top-color: #810b09;
+   background: #810b09;
+   color: #ccc;
+   }
+.button2:active {
+   border-top-color: #810b09;
+   background: #810b09;
+   }
+</style>  
+<link rel="apple-touch-icon" sizes="57x57" href="https://cruise.eecs.uottawa.ca/apple-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="https://cruise.eecs.uottawa.ca/apple-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="https://cruise.eecs.uottawa.ca/apple-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="https://cruise.eecs.uottawa.ca/apple-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="https://cruise.eecs.uottawa.ca/apple-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="https://cruise.eecs.uottawa.ca/apple-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="https://cruise.eecs.uottawa.ca/apple-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="https://cruise.eecs.uottawa.ca/apple-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://cruise.eecs.uottawa.ca/apple-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="192x192"  href="https://cruise.eecs.uottawa.ca/android-icon-192x192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://cruise.eecs.uottawa.ca/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="https://cruise.eecs.uottawa.ca/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://cruise.eecs.uottawa.ca/favicon-16x16.png">
+<link rel="manifest" href="https://cruise.eecs.uottawa.ca/manifest.json">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-TileImage" content="https://cruise.eecs.uottawa.ca/ms-icon-144x144.png">
+<meta name="theme-color" content="#ffffff">
 </head>
 <body>
   <?php if($showChrome) { ?> 
@@ -137,6 +188,30 @@ $output = $dataHandle->readData('model.ump');
   <input id="advancedMode" type="hidden" value="0" />
 
   <div id="topLine" class="bookmarkableUrl">
+    <span style="font-size: 30%">
+    <a class="button2" href="javascript:Page.clickShowEditableClassDiagram()"
+      title="Editable class diagram - ctrl-E">E</a>&nbsp;
+    <a class="button2" href="javascript:Page.clickShowGvClassDiagram()"
+      title="Graphviz class diagram - ctrl-G">G</a>&nbsp;
+    <a class="button2" href="javascript:Page.clickShowGvStateDiagram()"
+      title="State diagram - ctrl-S">S</a>&nbsp;
+    </span>
+    
+    &nbsp; 
+    <span style="font-size: 30%">
+    <a class="button2" href="javascript:Page.clickShowHideText()"
+      title="Show/hide text pane on left - ctrl-T">T</a>&nbsp;
+    <a class="button2" href="javascript:Page.clickShowHideCanvas()"
+      title="Show/hide diagram pane on right - ctrl-D">D</a>&nbsp;
+    </span>
+    
+    &nbsp; 
+    <span style="font-size: 30%">
+    <a class="button2" href="javascript:Page.clickToggleAttributes()"
+      title="Show/hide attributes in class diagrams - ctrl-A">A</a>&nbsp;
+    <a class="button2" href="javascript:Page.clickToggleMethods()"
+      title="Show/hide methods in class diagrams - ctrl-M">M</a>&nbsp;
+    </span>
     <span id="linetext">Line=<input size=2 id="linenum" value=1 onChange="Action.setCaretPosition(value);"></input>&nbsp; &nbsp;</span> 
   
     <?php if (isBookmark($dataHandle)) { ?>
@@ -432,16 +507,7 @@ $output = $dataHandle->readData('model.ump');
               <a id="labelManualSync" class="buttonExtend">Manual Sync</a> 
             </li>          
           </ul>
-          <ul class="second">
-            <li class="subtitle"> Other Views </li>
-            <!--<li id="buttonPngImage" class="png"><img src="scripts/png.png" title="Generate PNG Image" /> PNG View</li> //DISABLED -->
-            <li id="ttYumlImage">
-              <img id="buttonYumlImage" src="scripts/yuml.png"/> 
-              <a id="labelYumlImage" class="buttonExtend">Yuml View</a>
-            </li>
-            <!--<li id="buttonSimulateCode" class="simulate"><img src="scripts/simulate.png" title="Simulate Code" /> Simulate</li> //DISABLED -->
-          </ul>
-        </div>
+         </div>
       </div> 
     </div>
    


### PR DESCRIPTION
Adds some buttons to ensure that new users can discover graphviz, state machine and editable options, as well as options to hide/show text or diagrams, and options to hide/show methods and attributes.

Also fixes yUML displaying that had been broken.

And aligns the log output so  the three dates (log date, restart date and version date) are at the top of the log one after another.