### PR TITLE
Improving yuml access options

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,12 @@
-This is a *guide*, please remove this preamble and other irrelevant sections. Use [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for formatting. *Before writing*, please search to ensure the issue doesn't exist, and verify you are using the latest `master` branch and using Java 8.
+This is a *guide*, please remove this preamble and other irrelevant sections.
 
-## Brief Description
+*Before writing*, a) please search to ensure the issue doesn't exist. b) If you are using Eclipse, the command line or Docker please ensure you are using the latest version of the relevant Umple tools and dependencies: such as Java 8 or 9, Eclipse Oxygen with modeling tools, or the latest Docker image from docker.umple.org.
+
+## Specify a Brief Description
 
 Brief, one or two sentences explaining the problem. 
 
-## Minimum Steps to Reproduce
+## Give the minimum Steps to Reproduce
 
 This is a **minimum** test case to validate the problem. 
 
@@ -13,7 +15,7 @@ This is a **minimum** test case to validate the problem.
 
 If using a large code sample, feel free to use a [gist](https://gist.github.com/) or [UmpleOnline](http://cruise.eecs.uottawa.ca/umpleonline/).
 
-## Expected Result
+## Describe the expected result that didn't happen
 
 Expected results.
 
@@ -21,10 +23,12 @@ Expected results.
 
 Actual results
 
-Please include your build log output. If long, please paste it into a [gist](https://gist.github.com/) and link to it here. 
+Please include any build log output. If long, please paste it into a [gist](https://gist.github.com/) and link to it here. 
 
 ## Labelling and Assigning
 
-Add any relevant label's for this issue, such as 'associations', 'Component-UmpleOnline', etc. as well as Priority- and Diffic- label.
+If possible, please try to add any relevant label's for this issue, such as 'associations', 'Component-UmpleOnline', etc. as well as Priority- and Diffic- label.
 
-If you are planning on fixing this issue, or know who will, please assign it. Do **not** blindly assign an issue unless you are confident who will be fixing the issue.
+If you are planning on fixing this issue, or know who will, please assign it to yourself.
+
+In the above use [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for formatting. 

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -385,8 +385,7 @@ else if (isset($_REQUEST["umpleCode"]))
     else if ($yumlDiagram) {
       $thedir = dirname($outputFilename);
       exec("rm -rf " . $thedir . "/yuml.txt");
-      $command = "cp " . $thedir . "/model.ump.output " . $thedir .  "/yuml.txt";
-      exec($command);
+      copy($thedir . "/model.ump.output", $thedir .  "/yuml.txt");
       $command = "python yuml.py -i " . $thedir . "/yuml.txt -o " . $thedir .  "/yuml.png -s plain ";   
       $res = shell_exec($command . " 2>&1");           
       $yumllink = $workDir->makePermalink('yuml.txt');

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -391,8 +391,21 @@ else if (isset($_REQUEST["umpleCode"]))
       $res = shell_exec($command . " 2>&1");           
       $yumllink = $workDir->makePermalink('yuml.txt');
       $imglink = $workDir->makePermalink('yuml.png');
-      $html = "<a href=\"$yumllink\">Download the Yuml text for the following</a>&nbsp;<br/>
+      
+      if (file_exists($thedir . "/yuml.png"))
+      {
+        $dltext = "&nbsp;<a href=\"$imglink\">Download the PNG file for the image</a>&nbsp;<br/>
       <img src=\"$imglink\"\>";
+      }
+      else
+      {
+        // could not generate either because of Python problem
+        // or the yuml server not delivering because it doesn't like automated systems
+        $yumltxt = file_get_contents($thedir."/yuml.txt");        
+        $dltext = "&nbsp;<a target=\"yumlimg\" href=\"http://yuml.me/diagram/plain/class/".urlencode($yumltxt).".php\"> Click on this link to display the png in a different Tab (yuml.me doesn't like automated systems generating their images)</a>&nbsp;";
+      }  
+
+      $html = "<a href=\"$yumllink\">Download the Yuml text for the yuml image</a>. You can then use this text to generate various image formats at <a target=\"yumlimg\" href=\"https://yuml.me/diagram/plain/class/draw\">yuml.me</a>&nbsp;<br/>$dltext";
       echo $html;
     } // end yuml diagram  
 

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -167,9 +167,9 @@ $output = $dataHandle->readData('model.ump');
       </div>
       <div class="inRow">
         <p class="pagedescription">
-          Draw on the right, write (Umple) model code on the left. Generate Java, C++, PHP, Alloy, NuSMV or Ruby code from your models. <br/>
-          Visit <a href="http://manual.umple.org" target="helppage">the User Manual</a> or <a href="http://www.umple.org">the Umple Home Page</a> for help.
-          &nbsp;&nbsp;&nbsp;<a href="download_eclipse_umple_plugin.html">Download Umple or run this in Docker for speed</a>
+          Draw on the right, write (Umple) model code on the left. Generate Java, C++, PHP, formal methods and other outputs. <br/>
+          For help: <a href="http://manual.umple.org" target="helppage"> User Manual</a>.  &nbsp;<a href="http://www.umple.org" target="umplehome">Umple Home Page</a>.
+         &nbsp;&nbsp;<a href="download_eclipse_umple_plugin.html" target="dlpage">Download Umple or run this in Docker for speed</a>
           &nbsp;&nbsp;&nbsp;<a href="https://github.com/umple/umple/issues/new" target="newissue">Report an Issue</a>
         </p>
       </div>


### PR DESCRIPTION
It turns out that yuml.me does not always allow generation of images by other servers, also python availability may sometimes be a problem. As a result this PR adjusts Umpleonline to detect whether a yuml image is generated, and if not to instead present a link allowing it to be generated on the yuml,me site with a second click (so the request comes from the user's browser rather than from the server).

A minor change is also made to the issue template to simplify it for end-users; and some real estate is saved in the umpleonline main page by simplifying wording.