### PR TITLE
Fixes #1220 crash in multiple inheritance check instead of error 34

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1205,12 +1205,20 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     	  processGTemplateParameterAssignment(extendsToken, aClassifier, extendName);
       }
     }
+    
   	//Checks list of extends tokens to prevent multiple class inheritance
     if(numberOfExtendsClass(unlinkedExtendsTokens.get(aClassifier)) > 1)
-	{
-	  Token t = extendsTokenList.get(0);    	
-	  getParseResult().addErrorMessage(new ErrorMessage(34,t.getPosition(),aClassifier.getName(),t.getValue()));
-	}
+	  {
+      Token t = classifierToken;
+	    String otherClass = "indicated here";
+      Position thePosition = new Position("",0,0,0);
+	    if(extendsTokenList.size()>0) {
+	      t = extendsTokenList.get(0);
+	      otherClass = t.getValue();
+	      thePosition = t.getPosition();
+	    }
+	    setFailedPosition(thePosition, 34, aClassifier.getName(), otherClass);
+	  }
   }
 	
 	//Returns the number of umple class in extends list (extList)


### PR DESCRIPTION
When attempting to specify multiple inheritance, where the two superclasses were defined after the erroneous multiple inheritance spec, a crash occurred instead of raising error 34.

This fixes that crash that was reported in #1220 

However. a new issue #1221 has been raised to deal with some residual anomalies.
