### PR TITLE
Cleaning up user manual to fix bugs and make pages narrower

### DIFF
--- a/build/reference/9142TypeIsAccessSpecifier.txt
+++ b/build/reference/9142TypeIsAccessSpecifier.txt
@@ -4,13 +4,15 @@ noreferences
 
 @@description
 
-<h2>Umple warning when a type looks like it was meant as a Java access specifier</h2>
+<h2>Umple warning when a type looks like it was meant as a visibility specifier</h2>
 
 <p>
-Umple does not directly support Java-style access specifiers.
-All attributes are public by default, and other Umple constructs can be used to control how attributes can be used.
+Umple attributes do not support visibility specifiers such as public, private and protected.
+An attribute is private by default, and programmers are supposed to use the corresponding generated get
+method to read it, or the set method to modify it.
 </p>
 
+<p>This warning appears when one of the visibility keywords precedes an attribute.
 
 @@example
 @@source manualexamples/W142TypeIsAccessSpecifierAmbiguous.ump

--- a/build/reference/9180DuplicateAssociationNameSubclass.txt
+++ b/build/reference/9180DuplicateAssociationNameSubclass.txt
@@ -4,9 +4,9 @@ noreferences
 
 @@description
 
-<h2>Umple semantic error reported when a subclass has an association that is not a specialization named the same as a superclass association</h2>
+<h2>Umple semantic error reported when a subclass has an association that is not a specialization, but where the association has the same name as the superclass association</h2>
 
-<p>A subclass can not have an association with the same role name as an association of its superclass, unless it is a valid specialization. 
+<p>A subclass can not have an association with the same role name as an association of its superclass, unless it is a valid specialization. A valid specialization would be to the same class, but with a refined multiplicity (see the second example) 
 </p>
 
 
@@ -14,4 +14,6 @@ noreferences
 @@source manualexamples/E180DuplicateRoleNameSubclass.ump
 @@endexample
 
-
+@@example
+@@source manualexamples/E180DuplicateRoleNameSubclassValidSpecialization.ump
+@@endexample

--- a/build/reference/9906StateMachineSyntax.txt
+++ b/build/reference/9906StateMachineSyntax.txt
@@ -4,9 +4,9 @@ noreferences
 
 @@description
 
-<h2>Umple semantic warning reported when a state machine could not be fully parsed and is treated as 'extra code'.</h2>
+<h2>Umple semantic warning reported when a state machine could not be fully parsed and is treated as &#39;extra code&#39;.</h2>
 
-<p>In Umple, elements of a class not recognized as valid Umple are assumed to be elements of the target programming language that are embedded in the Umple. However, this warning is raised when the Umple compiler has reason to believe that the developer might have been trying to specify a state machine, because the segment of code starts with something like sm {.
+<p>In Umple, elements of a class not recognized as valid Umple are assumed to be elements of the target programming language that are embedded in the Umple. However, this warning is raised when the Umple compiler has reason to believe that the developer might have been trying to specify a state machine, because the segment of code starts with something like sm &#123;.
 </p>
 
 <p>

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -4042,7 +4042,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     {
       if("public".equals(type) || "private".equals(type) || "protected".equals(type))
       {
-	setFailedPosition(attributeToken.getPosition(), 142, type);
+	setFailedPosition(attributeToken.getPosition(), 142, name, type);
       }
     }
         

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -3,251 +3,251 @@
 # 1,2: Error; 3: Warning, code likely incorrect. 4 Warning: Code may be incorrect. 5. Umple compiled, but embedded code had problems.: 
 # Use PageBeingDeveloped.html for new messages before manual pages are created
 
-0: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Generic Umple Error '{0}' ; 
-1: 4, "http://cruise.eecs.uottawa.ca/umple/W001SingletonWithNon-LazyAttribute.html", Lazy keyword is needed on singleton class attribute '{0}' as the attribute cannot added at construction time ; 
-2: 4, "http://cruise.eecs.uottawa.ca/umple/W002SingletonWithRequiredObject.html", Association is referencing a singleton class with multiplicity 1 '{0}' ; 
-3: 4, "http://cruise.eecs.uottawa.ca/umple/W003RedundantLazyWithInitialization.html", The lazy keyword is redundant when the attribute is being initialized - in class '{0}' ;
-4: 1, "http://cruise.eecs.uottawa.ca/umple/E004InvalidMultiplicity.html", Invalid multiplicity '{0}' ; 
-5: 1, "http://cruise.eecs.uottawa.ca/umple/E005UndefinedClassinAssociation.html", Association end '{0}' is not a class or interface ; 
-6: 2, "http://cruise.eecs.uottawa.ca/umple/E006MissingDefault.html", No default value is specified for a defaulted attribute '{0}' ; 
-7: 3, "http://cruise.eecs.uottawa.ca/umple/W007KeyAlreadySpecified.html", Key already specified in class '{0}' ; 
-8: 1, "http://cruise.eecs.uottawa.ca/umple/E008AssociationClassMissingEnd.html", Association class '{0}' is missing an end ; 
-9: 2, "http://cruise.eecs.uottawa.ca/umple/E009ReflexiveLowerBound.html", Reflexive association with multiplicity '{0}' has lower bound > 0 ; 
-10: 3, "http://cruise.eecs.uottawa.ca/umple/W010SingletonMultiplicityOver1.html", Singleton class '{0}' cannot have multiplicity greater than 1 ; 
-11: 1, "http://cruise.eecs.uottawa.ca/umple/E011ClassisSubclassOfSelf.html", {0} '{1}' cannot cyclically extend itself ; 
-12: 1, "http://cruise.eecs.uottawa.ca/umple/E012ClassIndirectlySubclassofSelf.html", {0} '{1}' cannot cyclically extend {0} '{2}' ; 
-13: 2, "http://cruise.eecs.uottawa.ca/umple/E013NonImmutableAssociation.html", Class at directed end of immutable association must be an immutable class ;
-14: 3, "http://cruise.eecs.uottawa.ca/umple/E014ImmutableSubclassofMutable.html", Existing associations, state machines, or superclass for class '{0}' prevents class-level immutability ;
-15: 3, "http://cruise.eecs.uottawa.ca/umple/W015ImmutableClassStateMachine.html", Immutable class '{0}' may not contain state machines ;
-16: 1, "http://cruise.eecs.uottawa.ca/umple/E016NonImmutableSuperclass.html", Immutability rules prevent class '{0}' from subclassing '{1}' ;
-17: 2, "http://cruise.eecs.uottawa.ca/umple/E017NonImmutableBidirectionality.html", Two-way associations may not be immutable ;
-18: 2, "http://cruise.eecs.uottawa.ca/umple/E018ReflexiveImmutable.html", Reflexive immutable associations may not be mandatory ;
-19: 2, "http://cruise.eecs.uottawa.ca/umple/E019DuplicateAssociation.html", There are multiple associations between class '{0}' and class '{1}'. Unique role names need to be added at '{0}' side to distinguish the different association ends in that class. ;
-20: 1, "http://cruise.eecs.uottawa.ca/umple/E020InterfaceAssociationNotOneWay.html", The class-interface association declared in '{0}' must have the '->' arrow ;
+0: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Generic Umple Error '{0}' ; 
+1: 4, "http://manual.umple.org/?W001SingletonWithNon-LazyAttribute.html", Lazy keyword is needed on singleton class attribute '{0}' as the attribute cannot added at construction time ; 
+2: 4, "http://manual.umple.org/?W002SingletonWithRequiredObject.html", Association is referencing a singleton class with multiplicity 1 '{0}' ; 
+3: 4, "http://manual.umple.org/?W003RedundantLazyWithInitialization.html", The lazy keyword is redundant when the attribute is being initialized - in class '{0}' ;
+4: 1, "http://manual.umple.org/?E004InvalidMultiplicity.html", Invalid multiplicity '{0}' ; 
+5: 1, "http://manual.umple.org/?E005UndefinedClassinAssociation.html", Association end '{0}' is not a class or interface ; 
+6: 2, "http://manual.umple.org/?E006MissingDefault.html", No default value is specified for a defaulted attribute '{0}' ; 
+7: 3, "http://manual.umple.org/?W007KeyAlreadySpecified.html", Key already specified in class '{0}' ; 
+8: 1, "http://manual.umple.org/?E008AssociationClassMissingEnd.html", Association class '{0}' is missing an end ; 
+9: 2, "http://manual.umple.org/?E009ReflexiveLowerBound.html", Reflexive association with multiplicity '{0}' has lower bound > 0 ; 
+10: 3, "http://manual.umple.org/?W010SingletonMultiplicityOver1.html", Singleton class '{0}' cannot have multiplicity greater than 1 ; 
+11: 1, "http://manual.umple.org/?E011ClassisSubclassOfSelf.html", {0} '{1}' cannot cyclically extend itself ; 
+12: 1, "http://manual.umple.org/?E012ClassIndirectlySubclassofSelf.html", {0} '{1}' cannot cyclically extend {0} '{2}' ; 
+13: 2, "http://manual.umple.org/?E013NonImmutableAssociation.html", Class at directed end of immutable association must be an immutable class ;
+14: 3, "http://manual.umple.org/?E014ImmutableSubclassofMutable.html", Existing associations, state machines, or superclass for class '{0}' prevents class-level immutability ;
+15: 3, "http://manual.umple.org/?W015ImmutableClassStateMachine.html", Immutable class '{0}' may not contain state machines ;
+16: 1, "http://manual.umple.org/?E016NonImmutableSuperclass.html", Immutability rules prevent class '{0}' from subclassing '{1}' ;
+17: 2, "http://manual.umple.org/?E017NonImmutableBidirectionality.html", Two-way associations may not be immutable ;
+18: 2, "http://manual.umple.org/?E018ReflexiveImmutable.html", Reflexive immutable associations may not be mandatory ;
+19: 2, "http://manual.umple.org/?E019DuplicateAssociation.html", There are multiple associations between class '{0}' and class '{1}'. Unique role names need to be added at '{0}' side to distinguish the different association ends in that class. ;
+20: 1, "http://manual.umple.org/?E020InterfaceAssociationNotOneWay.html", The class-interface association declared in '{0}' must have the '->' arrow ;
 
-21: 2, "http://cruise.eecs.uottawa.ca/umple/E021InvalidReflexiveAssociation.html", Reflexive association to class '{0}' must use a role name or else the keyword self ;
-22: 2, "http://cruise.eecs.uottawa.ca/umple/E022DuplicateAttribute.html", Class '{0}' has duplicate attribute name {1} ;
-23: 2, "http://cruise.eecs.uottawa.ca/umple/E023AttributeAssociationNameClash.html", Class '{0}' has attribute name {1} that duplicates an association name, or vice-versa ;
-24: 2, "http://cruise.eecs.uottawa.ca/umple/E024SortKeyNotofUmpleType.html", Sort key attribute '{0}' in class {1} must be of type Integer, Short, Long, Double, Float or String ;
-25: 2, "http://cruise.eecs.uottawa.ca/umple/E025SortKeyNotFound.html", Class '{0}' does not contain attribute {1} that is used as sort key ;
-26: 2, "http://cruise.eecs.uottawa.ca/umple/E026DuplicateKeyItem.html", Duplicate item '{0}' in key statement(s) in class '{1}' ;
-27: 3, "http://cruise.eecs.uottawa.ca/umple/W027KeyIdentifierIncorrect.html", Item '{0}' in key statement is not defined in class '{1}' ;
-28: 3, "http://cruise.eecs.uottawa.ca/umple/E028ConstraintIdentifierIncorrect.html", Attribute '{0}' in constraint is not defined in class '{1}' ;
-29: 2, "http://cruise.eecs.uottawa.ca/umple/E029ConstraintTypeMismatch.html", Attribute '{0}' in constraint must be of type '{1}' ;
+21: 2, "http://manual.umple.org/?E021InvalidReflexiveAssociation.html", Reflexive association to class '{0}' must use a role name or else the keyword self ;
+22: 2, "http://manual.umple.org/?E022DuplicateAttribute.html", Class '{0}' has duplicate attribute name {1} ;
+23: 2, "http://manual.umple.org/?E023AttributeAssociationNameClash.html", Class '{0}' has attribute name {1} that duplicates an association name, or vice-versa ;
+24: 2, "http://manual.umple.org/?E024SortKeyNotofUmpleType.html", Sort key attribute '{0}' in class {1} must be of type Integer, Short, Long, Double, Float or String ;
+25: 2, "http://manual.umple.org/?E025SortKeyNotFound.html", Class '{0}' does not contain attribute {1} that is used as sort key ;
+26: 2, "http://manual.umple.org/?E026DuplicateKeyItem.html", Duplicate item '{0}' in key statement(s) in class '{1}' ;
+27: 3, "http://manual.umple.org/?W027KeyIdentifierIncorrect.html", Item '{0}' in key statement is not defined in class '{1}' ;
+28: 3, "http://manual.umple.org/?E028ConstraintIdentifierIncorrect.html", Attribute '{0}' in constraint is not defined in class '{1}' ;
+29: 2, "http://manual.umple.org/?E029ConstraintTypeMismatch.html", Attribute '{0}' in constraint must be of type '{1}' ;
 
-30: 4, "http://cruise.eecs.uottawa.ca/umple/W030RedefinedNamespace.html", Redefining the namespace of class {0} to {1} ;
-31: 4, "http://cruise.eecs.uottawa.ca/umple/W031NamespaceNotUsed.html", Declared namespace {0} was not used before declaring {1} ;
-32: 1, "http://cruise.eecs.uottawa.ca/umple/E032ReservedRoleName.html", The role name '{0}' has a conflict. Please don't use plural form of class name as a role name ;
-33: 3, "http://cruise.eecs.uottawa.ca/umple/W033MissingSuperclass.html", The indicated superclass {0} of class {1} does not exist and has been ignored. Declare {0} to be external if it is defined outside this Umple system ;
-34: 2, "http://cruise.eecs.uottawa.ca/umple/E034MultipleInheritance.html", Multiple inheritance not allowed in Umple so  code can be generated for languages that do not permit it. So class {0} cannot be a subclass of class {1} as well as other classes. Consider using multiple implementations of an interface or using traits ;
-35: 4, "http://cruise.eecs.uottawa.ca/umple/W035UninitializedConstant.html", 'const' variable '{0}' of type '{1}' was not initialized and its value was thus set to '{2}' ;
-36: 3, "http://cruise.eecs.uottawa.ca/umple/W036UnmanagedMultiplicity.html", The specific multiplicity bounds {0} cannot be managed by generated code, since this is a directed association ;
-37: 2, "http://cruise.eecs.uottawa.ca/umple/E037UninitializedConstantObject.html", 'const' variable '{0}' of type '{1}' was not initialized. Since '{1}' is not a built-in Umple data type no default value could be found. '{0}' must be initialized. ;
-38: 2, "http://cruise.eecs.uottawa.ca/umple/W9999FeatureUnderDevelopment.html", Attribute '{0}' has a name conflict with attribute auto generated by '{1}' variable '{2}';
-39: 3, "http://cruise.eecs.uottawa.ca/umple/W033MissingSuperclass.html", The interface {0} extends  an interface {1} that does not exist and has been ignored. Declare {1} to be external if it is defined outside this Umple system ;
+30: 4, "http://manual.umple.org/?W030RedefinedNamespace.html", Redefining the namespace of class {0} to {1} ;
+31: 4, "http://manual.umple.org/?W031NamespaceNotUsed.html", Declared namespace {0} was not used before declaring {1} ;
+32: 1, "http://manual.umple.org/?E032ReservedRoleName.html", The role name '{0}' has a conflict. Please don't use plural form of class name as a role name ;
+33: 3, "http://manual.umple.org/?W033MissingSuperclass.html", The indicated superclass {0} of class {1} does not exist and has been ignored. Declare {0} to be external if it is defined outside this Umple system ;
+34: 2, "http://manual.umple.org/?E034MultipleInheritance.html", Multiple inheritance not allowed in Umple so  code can be generated for languages that do not permit it. So class {0} cannot be a subclass of class {1} as well as other classes. Consider using multiple implementations of an interface or using traits ;
+35: 4, "http://manual.umple.org/?W035UninitializedConstant.html", 'const' variable '{0}' of type '{1}' was not initialized and its value was thus set to '{2}' ;
+36: 3, "http://manual.umple.org/?W036UnmanagedMultiplicity.html", The specific multiplicity bounds {0} cannot be managed by generated code, since this is a directed association ;
+37: 2, "http://manual.umple.org/?E037UninitializedConstantObject.html", 'const' variable '{0}' of type '{1}' was not initialized. Since '{1}' is not a built-in Umple data type no default value could be found. '{0}' must be initialized. ;
+38: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Attribute '{0}' has a name conflict with attribute auto generated by '{1}' variable '{2}';
+39: 3, "http://manual.umple.org/?W033MissingSuperclass.html", The interface {0} extends  an interface {1} that does not exist and has been ignored. Declare {1} to be external if it is defined outside this Umple system ;
 
-40: 2, "http://cruise.eecs.uottawa.ca/umple/E040SingletonHasSubclasses.html", Singleton classes have a private constructor and cannot be extended. So class {0} cannot be a subclass of singleton class {1} ;
-44: 3, "http://cruise.eecs.uottawa.ca/umple/W044AttributeDuplicatedinSuperclass.html", Class '{0}' has attribute name {1} that duplicates an attribute inherited from a superclass '{2}'. New definition is being disregarded ;
-45: 4, "http://cruise.eecs.uottawa.ca/umple/W045InitializedValueinKey.html", Attribute '{0}' in class '{1}' is in the key. Initializing it will result in all instances having this same value and being treated as equal ;
-46: 4, "http://cruise.eecs.uottawa.ca/umple/W046AttributeHasTemplateType.html", Attribute {0} in class {1} is declared using a collection template type {2}. Use a directed association (->) or multi-valued attribute([]) to follow proper modelling conventions ;
-47: 4, "http://cruise.eecs.uottawa.ca/umple/W047EmptyKeyStatement.html", Empty key statement in class {0} ;
-48: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute '{0}' in class '{1}' generates method '{2}' which is a duplicate;
-49: 4, "http://cruise.eecs.uottawa.ca/umple/W049DuplicatedMethodName.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file. New definition at line {4} of '{5}' file is being disregarded;
+40: 2, "http://manual.umple.org/?E040SingletonHasSubclasses.html", Singleton classes have a private constructor and cannot be extended. So class {0} cannot be a subclass of singleton class {1} ;
+44: 3, "http://manual.umple.org/?W044AttributeDuplicatedinSuperclass.html", Class '{0}' has attribute name {1} that duplicates an attribute inherited from a superclass '{2}'. New definition is being disregarded ;
+45: 4, "http://manual.umple.org/?W045InitializedValueinKey.html", Attribute '{0}' in class '{1}' is in the key. Initializing it will result in all instances having this same value and being treated as equal ;
+46: 4, "http://manual.umple.org/?W046AttributeHasTemplateType.html", Attribute {0} in class {1} is declared using a collection template type {2}. Use a directed association (->) or multi-valued attribute([]) to follow proper modelling conventions ;
+47: 4, "http://manual.umple.org/?W047EmptyKeyStatement.html", Empty key statement in class {0} ;
+48: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Attribute '{0}' in class '{1}' generates method '{2}' which is a duplicate;
+49: 4, "http://manual.umple.org/?W049DuplicatedMethodName.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file. New definition at line {4} of '{5}' file is being disregarded;
 
 # State-Machine related messages
-50: 4, "http://cruise.eecs.uottawa.ca/umple/W050TargetStateNotFound.html", State '{0}' has not been declared, it is being treated as an new state ;
-51: 2, "http://cruise.eecs.uottawa.ca/umple/E051EventParametersMustMatch.html", Event parameter(s) '{0}' inconsistent with previous declaration of the same event ; 
-52: 2, "http://cruise.eecs.uottawa.ca/umple/E052StateMachineNameClash.html", Association or attribute can not have same name as state machine '{0}' ;
-53: 2, "http://cruise.eecs.uottawa.ca/umple/E053NoConcurrencyAtTopLevel.html", State machine {0} has concurrent states, but concurrency is only allowed in nested substates or in 'active' blocks ;
-54: 4, "http://cruise.eecs.uottawa.ca/umple/W054DuplicateEvents.html", Transition {0} will be ignored due to a unguarded duplicate event;
-55: 4, "http://cruise.eecs.uottawa.ca/umple/W055DuplicateEventsWithinSubstates.html", Transition {0} in super-state will be ignored due to unguarded duplicate events in all sub-states ;
-56: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Queued State machine {0} has no events to be queued ;
-57: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Pooled State machine {0} has no events to be pooled ;
-58: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have queued state machine, pooled state machine, and regular state machine in the same class ;
-59: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have both queued state machine and pooled state machine in the same class ;
-60: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have both pooled state machine and regular state machine in the same class ;
-61: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", class {0} cannot have queued state machine and regular state machine in the same class ;
-62: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", (unspecified) must not be used in combination with Pooled State machine {0} - it is treated such as other regular events - it is pooled ;
-63: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", {0} is a reserved name for History or Deep History States ;
-64: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state in a non existent state within state machine {0} ;
-65: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state at a state without substates within state machine {0} ;
-66: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Transition to '{0}' has multiple possible destinations. Please use dot notation to clarify what state the transition should go to ;
-67: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html",  State '{0}' from StateMachine '{1}' is non-reachable. ;
-68: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Destination state '{0}' of transition on line '{1}' has not been found. This transition is being disregarded ;
-69: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Auto-Transition to '{0}' on line '{1}' conflicts with a previous exisiting transition. This transition is being disregarded ;
-70: 4, "http://cruise.eecs.uottawa.ca/umple/W054DuplicateEvents.html", Guarded Transition {0} will be ignored due to a duplicate event with an equivalent guard ;
+50: 4, "http://manual.umple.org/?W050TargetStateNotFound.html", State '{0}' has not been declared, it is being treated as an new state ;
+51: 2, "http://manual.umple.org/?E051EventParametersMustMatch.html", Event parameter(s) '{0}' inconsistent with previous declaration of the same event ; 
+52: 2, "http://manual.umple.org/?E052StateMachineNameClash.html", Association or attribute can not have same name as state machine '{0}' ;
+53: 2, "http://manual.umple.org/?E053NoConcurrencyAtTopLevel.html", State machine {0} has concurrent states, but concurrency is only allowed in nested substates or in 'active' blocks ;
+54: 4, "http://manual.umple.org/?W054DuplicateEvents.html", Transition {0} will be ignored due to a unguarded duplicate event;
+55: 4, "http://manual.umple.org/?W055DuplicateEventsWithinSubstates.html", Transition {0} in super-state will be ignored due to unguarded duplicate events in all sub-states ;
+56: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Queued State machine {0} has no events to be queued ;
+57: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Pooled State machine {0} has no events to be pooled ;
+58: 1, "http://manual.umple.org/?PageBeingDeveloped.html", class {0} cannot have queued state machine, pooled state machine, and regular state machine in the same class ;
+59: 1, "http://manual.umple.org/?PageBeingDeveloped.html", class {0} cannot have both queued state machine and pooled state machine in the same class ;
+60: 1, "http://manual.umple.org/?PageBeingDeveloped.html", class {0} cannot have both pooled state machine and regular state machine in the same class ;
+61: 1, "http://manual.umple.org/?PageBeingDeveloped.html", class {0} cannot have queued state machine and regular state machine in the same class ;
+62: 4, "http://manual.umple.org/?PageBeingDeveloped.html", (unspecified) must not be used in combination with Pooled State machine {0} - it is treated such as other regular events - it is pooled ;
+63: 1, "http://manual.umple.org/?PageBeingDeveloped.html", {0} is a reserved name for History or Deep History States ;
+64: 1, "http://manual.umple.org/?PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state in a non existent state within state machine {0} ;
+65: 1, "http://manual.umple.org/?PageBeingDeveloped.html", You declared a History (H) or Deep History (HStar) state at a state without substates within state machine {0} ;
+66: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Transition to '{0}' has multiple possible destinations. Please use dot notation to clarify what state the transition should go to ;
+67: 4, "http://manual.umple.org/?PageBeingDeveloped.html",  State '{0}' from StateMachine '{1}' is non-reachable. ;
+68: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Destination state '{0}' of transition on line '{1}' has not been found. This transition is being disregarded ;
+69: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Auto-Transition to '{0}' on line '{1}' conflicts with a previous exisiting transition. This transition is being disregarded ;
+70: 4, "http://manual.umple.org/?W054DuplicateEvents.html", Guarded Transition {0} will be ignored due to a duplicate event with an equivalent guard ;
 
-71: 4, "http://cruise.eecs.uottawa.ca/umple/W071DuplicateMethodDifferentType.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file, which returns a different type. New definition at line {4} of '{5}' file is being disregarded ;
-72: 4, "http://cruise.eecs.uottawa.ca/umple/W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
-73: 2, "http://cruise.eecs.uottawa.ca/umple/E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
-74: 2, "http://cruise.eecs.uottawa.ca/umple/E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
-80: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", State '{0}' was not found in state machine '{1}'. Processed as if the state exists ;
+71: 4, "http://manual.umple.org/?W071DuplicateMethodDifferentType.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file, which returns a different type. New definition at line {4} of '{5}' file is being disregarded ;
+72: 4, "http://manual.umple.org/?W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
+73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
+74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
+80: 4, "http://manual.umple.org/?PageBeingDeveloped.html", State '{0}' was not found in state machine '{1}'. Processed as if the state exists ;
 
 # Model Constraints' Error messages
-90: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute named {0} was not found in class {1}, as required in constraint ;
-91: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute with type {0} was not found in class {1}, as required in constraint ;
-92: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to be a subclass of class {1}, as required in constraint ;
-93: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to be a superclass of class {1}, as required in constraint ;
-94: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class {0} was not found to have an association to class {1}, as required in constraint ;
+90: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Attribute named {0} was not found in class {1}, as required in constraint ;
+91: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Attribute with type {0} was not found in class {1}, as required in constraint ;
+92: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Class {0} was not found to be a subclass of class {1}, as required in constraint ;
+93: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Class {0} was not found to be a superclass of class {1}, as required in constraint ;
+94: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Class {0} was not found to have an association to class {1}, as required in constraint ;
 
 # Enumeration Errors and Warnings
-95: 2, "http://cruise.eecs.uottawa.ca/umple/E095DuplicateEnumerations.html", Detected duplicate enumeration '{0}' on line '{1}' ;
-96: 2, "http://cruise.eecs.uottawa.ca/umple/E096EnumerationNameConflict.html", Enumeration name '{0}' on line '{1}' conflicts with model element on line '{2}' ;
-97: 2, "http://cruise.eecs.uottawa.ca/umple/E097EnumerationAndStateMachineConflict.html", Enumeration '{0}' on line '{1}' conflicts with state machine '{2}' in class '{3}' ;
-102: 4, "http://cruise.eecs.uottawa.ca/umple/W102EnumerationCausesMethodParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for method '{3}' on line '{4}' instead of class '{5}' ;
-103: 4, "http://cruise.eecs.uottawa.ca/umple/W103EnumerationCausesEventParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for event '{3}' in state machine '{4}' instead of class '{5}' ;
-104: 2, "http://cruise.eecs.uottawa.ca/umple/E104EnumerationInBidirectionalAssociation.html", Cannot use enumeration '{0}' on line '{1}' in bidirectional association on line '{2}' in class '{3}' ;
-105: 2, "http://cruise.eecs.uottawa.ca/umple/E105EnumerationInComposition.html", Cannot use enumeration '{0}' on line '{1}' in composition on line '{2}' in class '{3}' ;
-106: 4, "http://cruise.eecs.uottawa.ca/umple/W106EnumerationInUnidirectionalAssociation.html", Assuming enumeration '{0}' on line '{1}' is used in unidirectional association on line '{2}' instead of class '{3}' ; 
+95: 2, "http://manual.umple.org/?E095DuplicateEnumerations.html", Detected duplicate enumeration '{0}' on line '{1}' ;
+96: 2, "http://manual.umple.org/?E096EnumerationNameConflict.html", Enumeration name '{0}' on line '{1}' conflicts with model element on line '{2}' ;
+97: 2, "http://manual.umple.org/?E097EnumerationAndStateMachineConflict.html", Enumeration '{0}' on line '{1}' conflicts with state machine '{2}' in class '{3}' ;
+102: 4, "http://manual.umple.org/?W102EnumerationCausesMethodParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for method '{3}' on line '{4}' instead of class '{5}' ;
+103: 4, "http://manual.umple.org/?W103EnumerationCausesEventParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for event '{3}' in state machine '{4}' instead of class '{5}' ;
+104: 2, "http://manual.umple.org/?E104EnumerationInBidirectionalAssociation.html", Cannot use enumeration '{0}' on line '{1}' in bidirectional association on line '{2}' in class '{3}' ;
+105: 2, "http://manual.umple.org/?E105EnumerationInComposition.html", Cannot use enumeration '{0}' on line '{1}' in composition on line '{2}' in class '{3}' ;
+106: 4, "http://manual.umple.org/?W106EnumerationInUnidirectionalAssociation.html", Assuming enumeration '{0}' on line '{1}' is used in unidirectional association on line '{2}' instead of class '{3}' ; 
 
 # Messages relating to format of identifiers.
-100: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Class name '{0}' must be alphanumeric and start with an alpha character, or _ (underscore) ;
-101: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Class name '{0}' should start with a capital letter ;
+100: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Class name '{0}' must be alphanumeric and start with an alpha character, or _ (underscore) ;
+101: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Class name '{0}' should start with a capital letter ;
 
-110: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Interface name '{0}' must be alphanumeric and start with an alpha character or _ (underscore) ;
-111: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Interface name '{0}' should start with a capital letter ;
-112: 2, "http://cruise.eecs.uottawa.ca/umple/E112DuplicateConstantsinInterface.html", Interface '{0}' has duplicate constant name {1} ;
+110: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' must be alphanumeric and start with an alpha character or _ (underscore) ;
+111: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' should start with a capital letter ;
+112: 2, "http://manual.umple.org/?E112DuplicateConstantsinInterface.html", Interface '{0}' has duplicate constant name {1} ;
 
-# [TODO - issue 337] 120: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Association role name '{0}' must be alphanumeric and start with a letter ;
-# [TODO - issue 337] 121: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Association role name '{0}' should start with a lower-case letter ;
+# [TODO - issue 337] 120: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' must be alphanumeric and start with a letter ;
+# [TODO - issue 337] 121: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' should start with a lower-case letter ;
 
-130: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Attribute name '{0}' must be alphanumeric, starting with a lower-case letter ;
-131: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Attribute name '{0}' should start with a lower-case letter ;
-132: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Attribute name '{0}' contains special characters. Association declaration must be separated by spaces ;
+130: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' must be alphanumeric, starting with a lower-case letter ;
+131: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' should start with a lower-case letter ;
+132: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' contains special characters. Association declaration must be separated by spaces ;
 
-140: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Attribute type name '{0}' must be alphanumeric, starting with a letter ;
-141: 4, "http://cruise.eecs.uottawa.ca/umple/W141ValueTypeMismatch.html", Mismatch between type '{0}' and value {1} ;
-142: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Attribute '{0}' has a type of {public|private|protected}. This looks like an access specifier and is likely an error. In Umple attributes are private by default, and are Strings if no type is specified. ;
+140: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute type name '{0}' must be alphanumeric, starting with a letter ;
+141: 4, "http://manual.umple.org/?W141ValueTypeMismatch.html", Mismatch between type '{0}' and value {1} ;
+142: 3, "http://manual.umple.org/?W142Typeisaccessspecifier.html", Attribute '{0}' has a type of {public|private|protected}. This looks like a variable of type '{1}' and is likely an error. In Umple attributes are private by default, and are Strings if no type is specified. ;
 
-150: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", State machine name '{0}' must be alphanumeric and start with a letter ;
-152: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", State name '{0}' must be alphanumeric and start with a letter ;
+150: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", State machine name '{0}' must be alphanumeric and start with a letter ;
+152: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", State name '{0}' must be alphanumeric and start with a letter ;
 
-160: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Constant name '{0}' must be alphanumeric, starting with a upper-case letter ;
-161: 4, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Constant name '{0}' should start with a upper-case letter ;
+160: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Constant name '{0}' must be alphanumeric, starting with a upper-case letter ;
+161: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Constant name '{0}' should start with a upper-case letter ;
 
-180: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
+180: 2, "http://manual.umple.org/?E180DuplicateAssociationNameClassHierarchy", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
 
 # Messages related to traits starting with 200
-200: 2, "http://cruise.eecs.uottawa.ca/umple/E200TraitIdentifierInvalid.html", The name of trait '{0}' must be alphanumeric and start with an alpha character, or _ . ;
-201: 4, "http://cruise.eecs.uottawa.ca/umple/W201TraitNameSyntax.html", The name of trait '{0}' should be started with a capital letter. ;
-202: 1, "http://cruise.eecs.uottawa.ca/umple/E202Traitnotdefined.html", The trait named '{0}' is not available. ;
-203: 1, "http://cruise.eecs.uottawa.ca/umple/E203Nothavinganuniqueidentifier.html", There is a {0} and a trait with the same name '{1}'. Solution: Please just change the name of trait or {0} and give it an unique name. ;
-204: 1, "http://cruise.eecs.uottawa.ca/umple/E204SelfUseofTraits.html", The trait named '{0}' cannot use itself. Solution: Please check the name of used trait or change your design not to have this use. ;
+200: 2, "http://manual.umple.org/?E200TraitIdentifierInvalid.html", The name of trait '{0}' must be alphanumeric and start with an alpha character, or _ . ;
+201: 4, "http://manual.umple.org/?W201TraitNameSyntax.html", The name of trait '{0}' should be started with a capital letter. ;
+202: 1, "http://manual.umple.org/?E202Traitnotdefined.html", The trait named '{0}' is not available. ;
+203: 1, "http://manual.umple.org/?E203Nothavinganuniqueidentifier.html", There is a {0} and a trait with the same name '{1}'. Solution: Please just change the name of trait or {0} and give it an unique name. ;
+204: 1, "http://manual.umple.org/?E204SelfUseofTraits.html", The trait named '{0}' cannot use itself. Solution: Please check the name of used trait or change your design not to have this use. ;
 #need to be added to manual
-205: 1, "http://cruise.eecs.uottawa.ca/umple/E205CycleinTraits.html", Trait '{0}' cannot cyclically extend '{1}'. ;
-206: 1, "http://cruise.eecs.uottawa.ca/umple/E206SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must implement interface '{5}';
+205: 1, "http://manual.umple.org/?E205CycleinTraits.html", Trait '{0}' cannot cyclically extend '{1}'. ;
+206: 1, "http://manual.umple.org/?E206SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must implement interface '{5}';
 
 # 207 has not been used.
-207: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Variable '{0}' inside of the constraint in trait '{1}' is not available in class '{2}' or trait '{1}'. ;
-208: 1, "http://cruise.eecs.uottawa.ca/umple/E208RequiredMethodsNotAvailable.html", Required method '{0}' in trait '{1}' is not available in class '{2}'. ;
+207: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Variable '{0}' inside of the constraint in trait '{1}' is not available in class '{2}' or trait '{1}'. ;
+208: 1, "http://manual.umple.org/?E208RequiredMethodsNotAvailable.html", Required method '{0}' in trait '{1}' is not available in class '{2}'. ;
 # 209 has not been used.
-209: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Defined name '{0}' in trait '{1}' is not available in the trait's header. ;
-210: 1, "http://cruise.eecs.uottawa.ca/umple/E210ConflictinMethods.html", In {0} '{1}', there is a conflict on method '{2}' which comes from two different traits '{3}' and '{4}'. ;
-211: 1, "http://cruise.eecs.uottawa.ca/umple/E211TwoorMoreModifications.html", In the modification level of trait '{0}', method '{1}' has been defined two times. ;
-212: 1, "http://cruise.eecs.uottawa.ca/umple/E212MethodsNotAvailable.html", Method '{0}' is not available in trait '{1}' for modification. ;
-213: 1, "http://cruise.eecs.uottawa.ca/umple/E213BidirectionalAssociationinTraits.html", The bidirectional association inside trait '{0}' must be with a class. ;
+209: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Defined name '{0}' in trait '{1}' is not available in the trait's header. ;
+210: 1, "http://manual.umple.org/?E210ConflictinMethods.html", In {0} '{1}', there is a conflict on method '{2}' which comes from two different traits '{3}' and '{4}'. ;
+211: 1, "http://manual.umple.org/?E211TwoorMoreModifications.html", In the modification level of trait '{0}', method '{1}' has been defined two times. ;
+212: 1, "http://manual.umple.org/?E212MethodsNotAvailable.html", Method '{0}' is not available in trait '{1}' for modification. ;
+213: 1, "http://manual.umple.org/?E213BidirectionalAssociationinTraits.html", The bidirectional association inside trait '{0}' must be with a class. ;
 
-214: 1, "http://cruise.eecs.uottawa.ca/umple/E214TwoIdenticalParameterNames.html", It is impossible to have two parameters with the same name '{0}' in trait'{1}'. ;
-215: 1, "http://cruise.eecs.uottawa.ca/umple/E215TemplateParameterNotAvailable.html", Parameter '{0}' is not available. ;
-216: 1, "http://cruise.eecs.uottawa.ca/umple/E216TwiceBindingofaParameter.html", Parameter '{0}' cannot be allocated two times. ;
-217: 1, "http://cruise.eecs.uottawa.ca/umple/E217ConflictinTypesofAttributes.html", There is a conflict for attribute '{0}' in traits '{1}' because of assigning two different types '{2}' and '{3}'. ;
-218: 3, "http://cruise.eecs.uottawa.ca/umple/W218ConflictinAttributes.html", The attribute '{0}' which comes from trait '{1}' is also available in {2} '{3}'. ;
-219: 1, "http://cruise.eecs.uottawa.ca/umple/E219NoBindingforParameters.html", Please assign a value for type parameter '{0}' in trait '{1}' ;
-220: 1, "http://cruise.eecs.uottawa.ca/umple/E220TwoMethodsWiththeSameName.html", The new name '{0}' for method '{1}' is already available in the trait. ;
-221: 1, "http://cruise.eecs.uottawa.ca/umple/E221AvailabilityofBoundType.html", Binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' is not available in the system.;
-222: 1, "http://cruise.eecs.uottawa.ca/umple/E222SatisfactionofRequiredInterfaces.html", Class '{0}' must implement interface '{1}' so as to be able to use trait '{2}'.;
-223: 1, "http://cruise.eecs.uottawa.ca/umple/E223AvailabilityofTypes.html", The type of '{0}' in template parameter '{1}' in trait '{2}' has not been defined.;
-224: 1, "http://cruise.eecs.uottawa.ca/umple/E224MultipleInheritanceConstraint.html", Template parameter '{0}' in trait '{1}' has an multiple inheritance restriction, according to classes '{2}' and '{3}', which is not supported. Restrictions must cover single inheritance and multiple interface.;
-225: 1, "http://cruise.eecs.uottawa.ca/umple/E225SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must be a subclass of class '{5}';
+214: 1, "http://manual.umple.org/?E214TwoIdenticalParameterNames.html", It is impossible to have two parameters with the same name '{0}' in trait'{1}'. ;
+215: 1, "http://manual.umple.org/?E215TemplateParameterNotAvailable.html", Parameter '{0}' is not available. ;
+216: 1, "http://manual.umple.org/?E216TwiceBindingofaParameter.html", Parameter '{0}' cannot be allocated two times. ;
+217: 1, "http://manual.umple.org/?E217ConflictinTypesofAttributes.html", There is a conflict for attribute '{0}' in traits '{1}' because of assigning two different types '{2}' and '{3}'. ;
+218: 3, "http://manual.umple.org/?W218ConflictinAttributes.html", The attribute '{0}' which comes from trait '{1}' is also available in {2} '{3}'. ;
+219: 1, "http://manual.umple.org/?E219NoBindingforParameters.html", Please assign a value for type parameter '{0}' in trait '{1}' ;
+220: 1, "http://manual.umple.org/?E220TwoMethodsWiththeSameName.html", The new name '{0}' for method '{1}' is already available in the trait. ;
+221: 1, "http://manual.umple.org/?E221AvailabilityofBoundType.html", Binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' is not available in the system.;
+222: 1, "http://manual.umple.org/?E222SatisfactionofRequiredInterfaces.html", Class '{0}' must implement interface '{1}' so as to be able to use trait '{2}'.;
+223: 1, "http://manual.umple.org/?E223AvailabilityofTypes.html", The type of '{0}' in template parameter '{1}' in trait '{2}' has not been defined.;
+224: 1, "http://manual.umple.org/?E224MultipleInheritanceConstraint.html", Template parameter '{0}' in trait '{1}' has an multiple inheritance restriction, according to classes '{2}' and '{3}', which is not supported. Restrictions must cover single inheritance and multiple interface.;
+225: 1, "http://manual.umple.org/?E225SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must be a subclass of class '{5}';
 #226 and 227 must be explored.
-226: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' is the native state machine in {2} '{3}'.Therefore, it's disregarded.;
-227: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' in the {2} '{3}' has already been imported from the trait '{4}'.Therefore, it's disregarded.;
-228: 3, "http://cruise.eecs.uottawa.ca/umple/W228DifferentInitialStates.html", Since there are two state machines/composite states with the same name '{0}' and having two initial states is not acceptable. These two state machines/composite states are merged as a parallel state machine.;
-229: 1, "http://cruise.eecs.uottawa.ca/umple/E229TwoTimesRenaming.html", In the modification level of trait '{0}', the state machine/state/event '{1}' has been defined two times. ;
-230: 1, "http://cruise.eecs.uottawa.ca/umple/E230AvailabilityofStateMachines.html", In the modification level of trait '{0}', the state machine/state '{1}' does not exist. ;
-231: 1, "http://cruise.eecs.uottawa.ca/umple/E231AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machine '{1}', the event '{2}' does not exist. ;
-232: 1, "http://cruise.eecs.uottawa.ca/umple/E232AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machines, the event '{1}' does not exist. ;
-233: 1, "http://cruise.eecs.uottawa.ca/umple/E233RemovingInitialState.html", In the modification level of trait '{0}', the {1} state {2} cannot be removed.;
-234: 1, "http://cruise.eecs.uottawa.ca/umple/E234CompositingNon-DeterministicTransitions.html", In the composition level of trait, the event '{0}' which comes from '{1}' and '{2}' results in none-determinism so the composition is not allowed.;
-235: 1, "http://cruise.eecs.uottawa.ca/umple/E235SuperCallConflict.html", In the composition level of trait, the event '{0}' in state '{1}' which comes from traits '{2}' and '{3}' results in a conflict.;
-236: 1, "http://cruise.eecs.uottawa.ca/umple/E236TwoStateEntries.html", In the composition level of trait, the '{0}' activity/action in state '{1}', which comes from traits '{2}' and '{3}', results in a conflict.;
-237: 1, "http://cruise.eecs.uottawa.ca/umple/E237ComposingTwoStateEntries.html", In the modification level of trait '{0}', state '{1}' has already have another region with the name '{2}'.;
+226: 3, "http://manual.umple.org/?PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' is the native state machine in {2} '{3}'.Therefore, it's disregarded.;
+227: 3, "http://manual.umple.org/?PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' in the {2} '{3}' has already been imported from the trait '{4}'.Therefore, it's disregarded.;
+228: 3, "http://manual.umple.org/?W228DifferentInitialStates.html", Since there are two state machines/composite states with the same name '{0}' and having two initial states is not acceptable. These two state machines/composite states are merged as a parallel state machine.;
+229: 1, "http://manual.umple.org/?E229TwoTimesRenaming.html", In the modification level of trait '{0}', the state machine/state/event '{1}' has been defined two times. ;
+230: 1, "http://manual.umple.org/?E230AvailabilityofStateMachines.html", In the modification level of trait '{0}', the state machine/state '{1}' does not exist. ;
+231: 1, "http://manual.umple.org/?E231AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machine '{1}', the event '{2}' does not exist. ;
+232: 1, "http://manual.umple.org/?E232AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machines, the event '{1}' does not exist. ;
+233: 1, "http://manual.umple.org/?E233RemovingInitialState.html", In the modification level of trait '{0}', the {1} state {2} cannot be removed.;
+234: 1, "http://manual.umple.org/?E234CompositingNon-DeterministicTransitions.html", In the composition level of trait, the event '{0}' which comes from '{1}' and '{2}' results in none-determinism so the composition is not allowed.;
+235: 1, "http://manual.umple.org/?E235SuperCallConflict.html", In the composition level of trait, the event '{0}' in state '{1}' which comes from traits '{2}' and '{3}' results in a conflict.;
+236: 1, "http://manual.umple.org/?E236TwoStateEntries.html", In the composition level of trait, the '{0}' activity/action in state '{1}', which comes from traits '{2}' and '{3}', results in a conflict.;
+237: 1, "http://manual.umple.org/?E237ComposingTwoStateEntries.html", In the modification level of trait '{0}', state '{1}' has already have another region with the name '{2}'.;
 
 # Messages related to MOTL starting with 300
-301: 4,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Tracing of non-existent model entity ;
-302: 4,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Tracer not recognized - Console tracer is defaulted ;
-303: 1,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Parsing error: Incorrect attribute trace prefix '{0}' (Prefix can be set/get/both) ;
+301: 4,  "http://manual.umple.org/?PageBeingDeveloped.html", Tracing of non-existent model entity ;
+302: 4,  "http://manual.umple.org/?PageBeingDeveloped.html", Tracer not recognized - Console tracer is defaulted ;
+303: 1,  "http://manual.umple.org/?PageBeingDeveloped.html", Parsing error: Incorrect attribute trace prefix '{0}' (Prefix can be set/get/both) ;
 
 # Messages relating to deprecated features starting with 901
-901: 4, "http://cruise.eecs.uottawa.ca/umple/W901DeprecatedKeywordConstant.html", Keyword "constant" deprecated, please use "const" ;
+901: 4, "http://manual.umple.org/?W901DeprecatedKeywordConstant.html", Keyword "constant" deprecated, please use "const" ;
 
 # Messages relating to general parsing issues
-1002: 5, "http://cruise.eecs.uottawa.ca/umple/W1002-3UnexpectedEmbeddedCode.html", Embedded method with code or unparsed code found when strictness is 'modelOnly' ;
-1003: 5, "http://cruise.eecs.uottawa.ca/umple/W1002-3UnexpectedEmbeddedCode.html", Unparsed extra code found when strictness is 'noExtraCode' ;
-1004: 2, "http://cruise.eecs.uottawa.ca/umple/E1004-5MessagesnotasExpected.html", Expected message '{0}' not found ;
-1005: 2, "http://cruise.eecs.uottawa.ca/umple/E1004-5MessagesnotasExpected.html", Disallowed warning message '{0}' encountered ;
-1006: 3, "http://cruise.eecs.uottawa.ca/umple/W1006StateMachineNotParsed.html", State machine syntax could not be processed. It has been considered as Extra Code ;
-1007: 3, "http://cruise.eecs.uottawa.ca/umple/W1007ElementNotParsed.html", Attribute or Association syntax could not be processed. It has been considered as Extra Code ;
-1008: 3, "http://cruise.eecs.uottawa.ca/umple/W1008MethodNotParsed.html", Method syntax could not be processed. It has been considered as Extra Code ;
-1009: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' has a name conflict with automatic generated getter/setter methods for attribute '{1}' in class '{2}'. Please use a different method name ;
-1010: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Constraint syntax, {0}, could not be processed. It has been considered as Extra Code ;
-1011: 3, "http://cruise.eecs.uottawa.ca/umple/W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
-1012: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Method '{0}' cannot be found. Injection was ignored. ;
-1013: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
-1014: 3, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
+1002: 5, "http://manual.umple.org/?W1002-3UnexpectedEmbeddedCode.html", Embedded method with code or unparsed code found when strictness is 'modelOnly' ;
+1003: 5, "http://manual.umple.org/?W1002-3UnexpectedEmbeddedCode.html", Unparsed extra code found when strictness is 'noExtraCode' ;
+1004: 2, "http://manual.umple.org/?E1004-5MessagesnotasExpected.html", Expected message '{0}' not found ;
+1005: 2, "http://manual.umple.org/?E1004-5MessagesnotasExpected.html", Disallowed warning message '{0}' encountered ;
+1006: 3, "http://manual.umple.org/?W1006StateMachineNotParsed.html", State machine syntax could not be processed. It has been considered as Extra Code ;
+1007: 3, "http://manual.umple.org/?W1007ElementNotParsed.html", Attribute or Association syntax could not be processed. It has been considered as Extra Code ;
+1008: 3, "http://manual.umple.org/?W1008MethodNotParsed.html", Method syntax could not be processed. It has been considered as Extra Code ;
+1009: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Method '{0}' has a name conflict with automatic generated getter/setter methods for attribute '{1}' in class '{2}'. Please use a different method name ;
+1010: 3, "http://manual.umple.org/?PageBeingDeveloped.html", Constraint syntax, {0}, could not be processed. It has been considered as Extra Code ;
+1011: 3, "http://manual.umple.org/?W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
+1012: 3, "http://manual.umple.org/?PageBeingDeveloped.html", Method '{0}' cannot be found. Injection was ignored. ;
+1013: 3, "http://manual.umple.org/?PageBeingDeveloped.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
+1014: 3, "http://manual.umple.org/?PageBeingDeveloped.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
 
-1500 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: '{0}' not understood ; 
-1501 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 
-1502 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: Structure of '{0}' invalid ;
-1503 : 1, "http://cruise.eecs.uottawa.ca/umple/E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
-1510 : 1, "http://cruise.eecs.uottawa.ca/umple/E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
+1500 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: '{0}' not understood ; 
+1501 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 
+1502 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Structure of '{0}' invalid ;
+1503 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
+1510 : 1, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
 
 
 
 # Messages to be emitted when embedded code from another language is compiled and you are passing on the error. These have not yet been activated.
-2001: 5, "http://cruise.eecs.uottawa.ca/umple/W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;
-2002: 5, "http://cruise.eecs.uottawa.ca/umple/W20xxErrorinEmbeddedCode.html", Error in C++ embedded in Umple: '{0}' ;
-
-
-# Warning messages related to distributed systems
-
-7002: 4, "http://cruise.eecs.uottawa.ca/umple/AssociationDistToNonDistributed.html", Distributed class '{0}' has an association with non-distributed class '{1}'. ;
-7001: 4, "http://cruise.eecs.uottawa.ca/umple/StaticAttributeExists.html", System is distributed but class '{0}' has a static attribute {1}. This might result in multiple instances;
-7003: 4, "http://cruise.eecs.uottawa.ca/umple/DistributedWOAssociation.html", Distributed class '{0}' has no associations {1} It is better to define it as regular class if it is not called remotely;
-
-# Special testing messages for debugging
-8001: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Debug error : '{0}' ;
-8005: 5, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Debug warning : '{0}' ;
-
-# Messages related to code generator
-9000: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Compiler Error (Parsing). {0} ;
-9100: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Compiler Error (Analysis). {0} ;
-9200: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Compiler Error (Generation). {0} ;
-
-# Message to emit when you are parsing a construct but are not yet processing it in a sensible way/
-9999: 5, "http://cruise.eecs.uottawa.ca/umple/W9999FeatureUnderDevelopment.html", Feature under development. '{0}' found and ignored. processed as: '{1}' ;
-
+2001: 5, "http://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;
+2002: 5, "http://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in C++ embedded in Umple: '{0}' ;
 
 
 # Messages related to templates
-3500: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Template name '{0}' must be alphanumeric and start with an alpha character, or _  ;
-3501: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Template emit method can not be a main.;
-3502: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Template name '{0}' can not be resolved.;
-3503: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Template reference '{0}' cannot refer to itself.;
-3504: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Template reference '{0}' can not be resolved.;
-3505: 1, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Template reference '{0}' can not cyclically refer to '{1}'.;
-3506: 4, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class '{0}' has duplicate template name {1} ;
-3507: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Class '{0}' has duplicate method name {1} ;
-3508: 2, "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", Emit name '{0}' must be alphanumeric and start with an alpha character, or _  ;
+3500: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template name '{0}' must be alphanumeric and start with an alpha character, or _  ;
+3501: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template emit method can not be a main.;
+3502: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Template name '{0}' can not be resolved.;
+3503: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template reference '{0}' cannot refer to itself.;
+3504: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template reference '{0}' can not be resolved.;
+3505: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Template reference '{0}' can not cyclically refer to '{1}'.;
+3506: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Class '{0}' has duplicate template name {1} ;
+3507: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Class '{0}' has duplicate method name {1} ;
+3508: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Emit name '{0}' must be alphanumeric and start with an alpha character, or _  ;
 
 # Messages related to structure
-3601: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Port name '{0}' must be alphanumeric and start with a letter.;
-3602: 2, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Invalid Port direction '{0}' must be in, out, or port.;
-3603: 1, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Port binding from component '{0}' can not be resolved.;
-3604: 1, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Port binding to component '{0}' can not be resolved.;
-3605: 1, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Port binding from port can not be resolved.;
-3606: 1, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Port binding to port can not be resolved.;
-3607: 1, "http://cruise.eecs.uottawa.ca/umple/WE1xxIdentifierInvalid.html", Port name '{0}' from class '{1}' can not be resolved.;
+3601: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Port name '{0}' must be alphanumeric and start with a letter.;
+3602: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Invalid Port direction '{0}' must be in, out, or port.;
+3603: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding from component '{0}' can not be resolved.;
+3604: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding to component '{0}' can not be resolved.;
+3605: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding from port can not be resolved.;
+3606: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding to port can not be resolved.;
+3607: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port name '{0}' from class '{1}' can not be resolved.;
 
 # Messages related to fixml
-4500: 1,  "http://cruise.eecs.uottawa.ca/umple/PageBeingDeveloped.html", The tag '{0}' is not closed correctly.  ;
+4500: 1,  "http://manual.umple.org/?PageBeingDeveloped.html", The tag '{0}' is not closed correctly.  ;
+
+# Warning messages related to distributed systems
+
+7002: 4, "http://manual.umple.org/?AssociationDistToNonDistributed.html", Distributed class '{0}' has an association with non-distributed class '{1}'. ;
+7001: 4, "http://manual.umple.org/?StaticAttributeExists.html", System is distributed but class '{0}' has a static attribute {1}. This might result in multiple instances;
+7003: 4, "http://manual.umple.org/?DistributedWOAssociation.html", Distributed class '{0}' has no associations {1} It is better to define it as regular class if it is not called remotely;
+
+# Special testing messages for debugging
+8001: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Debug error : '{0}' ;
+8005: 5, "http://manual.umple.org/?PageBeingDeveloped.html", Debug warning : '{0}' ;
+
+# Messages related to code generator
+9000: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Compiler Error (Parsing). {0} ;
+9100: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Compiler Error (Analysis). {0} ;
+9200: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Compiler Error (Generation). {0} ;
+
+# Message to emit when you are parsing a construct but are not yet processing it in a sensible way/
+9999: 5, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Feature under development. '{0}' found and ignored. processed as: '{1}' ;
+
+

--- a/umpleonline/ump/manualexamples/E005UndefinedClassinAssociation3.ump
+++ b/umpleonline/ump/manualexamples/E005UndefinedClassinAssociation3.ump
@@ -1,4 +1,5 @@
-// It is also possible to designate that the class Y is external in the following manner
+// It is also possible to designate that
+// the class Y is external in the following manner
 class X {
   1 -- * Y;
 }

--- a/umpleonline/ump/manualexamples/E013NonImmutableAssociation1.ump
+++ b/umpleonline/ump/manualexamples/E013NonImmutableAssociation1.ump
@@ -1,4 +1,5 @@
-// The following example generates the error message
+// The following example generates
+// the error message
 class X {
    Integer x;
 }

--- a/umpleonline/ump/manualexamples/E013NonImmutableAssociation2.ump
+++ b/umpleonline/ump/manualexamples/E013NonImmutableAssociation2.ump
@@ -1,6 +1,8 @@
-// One way to solve this is to make the association point to
+// One way to solve this is to make
+// the association point to
 // another immutable class
-// But note that this only works for one-way associations
+// But note that this only works for
+// one-way associations
 class X {
    Integer x;
    immutable;

--- a/umpleonline/ump/manualexamples/E013NonImmutableAssociation3.ump
+++ b/umpleonline/ump/manualexamples/E013NonImmutableAssociation3.ump
@@ -1,5 +1,7 @@
-// Another solution is to not require the association to be immutable,
-// just the attributes. But this may not match the intended semantics.
+// Another solution is to not require
+// the association to be immutable,
+// just the attributes. But this may
+// not match the intended semantics.
 class X {
    immutable Integer x;
 }

--- a/umpleonline/ump/manualexamples/E019DuplicateAssociation1.ump
+++ b/umpleonline/ump/manualexamples/E019DuplicateAssociation1.ump
@@ -1,6 +1,9 @@
-// The following example shows how to generate error 19.
-// The solution is to at least one role name one or both of the Y ends
-// and at least one role name on one of both of the X ends.
+// The following example shows how 
+// to generate error 19.
+// The solution is to at least one
+// role name one or both of the Y ends
+// and at least one role name on one
+// of both of the X ends.
 class X {
 }
 

--- a/umpleonline/ump/manualexamples/E019DuplicateAssociation2.ump
+++ b/umpleonline/ump/manualexamples/E019DuplicateAssociation2.ump
@@ -1,4 +1,5 @@
-// Using role names rn1 and rn2 to avoid error 19
+// Using role names rn1 and rn2 to
+// avoid error 19
 class X {
 }
 

--- a/umpleonline/ump/manualexamples/E019DuplicateAssociation3.ump
+++ b/umpleonline/ump/manualexamples/E019DuplicateAssociation3.ump
@@ -1,5 +1,8 @@
-// Example of an association class definition that generates error 19
-// The solution is to add a role name such as menteeAssignments between the first * and Member
+// Example of an association class
+// definition that generates error 19
+// The solution is to add a role name
+// such as menteeAssignments between
+// the first * and Member
 
 class Member {
   name;

--- a/umpleonline/ump/manualexamples/E021InvalidReflexiveAssociation1.ump
+++ b/umpleonline/ump/manualexamples/E021InvalidReflexiveAssociation1.ump
@@ -1,4 +1,5 @@
-// The following example shows how to generate this error.
+// The following example shows
+// how to generate this error.
 class X {
     0..1 -- 0..1 X;
 }

--- a/umpleonline/ump/manualexamples/E021InvalidReflexiveAssociation2.ump
+++ b/umpleonline/ump/manualexamples/E021InvalidReflexiveAssociation2.ump
@@ -1,4 +1,6 @@
-// The following example shows how to fix the error if this is an asymmetric association.
+// The following example shows how
+// to fix the error if this is an
+// asymmetric association.
 class X {
     0..1 -- 0..1 X right;
 }

--- a/umpleonline/ump/manualexamples/E021InvalidReflexiveAssociation3.ump
+++ b/umpleonline/ump/manualexamples/E021InvalidReflexiveAssociation3.ump
@@ -1,4 +1,5 @@
-// The following example shows how to fix the error if this is a symmetric association.
+// The following example shows how to fix
+// the error if this is a symmetric association.
 class X {
     0..1 self right;
 }

--- a/umpleonline/ump/manualexamples/E022DuplicateAttribute1.ump
+++ b/umpleonline/ump/manualexamples/E022DuplicateAttribute1.ump
@@ -1,4 +1,5 @@
-// The following example shows how to generate this error.
+// The following example shows how
+// to generate this error.
 class X {
   a;
   a;

--- a/umpleonline/ump/manualexamples/E023AttributeAssociationNameClash1.ump
+++ b/umpleonline/ump/manualexamples/E023AttributeAssociationNameClash1.ump
@@ -1,4 +1,5 @@
-// This example generates error 23 because an attribute and role name share a name
+// This example generates error 23
+// because an attribute and role name share a name
 class X23atdupassoc1 {
    a;
    1 -- 0..1 Another a;

--- a/umpleonline/ump/manualexamples/E023AttributeAssociationNameClash2.ump
+++ b/umpleonline/ump/manualexamples/E023AttributeAssociationNameClash2.ump
@@ -1,4 +1,5 @@
-// This generates error 23 because attribute b clashes with
+// This generates error 23 because
+// attribute b clashes with
 // class name B in the association
 class X23atdupassoc2 {
    b;

--- a/umpleonline/ump/manualexamples/E026DuplicateKeyItem1.ump
+++ b/umpleonline/ump/manualexamples/E026DuplicateKeyItem1.ump
@@ -1,4 +1,5 @@
-// The following example has error 26 since they key has 'a' twice
+// The following example has error 26
+// since the key has 'a' twice
 class X26dupiteminkey {
   a;
   b;

--- a/umpleonline/ump/manualexamples/E034MultipleInheritance2.ump
+++ b/umpleonline/ump/manualexamples/E034MultipleInheritance2.ump
@@ -1,4 +1,6 @@
-// The following is another way of formulating the same declarations, also resulting in the error
+// The following is another way of
+// formulating the same declarations,
+// also resulting in the error
 
 class P1 {}
 class P2 {}

--- a/umpleonline/ump/manualexamples/E034MultipleInheritance3.ump
+++ b/umpleonline/ump/manualexamples/E034MultipleInheritance3.ump
@@ -1,4 +1,5 @@
-// If all but one of the parents is declared as an Interface, the problem is solved
+// If all but one of the parents is
+// declared as an Interface, the problem is solved
 
 interface P1 {}
 class P2 {}

--- a/umpleonline/ump/manualexamples/E040_singleton_inherited.ump
+++ b/umpleonline/ump/manualexamples/E040_singleton_inherited.ump
@@ -1,5 +1,5 @@
-
-// In this example a singleton class has subclasses and it generates an error
+// In this example a singleton class
+// has subclasses and it generates an error
 class Airplane
 {
   singleton;

--- a/umpleonline/ump/manualexamples/E040_singleton_inheritedFix.ump
+++ b/umpleonline/ump/manualexamples/E040_singleton_inheritedFix.ump
@@ -1,5 +1,5 @@
-
-//I this example the singleton class does not have a subclass and is correct
+//I this example the singleton class
+// does not have a subclass and is correct
 class Airplane
 {
   

--- a/umpleonline/ump/manualexamples/E052StateMachineNameClash1.ump
+++ b/umpleonline/ump/manualexamples/E052StateMachineNameClash1.ump
@@ -1,4 +1,5 @@
-// This example generates the message because the state machine a
+// This example generates the message
+// because the state machine a
 // clashes with the attribute a
 class X52assattnamestatemachine1 {
   a;

--- a/umpleonline/ump/manualexamples/E052StateMachineNameClash2.ump
+++ b/umpleonline/ump/manualexamples/E052StateMachineNameClash2.ump
@@ -1,4 +1,5 @@
-// The sample generates the message because the state machine a
+// The sample generates the message
+// because the state machine a
 // clashes with the association role name a
 class X52assattnamestatemachine2 {
   1 - 0.1 B a;

--- a/umpleonline/ump/manualexamples/E053NoConcurrencyAtTopLevel1.ump
+++ b/umpleonline/ump/manualexamples/E053NoConcurrencyAtTopLevel1.ump
@@ -2,12 +2,14 @@
 class X53conctoplevel {
   sm {
     s1 {
-      do {System.out.println("Reached s1");}
+      do {System.out.println(
+        "Reached s1");}
     }
     ||
     s2
     {
-      do {System.out.println("Reached s1");}
+      do {System.out.println(
+        "Reached s1");}
     }
   }
 }

--- a/umpleonline/ump/manualexamples/E053NoConcurrencyAtTopLevel2.ump
+++ b/umpleonline/ump/manualexamples/E053NoConcurrencyAtTopLevel2.ump
@@ -3,12 +3,14 @@ class X53conctoplevel {
   sm {
     s0 {
       s1 {
-        do {System.out.println("Reached s1");}
+        do {System.out.println(
+          "Reached s1");}
       }
       ||
       s2
       {
-        do {System.out.println("Reached s1");}
+        do {System.out.println(
+          "Reached s1");}
       }
     }
   }

--- a/umpleonline/ump/manualexamples/E095DuplicateEnumerations3.ump
+++ b/umpleonline/ump/manualexamples/E095DuplicateEnumerations3.ump
@@ -1,5 +1,7 @@
-// This example does not cause the error. The enumeration within the class is prioritized over
-// the enumeration defined outside of the class
+// This example does not cause the error.
+// The enumeration within the class
+// is prioritized over the enumeration
+// defined outside of the class
 
 enum Month {x,y,z}
 

--- a/umpleonline/ump/manualexamples/E096EnumerationNamingConflict1.ump
+++ b/umpleonline/ump/manualexamples/E096EnumerationNamingConflict1.ump
@@ -1,4 +1,5 @@
-// This example generates the error since the enumeration "X" will be added
+// This example generates the error
+// since the enumeration "X" will be added
 // to the class "X" because of attribute "t".
 
 enum X{ Red, Blue, Green }

--- a/umpleonline/ump/manualexamples/E096EnumerationNamingConflict2.ump
+++ b/umpleonline/ump/manualexamples/E096EnumerationNamingConflict2.ump
@@ -1,4 +1,6 @@
-// This generates the error because the enumeration "X" has the same name
+// This generates the error
+// because the enumeration "X"
+// has the same name
 // as the class it's defined in
  
 class X{

--- a/umpleonline/ump/manualexamples/E096EnumerationNamingConflict3.ump
+++ b/umpleonline/ump/manualexamples/E096EnumerationNamingConflict3.ump
@@ -1,4 +1,6 @@
-// This example generates the error since enumeration "Y" conflicts with interface "Y"
+// This example generates the error
+// since enumeration "Y"
+// conflicts with interface "Y"
 
 interface Y { 
   name;

--- a/umpleonline/ump/manualexamples/E096EnumerationNamingConflict4.ump
+++ b/umpleonline/ump/manualexamples/E096EnumerationNamingConflict4.ump
@@ -1,4 +1,5 @@
-// This example generates the error since enumeration "Y" conflicts with trait "Y"
+// This example generates the error
+// since enumeration "Y" conflicts with trait "Y"
 
 class X {
  isA Y;

--- a/umpleonline/ump/manualexamples/E097EnumerationAndStateMachineConflict1.ump
+++ b/umpleonline/ump/manualexamples/E097EnumerationAndStateMachineConflict1.ump
@@ -1,4 +1,6 @@
-// This example generates the error because enumeration "Y" has the same name as state machine "Y"
+// This example generates the error
+// because enumeration "Y" has the
+// same name as state machine "Y"
 
 class X {
  enum Y { Red, Blue, Green }

--- a/umpleonline/ump/manualexamples/E097EnumerationAndStateMachineConflict2.ump
+++ b/umpleonline/ump/manualexamples/E097EnumerationAndStateMachineConflict2.ump
@@ -1,10 +1,13 @@
-// This example generates the error because enumeration "Y" will be 
-// added to class "X" since the "attr" parameter of "showY" is "Y".
+// This example generates the error
+// because enumeration "Y" will be 
+// added to class "X" since the "attr"
+// parameter of "showY" is "Y".
 
 enum Y { Red, Blue, Green }
 
 class X {
-  showY(Y attr) { System.out.println(attr); }
+  showY(Y attr) {
+    System.out.println(attr); }
   Y {
    s1 {}
   }

--- a/umpleonline/ump/manualexamples/E180DuplicateRoleNameSubclassValidSpecialization.ump
+++ b/umpleonline/ump/manualexamples/E180DuplicateRoleNameSubclassValidSpecialization.ump
@@ -1,0 +1,21 @@
+// This example shows a valid specialization
+// of the friends association in which the
+// multiplicity 0..3 is refined to *, so a
+// student may have any number of dogs but
+// Persons in general are limited to 3.
+// This conforms to the Liskov substitution
+// principle: The preconditions on Person
+// operations such as addDog limiting to 3
+// are being relaxed in the subclass Student.
+
+class Person {
+	* -> 0..3 Dog friends;
+}
+
+class Student {
+	isA Person;
+	* -> * Dog friends;
+}
+
+class Dog {
+}

--- a/umpleonline/ump/manualexamples/E200InvalidTraitIdentifierE1.ump
+++ b/umpleonline/ump/manualexamples/E200InvalidTraitIdentifierE1.ump
@@ -1,4 +1,5 @@
-//This example shows an error in the name of trait
+//This example shows an error
+// in the name of trait
 trait T@ {
 	//traits elements
 }

--- a/umpleonline/ump/manualexamples/E200InvalidTraitIdentifierE2.ump
+++ b/umpleonline/ump/manualexamples/E200InvalidTraitIdentifierE2.ump
@@ -1,4 +1,5 @@
-//This example shows an error in the name of trait
+//This example shows an error
+// in the name of trait
 trait 1T {
 	//traits elements
 }

--- a/umpleonline/ump/manualexamples/E202AvailableTraits.ump
+++ b/umpleonline/ump/manualexamples/E202AvailableTraits.ump
@@ -1,4 +1,6 @@
-//In  this example, the error has been resolved just by defining trait T1. 
+//In  this example, the error
+// has been resolved just by
+// defining trait T1. 
 interface I{
 	//elements
 }

--- a/umpleonline/ump/manualexamples/E202NotAvailableTraits.ump
+++ b/umpleonline/ump/manualexamples/E202NotAvailableTraits.ump
@@ -1,4 +1,5 @@
-//In  this example, trait "T" uses trait "T1" which is not available. 
+//In  this example, trait "T"
+// uses trait "T1" which is not available. 
 interface I{
 	//elements
 }

--- a/umpleonline/ump/manualexamples/E203HavingUniqueID.ump
+++ b/umpleonline/ump/manualexamples/E203HavingUniqueID.ump
@@ -1,4 +1,5 @@
-//In  this example, Identifier of trait "T" is unique.
+//In  this example, Identifier of
+// trait "T" is unique.
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E203NotHavingUniqueID.ump
+++ b/umpleonline/ump/manualexamples/E203NotHavingUniqueID.ump
@@ -1,4 +1,5 @@
-//In  this example, Identifier of trait "I" is not unique. 
+// In  this example, Identifier of
+// trait "I" is not unique. 
 class A{
 	isA I;
 }

--- a/umpleonline/ump/manualexamples/E204CyclicUse1.ump
+++ b/umpleonline/ump/manualexamples/E204CyclicUse1.ump
@@ -1,4 +1,5 @@
-// In this example, there is a explicit use of a trait inside of itself.
+// In this example, there is an explicit
+// use of a trait inside of itself.
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E205CyclicUse1.ump
+++ b/umpleonline/ump/manualexamples/E205CyclicUse1.ump
@@ -1,4 +1,5 @@
-// In this example, there is a cycle created in a hierarchy.
+// In this example, there is a cycle
+// created in a hierarchy.
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E206SatisfactionOfConstraints.ump
+++ b/umpleonline/ump/manualexamples/E206SatisfactionOfConstraints.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because class C1 does not implement interface I. Any bound value to template parameter TP must implement interface I.
+// In this example, there is an error
+// because class C1 does not implement
+// interface I. Any bound value to template
+// parameter TP must implement interface I.
 trait T1<TP isA I>{
   /*implementation*/
 }

--- a/umpleonline/ump/manualexamples/E208NotRequiredMethod.ump
+++ b/umpleonline/ump/manualexamples/E208NotRequiredMethod.ump
@@ -1,4 +1,6 @@
-// In this example, the required method "FinalResult()" in Trait "T" is not satisfied by class "A".
+// In this example, the required method
+// "FinalResult()" in Trait "T" is
+// not satisfied by class "A".
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E208ValidRequiredMethod.ump
+++ b/umpleonline/ump/manualexamples/E208ValidRequiredMethod.ump
@@ -1,4 +1,6 @@
-// In this example, the require method "FinalResult()" in Trait "T" is satisfied by class "A".
+// In this example, the require method
+// "FinalResult()" in Trait "T" is
+// satisfied by class "A".
 class A{
 	isA T;	
 	internal Integer x;	

--- a/umpleonline/ump/manualexamples/E210ConflictMethods1.ump
+++ b/umpleonline/ump/manualexamples/E210ConflictMethods1.ump
@@ -1,4 +1,5 @@
-// In this example, there is a conflict in class "A" on the method "test()".
+// In this example, there is a conflict
+// in class "A" on the method "test()".
 class A{
 	isA T1;
 	isA T2;

--- a/umpleonline/ump/manualexamples/E210ConflictMethods2.ump
+++ b/umpleonline/ump/manualexamples/E210ConflictMethods2.ump
@@ -1,4 +1,6 @@
-// In this example, there is a conflict in trait "T" on the method "test()".
+// In this example, there is
+// a conflict in trait "T"
+// on the method "test()".
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E210ConflictMethods3.ump
+++ b/umpleonline/ump/manualexamples/E210ConflictMethods3.ump
@@ -1,4 +1,5 @@
-// In this example, there is a no conflict in class "A".
+// In this example, there is a
+// no conflict in class "A".
 class A{
 	isA T1;
 	isA T2;

--- a/umpleonline/ump/manualexamples/E210ConflictMethods4.ump
+++ b/umpleonline/ump/manualexamples/E210ConflictMethods4.ump
@@ -1,4 +1,6 @@
-// In this example, there is a conflict in class "A" because method "test" is overridden in trait "T2".
+// In this example, there is a conflict
+// in class "A" because method "test"
+// is overridden in trait "T2".
 class A{
 	isA T1;
 	isA T2;

--- a/umpleonline/ump/manualexamples/E211MoreModifications1.ump
+++ b/umpleonline/ump/manualexamples/E211MoreModifications1.ump
@@ -1,4 +1,7 @@
-// In this example, there are two modifications ("add") for the method "show()" when trait "T2" is used inside of trait "T1".
+// In this example, there are
+// two modifications ("add") for
+// the method "show()" when trait "T2"
+// is used inside of trait "T1".
 class A{
 	isA T1;
 }

--- a/umpleonline/ump/manualexamples/E211MoreModifications2.ump
+++ b/umpleonline/ump/manualexamples/E211MoreModifications2.ump
@@ -1,4 +1,7 @@
-// In this example, there are two modifications ("add" and "remove") for the method "show()" when trait "T2" is used inside of trait "T1".
+// In this example, there are
+// two modifications ("add" and "remove")
+// for the method "show()" when trait "T2"
+// is used inside of trait "T1".
 class A{
 	isA T1;
 }

--- a/umpleonline/ump/manualexamples/E212NoAvailableMethod1.ump
+++ b/umpleonline/ump/manualexamples/E212NoAvailableMethod1.ump
@@ -1,4 +1,8 @@
-// In this example, there is an error because trait "T1" tries to remove method "show()" from trait "T2" while it is not available in trait "T2".
+// In this example, there is an error
+// because trait "T1" tries to remove
+// method "show()" from trait "T2"
+// while it is not available
+// in trait "T2".
 class A{
 	isA T1;
 }

--- a/umpleonline/ump/manualexamples/E212NoAvailableMethod2.ump
+++ b/umpleonline/ump/manualexamples/E212NoAvailableMethod2.ump
@@ -1,4 +1,8 @@
-// In this example, there is an error because trait "T1" tries to add just method "show()" from trait "T2" to itself while it is not available in trait "T2".
+// In this example, there is an error
+// because trait "T1" tries to add
+// just method "show()" from trait "T2"
+// to itself. while it is not
+// available in trait "T2".
 class A{
 	isA T1;
 }

--- a/umpleonline/ump/manualexamples/E212NoAvailableMethod3.ump
+++ b/umpleonline/ump/manualexamples/E212NoAvailableMethod3.ump
@@ -1,4 +1,10 @@
-// In this example, there is an error in class "A" because it tries to change visibility of method "test()" which is not available in trait T. Consider that the method "test()" defined in trait "T" is a required method.
+// In this example, there is an error
+// in class "A" because it tries to
+// change visibility of method "test()"
+// which is not available in trait T.
+// Consider that the method "test()"
+// defined in trait "T" is a
+// required method.
 class A{
 	isA T<test() as private>;
 }

--- a/umpleonline/ump/manualexamples/E213BidirectionalTraitAssociation.ump
+++ b/umpleonline/ump/manualexamples/E213BidirectionalTraitAssociation.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because a bidirectional association is created with interface I, which is not valid.
+// In this example, there is an error
+// because a bidirectional association
+// is created with interface I,
+// which is not valid.
 interface I {
   /*implementation*/
 }

--- a/umpleonline/ump/manualexamples/E214Twosametemplateparameters.ump
+++ b/umpleonline/ump/manualexamples/E214Twosametemplateparameters.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because trait T has two template parameters with the same name.
+// In this example, there is an error
+// because trait T has two template
+// parameters with the same name.
 trait T<TP,TP>{  
   TP name;
 }

--- a/umpleonline/ump/manualexamples/E215NoAvailableTemplateParameter.ump
+++ b/umpleonline/ump/manualexamples/E215NoAvailableTemplateParameter.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because class A cannot bind type String to template parameter Y, which is not defined. for trait T.
+// In this example, there is an error
+// because class A cannot bind
+// type String to template parameter Y,
+// which is not defined. for trait T.
 class A{
   isA T< X= Integer, Y = String>;
 }

--- a/umpleonline/ump/manualexamples/E216TwiceBinding.ump
+++ b/umpleonline/ump/manualexamples/E216TwiceBinding.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because there is two bindings for template parameter "X" in class "A".
+// In this example, there is an error
+// because there is two bindings for
+// template parameter "X" in class "A".
 class A{
 	isA T< X = B , X = C >;
 }

--- a/umpleonline/ump/manualexamples/E217ConflictInTypeofAttributes.ump
+++ b/umpleonline/ump/manualexamples/E217ConflictInTypeofAttributes.ump
@@ -1,4 +1,9 @@
-// In this example, there is a conflict because in trait "T" there will be two attributes with the same name "data" but with different types which are "B" and "C".
+// In this example, there is a
+// conflict because in trait "T"
+// there will be two attributes
+// with the same name "data" but
+// with different types
+// which are "B" and "C".
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E219NoBindingParameters.ump
+++ b/umpleonline/ump/manualexamples/E219NoBindingParameters.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because class "A" doesn't bind a value to one of the template parameters of trait "T" named "Y".
+// In this example, there is an error
+// because class "A" doesn't bind
+// a value to one of the template
+// parameters of trait "T" named "Y".
 class A{
 	isA T<X = B>;
 }

--- a/umpleonline/ump/manualexamples/E219NoBindingParameters1.ump
+++ b/umpleonline/ump/manualexamples/E219NoBindingParameters1.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because class "A" doesn't bind a value to template parameters of trait "T".
+// In this example, there is an error
+// because class "A" doesn't bind
+// a value to template parameters
+// of trait "T".
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/E220TwoMethodWithSameName1.ump
+++ b/umpleonline/ump/manualexamples/E220TwoMethodWithSameName1.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because in class "A" there will be two methods with the name "ShowInConsole".
+// In this example, there is an error
+// because in class "A" there will be
+// two methods with the name "ShowInConsole".
 class A{
 	isA T<show() as ShowInConsole>;
 }

--- a/umpleonline/ump/manualexamples/E220TwoMethodWithSameName2.ump
+++ b/umpleonline/ump/manualexamples/E220TwoMethodWithSameName2.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because in class "A" there will be two methods with the name "ShowInConsole".
+// In this example, there is an error
+// because in class "A" there will be
+// two methods with the name "ShowInConsole".
 class A{
 	isA T<show() as ShowInConsole>;
 	isA T1;

--- a/umpleonline/ump/manualexamples/E220TwoMethodWithSameName3.ump
+++ b/umpleonline/ump/manualexamples/E220TwoMethodWithSameName3.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because in class "A" method "ShowInConslole" has high priority.
+// In this example, there is an error
+// because in class "A"
+// method "ShowInConslole" has high priority.
 class A{
 	isA T<show() as ShowInConsole>;
 	isA T1;

--- a/umpleonline/ump/manualexamples/E221BoundTypeAvailable.ump
+++ b/umpleonline/ump/manualexamples/E221BoundTypeAvailable.ump
@@ -1,4 +1,8 @@
-// In this example, there is an error because class C binds type C1 to the template parameter of trait T, while type C is not available in the system.
+// In this example, there is an error
+// because class C binds type C1 to the
+// template parameter of trait T,
+// while type C is not available
+// in the system.
 trait T<TP>{
 /*implementation*/
 }

--- a/umpleonline/ump/manualexamples/E222SatisfactionOfRequiredInterfaces.ump
+++ b/umpleonline/ump/manualexamples/E222SatisfactionOfRequiredInterfaces.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because class C must implement required interface of trait T, which is interface I.
+// In this example, there is an error
+// because class C must implement
+// required interface of trait T,
+// which is interface I.
 trait T{
   /*implementation*/
   isA I;

--- a/umpleonline/ump/manualexamples/E223AvailabilityOfTypes.ump
+++ b/umpleonline/ump/manualexamples/E223AvailabilityOfTypes.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because type I used to constraint template parameters TP in trait T does not exist.
+// In this example, there is an error
+// because type I used to constraint
+// template parameters TP in trait T
+// does not exist.
 trait T<TP isA I>{
   /*implementation*/
 }

--- a/umpleonline/ump/manualexamples/E224MultipleInheritanceConstraint.ump
+++ b/umpleonline/ump/manualexamples/E224MultipleInheritanceConstraint.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because trait T puts multiple inheritance constraint on its template parameter TP.
+// In this example, there is an error
+// because trait T puts multiple
+// inheritance constraint on its
+// template parameter TP.
 trait T<TP isA C1&C2>{
   /*implementation*/
 }

--- a/umpleonline/ump/manualexamples/E225SatisfactionOfConstraints.ump
+++ b/umpleonline/ump/manualexamples/E225SatisfactionOfConstraints.ump
@@ -1,4 +1,8 @@
-// In this example, there is an error because class C1 is not subclass of class C2. Any bound value to template parameter TP must be a subclass of class C2.
+// In this example, there is an error
+// because class C1 is not subclass
+// of class C2.
+// Any bound value to template parameter
+// TP must be a subclass of class C2.
 trait T<TP isA C2>{
   /*implementation*/
 }

--- a/umpleonline/ump/manualexamples/E229RenamingTwoTimesStates.ump
+++ b/umpleonline/ump/manualexamples/E229RenamingTwoTimesStates.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because class C tries two rename states s0 of trait T two times.
+// In this example, there is an error
+// because class C tries two
+// rename states s0 of trait T two times.
 trait T {
   sm{
     s0{

--- a/umpleonline/ump/manualexamples/E230SMAvailability.ump
+++ b/umpleonline/ump/manualexamples/E230SMAvailability.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because state machine sm3 is not available in trait T.
+// In this example, there is an error
+// because state machine sm3 is
+// not available in trait T.
 trait T {
   sm1{
 	s0 {e1-> s1;}

--- a/umpleonline/ump/manualexamples/E231EventAvailability.ump
+++ b/umpleonline/ump/manualexamples/E231EventAvailability.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because event e2() is not available in state machine sm.
+// In this example, there is an error
+// because event e2() is not available
+// in state machine sm.
 trait T {
   sm{
     s0{

--- a/umpleonline/ump/manualexamples/E232EventAvailability.ump
+++ b/umpleonline/ump/manualexamples/E232EventAvailability.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because event e2() is not available in state machines of trait T.
+// In this example, there is an error
+// because event e2() is not available
+// in state machines of trait T.
 trait T {
   sm{
     s0{

--- a/umpleonline/ump/manualexamples/E233RemoveInitialState.ump
+++ b/umpleonline/ump/manualexamples/E233RemoveInitialState.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because the initial state of a state machine cannot be removed.
+// In this example, there is an error
+// because the initial state of a
+// state machine cannot be removed.
 trait T {
   sm{
     s0{

--- a/umpleonline/ump/manualexamples/E234NonDeteministicComposition.ump
+++ b/umpleonline/ump/manualexamples/E234NonDeteministicComposition.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because the composed state machine will be nondeterministic.
+// In this example, there is an error
+// because the composed state machine
+// will be nondeterministic.
 trait T1{
   sm{
     s1{ e1[x>0] -> s2;  }

--- a/umpleonline/ump/manualexamples/E235SuperCallConflict.ump
+++ b/umpleonline/ump/manualexamples/E235SuperCallConflict.ump
@@ -1,4 +1,6 @@
-// In this example, there is an error because the keyword superCall can be pointed out to two used traits.
+// In this example, there is an error
+// because the keyword superCall can be
+// pointed out to two used traits.
 trait T1{
   sm{
     s1{ e1 -> /{action1();} s1; }

--- a/umpleonline/ump/manualexamples/E236TwoStateEntries.ump
+++ b/umpleonline/ump/manualexamples/E236TwoStateEntries.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because of having different ways to compose entries of two states S1 coming from traits T1 and T2.
+// In this example, there is an error
+// because of having different ways
+// to compose entries of two states
+// S1 coming from traits T1 and T2.
 trait T1{
   sm{
     s1{ entry /{action1();} }

--- a/umpleonline/ump/manualexamples/E237UniqueRegionName.ump
+++ b/umpleonline/ump/manualexamples/E237UniqueRegionName.ump
@@ -1,4 +1,7 @@
-// In this example, there is an error because class C rename the region name r1 to r2 which is already available in the state machine sm.
+// In this example, there is an error
+// because class C rename the region
+// name r1 to r2 which is already
+// available in the state machine sm.
 trait T{
   sm {
     s1{

--- a/umpleonline/ump/manualexamples/W015ImmutableClassStateMachine1.ump
+++ b/umpleonline/ump/manualexamples/W015ImmutableClassStateMachine1.ump
@@ -1,5 +1,7 @@
-// The following example shows how to generate this warning.
-// Removing the immutable keyword will solve the problem.
+// The following example shows how to
+// generate this warning.
+// Removing the immutable keyword will
+// solve the problem.
 class X {
   immutable;
   Integer y;

--- a/umpleonline/ump/manualexamples/W030RedefinedNamespace1.ump
+++ b/umpleonline/ump/manualexamples/W030RedefinedNamespace1.ump
@@ -1,5 +1,6 @@
 // This example generates the message
-// Namespace b, encountered later, will be the namespace of the class
+// Namespace b, encountered later, will
+// be the namespace of the class
 namespace a;
 
 class X30redefnamespace {

--- a/umpleonline/ump/manualexamples/W033MissingSuperclass1.ump
+++ b/umpleonline/ump/manualexamples/W033MissingSuperclass1.ump
@@ -1,4 +1,5 @@
-// This example generates the warning since T is not defined
+// This example generates the warning
+// since T is not defined
 class S {
   isA T;
 }

--- a/umpleonline/ump/manualexamples/W033MissingSuperclass2.ump
+++ b/umpleonline/ump/manualexamples/W033MissingSuperclass2.ump
@@ -1,5 +1,7 @@
-// This example solves the problem by defining T as an external class
-// Umple will not generate any code for T, but now knows it exists
+// This example solves the problem
+// by defining T as an external class
+// Umple will not generate any code for T,
+// but now knows it exists
 class S {
   isA T;
 }

--- a/umpleonline/ump/manualexamples/W036UnmanagedMultiplicity2.ump
+++ b/umpleonline/ump/manualexamples/W036UnmanagedMultiplicity2.ump
@@ -1,4 +1,5 @@
-// The following solves the problem by either making the association unndirected
+// The following solves the problem
+// by either making the association unndirected
 // or making the bounds have soft constraints
 
 class X {

--- a/umpleonline/ump/manualexamples/W046AttributeHasTemplateType2.ump
+++ b/umpleonline/ump/manualexamples/W046AttributeHasTemplateType2.ump
@@ -1,4 +1,5 @@
-// The following shows how to avoid the message using a multivalued attribute
+// The following shows how to avoid
+// the message using a multivalued attribute
 class A {
   OtherClass[] otherClassGroup;
 }

--- a/umpleonline/ump/manualexamples/W046AttributeHasTemplateType3.ump
+++ b/umpleonline/ump/manualexamples/W046AttributeHasTemplateType3.ump
@@ -1,4 +1,5 @@
-// The following shows how to avoid the message using an association
+// The following shows how to avoid
+// the message using an association
 class A {
   0..1 -- * OtherClass;
 }

--- a/umpleonline/ump/manualexamples/W1002-3UnexpectedEmbeddedCode1.ump
+++ b/umpleonline/ump/manualexamples/W1002-3UnexpectedEmbeddedCode1.ump
@@ -1,4 +1,5 @@
-// The following example shows how to generate this warning.
+// The following example shows how to
+// generate this warning.
 strictness modelOnly;
 class X {
   public static void main() {

--- a/umpleonline/ump/manualexamples/W1006StateMachineNotParsed1.ump
+++ b/umpleonline/ump/manualexamples/W1006StateMachineNotParsed1.ump
@@ -1,4 +1,5 @@
-// This example generates the warning because there is a missing semicolon
+// This example generates the warning
+// because there is a missing semicolon
 class X {
   sm {
     a -> b

--- a/umpleonline/ump/manualexamples/W1008MethodNotParsed1.ump
+++ b/umpleonline/ump/manualexamples/W1008MethodNotParsed1.ump
@@ -1,4 +1,5 @@
-// This example generates the warning because there is a missing return type
+// This example generates the warning
+// because there is a missing return type
 class X {
   m() {}
 }

--- a/umpleonline/ump/manualexamples/W1011InvalidAssociationClassKey1.ump
+++ b/umpleonline/ump/manualexamples/W1011InvalidAssociationClassKey1.ump
@@ -1,4 +1,6 @@
-// This example generates the warning because one participating class is missing from the key
+// This example generates the warning
+// because one participating class is
+// missing from the key
 class Passenger {}
 
 class Flight {}

--- a/umpleonline/ump/manualexamples/W1011InvalidAssociationClassKey2.ump
+++ b/umpleonline/ump/manualexamples/W1011InvalidAssociationClassKey2.ump
@@ -1,4 +1,5 @@
-// This example shows how to remove the warning by completing the key
+// This example shows how to remove
+// the warning by completing the key
 class Passenger {}
 
 class Flight {}

--- a/umpleonline/ump/manualexamples/W102EnumerationCausesMethodParameterAmbiguity1.ump
+++ b/umpleonline/ump/manualexamples/W102EnumerationCausesMethodParameterAmbiguity1.ump
@@ -1,9 +1,12 @@
-// This example generates the warning because it is ambiguous if "param"
-// is an object of class "Y" or the enumeration "Y".
+// This example generates the warning
+// because it is ambiguous if "param"
+// is an object of class "Y" or
+// the enumeration "Y".
 
 class X {
   enum Y { Red, Blue, Green }
-  showY(Y param) { System.out.println(param); }
+  showY(Y param) {
+    System.out.println(param); }
 }
 
 class Y { }

--- a/umpleonline/ump/manualexamples/W102EnumerationCausesMethodParameterAmbiguity2.ump
+++ b/umpleonline/ump/manualexamples/W102EnumerationCausesMethodParameterAmbiguity2.ump
@@ -2,7 +2,8 @@
 
 class X {
   enum Y { Red, Blue, Green }
-  showY(Y param) { System.out.println(param); }
+  showY(Y param) {
+    System.out.println(param); }
 }
 
 class Z { }

--- a/umpleonline/ump/manualexamples/W102EnumerationCausesMethodParameterAmbiguity3.ump
+++ b/umpleonline/ump/manualexamples/W102EnumerationCausesMethodParameterAmbiguity3.ump
@@ -3,7 +3,8 @@
 enum Z { Red, Blue, Green }
 
 class X {
-  showY(Y param) { System.out.println(param); }
+  showY(Y param) {
+    System.out.println(param); }
 }
 
 class Y { }

--- a/umpleonline/ump/manualexamples/W103EnumerationCausesEventParameterAmbiguity1.ump
+++ b/umpleonline/ump/manualexamples/W103EnumerationCausesEventParameterAmbiguity1.ump
@@ -1,11 +1,14 @@
-// This example generates the warning because "goToS2" has "param" which could be
-// either an object of class "Y" or the enumeration "Y"
+// This example generates the warning
+// because "goToS2" has "param" which could be
+// either an object of class "Y"
+// or the enumeration "Y"
 
 class X {
   enum Y { Red, Blue, Green }
   sm {
     s1 {
-      goToS2(Y param) /{ System.out.println(param); } -> s2;
+      goToS2(Y param) /{
+        System.out.println(param); } -> s2;
     }
     s2 {}
   }

--- a/umpleonline/ump/manualexamples/W103EnumerationCausesEventParameterAmbiguity2.ump
+++ b/umpleonline/ump/manualexamples/W103EnumerationCausesEventParameterAmbiguity2.ump
@@ -4,7 +4,8 @@ class X {
   enum Y { Red, Blue, Green }
   sm {
     s1 {
-      goToS2(Y param) /{ System.out.println(param); } -> s2;
+      goToS2(Y param) /
+        { System.out.println(param); } -> s2;
     }
     s2 {}
   }

--- a/umpleonline/ump/manualexamples/W141ValueTypeMismatch1.ump
+++ b/umpleonline/ump/manualexamples/W141ValueTypeMismatch1.ump
@@ -1,4 +1,5 @@
-// The following will generate this warning on every line of the class
+// The following will generate
+// this warning on every line of the class
 class X {
   Date d = "20130708";
   Integer i = "abc";

--- a/umpleonline/ump/manualexamples/W141ValueTypeMismatch3.ump
+++ b/umpleonline/ump/manualexamples/W141ValueTypeMismatch3.ump
@@ -1,4 +1,5 @@
-// The following shows how to solve the above problem not even showing the type at all
+// The following shows how to solve
+// the above problem not even showing the type at all
 class X {
   d = "2013-07-08";
   i = 7;

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierAmbiguous.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierAmbiguous.ump
@@ -1,4 +1,6 @@
-// This case is probably an error - Umple will consider "x" to have type "public"
+// This case raises the warning
+// because it is probably an error
+// Umple will consider "x" to have type "public"
 class X {
   public x;
 }

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierCorrect.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierCorrect.ump
@@ -1,4 +1,8 @@
-// This is equivalent, attributes have public access by default
+// This is probably what was intended,
+// attributes have private access by default
+// but the programmer would call
+// public String getX() to read it
+// and public boolean setX(String) to set it
 class X {
   x;
 }

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierExplicit.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierExplicit.ump
@@ -1,5 +1,9 @@
-// If you want to bypass Umple and directly include the attribute in the generated code, write the full declaration.
-// The generated code will include the attribute verbatim.
+// Although not recommended, the programmer
+// can also bypass Umple and directly specify
+// both the visibility directive and the type.
+// Umple will not see that as an attribute
+// and will inject the line of code into the
+// output directly.
 class X {
   public String x;
 }

--- a/umpleonline/ump/manualexamples/W201NotWellDefinedIdentifier.ump
+++ b/umpleonline/ump/manualexamples/W201NotWellDefinedIdentifier.ump
@@ -1,4 +1,6 @@
-//This example shows a warning in the name of traits because they start with lower cases.
+// This example shows a warning
+// in the name of traits because
+// they start with lower case.
 trait color {
 	//traits elements
 }

--- a/umpleonline/ump/manualexamples/W218ConflictInAttributes1.ump
+++ b/umpleonline/ump/manualexamples/W218ConflictInAttributes1.ump
@@ -1,4 +1,6 @@
-// In this example, there is a warning because in class "A" there will be two attributes with the name called "name".
+// In this example, there is a warning
+// because in class "A" there will be
+// two attributes with the name called "name".
 
 class A{
 	isA T;

--- a/umpleonline/ump/manualexamples/W218ConflictInAttributes2.ump
+++ b/umpleonline/ump/manualexamples/W218ConflictInAttributes2.ump
@@ -1,4 +1,7 @@
-// In this example, there is a warning because in trait "T" there will be two attributes with the name called "name".
+// In this example, there is a
+// warning because in trait "T"
+// there will be two attributes
+// with the name called "name".
 class A{
 	isA T;
 }

--- a/umpleonline/ump/manualexamples/W228InitialStates.ump
+++ b/umpleonline/ump/manualexamples/W228InitialStates.ump
@@ -1,4 +1,7 @@
-// In this example, there is an warning because two traits T1 and T2 have state machines with the same name but with different initial states.
+// In this example, there is an warning
+// because two traits T1 and T2 have
+// state machines with the same name but
+// with different initial states.
 trait T1{
   sm{
     s1{ e1 ->  s2;}

--- a/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid2.ump
+++ b/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid2.ump
@@ -1,4 +1,5 @@
-// Warnings from attribute starting with upper case letter (131)
+// Warnings from attribute starting with
+// upper case letter (131)
 class X {
   Attrib;
 }

--- a/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid4.ump
+++ b/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid4.ump
@@ -1,5 +1,7 @@
-// Attribute name with special characters that looks like an association (132)
-// If this is supposed to be an association, put spaces before and after the -- and *
+// Attribute name with special characters
+// that looks like an association (132)
+// If this is supposed to be an association,
+// put spaces before and after the -- and *
 class X {
   1--*Y;
 }

--- a/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid5.ump
+++ b/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid5.ump
@@ -1,5 +1,7 @@
-// Attribute type with special characters that looks like an association (140)
-// If this is supposed to be an association, put spaces before and after the --
+// Attribute type with special characters
+// that looks like an association (140)
+// If this is supposed to be an association,
+// put spaces before and after the --
 class X {
   1--* Y;
 }

--- a/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid6.ump
+++ b/umpleonline/ump/manualexamples/WE1xxIdentifierInvalid6.ump
@@ -1,4 +1,5 @@
-// State machine name with special characters (150)
+// State machine name with special
+// characters (150)
 class X {
   ed%4 {
     s1 {}

--- a/umpleonline/ump/manualexamples/traits_example_005.ump
+++ b/umpleonline/ump/manualexamples/traits_example_005.ump
@@ -1,13 +1,14 @@
 /*
-  Example 1: implementing observable pattern with traits and associations.
+  Example 1: implementing observable pattern
+  with traits and associations.
 */
 class Dashboard{
-  void update (Sensor sensor){ /*implementation*/ }
+  void update (Sensor sensor){ /* code */ }
 }
 class Sensor{
   isA Subject< Observer = Dashboard >;
 }
 trait Subject <Observer>{
   0..1  -> * Observer;
-  void notifyObservers() { /*implementation*/ }
+  void notifyObservers() { /* code */ }
 }

--- a/umpleonline/ump/manualexamples/traits_example_009.ump
+++ b/umpleonline/ump/manualexamples/traits_example_009.ump
@@ -1,5 +1,6 @@
 /*
-	Example 1: showing how required interfaces in traits are defined and used.
+	Example 1: showing how required interfaces
+	in traits are defined and used.
 */
 interface I1{
   void method1();

--- a/umpleonline/ump/manualexamples/traits_example_010.ump
+++ b/umpleonline/ump/manualexamples/traits_example_010.ump
@@ -1,5 +1,6 @@
 /*
-	Example 1: showing how the operator "Removing/keeping provided methods" works.
+	Example 1: showing how the operator
+	"Removing/keeping provided methods" works.
 */
 trait T1{
   abstract method1(); 
@@ -10,9 +11,9 @@ trait T1{
 }
 class C1{
   isA T1<-method2() , -method3()>;
-  void method1() {/*implementation related to C1*/}
+  void method1() {/*implementation for C1*/}
 }
 class C2{
   isA T1<+method5()>;
-  void method1() {/*implementation related to C2*/}
+  void method1() {/*implementation for C2*/}
 }

--- a/umpleonline/ump/manualexamples/traits_example_013.ump
+++ b/umpleonline/ump/manualexamples/traits_example_013.ump
@@ -1,5 +1,6 @@
 /*
-	Example 2: showing how state machines are defined through different traits.
+	Example 2: showing how state machines
+	are defined through different traits.
 */
 trait T1 {
   sm1{

--- a/umpleonline/ump/manualexamples/traits_example_014.ump
+++ b/umpleonline/ump/manualexamples/traits_example_014.ump
@@ -1,5 +1,7 @@
 /*
-	Example 3:showing how required methods of traits are satisfied by events of state machines.
+	Example 3:showing how required methods
+	of traits are satisfied by events of
+	state machines.
 */
 trait T1{
   Boolean m1(String input);

--- a/umpleonline/ump/manualexamples/traits_example_015.ump
+++ b/umpleonline/ump/manualexamples/traits_example_015.ump
@@ -1,5 +1,6 @@
 /*
-	Example 4: showing how template parameters in traits are used inside state machines.
+	Example 4: showing how template parameters
+	in traits are used inside state machines.
 */
 trait T1<TP>{
   sm{

--- a/umpleonline/ump/manualexamples/traits_example_018.ump
+++ b/umpleonline/ump/manualexamples/traits_example_018.ump
@@ -1,5 +1,6 @@
 /*
-	Example 3: showing how the operator "Changing the name of a state" works.
+	Example 3: showing how the operator
+	"Changing the name of a state" works.
 */
 trait T1 {
   sm{

--- a/umpleonline/ump/manualexamples/traits_example_019.ump
+++ b/umpleonline/ump/manualexamples/traits_example_019.ump
@@ -1,5 +1,6 @@
 /*
-	Example 4: showing how the operator "Change the name of events" works.
+	Example 4: showing how the operator
+	"Change the name of events" works.
 */
 trait T1 {
   sm1{
@@ -12,5 +13,6 @@ sm2{
 }
 }
 class C1 {
-  isA T1<sm1.e1(Integer) as event1, *.e0() as event0>;
+  isA T1<sm1.e1(Integer) as event1,
+    *.e0() as event0>;
 }

--- a/umpleonline/ump/manualexamples/traits_example_020.ump
+++ b/umpleonline/ump/manualexamples/traits_example_020.ump
@@ -1,5 +1,6 @@
 /*
-	Example 5: showing how the operator "Removing/keeping a state machine" works.
+	Example 5: showing how the operator
+	"Removing/keeping a state machine" works.
 */
 trait T1 {
   sm1{

--- a/umpleonline/ump/manualexamples/traits_example_021.ump
+++ b/umpleonline/ump/manualexamples/traits_example_021.ump
@@ -1,5 +1,6 @@
 /*
-	Example 6: showing how the operator "Removing/keeping a state" works.
+	Example 6: showing how the operator
+	"Removing/keeping a state" works.
 */
 trait T1 {
   sm1{

--- a/umpleonline/ump/manualexamples/traits_example_022.ump
+++ b/umpleonline/ump/manualexamples/traits_example_022.ump
@@ -1,5 +1,6 @@
 /*
-	Example 7: showing how the operator "Removing/keeping a region" works.
+	Example 7: showing how the operator
+	"Removing/keeping a region" works.
 */
 trait T1{
   sm {

--- a/umpleonline/ump/manualexamples/traits_example_023.ump
+++ b/umpleonline/ump/manualexamples/traits_example_023.ump
@@ -1,5 +1,6 @@
 /*
-	Example 8: showing how the operator "Removing/keeping a transition" works.
+	Example 8: showing how the operator
+	"Removing/keeping a transition" works.
 */
 trait T1{
   internal Boolean cond;


### PR DESCRIPTION
This changes many code examples in the user manual so their comments use 40 or fewer characters per line. This makes the user manual look better and be more responsive.

This also changes en.error to point to manual.umple.org instead of the cruise site, making the URLs shorter and more portable. That could make oustanding work unmergable since all lines in en.error are changing.

Finally it fixes a few missing links in en.error to manual pages.