### PR TITLE
Partly fix for issue 1260 - added specializedFromVariable to association variable

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -985,6 +985,9 @@ class AssociationVariable
 
   0..1 self relatedAssociation;
 
+  // specialized from this association variable
+  AssociationVariable specializedFromVariable = null;
+
   // code relevant to specialization of associations
   Boolean isSpecialized = false;		// is it ever specialized?
   Boolean isSpecialization = false;		// is it a specialization of another?

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -2356,6 +2356,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           {
             // i.e. same name as parent, so common code is required.
             aSecondEnd.setNeedsCommonCode(true);
+            UmpleClass commonClass = model.getUmpleClass(aFirstEnd.getClassName());
+            AssociationVariable specializedAv = commonClass.getAssociationVariable(aSecondEnd.getClassName(), aSecondEnd.getRoleName());
+            AssociationVariable fromAv = commonClass.getAssociationVariable(bSecondEnd.getClassName(), bSecondEnd.getRoleName());
+            specializedAv.setSpecializedFromVariable(fromAv);
           }
           else
           {
@@ -2366,6 +2370,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           if (aSecondEnd.getClassName().equals(bSecondEnd.getClassName()))
           {
             aFirstEnd.setNeedsCommonCode(true);
+            UmpleClass commonClass = model.getUmpleClass(aSecondEnd.getClassName());
+            AssociationVariable specializedAv = commonClass.getAssociationVariable(aFirstEnd.getClassName(), aFirstEnd.getRoleName());
+            AssociationVariable fromAv = commonClass.getAssociationVariable(bFirstEnd.getClassName(), bFirstEnd.getRoleName());
+            specializedAv.setSpecializedFromVariable(fromAv);
           }
           else
           {

--- a/cruise.umple/test/cruise/umple/compiler/AssociationVariableTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/AssociationVariableTest.java
@@ -422,6 +422,18 @@ public class AssociationVariableTest
     Assert.assertTrue(c.setImmutable());
     Assert.assertTrue(assoc1.setImmutable());
   }
+
+  @Test
+  public void testAssociationVariable()
+  {
+    AssociationVariable av1 = new AssociationVariable("x","Mentor","","",createMultiplicity(1,1),true);
+    AssociationVariable av2 = new AssociationVariable("y","Student","","",createMultiplicity(1,1),true);
+    Assert.assertNull(av1.getSpecializedFromVariable());
+    Assert.assertNull(av2.getSpecializedFromVariable());
+
+    av1.setSpecializedFromVariable(av2);
+    Assert.assertEquals(av1.getSpecializedFromVariable(), av2);
+  }
   
   @Test
   public void canOnlySetRelatedAssociationToCreateValidAssociationsWithImmutableClass()


### PR DESCRIPTION
When _relatedSpecialization templates are triggered, some non-existing variables in a class are accessed. Therefore, for this case, we need to know from which association variable is one association variable specialized so that we can call their common code. Templates will be modified in next PR.