### PR TITLE
Fixes #1274 Abstract class association creating erroneous code

### DIFF
--- a/build/reference/9080InvalidAbstractClassAssociation.txt
+++ b/build/reference/9080InvalidAbstractClassAssociation.txt
@@ -1,0 +1,20 @@
+E080 Invalid Abstract Class Association
+Errors and Warnings 51-99
+noreferences
+
+@@description
+
+<h2>Umple semantic error raised when an association with an abstract class forces instantiation of an object</h2>
+
+<p>An association with an abstract class must either be a directed association or must have a multiplicity with lower bound
+of zero. <br/>
+</p>
+
+
+@@example
+@@source manualexamples/E080InvalidAbstractClassAssociation1.ump
+@@endexample
+
+@@example
+@@source manualexamples/E080InvalidAbstractClassAssociation2.ump
+@@endexample

--- a/build/reference/9080InvalidAbstractClassAssociation.txt
+++ b/build/reference/9080InvalidAbstractClassAssociation.txt
@@ -7,7 +7,8 @@ noreferences
 <h2>Umple semantic error raised when an association with an abstract class forces instantiation of an object</h2>
 
 <p>An association with an abstract class must either be a directed association or must have a multiplicity with lower bound
-of zero. <br/>
+of zero at both ends. This is necessary to prevent situations where it would be needed to instantiate the abstract class (which
+is never allowed).<br/>
 </p>
 
 

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -388,7 +388,7 @@ class UmpleInternalParser
 
       checkExtendsForCycles();
       checkSortedAssociations();
-      checkClassInterfaceAssocations();
+      checkAssociationsValidity();
       
       //Issue 1084
       addUnlinkedKeys();
@@ -1503,6 +1503,22 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
        return false;
       
    }
+   
+  private boolean associationIsBetweenClassAndAbstractClass (Association a) {
+  	AssociationEnd endA = a.getEnd(0);
+  	AssociationEnd endB = a.getEnd(1);
+  	
+  	UmpleClass classA = model.getUmpleClass(endA.getClassName());
+  	UmpleClass classB = model.getUmpleClass(endB.getClassName());
+  	
+  	if (classA != null && classB != null) {
+  	  if (classB.getIsAbstract() && !classA.getIsAbstract()) {
+  	    return true;
+  	  }
+  	}
+  	
+  	return false;
+  } 
   
   private boolean associationIsBetweenClassAndTrait(Association a){
 	    AssociationEnd myEnd = a.getEnd(0);
@@ -2862,15 +2878,32 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     }
   }
   
-   private void checkClassInterfaceAssocations(){
-    for (Association a : model.getAssociations()){
-      if (associationIsBetweenClassAndInterface(a)){
-        boolean hasCorrectArrow = !a.getIsLeftNavigable()&&a.getIsRightNavigable(); // Assocation has "->" arrow
-        if (!hasCorrectArrow){
+   private void checkClassInterfaceAssocations(Association a){
+     if (associationIsBetweenClassAndInterface(a)){
+       boolean hasCorrectArrow = !a.getIsLeftNavigable()&&a.getIsRightNavigable(); // Assocation has "->" arrow
+       if (!hasCorrectArrow){
           setFailedPosition(a.getTokenPosition(), 20, a.getEnd(0).getClassName());
         }
       }
+  }
+  
+  private void checkAbstractClassAssociations(Association a) {
+    if(associationIsBetweenClassAndAbstractClass(a)) {
+      boolean hasCorrectArrow = !a.getIsLeftNavigable()&&a.getIsRightNavigable(); //association has "->" arrow
+      
+      Multiplicity multipl = a.getEnd(1).getMultiplicity();
+      boolean hasManyMultiplicityEnd = "*".equals(multipl.getBound()) || (multipl.getLowerBound() == 0); //association has * end
+      if (!hasCorrectArrow && !hasManyMultiplicityEnd) {
+        setFailedPosition(a.getTokenPosition(), 80, a.getEnd(0).getClassName());
+      }
     }
+  }
+  
+  private void checkAssociationsValidity() {
+  	for (Association a : model.getAssociations()){
+  	  checkClassInterfaceAssocations(a);
+  	  checkAbstractClassAssociations(a);
+  	}
   }
   
   /*

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -1518,7 +1518,23 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   	}
   	
   	return false;
-  } 
+  }
+  
+  private boolean associationIsBetweenAbstractClassAndClass (Association a) {
+  	AssociationEnd endA = a.getEnd(0);
+  	AssociationEnd endB = a.getEnd(1);
+  	
+  	UmpleClass classA = model.getUmpleClass(endA.getClassName());
+  	UmpleClass classB = model.getUmpleClass(endB.getClassName());
+  	
+  	if (classA != null && classB != null) {
+  	  if (!classB.getIsAbstract() && classA.getIsAbstract()) {
+  	    return true;
+  	  }
+  	}
+  	
+  	return false;
+  }
   
   private boolean associationIsBetweenClassAndTrait(Association a){
 	    AssociationEnd myEnd = a.getEnd(0);
@@ -2888,12 +2904,23 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   }
   
   private void checkAbstractClassAssociations(Association a) {
-    if(associationIsBetweenClassAndAbstractClass(a)) {
-      boolean hasCorrectArrow = !a.getIsLeftNavigable()&&a.getIsRightNavigable(); //association has "->" arrow
+    boolean isBetweenClassAndAbstractClass = associationIsBetweenClassAndAbstractClass(a);
+    boolean isBetweenAbstractClassAndClass = associationIsBetweenAbstractClassAndClass(a);
+    
+    if(isBetweenClassAndAbstractClass || isBetweenAbstractClassAndClass) {
+      boolean hasCorrectArrow = false;
+    
+      if(isBetweenClassAndAbstractClass)
+        hasCorrectArrow = !a.getIsLeftNavigable()&&a.getIsRightNavigable(); //association has "->" arrow
+        
+      if(isBetweenAbstractClassAndClass)
+        hasCorrectArrow = a.getIsLeftNavigable()&&!a.getIsRightNavigable(); //association has "<-" arrow
       
-      Multiplicity multipl = a.getEnd(1).getMultiplicity();
-      boolean hasManyMultiplicityEnd = "*".equals(multipl.getBound()) || (multipl.getLowerBound() == 0); //association has * end
-      if (!hasCorrectArrow && !hasManyMultiplicityEnd) {
+      Multiplicity endAMultiplicity = a.getEnd(0).getMultiplicity();
+      Multiplicity endBMultiplicity = a.getEnd(1).getMultiplicity();
+      
+      boolean lowerBoundGreaterThanZero = endAMultiplicity.getLowerBound() > 0 && endBMultiplicity.getLowerBound() > 0;
+      if (!hasCorrectArrow && lowerBoundGreaterThanZero) {
         setFailedPosition(a.getTokenPosition(), 80, a.getEnd(0).getClassName());
       }
     }

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -82,7 +82,7 @@
 73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
 74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
 
-80: 2, "http://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The abstract class - class association declared in '{0}' must have a directed association or one end with lower bound multiplicity of 0 ;
+80: 2, "http://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The association bettween a class and an abstract class declared in '{0}' must be a directed association or have one end whose multiplicity lower bound is 0 ;
 
 # Model Constraints' Error messages
 90: 2, "http://manual.umple.org/?E090AttributeNameNotFoundConstraint.html", Attribute named {0} was not found in class {1}, as required in constraint ;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -82,6 +82,8 @@
 73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
 74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
 
+80: 2, "http://manual.umple.org/?PageBeingDeveloped.html", The abstract class - class association declared in '{0}' must have the '->' arrow or a many end multiplicity ;
+
 # Model Constraints' Error messages
 90: 2, "http://manual.umple.org/?E090AttributeNameNotFoundConstraint.html", Attribute named {0} was not found in class {1}, as required in constraint ;
 91: 2, "http://manual.umple.org/?E091AttributeOfTypeNotFoundConstraint.html", Attribute with type {0} was not found in class {1}, as required in constraint ;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -82,7 +82,7 @@
 73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
 74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
 
-80: 2, "http://manual.umple.org/?PageBeingDeveloped.html", The abstract class - class association declared in '{0}' must have the '->' arrow or a many end multiplicity ;
+80: 2, "http://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The abstract class - class association declared in '{0}' must have a directed association or one end with lower bound multiplicity of 0 ;
 
 # Model Constraints' Error messages
 90: 2, "http://manual.umple.org/?E090AttributeNameNotFoundConstraint.html", Attribute named {0} was not found in class {1}, as required in constraint ;

--- a/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation1.ump
@@ -1,0 +1,7 @@
+class AbstractClassAssociationHasOne
+{
+   1 -- 1 AbstractClass hasOne;
+}
+class AbstractClass{
+  abstract;
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation2.ump
@@ -1,0 +1,7 @@
+class AbstractClassAssociationOneOrMany
+{
+   1 -- 1..* AbstractClass hasOneorMany; 
+}
+class AbstractClass{
+  abstract;
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation3.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation3.ump
@@ -1,0 +1,7 @@
+class AbstractClass {
+  abstract;
+  1..* -- 1 AbstractClassAssociationOneOrMany;
+}
+
+class AbstractClassAssociationOneOrMany {
+}

--- a/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation4.ump
+++ b/cruise.umple/test/cruise/umple/compiler/422_abstractClassAssociation4.ump
@@ -1,0 +1,7 @@
+class AbstractClass {
+  abstract;
+  1 -- 1 AbstractClassAssociation;
+}
+
+class AbstractClassAssociation {
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -421,6 +421,15 @@ public class UmpleParserTest
     Assert.assertEquals(false,model.getUmpleClass("D").getIsAbstract());
     Assert.assertEquals(false,model.getUmpleClass("E").getIsAbstract());
   }
+  
+  @Test
+  public void abstractClassAssociation()
+  {
+    assertFailedParse("422_abstractClassAssociation1.ump",80);
+    assertFailedParse("422_abstractClassAssociation2.ump",80);
+    assertFailedParse("422_abstractClassAssociation3.ump",80);
+    assertFailedParse("422_abstractClassAssociation4.ump",80);
+  }
 
   //Issue 1159
   @Test

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest.java
@@ -396,7 +396,6 @@ public class ClassTemplateTest extends TemplateTest
 		  assertUmpleTemplateFor("ClassTemplateTest_AbstractClassAvoidingInstantiation2.ump",languagePath + "/ClassTemplateTest_AbstractClassAvoidingInstantiation2."+languagePath+".txt","Teacher");
 	  }
   }
-
   
 @Ignore @Test
   public void LazyAttributeOnImmutableClass()

--- a/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_AbstractClassAvoidingInstantiation2.ump
+++ b/cruise.umple/test/cruise/umple/implementation/ClassTemplateTest_AbstractClassAvoidingInstantiation2.ump
@@ -1,14 +1,7 @@
 class Teacher {
  1 -- 0..2 Foo myFooss;
-
- 1 -- 1..2 Student myStudentss;
-
 }
 
 class Foo {
-  abstract;
-}
-
-class Student {
   abstract;
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassAvoidingInstantiation2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_AbstractClassAvoidingInstantiation2.java.txt
@@ -4,7 +4,7 @@
 
 import java.util.*;
 
-// line 2 "model.ump"
+// line 1 "A.ump"
 public class Teacher
 {
 
@@ -14,7 +14,6 @@ public class Teacher
 
   //Teacher Associations
   private List<Foo> myFooss;
-  private List<Student> myStudentss;
 
   //------------------------
   // CONSTRUCTOR
@@ -23,7 +22,6 @@ public class Teacher
   public Teacher()
   {
     myFooss = new ArrayList<Foo>();
-    myStudentss = new ArrayList<Student>();
   }
 
   //------------------------
@@ -57,36 +55,6 @@ public class Teacher
   public int indexOfMyFooss(Foo aMyFooss)
   {
     int index = myFooss.indexOf(aMyFooss);
-    return index;
-  }
-  /* Code from template association_GetMany */
-  public Student getMyStudentss(int index)
-  {
-    Student aMyStudentss = myStudentss.get(index);
-    return aMyStudentss;
-  }
-
-  public List<Student> getMyStudentss()
-  {
-    List<Student> newMyStudentss = Collections.unmodifiableList(myStudentss);
-    return newMyStudentss;
-  }
-
-  public int numberOfMyStudentss()
-  {
-    int number = myStudentss.size();
-    return number;
-  }
-
-  public boolean hasMyStudentss()
-  {
-    boolean has = myStudentss.size() > 0;
-    return has;
-  }
-
-  public int indexOfMyStudentss(Student aMyStudentss)
-  {
-    int index = myStudentss.indexOf(aMyStudentss);
     return index;
   }
   /* Code from template association_MinimumNumberOfMethod */
@@ -168,104 +136,6 @@ public class Teacher
     }
     return wasAdded;
   }
-  /* Code from template association_IsNumberOfValidMethod */
-  public boolean isNumberOfMyStudentssValid()
-  {
-    boolean isValid = numberOfMyStudentss() >= minimumNumberOfMyStudentss() && numberOfMyStudentss() <= maximumNumberOfMyStudentss();
-    return isValid;
-  }
-  /* Code from template association_MinimumNumberOfMethod */
-  public static int minimumNumberOfMyStudentss()
-  {
-    return 1;
-  }
-  /* Code from template association_MaximumNumberOfMethod */
-  public static int maximumNumberOfMyStudentss()
-  {
-    return 2;
-  }
-  /* Code from template association_AddMNToOnlyOne */
-
-
-  public boolean addMyStudentss(Student aMyStudentss)
-  {
-    boolean wasAdded = false;
-    if (myStudentss.contains(aMyStudentss)) { return false; }
-    if (numberOfMyStudentss() >= maximumNumberOfMyStudentss())
-    {
-      return wasAdded;
-    }
-
-    Teacher existingTeacher = aMyStudentss.getTeacher();
-    boolean isNewTeacher = existingTeacher != null && !this.equals(existingTeacher);
-
-    if (isNewTeacher && existingTeacher.numberOfMyStudentss() <= minimumNumberOfMyStudentss())
-    {
-      return wasAdded;
-    }
-
-    if (isNewTeacher)
-    {
-      aMyStudentss.setTeacher(this);
-    }
-    else
-    {
-      myStudentss.add(aMyStudentss);
-    }
-    wasAdded = true;
-    return wasAdded;
-  }
-
-  public boolean removeMyStudentss(Student aMyStudentss)
-  {
-    boolean wasRemoved = false;
-    //Unable to remove aMyStudentss, as it must always have a teacher
-    if (this.equals(aMyStudentss.getTeacher()))
-    {
-      return wasRemoved;
-    }
-
-    //teacher already at minimum (1)
-    if (numberOfMyStudentss() <= minimumNumberOfMyStudentss())
-    {
-      return wasRemoved;
-    }
-    myStudentss.remove(aMyStudentss);
-    wasRemoved = true;
-    return wasRemoved;
-  }
-  /* Code from template association_AddIndexControlFunctions */
-  public boolean addMyStudentssAt(Student aMyStudentss, int index)
-  {  
-    boolean wasAdded = false;
-    if(addMyStudentss(aMyStudentss))
-    {
-      if(index < 0 ) { index = 0; }
-      if(index > numberOfMyStudentss()) { index = numberOfMyStudentss() - 1; }
-      myStudentss.remove(aMyStudentss);
-      myStudentss.add(index, aMyStudentss);
-      wasAdded = true;
-    }
-    return wasAdded;
-  }
-
-  public boolean addOrMoveMyStudentssAt(Student aMyStudentss, int index)
-  {
-    boolean wasAdded = false;
-    if(myStudentss.contains(aMyStudentss))
-    {
-      if(index < 0 ) { index = 0; }
-      if(index > numberOfMyStudentss()) { index = numberOfMyStudentss() - 1; }
-      myStudentss.remove(aMyStudentss);
-      myStudentss.add(index, aMyStudentss);
-      wasAdded = true;
-    } 
-    else 
-    {
-      wasAdded = addMyStudentssAt(aMyStudentss, index);
-    }
-    return wasAdded;
-  }
 
   public void delete()
   {
@@ -273,11 +143,6 @@ public class Teacher
     {
       Foo aMyFooss = myFooss.get(i - 1);
       aMyFooss.delete();
-    }
-    for(int i=myStudentss.size(); i > 0; i--)
-    {
-      Student aMyStudentss = myStudentss.get(i - 1);
-      aMyStudentss.delete();
     }
   }
 

--- a/umpleonline/ump/manualexamples/E080InvalidAbstractClassAssociation1.ump
+++ b/umpleonline/ump/manualexamples/E080InvalidAbstractClassAssociation1.ump
@@ -1,0 +1,11 @@
+//Class A contains an association
+//with abstract class B, causing
+//the error by using mandatory
+//multiplicity
+class A {
+  1 -- 1 B;
+}
+
+abstract class B{
+  abstract; 
+}

--- a/umpleonline/ump/manualexamples/E080InvalidAbstractClassAssociation2.ump
+++ b/umpleonline/ump/manualexamples/E080InvalidAbstractClassAssociation2.ump
@@ -1,0 +1,9 @@
+//The following association does not
+//cause the error
+class A {
+  0..1 -- 0..1 B;
+}
+
+abstract class B{
+  abstract; 
+}


### PR DESCRIPTION
Adds E080 to be raised if an association with an abstract class forces instantiation of an abstract class (if the association is not directed and has a multiplicity with lower bounds > 0 on both ends).

Adds test cases, and modifies one existing test case.
Adds manual page with an example.