### PR TITLE
Fix build of examples

### DIFF
--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -106,6 +106,7 @@
       <exclude name="E0*.ump" />
       <exclude name="E1*.ump" />
       <exclude name="E2*.ump" />
+      <exclude name="E3*.ump" />      
       <exclude name="WE1xxIdentifierInvalid1.ump" />
       <exclude name="WE1xxIdentifierInvalid3.ump" />
       <exclude name="WE1xxIdentifierInvalid5.ump" />


### PR DESCRIPTION
Examples that are known to generate errors were mostly being excluded from example testing, but there were are new series of error numbers in the 3* range being compiled. This excludes them too.