### PR TITLE
Fix 958: Conflict Constructors for Java

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -38,6 +38,7 @@ class JavaClassGenerator {
     depend cruise.umple.util.*;
     depend java.util.*;
     depend cruise.umple.parser.Position;
+    depend cruise.umple.parser.ErrorMessage;
 
     isA ILang;
 
@@ -179,6 +180,7 @@ for (StateMachine smq : uClass.getStateMachines())
   getEnumerationCode(realSb, model, uClass, isFirst);
   getMemberCode(realSb, model,uClass,gClass,gen,isFirst);
   getConstructorCode(realSb, model,uClass,gClass,gen,isFirst, false);
+  checkConflictBetweenGeneratedAndManualConstructors(realSb, model, uClass); 
   getProxyReferenceCode(realSb, model,uClass);
   getDistributedMethodsCode(realSb, model,uClass);
   getAttributeCode(realSb, model,uClass,gClass,gen,isFirst,false);
@@ -406,6 +408,52 @@ for (StateMachine smq : uClass.getStateMachines())
 }<<#}
   return realSb.toString();
 }
+
+ /*
+	Method name: checkConflictBetweenGeneratedAndManualConstructors
+	This method check conflicts between generated and constructors added by the user. 
+	This check is better to be done after umple compiler generates class constructors. 
+
+ */
+	private void checkConflictBetweenGeneratedAndManualConstructors(StringBuilder realSb, UmpleModel model, UmpleClass uClass) {
+
+		// generated constructors will be in one line string, to be prepared for ReqularExpression
+		String generatedConstructorsNocomments = realSb.toString().replaceAll("//.*.\\n", " ").replaceAll("/.*./", " "); // strip out all
+																									// comments
+		String generatedConstructorsNospace = generatedConstructorsNocomments.replaceAll("\\s+", " "); // strip out all spaces
+
+		List<Method> manualConstructorList = uClass.getMethods().stream()
+				.filter(aMethod -> (!aMethod.getIsConstructor() && aMethod.getName().equals(uClass.getName())))
+				.collect(java.util.stream.Collectors.toList());
+
+		for (Method manualConstructor : manualConstructorList) {
+			List<String> constructorParameterTypes = manualConstructor.getMethodParameters().stream().map(p -> p.getType())
+					.collect(java.util.stream.Collectors.toList());
+			//Position p = manualConstructor.getPosition();
+			String reqExpParameterString = "";
+			if (constructorParameterTypes.size() > 0)
+				{
+					reqExpParameterString = constructorParameterTypes.get(0) + "\\s+\\w+";
+					for (int i = 1; i < constructorParameterTypes.size(); i++) {
+						reqExpParameterString = reqExpParameterString + "\\s*,\\s*" + constructorParameterTypes.get(i) + "\\s+\\w+";
+						}
+				}
+
+			String manualConstructorReqExpression = ".*" + uClass.getName() + "\\s*" + "[(]\\s*" + reqExpParameterString + "[)].*";
+
+			if(generatedConstructorsNospace.matches(manualConstructorReqExpression))
+			{
+				//model.getLastResult().
+				model.getLastResult().setPosition(manualConstructor.getPosition());
+				model.getLastResult().addErrorMessage(new ErrorMessage(171,manualConstructor.getPosition(),""));
+				
+			
+			}
+			//System.out.println("search string : " + manualConstructorReqExpression + " ... found: " + generatedConstructorsNospace.matches(manualConstructorReqExpression));
+		}
+		
+	}
+
 #>><<@ UmpleToJava.uncaught_exception >><<#
 
 

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3178,6 +3178,9 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         	if(uClass.getName().equals(methodToken.getValue()))
         	{
         		setFailedPosition(token.getPosition(), 170, "");
+        	// Manual constructors should not be flagged wih setIsConstructor(true) of aMethod.
+        	// Otherwise, they will be mixed with umple generated constructors.
+        	
         	}
         	
         }

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -127,6 +127,7 @@
 
 
 170: 3, "http://manual.umple.org/build/reference/09170CustomConstructor.txt", Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.;
+171: 1, "http://manual.umple.org/build/reference/09170CustomConstructor.txt", A custom constructor should not conflict with an auto-generated constructor.;
 180: 2, "http://manual.umple.org/?E180DuplicateAssociationNameClassHierarchy", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
 
 # Messages related to traits starting with 200

--- a/testbed/test/cruise/compiler/CompilerErrorOutputTests.java
+++ b/testbed/test/cruise/compiler/CompilerErrorOutputTests.java
@@ -56,6 +56,10 @@ public class CompilerErrorOutputTests
 	}
 	
 	@Test
+	public void ConflictConstructorTest() {
+		CompilerErrorUtil.AssertCompileError("ConflictConstructor.ump", "ConflictConstructor.txt");
+	}
+	@Test
 	public void OneLineTest() {
 		CompilerErrorUtil.AssertCompileError("One_Line.ump", "One_Line.txt");
 	}

--- a/testbed/test/cruise/compiler/expected/ConflictConstructor.txt
+++ b/testbed/test/cruise/compiler/expected/ConflictConstructor.txt
@@ -1,8 +1,4 @@
 Warning 170 on line 4 of file "ConflictConstructor.ump":
 Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.
-Error 171 on line 4 of file "extraCode.ump":
+Error 171 on line 4 of file "ConflictConstructor.ump":
 A custom constructor should not conflict with an auto-generated constructor.
-A.java:69: error: constructor A(D) is already defined in class A
-       public  A(D d){
-               ^
-

--- a/testbed/test/cruise/compiler/expected/ConflictConstructor.txt
+++ b/testbed/test/cruise/compiler/expected/ConflictConstructor.txt
@@ -1,0 +1,8 @@
+Warning 170 on line 4 of file "ConflictConstructor.ump":
+Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.
+Error 171 on line 4 of file "extraCode.ump":
+A custom constructor should not conflict with an auto-generated constructor.
+A.java:69: error: constructor A(D) is already defined in class A
+       public  A(D d){
+               ^
+

--- a/testbed/test/cruise/compiler/src/ConflictConstructor.ump
+++ b/testbed/test/cruise/compiler/src/ConflictConstructor.ump
@@ -4,8 +4,9 @@ class A
 	A (D d) {} 
 }
 
-class D{
+class D
+{
 
 	1 -- * A a;
-	}
 }
+

--- a/testbed/test/cruise/compiler/src/ConflictConstructor.ump
+++ b/testbed/test/cruise/compiler/src/ConflictConstructor.ump
@@ -1,0 +1,11 @@
+generate Java "../src-gen-umple";
+class A
+{
+	A (D d) {} 
+}
+
+class D{
+
+	1 -- * A a;
+	}
+}


### PR DESCRIPTION
This PR will make umple raise error if a hard-coded constructor matches one that generated by umple. More discussion about this error can be found in[ issue 958](https://github.com/umple/umple/issues/958)

The error will be present to the user as the screenshot shows: 
![](https://user-images.githubusercontent.com/11878501/37626333-ff25a020-2ba5-11e8-99c1-829f0bb3212f.png)
