### PR TITLE
Fix Issue 1002 and Refactor Methods

### DIFF
--- a/cruise.umple/src/StateMachine.ump
+++ b/cruise.umple/src/StateMachine.ump
@@ -93,7 +93,7 @@ class Activity
   
   CodeBlock codeblock = null;
   after constructor {codeblock = aActivityCode!=null ? new CodeBlock(aActivityCode) : new CodeBlock();}
-  before setActivityCode {codeblock.setCode(aActivityCode);}
+  before generated setActivityCode {codeblock.setCode(aActivityCode);}
   after getActivityCode{
   	if (codeblock.getCode()!=null)
   	  return codeblock.getCode();
@@ -158,7 +158,7 @@ class Action
   
   CodeBlock codeblock = null;
   after constructor {codeblock = aActionCode!=null ? new CodeBlock(aActionCode) : new CodeBlock();}
-  before setActionCode {codeblock.setCode(aActionCode);}
+  before generated setActionCode {codeblock.setCode(aActionCode);}
   after getActionCode{
   	if (codeblock.getCode()!=null)
   	  return codeblock.getCode();

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -634,7 +634,9 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       for(Token injectToken : entry.getValue())
       {
         String operationSource = getOperationSource(injectToken);
-        checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
+        if ("".equals(operationSource))
+          operationSource = "generated";
+        checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey(), operationSource);
       }
     } 
   }
@@ -3334,23 +3336,18 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     return methodNames;
   }
 
-  private void checkCodeInjectionValidity(Token injectToken, UmpleClass uClass) {
+  private void checkCodeInjectionValidity(Token injectToken, UmpleClass uClass, String operationSource) {
     List<Method> methods = uClass.getMethods();
     ArrayList<String> methodNames = getAllMethodNames(uClass);
     String[] allOperations = getOperationName(injectToken).split(",");
     List<String> allParameters = getOperationsParameters(injectToken);
-
-    String operationSource = getOperationSource(injectToken);
-    if("".equals(operationSource)) {
-      operationSource = "generated";
-    }
 
     for(int opInd = 0; opInd < allOperations.length; opInd++)
     {
       String operation = allOperations[opInd];
       String currentParameters = allParameters.get(opInd);
       Boolean hasExclusion = false;
-      if(operation.charAt(0) == '!') {
+      if(operation.charAt(0) == '!' && "generated".equals(operationSource)) {
         hasExclusion = true;
         operation = operation.substring(1);
       }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -634,18 +634,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       for(Token injectToken : entry.getValue())
       {
         String operationSource = getOperationSource(injectToken);
-        if("all".equals(operationSource))
-        {
-          checkCodeInjectionValidityAll(injectToken, (UmpleClass) entry.getKey());
-        }
-        else if("custom".equals(operationSource)) 
-        {
-          checkCodeInjectionValidityCustom(injectToken, (UmpleClass) entry.getKey());
-        }
-        else
-        {
-          checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
-        }
+        checkCodeInjectionValidity(injectToken, (UmpleClass) entry.getKey());
       }
     } 
   }
@@ -3239,7 +3228,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     String operationSource = getOperationSource(injectToken).toLowerCase();
 
     if(operationSource.equals("")) {
-      operationSource = "generated";
+      operationSource = "all";
     }
 
     CodeInjection injection = new CodeInjection(type,operationName,"",uClassifier);
@@ -3345,84 +3334,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     return methodNames;
   }
 
-  
-  private void checkCodeInjectionValidityCustom(Token injectToken, UmpleClass uClass) {
-    List<Method> methods = uClass.getMethods();
-    String[] allOperations = getOperationName(injectToken).split(",");
-    List<String> allParameters = getOperationsParameters(injectToken);
-
-    String operationSource = getOperationSource(injectToken);
-    if("".equals(operationSource)) {
-      operationSource = "generated";
-    }
-
-    for(int opInd = 0; opInd < allOperations.length; opInd++)
-    {
-      String operation = allOperations[opInd];
-      String currentParameters = allParameters.get(opInd);
-
-      Boolean matches = false;
-
-      for(Method method : methods) 
-      { 
-        boolean tmpMatches = uClass.matchOperationMethod(operation, method.getName()) && checkParameterMatch(method.getMethodParameters(), currentParameters);
-        matches = matches || tmpMatches;
-      }
-
-      if(!matches) {
-        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
-      }
-    }
-  } 
-
-  private void checkCodeInjectionValidityAll(Token injectToken, UmpleClass uClass) {
-    List<Method> methods = uClass.getMethods();
-    ArrayList<String> methodNames = getAllMethodNames(uClass);
-    String[] allOperations = getOperationName(injectToken).split(",");
-    List<String> allParameters = getOperationsParameters(injectToken);
-
-    String operationSource = getOperationSource(injectToken);
-    if("".equals(operationSource)) {
-      operationSource = "generated";
-    }
-
-    for(int opInd = 0; opInd < allOperations.length; opInd++)
-    {
-      String operation = allOperations[opInd];
-      String currentParameters = allParameters.get(opInd);
-
-      Boolean matches = false;
-
-      // check against generated methods
-      for(String methodName : methodNames) 
-      { 
-        if (uClass.matchOperationMethod(operation, methodName)) {
-          matches = true;
-        }
-      }
-
-      // check against custom methods
-      for(Method method : methods) 
-      { 
-        boolean tmpMatches = uClass.matchOperationMethod(operation, method.getName()) && checkParameterMatch(method.getMethodParameters(), currentParameters);
-        matches = matches || tmpMatches;
-      }
-
-      if(!matches) {
-        getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
-      }
-
-      if(!"...".equals(currentParameters)) {
-        getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
-      }
-    }
-  }
-
   private void checkCodeInjectionValidity(Token injectToken, UmpleClass uClass) {
+    List<Method> methods = uClass.getMethods();
     ArrayList<String> methodNames = getAllMethodNames(uClass);
-    
     String[] allOperations = getOperationName(injectToken).split(",");
-    
     List<String> allParameters = getOperationsParameters(injectToken);
 
     String operationSource = getOperationSource(injectToken);
@@ -3437,32 +3352,42 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       Boolean hasExclusion = false;
       if(operation.charAt(0) == '!') {
         hasExclusion = true;
-      	operation = operation.substring(1);
+        operation = operation.substring(1);
       }
 
       Boolean matches = false;
 
-      for(String methodName : methodNames) 
-      { 
-        if (uClass.matchOperationMethod(operation, methodName)) {
-          matches = true;
+      // check against generated methods
+      if ("all".equals(operationSource) || "generated".equals(operationSource)) {
+        for(String methodName : methodNames) 
+        { 
+          if (uClass.matchOperationMethod(operation, methodName)) {
+            matches = true;
+          }
         }
-        
+      }
+
+      // check against custom methods
+      if("all".equals(operationSource) || "custom".equals(operationSource)){
+        for(Method method : methods) 
+        { 
+          boolean tmpMatches = uClass.matchOperationMethod(operation, method.getName()) && checkParameterMatch(method.getMethodParameters(), currentParameters);
+          matches = matches || tmpMatches;
+        }
       }
 
       if(!matches) {
-        if(hasExclusion) {
+        if(hasExclusion && "generated".equals(operationSource)) {
           getParseResult().addErrorMessage(new ErrorMessage(1014, injectToken.getPosition(), operation));
         }
         else {
           getParseResult().addErrorMessage(new ErrorMessage(1012, injectToken.getPosition(), operation));
-      	}
+        }
       }
 
-      if(!"...".equals(currentParameters)) {
+      if(!"...".equals(currentParameters) && !"custom".equals(operationSource)) {
         getParseResult().addErrorMessage(new ErrorMessage(1013, injectToken.getPosition(), operationSource));
       }
-       
     }
   }
   

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -1469,12 +1469,26 @@ class UmpleClass
         methodNames.add(ev.getName());
       }
     }
+    
+    for (Method m: this.getMethods()) {
+      if (!isGetterSetter(m) && !m.isIsConstructor()) {
+        methodNames.add(m.getName());
+      }
+    }
 
     methodNames.add("constructor");
     methodNames.add("delete");
     methodNames.add("toString");
 
     return methodNames;
+  }
+  
+    // line 1869 "../../../../src/UmpleInternalParser_CodeClass.ump"
+   private boolean isGetterSetter(Method method){
+    if (method.getName().length() <= 2)
+  		return false;
+    String accessorName = method.getName().substring(0,3);
+  	return ((accessorName.equals("get")) || (accessorName.equals("set"))) && method.getSource() == Method.Source.fAutoAPI && !method.getIsConstructor();
   }
 
   public Boolean matchOperationMethod(String fullOperation, String method) {

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -1538,7 +1538,7 @@ class UmpleClass
 
     for (CodeInjection code : getCodeInjections())
     {
-      if (code.getOperation() == null || !type.equals(code.getType()) || (!"all".equals(code.getOperationSource()) && !"generated".equals(code.getOperationSource())))
+      if (code.getOperation() == null || !type.equals(code.getType()) || !("all".equals(code.getOperationSource()) || "generated".equals(code.getOperationSource())))
       {
         continue;
       }
@@ -1600,7 +1600,7 @@ class UmpleClass
     String formattedMethod = method;
     for (CodeInjection code : getCodeInjections())
     {
-      if (code.getOperation() == null || !type.equals(code.getType()) || (!"all".equals(code.getOperationSource()) && !"custom".equals(code.getOperationSource())))
+      if (code.getOperation() == null || !type.equals(code.getType()) || !("all".equals(code.getOperationSource()) || "custom".equals(code.getOperationSource())))
       {
         continue;
       }


### PR DESCRIPTION
Initially, custom methods without the prefix "custom" or "all" threw a 1012 error when before/after functionality was added. This PR fixes that issue and provides a number of code refactors.

- `getAllMethodNames()` now returns custom methods in addition to only generated ones
- Change default operationSource from "generated" to "all" when checking if code should be injected
- Combine 3 similar methods (`checkCodeInjectionValidityAll()`, `checkCodeInjectionValidityCustom()`) into 1, `checkCodeInjectionValidity()`
- Apply DeMorgan's law to Umple_Code.ump for better readability