### PR TITLE
Fixes #1162 a guard that has a function with more than one parameter 

### DIFF
--- a/cruise.umple/src/UmpleAnalysis.ump
+++ b/cruise.umple/src/UmpleAnalysis.ump
@@ -670,10 +670,10 @@ class ConstraintParameterListCommaAnalyzer
   depend cruise.umple.compiler.*;
   depend java.util.*;
 
-  lazy ConstraintTree rawLine;
+  lazy ConstraintTree cv;
   public void analyze(Token token)
   {
-    rawLine.addElement(new ConstraintOperator(","));
+    cv.addElement(new ConstraintOperator(","));
   }
 }
 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/StateMachineTest.java
@@ -76,6 +76,12 @@ public class StateMachineTest extends StateMachineTemplateTest
     assertUmpleTemplateFor("oneGuard.ump",languagePath + "/oneGuard."+ languagePath +".txt","LightFixture");
   }
 
+ @Test
+  public void testTwoParameterGuard_1()
+  {
+    assertUmpleTemplateFor("testTwoParameterGuard.ump",languagePath + "/testTwoParameterGuard."+ languagePath +".txt","A_Guard");
+  }
+
   @Test
   public void multipleGuardsSameEvent()
   {
@@ -113,6 +119,8 @@ public class StateMachineTest extends StateMachineTemplateTest
     Event.setNextAutoTransitionId(1);
   }
   
+
+
   // SPACING
   
   // Spacing of state transaction actions
@@ -876,5 +884,7 @@ public class StateMachineTest extends StateMachineTemplateTest
   {
     assertUmpleTemplateFor("testRegionFinalStates_6.ump",languagePath + "/testRegionFinalStates_6."+ languagePath +".txt","X");
   }
+
+
   
 }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testTwoParameterGuard.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testTwoParameterGuard.java.txt
@@ -1,0 +1,111 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+package example;
+
+public class A_Guard
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //A_Guard State Machines
+  public enum Status { S1, S2, S3 }
+  private Status status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public A_Guard()
+  {
+    setStatus(Status.S1);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public String getStatusFullName()
+  {
+    String answer = status.toString();
+    return answer;
+  }
+
+  public Status getStatus()
+  {
+    return status;
+  }
+
+  public boolean e1(B myB)
+  {
+    boolean wasEventProcessed = false;
+    
+    Status aStatus = status;
+    switch (aStatus)
+    {
+      case S1:
+        if (checkGuard(myB))
+        {
+          setStatus(Status.S2);
+          wasEventProcessed = true;
+          break;
+        }
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  public boolean e2(B myB,B mySecondB)
+  {
+    boolean wasEventProcessed = false;
+    
+    Status aStatus = status;
+    switch (aStatus)
+    {
+      case S2:
+        if (checkGuard(myB))
+        {
+          setStatus(Status.S3);
+          wasEventProcessed = true;
+          break;
+        }
+        break;
+      case S3:
+        if (checkGuard(myB,mySecondB))
+        {
+          setStatus(Status.S1);
+          wasEventProcessed = true;
+          break;
+        }
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  private void setStatus(Status aStatus)
+  {
+    status = aStatus;
+  }
+
+  public void delete()
+  {}
+
+  // line 18 "../twoParameterGuard.ump"
+   private boolean checkGuard(B myB){
+    return true;
+  }
+
+  // line 21 "../twoParameterGuard.ump"
+   private boolean checkGuard(B myB, B mySecondB){
+    return true;
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/testTwoParameterGuard.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/testTwoParameterGuard.php.txt
@@ -1,0 +1,109 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.27.0.3728.d139ed893 modeling language!*/
+
+class A_Guard
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //A_Guard State Machines
+  private static $StatusS1 = 1;
+  private static $StatusS2 = 2;
+  private static $StatusS3 = 3;
+  private $Status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct()
+  {
+    $this->setStatus(self::$StatusS1);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getStatusFullName()
+  {
+    $answer = $this->getStatus();
+    return $answer;
+  }
+
+  public function getStatus()
+  {
+    if ($this->Status == self::$StatusS1) { return "StatusS1"; }
+    elseif ($this->Status == self::$StatusS2) { return "StatusS2"; }
+    elseif ($this->Status == self::$StatusS3) { return "StatusS3"; }
+    return null;
+  }
+
+  public function e1($myB)
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->Status;
+    if ($aStatus == self::$StatusS1)
+    {
+      if ($this->checkGuard($this->myB))
+      {
+        $this->setStatus(self::$StatusS2);
+        $wasEventProcessed = true;
+      }
+    }
+    return $wasEventProcessed;
+  }
+
+  public function e2($myB, $mySecondB)
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->Status;
+    if ($aStatus == self::$StatusS2)
+    {
+      if ($this->checkGuard($this->myB))
+      {
+        $this->setStatus(self::$StatusS3);
+        $wasEventProcessed = true;
+      }
+    }
+    elseif ($aStatus == self::$StatusS3)
+    {
+      if ($this->checkGuard($this->myB,$this->mySecondB))
+      {
+        $this->setStatus(self::$StatusS1);
+        $wasEventProcessed = true;
+      }
+    }
+    return $wasEventProcessed;
+  }
+
+  private function setStatus($aStatus)
+  {
+    $this->Status = $aStatus;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+   private function checkGuard(B $myB)
+  {
+    return true;
+  }
+
+   private function checkGuard(B $myB, B $mySecondB)
+  {
+    return true;
+  }
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/testTwoParameterGuard.ump
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/testTwoParameterGuard.ump
@@ -1,0 +1,25 @@
+namespace example;
+
+class A_Guard {
+  Status {
+    S1 {
+      // one parameter for the guard works
+      e1(B myB) [checkGuard(myB)] -> S2;
+    }
+    S2 {
+      // one parameter for the guard works
+      e2(B myB, B mySecondB) [checkGuard(myB)] -> S3;
+    }
+    S3 {
+      // two parameters for the guard do not compile
+      e2(B myB, B mySecondB) [checkGuard(myB, mySecondB)] -> S1;
+    }
+  }
+  private boolean checkGuard(B myB) {
+    return true;
+  } 
+  private boolean checkGuard(B myB, B mySecondB) {
+    return true;
+  }
+}
+class B {}


### PR DESCRIPTION
A transition guard with more than one parameter will cause a crash to umple compiler. This error occurs because ConstraintParameterListCommaAnalyzer has lazy a ConstraintTree variable that is not initialized. The issue is solved here by renaming the ConstraintTree as "cv", since it will be initialized by analyzeToken (..) method of the Analyzer class. Other names will cause failure to umple compiler. 