### PR TITLE
Fixed the bug which triggers wrong templates.

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/specializationCode_Get.ump
+++ b/UmpleToJava/UmpleTLTemplates/specializationCode_Get.ump
@@ -11,6 +11,5 @@ class UmpleToJava {
     boolean reqCommonCode = av.getNeedsCommonCode();
     boolean mulChangedToOne = av.getMulChangedToOne();
     boolean relReqSuperCode = relatedAssociation.getNeedsSuperCode();
-
 #>>!>>
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2342,7 +2342,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       	  // so B is a parent
           aFirstEnd.setSuperClassName(bFirstEnd.getClassName());
           aSecondEnd.setSuperClassName(bSecondEnd.getClassName());
-          
+
           // Refer to the Association Specialization manual page --
           // There are 2 cases for specialized code:
           // 1- either the class will need code from it's superclass
@@ -2355,21 +2355,21 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           if (aFirstEnd.getClassName().equals(bFirstEnd.getClassName()))
           {
             // i.e. same name as parent, so common code is required.
-            aSecondEnd.setNeedsSuperCode(true);
+            aSecondEnd.setNeedsCommonCode(true);
           }
           else
           {
-            aSecondEnd.setNeedsCommonCode(true);
+            aSecondEnd.setNeedsSuperCode(true);
           }
           
           // need to check both ends...
           if (aSecondEnd.getClassName().equals(bSecondEnd.getClassName()))
           {
-            aFirstEnd.setNeedsSuperCode(true);
+            aFirstEnd.setNeedsCommonCode(true);
           }
           else
           {
-            aFirstEnd.setNeedsCommonCode(true);
+            aFirstEnd.setNeedsSuperCode(true);
           }
       	  
       	  // -- probably legacy, comment out and see if it breaks.

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1522,9 +1522,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   {
     for (AssociationVariable av : unlinkedAssociationVariables)
     {
+      AssociationVariable relatedAv = av.getRelatedAssociation();
 
       UmpleClass aClass = model.getUmpleClass(av.getType());
-      UmpleClass bClass = model.getUmpleClass(av.getRelatedAssociation().getType());   
+      UmpleClass bClass = model.getUmpleClass(relatedAv.getType());   
 
       if (aClass == null || bClass == null){ //Association is between Class and Interface
         continue;
@@ -1532,7 +1533,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 
       Association assoc = bClass.getAssociation(bClass.indexOfAssociationVariable(av));
 
-      boolean added = aClass.addAssociationVariable(av.getRelatedAssociation());
+      boolean added = aClass.addAssociationVariable(relatedAv);
 
       if (!added)
       {
@@ -1545,6 +1546,18 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       }
 
       aClass.addAssociation(assoc);
+
+      // Set the proper end number for both association variable
+      AssociationEnd end0 = assoc.getEnd(0);
+      AssociationEnd end1 = assoc.getEnd(1);
+      if (end0.getClassName().equals(aClass.getName()) && end1.getClassName().equals(bClass.getName()))
+      {
+        av.setRelevantEnd(0);
+        relatedAv.setRelevantEnd(1);
+      } else {
+        av.setRelevantEnd(1);
+        relatedAv.setRelevantEnd(0);
+      }
 
       if (av.getIsNavigable())
       {
@@ -2342,21 +2355,21 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           if (aFirstEnd.getClassName().equals(bFirstEnd.getClassName()))
           {
             // i.e. same name as parent, so common code is required.
-            aSecondEnd.setNeedsCommonCode(true);
+            aSecondEnd.setNeedsSuperCode(true);
           }
           else
           {
-            aSecondEnd.setNeedsSuperCode(true);
+            aSecondEnd.setNeedsCommonCode(true);
           }
           
           // need to check both ends...
           if (aSecondEnd.getClassName().equals(bSecondEnd.getClassName()))
           {
-            aFirstEnd.setNeedsCommonCode(true);
+            aFirstEnd.setNeedsSuperCode(true);
           }
           else
           {
-            aFirstEnd.setNeedsSuperCode(true);
+            aFirstEnd.setNeedsCommonCode(true);
           }
       	  
       	  // -- probably legacy, comment out and see if it breaks.

--- a/cruise.umple/test/cruise/umple/compiler/AssociationVariableTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/AssociationVariableTest.java
@@ -11,6 +11,8 @@ package cruise.umple.compiler;
 
 import org.junit.*;
 
+import cruise.umple.util.SampleFileWriter;
+
 public class AssociationVariableTest
 {
 
@@ -461,6 +463,26 @@ public class AssociationVariableTest
     Assert.assertTrue(a.setRelatedAssociation(b));
   }
 
+  @Test
+  public void testAssociationVariableEnds()
+  {
+    String code = "class A{1 -- * C;} class B{isA A; 1 -- 4 C;} class C{}";
+
+    UmpleModel model = getModel(code);
+    model.run();
+    for (UmpleClass uClass : model.getUmpleClasses()) {
+      int numAv = uClass.numberOfAssociationVariables();
+      for (int i = 0; i < numAv; i ++) {
+        AssociationVariable av = uClass.getAssociationVariable(i);
+        Association assoc = uClass.getAssociation(i);
+        AssociationEnd aEnd = assoc.getEnd(av.getRelevantEnd());
+
+        Assert.assertEquals(av.getType(), aEnd.getClassName());
+        Assert.assertEquals(av.getName(), aEnd.getRoleName());
+      }
+    }
+  }
+
   private Multiplicity createMultiplicity(int lower, int upper)
   {
     Multiplicity m = new Multiplicity();
@@ -468,4 +490,9 @@ public class AssociationVariableTest
     return m;
   }
 
+  private UmpleModel getModel(String inCode) {
+    SampleFileWriter.createFile("umpleAssociationVariableTest.ump",inCode);  
+    UmpleFile uFile = new UmpleFile("umpleAssociationVariableTest.ump"); 
+    return new UmpleModel(uFile);
+  }
 }


### PR DESCRIPTION
Fixed the bug which triggers wrong templates. By labelling each association variable with correct *relevantEnd* value.