### PR TITLE
Raise warnings for duplicate method implementations

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2822,18 +2822,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     	  {
           for(String l : implementations)
           {
-        	  if((actualMethod.getMethodBody().getExtraCode(l).equals("") || 
-              actualMethod.getMethodBody().getExtraCode(l).equals("\n"))&&
-             (!aMethod.getMethodBody().getExtraCode(l).equals("") ||
-        	      !aMethod.getMethodBody().getExtraCode(l).equals("\n")) &&
-        	     (!actualMethod.getMethodBody().getExtraCode(l).equals(aMethod.getMethodBody().getExtraCode(l))))
-        	  {
-              actualMethod.getMethodBody().setExtraCode(l, aMethod.getMethodBody().getExtraCode(l));
-              actualMethod.getMethodBody().getImplementationPositions().put(l, aMethod.getMethodBody().getImplementationPositions().get(l));
-        	  }
-        	  else
-        	  {
-        	  
     	      if (isGetterSetter(actualMethod)) {
               String methodName = aMethod.getName();
               String attributeName = methodName.substring(3,methodName.length()).toLowerCase();
@@ -2852,7 +2840,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
                   	  aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
                   	  aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
               }
-        	  }
         	  
           }
     	  }

--- a/cruise.umple/test/cruise/umple/compiler/001_methodConflictWithAutoGeneratedGetterAndSetterAndNoUserGeneratedMethodBody.ump
+++ b/cruise.umple/test/cruise/umple/compiler/001_methodConflictWithAutoGeneratedGetterAndSetterAndNoUserGeneratedMethodBody.ump
@@ -1,7 +1,0 @@
-class A{
-    abc;
-    boolean setAbc(String data){	
-    }    
-    String getAbc(){
-    }  
-}

--- a/cruise.umple/test/cruise/umple/compiler/001_methodconflictWithAutoGeneratedGetterAndSetter.ump
+++ b/cruise.umple/test/cruise/umple/compiler/001_methodconflictWithAutoGeneratedGetterAndSetter.ump
@@ -1,7 +1,6 @@
 class A{
     abc;
     boolean setAbc(String data){
-    	int a;
     }    
     String getAbc(){
     	int a;


### PR DESCRIPTION
Consider the following code:
```
class X {
  doThings() {
  }
  doThings() {
    int x;
  }
}
```
This appears to have been designed not to throw an error; instead, it appends the body of the second method into the first, provided the first has no method body. This should not be the case, and this PR updates it to throw a 49 "Duplicate method definition" warning. 

This PR also fixes issue #1215, namely, that conflicts with auto-generated getter/setters weren't being raised as warnings _if the user-generated method had a method body_. For this case, the error message 1009 should be updated to tell the user to add a before/after directive instead of directly overriding the API method body.

