### PR TITLE
Fixing unspec events example

### DIFF
--- a/umpleonline/ump/manualexamples/UnspecifiedEvents2.ump
+++ b/umpleonline/ump/manualexamples/UnspecifiedEvents2.ump
@@ -55,4 +55,7 @@ class AutomatedTellerMachine{
     }
     
   }
+  void readCard() {/*Code would be written here*/}
+  void ejectCard() {/*Code would be written here*/}
+
 }


### PR DESCRIPTION
The file UnspecifiedEvents2.ump user manual example that was added in PR #1292  resulted in calls to two methods that were missing. This adds those methods so the example testing will work (all generated Java for examples compiles).