### PR TITLE
Activation of build.exampletests.xml issue #758

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ nohup.out
 
 # umple specific
 umpleonline/ump/tmp*
+build/UserManualAndExampleTests_output.txt
 
 # generated Umple code that is not saved
 src-gen-umple/

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - ANT_FIRST='ant -f build.umple.xml'
     - ANT_BUILD='ant -f build.umple.xml -Dfirst.build=false'
     - ANT_TESTBED='ant -f build.testbed.xml -Dfirst.build=false'
+    - ANT_EXAMPLES='ant -f build.exampletests.xml'
 
 script:
   - php --version ; ruby -v
@@ -50,6 +51,7 @@ script:
   - $ANT_TESTBED clean template.clean init
   - $ANT_TESTBED compile 
   - $ANT_TESTBED test 
+  - $ANT_EXAMPLES allUserManualAndExampleTests   
   - $ANT_TESTBED template.resetVersion 
 
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,4 +52,4 @@ build_script:
 test_script:
 
 - cmd: ant -f build.testbed.xml -Dfirst.build=false
-
+- cmd: ant -f build.exampletests.xml allUserManualAndExampleTests

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -27,20 +27,26 @@
 
   <!-- Entry points -->
 
-  <target name="allUserManualAndExampleTests" depends="startLog,deleteTempFolders,testSetup,checkRuby">
+  <target name="allUserManualAndExampleTests" depends="startLog,deleteTempFolders,testSetup">
     <echo>Building User Manual and UmpleOnline Examples</echo>
     <echo>See ${fulllogfile} for build results</echo>
 
     <!-- Forces ruby to be skipped unless allowruby is set to true 
-    on the command line or in the ruby-specific target -->
+    on the command line or in the ruby-specific target. -->
     <property name="allowruby" value="false" />
+    <antcall target="checkRuby" />
+
+    <!-- Forces C++ to be skipped unless allowcpp is set to true
+    on the command line or if the C++ specific target is used. -->
+    <property name="allowcpp" value="false" />
+    <antcall target="checkCpp" />
 
     <trycatch>
       <try>
         <antcall target="doJava" />
-        <!--<antcall target="doCpp" />-->
-        <antcall target="doPhp" />
-        <antcall target="doRuby" />
+        <!-- <antcall target="doCpp" />-->
+        <!--<antcall target="doPhp" />-->
+        <!--<antcall target="doRuby" />-->
       </try>
       
       <finally>
@@ -65,6 +71,7 @@
   </target>
 
   <target name="cppUserManualAndExampleTests">
+    <property name="allowcpp" value="true" />
     <property name="mode.notjava" value="true" />
     <property name="mode.notphp" value="true" />
     <property name="mode.notruby" value="true" />
@@ -104,6 +111,7 @@
       <exclude name="WE1xxIdentifierInvalid5.ump" />
       <exclude name="WE1xxIdentifierInvalid6.ump" />
       <exclude name="WE1xxIdentifierInvalid7.ump" />
+      <exclude name="W142TypeIsAccessSpecifierAmbiguous.ump" />
       <!-- This fails to compile because they are incomplete examples of umple -->
       <exclude name="UseStatements1.ump" />
     </fileset>  
@@ -733,5 +741,12 @@
       <isfalse value="${allowruby}" />
     </condition>
     <echo>NotRuby: ${mode.notruby}</echo>
+  </target>
+
+  <target name="checkCpp">
+    <condition property="mode.notcpp">
+      <isfalse value="${allowcpp}" />
+    </condition>
+    <echo>Not C++: ${mode.notcpp}</echo>
   </target>
 </project>

--- a/build/build.xml
+++ b/build/build.xml
@@ -28,7 +28,9 @@
         <echo>Building Java Testbed (Testing that Umple Generated Code Works)</echo>
         <ant antfile="build/build.testbed.xml" target="build" inheritAll="false" />
 
-      </try>
+       <echo>Testing UmpleOnline Examples and Manual Examples</echo>
+       <ant antfile="build/build.exampletests.xml" target="allUserManualAndExampleTests" inheritAll="false" />
+     </try>
 
       <finally>
         <antcall target="qaLandingPage" />

--- a/umpleonline/ump/AccessControl.ump
+++ b/umpleonline/ump/AccessControl.ump
@@ -102,8 +102,4 @@ class RoleFacilityAccessRight{
   position.association Facility__RoleFacilityAccessRight 27,0 163,130;
 }
 
-/*
-@@@testlanguage=java,cpp,php
-*/
-
 // @@@skipphpcompile - remove when issue 697 is fixed

--- a/umpleonline/ump/CollisionAvoidanceA1.ump
+++ b/umpleonline/ump/CollisionAvoidanceA1.ump
@@ -90,3 +90,4 @@ class CollisionAvoidanceA1 {
 		} 
 	}	 
 }
+// @@@skipcompile incomplete Java

--- a/umpleonline/ump/CollisionAvoidanceA2.ump
+++ b/umpleonline/ump/CollisionAvoidanceA2.ump
@@ -104,4 +104,4 @@ class CollisionAvoidanceA2 {
 		} 
 	}	 
 }
-
+// @@@skipcompile incomplete Java

--- a/umpleonline/ump/CollisionAvoidanceA3.ump
+++ b/umpleonline/ump/CollisionAvoidanceA3.ump
@@ -105,3 +105,4 @@ class CollisionAvoidanceA3 {
 		} 
 	}	 
 }
+// @@@skipcompile incomplete Java

--- a/umpleonline/ump/HomeHeater.ump
+++ b/umpleonline/ump/HomeHeater.ump
@@ -115,3 +115,4 @@ class HeatControlSystem {
 		}
 	}
 }
+// @@@skipcompile incomplete Java

--- a/umpleonline/ump/OBDCarSystem.ump
+++ b/umpleonline/ump/OBDCarSystem.ump
@@ -218,3 +218,4 @@ class CarSystem {
  motorOilQuantity.motorOilQuantity -> motorOilCheck.motorOilQuantity;
  motorOilViscosity.motorOilViscosity -> motorOilCheck.motorOilViscosity;
 }
+// @@@@@@testlanguage=none generated code does not compile - likely incomplete

--- a/umpleonline/ump/manualexamples/W049DuplicatedMethodName1.ump
+++ b/umpleonline/ump/manualexamples/W049DuplicatedMethodName1.ump
@@ -1,7 +1,7 @@
 // This example generates the message
 class A{
-  void test1(){return("hello world")}
-  void test1(){return("dlrow olleh")}
+  String test1(){return("hello world");}
+  String test1(){return("dlrow olleh");}
 }
 
 

--- a/umpleonline/ump/manualexamples/W071DuplicateMethodDifferentType1.ump
+++ b/umpleonline/ump/manualexamples/W071DuplicateMethodDifferentType1.ump
@@ -1,7 +1,7 @@
 // This example generates the message
 class A{
-  void test1(){return("hello world")}
-  Integer test1(){return("dlrow olleh")}
+  String test1(){return("hello world");}
+  int test1(){return(1);}
 }
 
 

--- a/umpleonline/ump/manualexamples/W071DuplicateMethodDifferentType2.ump
+++ b/umpleonline/ump/manualexamples/W071DuplicateMethodDifferentType2.ump
@@ -3,4 +3,4 @@ class A{
   void test2(){}
   Integer test1(){}
 }
-
+// @@@skipcompile no return from test1

--- a/umpleonline/ump/manualexamples/W072RefactoredFinalState1.ump
+++ b/umpleonline/ump/manualexamples/W072RefactoredFinalState1.ump
@@ -27,3 +27,4 @@ class InvalidFinalState {
     }
   }
 }
+// @@@skipcompile no method entry written for line 15

--- a/umpleonline/ump/manualexamples/W072RefactoredFinalState2.ump
+++ b/umpleonline/ump/manualexamples/W072RefactoredFinalState2.ump
@@ -14,3 +14,4 @@ class X {
     }
   }
 }
+// @@@skipcompile no method entry written line 13

--- a/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierExplicit.ump
+++ b/umpleonline/ump/manualexamples/W142TypeIsAccessSpecifierExplicit.ump
@@ -9,3 +9,4 @@ class X {
 }
 
 //$?[End_of_model]$?
+// @@@testlanguage=none because msg says likely error

--- a/umpleonline/ump/manualexamples/W201NotWellDefinedIdentifier.ump
+++ b/umpleonline/ump/manualexamples/W201NotWellDefinedIdentifier.ump
@@ -8,3 +8,4 @@ trait color {
 trait equality{
 	//traits elements
 }
+// @@@skipcompile no code

--- a/umpleonline/ump/manualexamples/traits_example_001.ump
+++ b/umpleonline/ump/manualexamples/traits_example_001.ump
@@ -9,3 +9,4 @@ trait TEquality{
     return isEqual(object) ? true : false;
   }
 } 
+// @@@skipcompile Java code not compilable no class

--- a/umpleonline/ump/manualexamples/traits_example_004.ump
+++ b/umpleonline/ump/manualexamples/traits_example_004.ump
@@ -15,3 +15,4 @@ class C1{
   Integer data;
   isA T1;
 }
+// @@@@@@testlanguage=none Java code not compile

--- a/umpleonline/ump/manualexamples/traits_example_006.ump
+++ b/umpleonline/ump/manualexamples/traits_example_006.ump
@@ -21,3 +21,4 @@ class C2{
   void method1(){/*implementation*/}
   C2 method2(C2 data){ /*implementation*/ }
 }
+// @@@skipcompile issue needs raising missing return statement

--- a/umpleonline/ump/manualexamples/traits_example_008.ump
+++ b/umpleonline/ump/manualexamples/traits_example_008.ump
@@ -16,3 +16,5 @@ class C2{
   isA T1< TP = C1 >;
   String method1(){/*implementation*/ }
 }
+// @@@skipcompile issue needs raising as Java
+// compile fails missing return statement

--- a/umpleonline/ump/manualexamples/traits_example_009.ump
+++ b/umpleonline/ump/manualexamples/traits_example_009.ump
@@ -32,3 +32,4 @@ class C2 {
   isA C3, I2, T3;
   Boolean method3(){/*implementation*/ }
 }
+// @@@skipcompile Java code not compilable

--- a/umpleonline/ump/manualexamples/traits_example_022.ump
+++ b/umpleonline/ump/manualexamples/traits_example_022.ump
@@ -26,5 +26,6 @@ class C1{
 class C2{
   isA T1<+sm.s1.r2>;
 }
+// @@@skipcompile issue needs raising as Java compile fails
 
 


### PR DESCRIPTION
The build.exampletests.xml created two years ago by Craig Bryan was never added to the full build, as a result there has been some regression (examples failing to compile and/or generate valid code). This PR activates this testing so that all UmpleOnline examples and user manual examples are compiled, and then Java is generated from them.

However see issue #758 for further steps. Php and C++ are being skipped for now as there are some errors that need dealing with. 

This PR will add about 50% to full build time, but it is necessary to keep boosting Umple quality 