### PR TITLE
Fixes #641 Adds remaining missing error pages

### DIFF
--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -106,7 +106,8 @@
       <exclude name="E0*.ump" />
       <exclude name="E1*.ump" />
       <exclude name="E2*.ump" />
-      <exclude name="E3*.ump" />      
+      <exclude name="E3*.ump" />
+      <exclude name="E4*.ump" />      
       <exclude name="WE1xxIdentifierInvalid1.ump" />
       <exclude name="WE1xxIdentifierInvalid3.ump" />
       <exclude name="WE1xxIdentifierInvalid5.ump" />

--- a/build/reference/9450TagNotClosedCorrectly.txt
+++ b/build/reference/9450TagNotClosedCorrectly.txt
@@ -1,0 +1,21 @@
+E4500 Tag Not Closed Correctly
+Errors and Warnings
+noreferences
+
+@@description
+
+<h2>Umple semantic error raised when a FIXML tag is not closed properly</h2>
+
+<p>
+In FIXML, a start tag must be closed properly with its respective end tag. Elements must also
+be correctly nested within each other.<br/>
+</p>
+
+
+@@example
+@@source manualexamples/E4500TagNotClosedCorrectly1.ump
+@@endexample
+
+@@example
+@@source manualexamples/E4500TagNotClosedCorrectly2.ump
+@@endexample

--- a/build/reference/9990CompilerError.txt
+++ b/build/reference/9990CompilerError.txt
@@ -1,0 +1,14 @@
+E9x00 Compiler Error
+Errors and Warnings
+noreferences
+
+@@description
+
+<h2>Umple compiler error raised when an internal crash occurs</h2>
+
+<p>
+The Umple compiler may crash with certain code input, causing an error in the parsing
+phase (E9000), analysis phase (E9100) or generation phase (E9200). Please 
+<a href="https://github.com/umple/umple/issues/new">report the issue</a>, by including
+the code that generated the error and the stack trace.<br/>
+</p>

--- a/build/reference/9990CompilerError.txt
+++ b/build/reference/9990CompilerError.txt
@@ -7,8 +7,13 @@ noreferences
 <h2>Umple compiler error raised when an internal crash occurs</h2>
 
 <p>
-The Umple compiler may crash with certain code input, causing an error in the parsing
-phase (E9000), analysis phase (E9100) or generation phase (E9200). Please 
-<a href="https://github.com/umple/umple/issues/new">report the issue</a>, by including
-the code that generated the error and the stack trace.<br/>
+Occasionally the Umple compiler may crash with certain code input,
+causing an error in the parsing phase (E9000), analysis phase (E9100)
+or generation phase (E9200). As soon as the Umple development team
+becomes aware of such a situation, we try to deal with it with
+a high level of priority.</p>
+
+<p>In order to ensure the Umple development team is aware of the problem, please 
+<a href="https://github.com/umple/umple/issues/new">report the issue</a>, including
+the code that generated the error and the stack trace that accompanied the message.<br/>
 </p>

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -231,7 +231,7 @@
 3607: 1, "http://manual.umple.org/?E3607PortNameCannotBeResolved.html", Port name '{0}' from class '{1}' can not be resolved.;
 
 # Messages related to fixml
-4500: 1,  "http://manual.umple.org/?PageBeingDeveloped.html", The tag '{0}' is not closed correctly.  ;
+4500: 1,  "http://manual.umple.org/?E4500TagNotClosedCorrectly.html", The tag '{0}' is not closed correctly.  ;
 
 # Warning messages related to distributed systems
 
@@ -244,9 +244,9 @@
 8005: 5, "http://manual.umple.org/?PageBeingDeveloped.html", Debug warning : '{0}' ;
 
 # Messages related to code generator
-9000: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Compiler Error (Parsing). {0} ;
-9100: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Compiler Error (Analysis). {0} ;
-9200: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Compiler Error (Generation). {0} ;
+9000: 1, "http://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Parsing). {0} ;
+9100: 1, "http://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Analysis). {0} ;
+9200: 1, "http://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Generation). {0} ;
 
 # Message to emit when you are parsing a construct but are not yet processing it in a sensible way/
 9999: 5, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Feature under development. '{0}' found and ignored. processed as: '{1}' ;

--- a/umpleonline/ump/manualexamples/E4500TagNotClosedCorrectly1.ump
+++ b/umpleonline/ump/manualexamples/E4500TagNotClosedCorrectly1.ump
@@ -1,0 +1,8 @@
+//The tags are not properly
+//nested, causing E4500
+<FIXML>
+  <tag>
+    <othertag>
+      </tag>
+  </othertag>
+ </FIXML>

--- a/umpleonline/ump/manualexamples/E4500TagNotClosedCorrectly2.ump
+++ b/umpleonline/ump/manualexamples/E4500TagNotClosedCorrectly2.ump
@@ -1,0 +1,8 @@
+//Each tag is now correctly
+//closed
+<FIXML>
+  <tag>
+    <othertag>
+    </othertag>
+  </tag>
+ </FIXML>


### PR DESCRIPTION
Adds E4500 and a page for errors 9x00, updates en.error. Excluded errors E4- from build.

The remaining missing error/warning pages concern error messages that are not yet fully implemented.