### PR TITLE
Progress on #1164 Added check for error 28

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeConstraints.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeConstraints.ump
@@ -46,6 +46,15 @@ class UmpleInternalParser
     if(((InvariantAnalyzer)model.getAnalyzer("invariant"))!=null){
       ((InvariantAnalyzer)model.getAnalyzer("invariant")).setUClassifier(uClassifier);
       model.getAnalyzer("invariant").analyzeToken(invariantToken);
+      if (uClassifier instanceof UmpleClass) {
+        List<String> variableNames = new ArrayList<>();
+        for (Attribute attr: ((UmpleClass)uClassifier).getAttributes()) {
+          variableNames.add(attr.getName());
+        }
+        List<ConstraintTree> constraintTrees = ((UmpleClass)uClassifier).getConstraintTrees();
+        String className = ((UmpleClass)uClassifier).getName();
+        checkVariableNames(variableNames, constraintTrees.get(constraintTrees.size() - 1), invariantToken, className);
+      }
     }
   }
      
@@ -60,6 +69,19 @@ class UmpleInternalParser
       model.getAnalyzer("modelConstraintBody").analyzeToken(modelConstraintToken);
       uClassifier.addModelConstraint(((ModelConstraintBodyAnalyzer)model.getAnalyzer("modelConstraintBody")).getModelConstraint());
       ((ModelConstraintBodyAnalyzer)model.getAnalyzer("modelConstraintBody")).reset();
+    }
+  }
+  
+  private void checkVariableNames(List<String> variableNames, ConstraintVariable cur, Token token, String className) {
+    if (cur instanceof ConstraintOperator) {
+      checkVariableNames(variableNames, ((ConstraintOperator)cur).getLeft(), token, className);
+      checkVariableNames(variableNames, ((ConstraintOperator)cur).getRight(), token, className);
+    } else if (cur instanceof ConstraintTree) {
+      checkVariableNames(variableNames, ((ConstraintTree)cur).getRoot(), token, className);
+    } else if (cur instanceof ConstraintNamed) {
+      if (!variableNames.contains(((ConstraintNamed)cur).getName())) {
+        setFailedPosition(token.getPosition(), 28, ((ConstraintNamed)cur).getName(), className);
+      }
     }
   }
 }

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -32,8 +32,8 @@
 25: 2, "http://manual.umple.org/?E025SortKeyNotFound.html", Class '{0}' does not contain attribute {1} that is used as sort key ;
 26: 2, "http://manual.umple.org/?E026DuplicateKeyItem.html", Duplicate item '{0}' in key statement(s) in class '{1}' ;
 27: 3, "http://manual.umple.org/?W027KeyIdentifierIncorrect.html", Item '{0}' in key statement is not defined in class '{1}' ;
-28: 3, "http://manual.umple.org/?E028ConstraintIdentifierIncorrect.html", Attribute '{0}' in constraint is not defined in class '{1}' ;
-29: 2, "http://manual.umple.org/?E029ConstraintTypeMismatch.html", Attribute '{0}' in constraint must be of type '{1}' ;
+28: 2, "http://manual.umple.org/?E028ConstraintIdentifierIncorrect.html", Attribute '{0}' in constraint is not defined in class '{1}' ;
+29: 2, "http://manual.umple.org/?E029ConstraintTypeMismatch.html", Constraint contains comparison between incompatible types ;
 
 30: 4, "http://manual.umple.org/?W030RedefinedNamespace.html", Redefining the namespace of class {0} to {1} ;
 31: 4, "http://manual.umple.org/?W031NamespaceNotUsed.html", Declared namespace {0} was not used before declaring {1} ;

--- a/cruise.umple/test/cruise/umple/compiler/ParserConstraintExpressionsTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/ParserConstraintExpressionsTest.java
@@ -12,9 +12,9 @@ public class ParserConstraintExpressionsTest extends UmpleParserTest {
 		assertParse("700_DateConstraint.ump");
 	}
 	
-	@Test @Ignore
+	@Test
 	public void BasicConstraint2(){ // [agedfd > 12]
-		assertHasWarningsParse("700_BasicConstraint2.ump",28);
+		assertFailedParse("700_BasicConstraint2.ump",28);
 	}
 	
 }


### PR DESCRIPTION
## Pull request title

Progress on #1164 Added check for error 28

## Pull request description

Adds checking for non existent variable names in constraints and throws error 28 if encountered.

## Pull request content

UmpleInternalParser_CodeConstraints.ump - Added check for error 28
en.error - Updated error message, changed 28 from a warning to an error (to match the definition in the manual)
ParserConstraintExpressionsTest.java - Updated test for error 28 to look for error instead of warning, removed @​Ignore flag from test