### PR TITLE
Fix issue 1027

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/attribute_Set_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set_All.ump
@@ -70,6 +70,9 @@ class UmpleToJava {
 
       String customSetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("setMethod",av)));
       String customSetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("setMethod",av)));
+      
+      String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+      String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getMethod",av)));
 
 //      String customResetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("resetMethod",av)));
 //      String customResetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("resetMethod",av)));
@@ -80,7 +83,7 @@ class UmpleToJava {
 //      String customRemovePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("removeMethod",av)));
 //      String customRemovePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("removeMethod",av)));
 
-      if(customSetPrefixCode!=null||customSetPostfixCode!=null)
+      if(customSetPrefixCode!=null || customSetPostfixCode!=null || customGetPrefixCode != null || customGetPostfixCode != null)
       {
         if (av.getModifier().equals("defaulted"))
         {

--- a/UmpleToJava/UmpleTLTemplates/attribute_Set_subclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set_subclass.ump
@@ -6,12 +6,18 @@ class UmpleToJava {
     <<# if (customSetPrefixCode != null) {
       addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPrefixCode,gen.translate("setMethod",av)); 
       append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
+      <<# if (customGetPrefixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
       <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_s", uClass,gen.translate("parameterOne",av)):"")>>
       wasSet = super.<<= gen.translate("setMethod",av) >>(<<=gen.translate("parameterOne",av)>>);
       <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_s", uClass):"")>>
     <<# if (customSetPostfixCode != null) {
       addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customSetPostfixCode,gen.translate("setMethod",av)); 
       append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
+      <<# if (customGetPostfixCode != null) {
+      addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
     return wasSet;
   }
 !>>


### PR DESCRIPTION
This PR fixes issue #1027, where inherited subclass methods couldn't have before/after functionality applied. As it turns out, the functionality was already built in, but only for `set` methods, not `get`. This PR extends functionality so it works on both getters and setters.