### PR TITLE
Fixes #1277 Generating E3504 when referencing a non-existent template

### DIFF
--- a/build/reference/9354TemplateReferenceCannotBeResolved.txt
+++ b/build/reference/9354TemplateReferenceCannotBeResolved.txt
@@ -1,5 +1,5 @@
 E3504 Template Reference Cannot Be Resolved
-Errors and Warnings
+Errors and Warnings 1000+
 noreferences
 
 @@description

--- a/build/reference/9354TemplateReferenceCannotBeResolved.txt
+++ b/build/reference/9354TemplateReferenceCannotBeResolved.txt
@@ -1,0 +1,21 @@
+E3504 Template Reference Cannot Be Resolved
+Errors and Warnings
+noreferences
+
+@@description
+
+<h2>Umple semantic error raised when a template reference cannot be resolved</h2>
+
+<p>
+When referencing a template, an error is thrown if the template cannot be found. The
+template name might be misspelled. <br/>
+</p>
+
+
+@@example
+@@source manualexamples/E3504TemplateReferenceCannotBeResolved1.ump
+@@endexample
+
+@@example
+@@source manualexamples/E3504TemplateReferenceCannotBeResolved2.ump
+@@endexample

--- a/cruise.umple/src/UmpleInternalParser_CodeTemplate.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTemplate.ump
@@ -686,11 +686,19 @@ class TemplateTokenAnalyzer {
 
 							HashMap<String, Boolean> map = new HashMap<String,Boolean>();
 							map.put(key, true);
-							boolean check = recursiveIncludeTemplateElementCycleCheck(referenceTemplate, refValue, map);
-							if(!check) {
+							
+							if (refValue == null) {
 								parser.getParseResult().setPosition(incElm.getPosition());
-								parser.getParseResult().addErrorMessage(new ErrorMessage(3505,incElm.getPosition(),name,refKey));
-								ret = false;
+								parser.getParseResult().addErrorMessage(new ErrorMessage(3504, incElm.getPosition(),key));
+							}
+							else {
+								boolean check = recursiveIncludeTemplateElementCycleCheck(referenceTemplate, refValue, map);
+								
+								if(!check) {
+									parser.getParseResult().setPosition(incElm.getPosition());
+									parser.getParseResult().addErrorMessage(new ErrorMessage(3505,incElm.getPosition(),name,refKey));
+									ret = false;
+								}
 							}
 						}
 					}	

--- a/cruise.umple/src/UmpleInternalParser_CodeTemplate.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTemplate.ump
@@ -687,11 +687,8 @@ class TemplateTokenAnalyzer {
 							HashMap<String, Boolean> map = new HashMap<String,Boolean>();
 							map.put(key, true);
 							
-							if (refValue == null) {
-								parser.getParseResult().setPosition(incElm.getPosition());
-								parser.getParseResult().addErrorMessage(new ErrorMessage(3504, incElm.getPosition(),key));
-							}
-							else {
+							if (refValue != null)
+							{
 								boolean check = recursiveIncludeTemplateElementCycleCheck(referenceTemplate, refValue, map);
 								
 								if(!check) {

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -215,7 +215,7 @@
 3501: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template emit method can not be a main.;
 3502: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Template name '{0}' can not be resolved.;
 3503: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template reference '{0}' cannot refer to itself.;
-3504: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Template reference '{0}' can not be resolved.;
+3504: 2, "http://manual.umple.org/?E3504TemplateReferenceCannotBeResolved.html", Template reference '{0}' can not be resolved.;
 3505: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Template reference '{0}' can not cyclically refer to '{1}'.;
 3506: 4, "http://manual.umple.org/?PageBeingDeveloped.html", Class '{0}' has duplicate template name {1} ;
 3507: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Class '{0}' has duplicate method name {1} ;

--- a/cruise.umple/test/cruise/umple/compiler/028_multipleTemplateInexistentReferences.ump
+++ b/cruise.umple/test/cruise/umple/compiler/028_multipleTemplateInexistentReferences.ump
@@ -1,0 +1,5 @@
+class MultipleInexistentTemplateReferences {
+	template1 <<! <<@aTemplate>> <<@otherTemplate>> <<@anotherTemplate>>!>>
+	
+	emit method()(template1);
+}

--- a/cruise.umple/test/cruise/umple/compiler/028_templateInexistentReference.ump
+++ b/cruise.umple/test/cruise/umple/compiler/028_templateInexistentReference.ump
@@ -1,0 +1,5 @@
+class InexistentTemplateReference {
+	template1 <<! <<@aTemplate>> !>>
+	
+	emit method()(template1);
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3025,6 +3025,14 @@ public class UmpleParserTest
 
   }
   
+  //Issue 1277
+  @Test
+  public void templateInexistentReference()
+  {
+    assertFailedParse("028_templateInexistentReference.ump",3504);
+    assertFailedParse("028_multipleTemplateInexistentReferences.ump",3504);
+  }
+  
   public boolean parse(String filename)
   {
     //String input = SampleFileWriter.readContent(new File(pathToInput, filename));

--- a/umpleonline/ump/manualexamples/E3504TemplateReferenceCannotBeResolved1.ump
+++ b/umpleonline/ump/manualexamples/E3504TemplateReferenceCannotBeResolved1.ump
@@ -1,0 +1,7 @@
+//The template otherTemplate
+//is not found, generating the
+//error
+class A {
+  temp <<! <<@otherTemplate>> !>>
+  emit method()(temp);
+}

--- a/umpleonline/ump/manualexamples/E3504TemplateReferenceCannotBeResolved2.ump
+++ b/umpleonline/ump/manualexamples/E3504TemplateReferenceCannotBeResolved2.ump
@@ -1,0 +1,7 @@
+//otherTemplate exists and can
+//be referenced
+class A {
+  otherTemplate <<! output !>>
+  temp <<! <<@otherTemplate>> !>>
+  emit method()(temp);
+}


### PR DESCRIPTION
Added a check for the template reference value, an inexistent template no longer
generates E9100. Added manual page for E3504.