### PR TITLE
Fixes #1268 Manual pages not generating previous link

### DIFF
--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -140,7 +140,7 @@ class Documenter
         if(ci>0) {
           prevNextOutput +="<a href=\"" + group.getContent(ci-1).getTitleFilename() + "\">[Previous]</a>&nbsp &nbsp;";
         }
-        else if(gi > 0&&getParser().getGroup(gi-1).numberOfContents()>1) {
+        else if(gi > 0&&getParser().getGroup(gi-1).numberOfContents()>=1) {
           prevNextOutput +="<a href=\"" + getParser().getGroup(gi-1).getContent(getParser().getGroup(gi-1).numberOfContents()-1).getTitleFilename() + "\">[Previous]</a>&nbsp &nbsp;";
         }
 


### PR DESCRIPTION
The Documenter would not generate a previous link if there was was <= 1 page of content in the previous section of a page, and would therefore not generate previous links for some pages. This PR simply changes the condition in which a previous page is generated.