### PR TITLE
Fix issue #1153

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -201,7 +201,7 @@ class UmpleToJava {
               String[] properMethodLines = properMethodBody.split("\\n");
               String fixedProperMethodBody = "";
               for(int i = 0; i < properMethodLines.length; i++) {
-                if(properMethodLines[i].contains("return") && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
+                if(GeneratorHelper.isValidReturnStatement(properMethodLines[i]) && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
                   String[] splitLines = properMethodLines[i].split("return", 2); 
                   // Determine indentation of return by adding indentation amount to previous line
                   String returnIndent = "";
@@ -236,6 +236,13 @@ class UmpleToJava {
               // inject the after injection code after every return, while appropriate indentation
               List<Integer> injectedLineNumbers = new ArrayList<Integer>();
               for(int i = -1; (i = properMethodBody.indexOf("return", i + 1)) != -1; ) {
+              	//Check if return statement is on its own line
+              	int lastChar = i - 1;
+              	while (properMethodBody.charAt(lastChar) == ' ')
+              	  lastChar--;
+              	if (properMethodBody.charAt(lastChar) != '\n') // If it has any non-space characters before it, it's invalid
+              	  continue;
+              
                 // determine the indentation of the return
                 String indent = "";
                 while(i >= 1 && properMethodBody.charAt(--i) == ' ') {

--- a/UmpleToPhp/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToPhp/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -96,7 +96,7 @@ class UmpleToPhp {
               String[] properMethodLines = properMethodBody.split("\\n");
               String fixedProperMethodBody = "";
               for(int i = 0; i < properMethodLines.length; i++) {
-                if(properMethodLines[i].contains("return") && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
+                if(GeneratorHelper.isValidReturnStatement(properMethodLines[i]) && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
                   String[] splitLines = properMethodLines[i].split("return", 2);
                   // Determine indentation of return by adding indentation amount to previous line
                   String returnIndent = "";
@@ -131,6 +131,12 @@ class UmpleToPhp {
 
               // inject the after injection code after every return, while appropriate indentation
               for(int i = -1; (i = properMethodBody.indexOf("return", i + 1)) != -1; ) {
+                //Check if return statement is on its own line
+                int lastChar = i - 1;
+                while (properMethodBody.charAt(lastChar) == ' ')
+                lastChar--;
+                if (properMethodBody.charAt(lastChar) != '\n') // If it has any non-space characters before it, it's invalid
+                  continue;
                 // determine the indentation of the return
                 String indent = "";
                 while(i >= 1 && properMethodBody.charAt(--i) == ' ') {

--- a/UmpleToRuby/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToRuby/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -66,7 +66,7 @@ class UmpleToRuby {
           String[] properMethodLines = properMethodBody.split("\\n");
           String fixedProperMethodBody = "";
           for(int i = 0; i < properMethodLines.length; i++) {
-            if(properMethodLines[i].contains("return") && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
+            if(GeneratorHelper.isValidReturnStatement(properMethodLines[i]) && !properMethodLines[i].trim().substring(0, 6).equals("return")) {
               String[] splitLines = properMethodLines[i].split("return", 2);
               // Determine indentation of return by adding indentation amount to previous line
               String returnIndent = "";
@@ -100,6 +100,13 @@ class UmpleToRuby {
 
           // inject the after injection code after every return, while appropriate indentation
           for(int i = -1; (i = properMethodBody.indexOf("return", i + 1)) != -1; ) {
+          
+            //Check if return statement is on its own line
+            int lastChar = i - 1;
+            while (properMethodBody.charAt(lastChar) == ' ')
+            lastChar--;
+            if (properMethodBody.charAt(lastChar) != '\n') // If it has any non-space characters before it, it's invalid
+              continue;
             // determine the indentation of the return
             String indent = "";
             while(i >= 1 && properMethodBody.charAt(--i) == ' ') {

--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -117,6 +117,29 @@ class GeneratorHelper
     }
     return builder.toString();
   }
+  
+  public static boolean isValidReturnStatement(String statement) {
+    int returnInd = statement.indexOf("return");
+  	if (returnInd == -1) {
+  	  return false;
+  	}
+  	if (statement.trim().substring(0,2).equals("//")) { // Can't be in a comment
+  	  return false;
+  	}
+  	if (!(statement.charAt(returnInd + 6) == ';' || statement.charAt(returnInd + 6) == ' ')){
+  	  return false;
+  	}
+  	//Check if it's in a quote
+	int openQuote = statement.indexOf("\"");
+	while (openQuote != -1 && openQuote < returnInd){
+	  int closeQuote = statement.indexOf("\"",openQuote + 1);
+	  if (closeQuote > returnInd){
+	  	return false;
+	  }
+	  openQuote = statement.indexOf("\"",closeQuote + 1);
+	}
+	return true;
+  }
 
 }
 

--- a/cruise.umple/test/cruise/umple/implementation/CodeInjectionTest.ump
+++ b/cruise.umple/test/cruise/umple/implementation/CodeInjectionTest.ump
@@ -59,5 +59,17 @@ class Student
   before delete { print "start delete"; }
   after delete { print "after delete"; }
   
+  after custom foo(int) { print "Such fun!" }
+  
+  String foo(int a) {
+    	System.out.println("This is great " + " I will return to this");
+    if(a == 3) return "4"; //Testing inline return
+    
+    // inject before return
+    return "";
+  }
+  
+  }
+  
  
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTest_Attributes.java.txt
@@ -219,6 +219,19 @@ public class Student
     print "after delete";
   }
 
+  public String foo(int a){
+    System.out.println("This is great " + " I will return to this");
+    if(a == 3) {      
+      print "Such fun!"
+      return "4";
+    }
+    //Testing inline return
+    
+    // inject before return    
+    print "Such fun!"
+    return "";
+  }
+
 
   public String toString()
   {

--- a/cruise.umple/test/cruise/umple/implementation/php/CodeInjectionTest_Attributes.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/CodeInjectionTest_Attributes.php.txt
@@ -226,5 +226,23 @@ class Student
     print "after delete";
   }
 
+  public function foo(int $a)
+  {
+    System.out.println("This is great " + " I will return to this");
+    if(a == 3) {      
+      // line 60 "TestingTest.ump"
+      print "Such fun!"
+      // END OF UMPLE AFTER INJECTION
+      return "4";
+    }
+    //Testing inline return
+    
+    // inject before return    
+    // line 60 "TestingTest.ump"
+    print "Such fun!"
+    // END OF UMPLE AFTER INJECTION
+    return "";
+  }
+
 }
 ?>

--- a/cruise.umple/test/cruise/umple/implementation/ruby/CodeInjectionTest_Attributes.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/CodeInjectionTest_Attributes.ruby.txt
@@ -196,5 +196,23 @@ class Student
     print "after delete";
   end
 
-end
+  def foo (a)
+    System.out.println("This is great " + " I will return to this");
+    if(a == 3)      
+      // line 60 "TestingTest.ump"
+      print "Such fun!"
+      // END OF UMPLE AFTER INJECTION
+      return "4";
+    //Testing inline return
+    
+    // inject before return    
+    // line 60 "TestingTest.ump"
+    print "Such fun!"
+    // END OF UMPLE AFTER INJECTION
+    return "";
+
+  end
+
+
+
 end


### PR DESCRIPTION
This PR fixes issue #1153, where any mention of the word "return" would trigger after behaviour. Even when the word 'return' was in quotes, a comment, or was part of a longer word (eg 'returning'). 