### PR TITLE
Fix issue 1028

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/attribute_Get_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Get_All.ump
@@ -56,7 +56,7 @@ class UmpleToJava {
     else 
     {
 
-      if (av.getIsDerived() && customGetPostfixCode != null)
+      if (av.getIsDerived() && (customGetPostfixCode != null || customGetPrefixCode != null))
       {
         #>><<@ UmpleToJava.attribute_GetDerivedCodeInjection >><<#
       }

--- a/cruise.umple/test/cruise/umple/implementation/CodeInjectionTest.ump
+++ b/cruise.umple/test/cruise/umple/implementation/CodeInjectionTest.ump
@@ -7,6 +7,7 @@ class Student
   defaulted type = "None";
   String[] roles;
   funName = { name + "sillypans" }
+  otherFunName = { name + "Other Fun" }
   
   Boolean injBool;
   Boolean dInjBool = { 2/3 }
@@ -22,6 +23,8 @@ class Student
 
   before getFunName { print "start funName"; }
   after getFunName { print "end funName"; }
+  
+  before getOtherFunName { print "This was so much fun"; }
 
   before setId { print "start setId"; }
   after setId { print "end setId"; }

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
@@ -186,6 +186,13 @@ public class Student
     print "end funName";
     return aFunName;
   }
+  
+  public String getOtherFunName()
+  {
+    print "This was so much fun";
+    String aOtherFunName = name + "Other Fun";
+    return aOtherFunName;
+  }
 
   public boolean getInjBool()
   {
@@ -227,6 +234,7 @@ public class Student
             "name" + ":" + getName()+ "," +
             "type" + ":" + getType()+ "," +
             "funName" + ":" + getFunName()+ "," +
+            "otherFunName" + ":" + getOtherFunName()+ "," +
             "injBool" + ":" + getInjBool()+ "," +
             "dInjBool" + ":" + getDInjBool()+ "]";
   }

--- a/cruise.umple/test/cruise/umple/implementation/php/CodeInjectionTest_Attributes.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/CodeInjectionTest_Attributes.php.txt
@@ -189,6 +189,12 @@ class Student
     return $aFunName;
   }
 
+  public function getOtherFunName()
+  {
+    print "This was so much fun";
+    return name + "Other Fun";
+  }
+
   public function getInjBool()
   {
     return $this->injBool;

--- a/cruise.umple/test/cruise/umple/implementation/ruby/CodeInjectionTest_Attributes.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/CodeInjectionTest_Attributes.ruby.txt
@@ -168,6 +168,11 @@ class Student
     a_funName
   end
 
+  def get_otherFunName
+    print "This was so much fun";
+    name + "Other Fun"
+  end
+
   def get_injBool
     @injBool
   end


### PR DESCRIPTION
Issue #1028 is that `before` functionality can't be applied to derived attributes. After some digging, I realized that it's because the `if` block to inject `before` and `after` validates the existence of `after` functionality. If there is no `after` block, this injection is skipped over.  See my comment on the issue.

This small fix updates the `if` block to check for _either_ `before` or `after`, not just the `after`.