### PR TITLE
Investigate appveyor fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ cache:
 init:
 
 - cmd: gem update --system
-#- ps: cinst ant 2>&1 | Out-Null
-- ps: cinst ant
+#- ps: cinst ant 2>&1 | Out-Null  ## used to work
+- ps: choco install ant --ignore-dependencies
 
 # install some dependencies needed by php
 - ps: choco install chocolatey-core.extension --ignore-dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,8 @@ cache:
 init:
 
 - cmd: gem update --system
-- ps: cinst ant 2>&1 | Out-Null
+#- ps: cinst ant 2>&1 | Out-Null
+- ps: cinst ant
 
 # install some dependencies needed by php
 - ps: choco install chocolatey-core.extension --ignore-dependencies


### PR DESCRIPTION
Appveyor install of ant was failing, thus failing the build. This fixes by moving from cinst to chocolatey install