### PR TITLE
Progress on #583 Layout of some Umpleonline examples fixed

### DIFF
--- a/umpleonline/ump/AccessControl.ump
+++ b/umpleonline/ump/AccessControl.ump
@@ -66,7 +66,7 @@ associationClass RoleFacilityAccessRight
   CRUD_Value { R, RW }
 }
 
-
+//$?[End_of_model]$?
 // Positioning
 
 class FacilityType

--- a/umpleonline/ump/AccessControl.ump
+++ b/umpleonline/ump/AccessControl.ump
@@ -65,41 +65,42 @@ associationClass RoleFacilityAccessRight
   * Role;
   CRUD_Value { R, RW }
 }
-//$?[End_of_model]$?
+
 
 // Positioning
+
+class FacilityType
+{
+  position 74 358 109 57;
+}
+
 class FunctionalArea
 {
-  position 21 28 109 62;
-  position.association FunctionalArea:parent__FunctionalArea:child 109,48 95,62;
+  position 48 23 112 57;
 }
 
 class Facility
 {
-  position 21 134 178 130;
-  position.association Facility__FacilityType 70,130 50,0;
-}
-
-class FacilityType
-{
-  position 41 314 109 62;
-}
-
-class User
-{
-  position 247 25 146 113;
-  position.association Role__User 72,113 45,0;
+  position 48 159 173 127;
+  position.association Facility__FacilityType 50,127 24,0;
 }
 
 class Role
 {
-  position 274 194 110 61;
+  position 372 235 109 57;
 }
 
-class RoleFacilityAccessRight{
-  position 225 315 165 57;
-  position.association Role__RoleFacilityAccessRight 77,0 28,62;
-  position.association Facility__RoleFacilityAccessRight 27,0 163,130;
+class User
+{
+  position 332 46 162 127;
+  position.association Role__User 102,127 62,0;
+}
+
+class RoleFacilityAccessRight
+{
+  position 270 362 166 45;
+  position.association Facility__RoleFacilityAccessRight 24,0 173,115;
+  position.association Role__RoleFacilityAccessRight 145,0 43,57;
 }
 
 // @@@skipphpcompile - remove when issue 697 is fixed

--- a/umpleonline/ump/AccessControl2.ump
+++ b/umpleonline/ump/AccessControl2.ump
@@ -170,11 +170,7 @@ class Code{
 }
 
 
-
-
-
-
-
+//$?[End_of_model]$?
 
 class User
 {

--- a/umpleonline/ump/AccessControl2.ump
+++ b/umpleonline/ump/AccessControl2.ump
@@ -172,53 +172,57 @@ class Code{
 
 
 
-//$?[End_of_model]$?
 
-class Code
-{
-  position 565 182 109 60;
-}
 
-class Card
-{
-  position.association Card__Code:cardId 49,63 30,0;
-  position 510 35 109 60;
-}
+
 
 class User
 {
-  position.association Card__User:owns 111,11 0,10;
-  position.association AccessPoint__User:mayEnterThrough 104,40 30,0;
-  position.association AccessZone:mayAccept__User:mayEnter 32,63 30,0;
-}
-
-class ACSystem
-{
-  position 381 181 136 60;
-  position.association ACSystem:mayAcceptAndValidate__User:mayUse 29,0 111,10;
-  position.association ACSystem:exitControls__AccessZone:exiting 0,10 110,9;
-  position.association ACSystem:entryControls__AccessZone:enteriing 0,30 110,29;
-}
-
-class Authorizer
-{
-  position.association AccessPoint__Authorizer:controls 129,56 0,28;
+  position 21 21 112 58;
+  position.association Card__User:owns 112,10 0,10;
+  position.association AccessPoint__User:mayEnterThrough 112,44 30,0;
+  position.association AccessZone:mayAccept__User:mayEnter 49,58 30,0;
 }
 
 class AccessPoint
 {
-  position 434 369 181 60;
-  position.association AccessPoint:controls__Door 0,51 112,8;
-}
-
-class Door
-{
-  position 243 305 109 60;
+  position 425 294 192 58;
+  position.association AccessPoint:controls__Door 0,46 114,25;
 }
 
 class AccessZone
 {
-  position.association AccessZone:accessedThrough__Door 36,46 30,0;
-  position 83 230 109 45;
+  position 40 205 109 40;
+  position.association AccessZone:accessedThrough__Door 65,45 0,4;
+}
+
+class Authorizer
+{
+  position 24 364 131 58;
+  position.association AccessPoint__Authorizer:controls 131,4 0,44;
+  position.association AccessZone__Authorizer:hasKnowledge 46,0 30,40;
+}
+
+class Door
+{
+  position 176 290 114 58;
+}
+
+class ACSystem
+{
+  position 307 164 147 58;
+  position.association ACSystem:mayAcceptAndValidate__User:mayUse 59,0 112,22;
+  position.association ACSystem:entryControls__AccessZone:enteriing 0,42 109,30;
+}
+
+class Card
+{
+  position 318 44 116 58;
+  position.association Card__Code:cardId 116,32 0,34;
+}
+
+class Code
+{
+  position 515 41 120 58;
 }
 // @@@skipcompile - issue relating to more than one 1..* creating problem constructor

--- a/umpleonline/ump/Accidents.ump
+++ b/umpleonline/ump/Accidents.ump
@@ -42,25 +42,27 @@ class Accident
 }
 //$?[End_of_model]$?
 //Positioning
-class Accident
-{
-  position 11 24 163 145;
-  position.association Accident__Employee 164,144 50,0;
-  position.association Accident__AccidentType 74,145 74,0;
-  position.association Accident__SeriousnessLevel 164,116 0,7;
-}
 
-class Employee
+
+class AccidentType
 {
-  position 184 260 233 128;
+  position 57 247 148 75;
 }
 
 class SeriousnessLevel
 {
-  position 266 133 149 79;
+  position 305 55 148 75;
 }
 
-class AccidentType
+class Employee
 {
-  position 11 230 149 74;
+  position 242 207 236 126;
+}
+
+class Accident
+{
+  position 39 29 163 126;
+  position.association Accident__Employee 163,126 56,0;
+  position.association Accident__SeriousnessLevel 163,46 0,20;
+  position.association Accident__AccidentType 49,126 31,0;
 }

--- a/umpleonline/ump/AfghanRainDesign.ump
+++ b/umpleonline/ump/AfghanRainDesign.ump
@@ -132,78 +132,80 @@ class Village
 }
 //$?[End_of_model]$?
 //Positioning
-class SurveyObservation
-{
-  position 42 20 248 128;
-  position.association SurveyObservation__VillageSurvey 118,130 91,0;
-}
 
-class Bulletin
-{
-  position 665 32 223 113;
-  position.association AgriculturalResearchStation__Bulletin 98,113 81,0;
-}
 
-class Worker
+class Watershed
 {
-  position 366 188 203 124;
-  position.association Office__Worker 203,108 0,0;
-  position.association Worker__WorkerRole 160,124 40,0;
-}
-
-class VillageSurvey
-{
-  position 69 198 178 110;
-  position.association Village__VillageSurvey 80,110 124,0;
-}
-
-class Village
-{
-  position 25 355 212 93;
-  position.association AgriculturalZone__Village 190,93 57,0;
-  position.association Village__Watershed 60,93 59,0;
-}
-
-class WorkersOnSurvey
-{
-  position 364 36 201 96;
-  position.association VillageSurvey__WorkersOnSurvey 0,93 178,0;
-  position.association Worker__WorkersOnSurvey 108,96 108,0;
-}
-
-class Office
-{
-  position 677 344 208 93;
-}
-
-class AgriculturalResearchStation
-{
-  position 682 198 189 54;
-}
-
-class Farm
-{
-  position 299 357 157 76;
-  position.association Farm__Village 0,8 212,10;
-}
-
-class WorkerRole
-{
-  position 486 359 149 79;
-}
-
-class AgriculturalZone
-{
-  position 158 510 120 76;
-  position.association AgriculturalZone__Disctrict 120,12 0,12;
+  position 1 502 119 75;
 }
 
 class District
 {
-  position 350 510 112 76;
+  position 301 502 112 75;
 }
 
-class Watershed
+class Office
 {
-  position 26 510 120 76;
+  position 667 324 207 92;
+}
+
+class WorkerRole
+{
+  position 452 408 148 75;
+}
+
+class Worker
+{
+  position 423 265 204 109;
+  position.association Worker__WorkerRole 64,109 35,0;
+  position.association Office__Worker 204,67 0,21;
+}
+
+class WorkersOnSurvey
+{
+  position 382 43 203 92;
+  position.association Worker__WorkersOnSurvey 106,92 65,0;
+  position.association VillageSurvey__WorkersOnSurvey 0,85 177,27;
+}
+
+class VillageSurvey
+{
+  position 44 190 177 92;
+  position.association Village__VillageSurvey 88,92 131,0;
+}
+
+class SurveyObservation
+{
+  position 11 24 249 126;
+  position.association SurveyObservation__VillageSurvey 123,126 90,0;
+}
+
+class Farm
+{
+  position 250 348 159 75;
+  position.association Farm__Village 0,38 214,41;
+}
+
+class Bulletin
+{
+  position 682 34 165 125;
+  position.association AgriculturalResearchStation__Bulletin 81,125 83,0;
+}
+
+class AgriculturalResearchStation
+{
+  position 680 199 169 73;
+}
+
+class AgriculturalZone
+{
+  position 132 502 119 75;
+  position.association AgriculturalZone__District 119,40 0,40;
+}
+
+class Village
+{
+  position 1 345 214 92;
+  position.association Village__Watershed 63,92 63,0;
+  position.association AgriculturalZone__Village 174,92 43,0;
 }

--- a/umpleonline/ump/Airline.ump
+++ b/umpleonline/ump/Airline.ump
@@ -49,58 +49,56 @@ class Booking{
   String seatNumber;
   * Booking -- 1 SpecificFlight;
 }
-//$?[End_of_model]$?
+
 // LAYOUT INFORMATION
-class Person
-{
-  position 414 11 152 80;
-  position.association Person__PersonRole 0,32 109,19;
-}
 
-
-class RegularFlight
-{
-  position 414 248 109 60;
-  position.association RegularFlight__SpecificFlight 0,18 109,18;
-}
-
-class PersonRole
-{
-  position 60 24 109 42;
-}
-
-class Booking
-{
-  position 13 248 159 60;
-  position.association Booking__SpecificFlight 159,18 0,18;
-}
-
-
-class EmployeeRole
-{
-  position 154 114 154 76;
-  position.association EmployeeRole__EmployeeRole:supervisor 0,64 9,76;
-  position.association EmployeeRole__SpecificFlight 141,76 49,0;
-}
-
-
-class PassengerRole
-{
-  position 8 112 122 70;
-  position.association Booking__PassengerRole 27,70 22,0;
-}
-
-
-class SpecificFlight
-{
-  position 246 248 109 60;
-}
 
 
 class Airline
 {
-  position 414 136 109 42;
-  position.association Airline__RegularFlight 49,42 49,0;
-  position.association Airline__Person 49,0 49,80;
+  position 389 228 109 40;
+  position.association Airline__Person 16,0 78,75;
+  position.association Airline__RegularFlight 30,45 51,0;
 }
 
+class RegularFlight
+{
+  position 368 347 168 75;
+  position.association RegularFlight__SpecificFlight 0,38 109,22;
+}
+
+class SpecificFlight
+{
+  position 214 363 109 58;
+}
+
+class PassengerRole
+{
+  position 1 193 112 58;
+  position.association Booking__PassengerRole 58,58 40,0;
+}
+
+class EmployeeRole
+{
+  position 208 183 150 58;
+  position.association EmployeeRole__EmployeeRole:supervisor 15,58 0,30;
+  position.association EmployeeRole__SpecificFlight 68,58 62,0;
+}
+
+class Person
+{
+  position 327 39 146 75;
+  position.association Person__PersonRole 0,10 110,24;
+}
+
+class PersonRole
+{
+  position 38 25 109 45;
+}
+
+class Booking
+{
+  position 19 365 154 58;
+  position.association Booking__SpecificFlight 154,33 0,35;
+  position.association Booking:Booking__SpecificFlight 154,41 0,43;
+}

--- a/umpleonline/ump/Airline.ump
+++ b/umpleonline/ump/Airline.ump
@@ -50,9 +50,8 @@ class Booking{
   * Booking -- 1 SpecificFlight;
 }
 
+//$?[End_of_model]$?
 // LAYOUT INFORMATION
-
-
 
 class Airline
 {

--- a/umpleonline/ump/BankingSystemA.ump
+++ b/umpleonline/ump/BankingSystemA.ump
@@ -87,6 +87,8 @@ class Division{
 }
 //$?[End_of_model]$?
 // Positioning
+
+// Positioning
 namespace BankingSystem.core.intangableResources;
 class Account
 {
@@ -152,8 +154,8 @@ class Card
 
 class Division
 {
-  position 86 185 112 77;
-  position.association Division__Employee 112,0 0,31;
-  position.association Division__Division:subDivision 0,63 10,77;
+  position 78 204 112 58;
+  position.association Division__Employee 40,0 0,37;
+  position.association Division__Division:subDivision 15,58 0,30;
 }
 

--- a/umpleonline/ump/BankingSystemB.ump
+++ b/umpleonline/ump/BankingSystemB.ump
@@ -73,13 +73,8 @@ class Loan{
  isA BankAccount;
 }
 //$?[End_of_model]$?
+
 //Positioning
-class BankAccount
-{
-  position 46 334 216 96;
-  position.association BankAccount__DebitCard 217,93 0,17;
-  position.association BankAccount__Cheque 217,10 0,8;
-}
 
 class Cheque
 {
@@ -102,22 +97,11 @@ class CreditCard
   position 669 467 145 76;
 }
 
-class Branch
-{
-  position 103 195 128 79;
-  position.association 0 1,76 81,0;
-  position.association BankAccount__Branch 26,79 30,0;
-}
 
-class FinancialInstitution
-{
-  position 379 12 131 62;
-  position.association FinancialInstitution__ReusableFinancialInstrument 92,62 0,0;
-}
 
 class Loan
 {
-  position 99 473 109 41;
+  position 125 473 109 41;
 }
 
 class DebitCard
@@ -133,10 +117,29 @@ class FinancialInstrument
 class Bank
 {
   position 242 119 109 45;
-  position.association Bank__Branch 0,41 100,0;
+  position.association Bank__Branch 0,25 100,0;
 }
 
 class CreditCardCompany
 {
   position 520 119 139 45;
+}
+
+class BankAccount
+{
+  position 71 328 218 92;
+  position.association BankAccount__DebitCard 200,92 0,21;
+  position.association BankAccount__Cheque 218,20 0,12;
+}
+
+class Branch
+{
+  position 75 178 127 75;
+  position.association BankAccount__Branch 39,75 43,0;
+}
+
+class FinancialInstitution
+{
+  position 359 15 133 58;
+  position.association FinancialInstitution__ReusableFinancialInstrument 114,58 0,10;
 }

--- a/umpleonline/ump/CoOpSystem.ump
+++ b/umpleonline/ump/CoOpSystem.ump
@@ -70,26 +70,23 @@ class Offer
 
 //$?[End_of_model]$?
 
+
+
 class Program
 {
   position 40 459 113 64;
-  position.association Program__Student 113,22 0,34;
+  position.association Program__Student 113,22 0,42;
 }
 
 class Application
 {
   position 128 355 109 46;
   position.association Application__Student 109,35 0,8;
-  position.association Application__Job 0,0 95,118;
+  position.association Application__Job 0,0 90,109;
   position.association Application__Interview 109,3 0,43;
   position.association Application__Offer 68,0 0,70;
 }
 
-class Job
-{
-  position 33 115 149 118;
-  position.association Job__Program 17,118 21,0;
-}
 
 class Employer
 {
@@ -109,13 +106,6 @@ class TimeSlot
   position 543 212 140 108;
 }
 
-class Student
-{
-  position 344 444 128 82;
-  position.association Student__Transcript 128,67 0,10;
-  position.association Student__TimeSlot 100,-3 11,108;
-}
-
 class Resume
 {
   position 563 414 109 46;
@@ -130,4 +120,17 @@ class Transcript
 class Offer
 {
   position 265 170 148 82;
+}
+
+class Job
+{
+  position 38 130 148 109;
+  position.association Job__Program 32,109 30,0;
+}
+
+class Student
+{
+  position 289 439 127 58;
+  position.association Student__Transcript 127,32 0,10;
+  position.association Student__TimeSlot 116,0 0,10;
 }

--- a/umpleonline/ump/Decisions.ump
+++ b/umpleonline/ump/Decisions.ump
@@ -148,6 +148,8 @@ Committees have members. Each member has a start and end date on the committee. 
 */
 //$?[End_of_model]$?
 
+
+
 class ChangeRequest
 {
   position 368 523 109 45;
@@ -160,7 +162,8 @@ class DecisionByBody
   position.association DecisionByBody__DecisionSummaryVersion 55,80 16,0;
   position.association DecisionByBody:usedInDecision__DocumentVersion:documentsForDecision 119,0 0,10;
   position.association DecisionByBody__DecisionMakingBody:decider 30,0 12,60;
-  position 203 444 159 77;
+    position.association Decision:onlyApprovedConditionalOnDecision__DecisionByBody 0,0 143,75;
+position 203 444 159 77;
 }
 
 class Comment
@@ -172,6 +175,7 @@ class Annotation
 {
   position 572 401 123 77;
   position.association Annotation__Person:madeByUser 97,0 64,63;
+  position.association Annotation__DecisionMakingBody:madeByBody 0,10 147,39;
 }
 
 class Person
@@ -183,12 +187,13 @@ class Organization
 {
   position.association Organization__Person:users 113,13 0,10;
   position.association DecisionMakingBody__Organization 75,63 30,0;
+  position.association Decision__Organization 52,58 34,0;
 }
 
 class Membership
 {
-  position.association Membership__Person 129,14 0,10;
-  position 93 130 121 77;
+  position.association Membership__Person 112,0 60,60;
+  position 113 170 129 77;
 }
 
 class DecisionSummaryVersion
@@ -208,11 +213,6 @@ class DecisionType
   position.association ApprovalLevel:highestApprovalLevelRequired__DecisionType 102,0 1,63;
 }
 
-class Decision
-{
-  position.association Decision__DecisionType 211,48 0,10;
-  position.association Decision__DecisionByBody:currentStatus 35,80 30,0;
-}
 
 class Document
 {
@@ -222,12 +222,20 @@ class Document
 
 class DecisionMakingBody
 {
-  position 300 175 130 60;
-  position.association ApprovalLevel__DecisionMakingBody 131,40 0,10;
-  position.association DecisionMakingBody__Membership 0,46 122,29;
+  position 289 190 147 60;
+  position.association ApprovalLevel__DecisionMakingBody 147,47 0,10;
+  position.association DecisionMakingBody__Membership 0,46 129,35;
 }
 
 class ApprovalLevel
 {
   position 581 259 141 60;
+}
+
+class Decision
+{
+  position 68 298 211 75;
+  position.association Decision__DecisionType 211,54 0,10;
+  position.association Decision__DecisionByBody:currentStatus 109,75 0,0;
+  position.association Decision:predecessors__Decision:successors 14,0 0,22;
 }

--- a/umpleonline/ump/ElectionSystem.ump
+++ b/umpleonline/ump/ElectionSystem.ump
@@ -82,7 +82,6 @@ class ElectoralDistrict{
  0..1 -- * ElectoralDistrict subDistrict;
 }    
 //$?[End_of_model]$?
-//Positioning
 
 //Positioning
 class Candidate
@@ -117,7 +116,7 @@ class PollInElection
 class VotesInPoll{
   position 518 327 151 62;
   position.association PollInElection__VotesInPoll 40,0 32,62;
-  position.association Candidature__VotesInPoll 12,62 170,19;
+  position.association Candidature__VotesInPoll 0,55 170,19;
 }
 
 class Position
@@ -147,10 +146,9 @@ class ElectionForPosition
 
 class ElectoralDistrict
 {
-  position 104 74 115 59;
-  position.association ElectoralDistrict__Voter 109,15 0,30;
-  position.association ElectoralDistrict__Position 50,59 112,0;
-  position.association ElectoralDistrict__ElectoralDistrict:subDistrict 0,38 15,59;
+  position 67 57 115 45;
+  position.association ElectoralDistrict__Voter 115,17 0,15;
+  position.association ElectoralDistrict__Position 70,45 95,0;
 }
 
 // @@@skipcppcompile - Contains Java Code

--- a/umpleonline/ump/ElevatorSystemA.ump
+++ b/umpleonline/ump/ElevatorSystemA.ump
@@ -43,28 +43,29 @@ class Elevator{
 //$?[End_of_model]$?
 
 //Positioning
-class Elevator
-{
-  position 189 139 193 96;
-  position.association Elevator__Floor:hasAccess 60,96 44,0;
-}
-
-class Floor
-{
-  position 205 289 157 93;
-  position.association Floor__Floor:onSameLevelAs 0,74 12,93;
-  position.association Elevator:onFloor__Floor 99,0 115,96;
-}
-
-class Bank
-{
-  position 233 25 109 62;
-  position.association Bank__Elevator 56,62 100,0;
-}
 
 class Building
 {
   position 27 158 112 57;
   position.association Building__Floor 112,57 0,0;
   position.association Bank__Building 112,0 0,57;
+}
+
+class Floor
+{
+  position 205 291 157 75;
+  position.association Floor__Floor:onSamelevelAs 26,75 0,59;
+  position.association Elevator:onFloor__Floor 127,0 129,92;
+}
+
+class Elevator
+{
+  position 203 148 196 92;
+  position.association Elevator__Floor:hasAccess 47,92 45,0;
+}
+
+class Bank
+{
+  position 218 30 109 58;
+  position.association Bank__Elevator 66,58 81,0;
 }

--- a/umpleonline/ump/GenealogyA.ump
+++ b/umpleonline/ump/GenealogyA.ump
@@ -27,15 +27,17 @@ class Union{
 association {
  * Person child -- 0..1 Union parents;
 }
-//$?[End_of_model]$?
+
+
 //Positioning
+
 class Person
 {
-  position 126 44 167 148;
+  position 72 26 165 143;
 }
 
 class Union
 {
-  position 124 267 183 91;
-  position.association Person:partner__Union 140,0 138,148;
+  position.association Person:partner__Union 30,0 8,143;
+  position 63 282 184 92;
 }

--- a/umpleonline/ump/GenealogyA.ump
+++ b/umpleonline/ump/GenealogyA.ump
@@ -28,7 +28,7 @@ association {
  * Person child -- 0..1 Union parents;
 }
 
-
+//$?[End_of_model]$?
 //Positioning
 
 class Person

--- a/umpleonline/ump/GenealogyB.ump
+++ b/umpleonline/ump/GenealogyB.ump
@@ -31,6 +31,7 @@ association {
  0..2 Person adoptiveParents -- * Person adoptedChild;
 }
 
+//$?[End_of_model]$?
 //Positioning
 
 class Union

--- a/umpleonline/ump/GenealogyB.ump
+++ b/umpleonline/ump/GenealogyB.ump
@@ -30,15 +30,16 @@ association {
 association {
  0..2 Person adoptiveParents -- * Person adoptedChild;
 }
-//$?[End_of_model]$?
+
 //Positioning
-class Person
-{
-  position 128 48 166 154;
-}
 
 class Union
 {
-  position 128 265 183 93;
-  position.association Person:partner__Union 150,0 150,154;
+  position 391 113 183 93;
+  position.association Person:partner__Union 0,60 165,95;
+}
+
+class Person
+{
+  position 87 78 165 143;
 }

--- a/umpleonline/ump/GenealogyC.ump
+++ b/umpleonline/ump/GenealogyC.ump
@@ -37,20 +37,21 @@ association {
 //$?[End_of_model]$?
 
 //Positioning
-class Person
-{
-  position 223 18 167 147;
-}
 
 class Union
 {
-  position 218 340 183 96;
-  position.association Person:parent__Union 150,0 146,147;
+  position 217 341 183 96;
+  position.association Person:parent__Union 150,0 131,143;
 }
 
 class Adoption
 {
-  position 198 203 180 58;
-  position.association Adoption__Union:adoptiveParents 96,62 0,49;
-  position.association Adoption__Person:adoptedChild 90,0 0,73;
+  position 30 203 179 58;
+  position.association Adoption__Union:adoptiveParents 84,58 0,10;
+  position.association Adoption__Person:adoptedChild 76,0 0,106;
+}
+
+class Person
+{
+  position 236 30 165 143;
 }

--- a/umpleonline/ump/Hospital.ump
+++ b/umpleonline/ump/Hospital.ump
@@ -62,20 +62,14 @@ class Patient
 {
      String name;
      * -- * Doctor;
-}//$?[End_of_model]$?
+}
+//$?[End_of_model]$?
 
 class Hospital
 {
   position 231 11 109 45;
   position.association Employee__Hospital 49,46 55,0;
   position.association Hospital__Ward 110,37 74,0;
-}
-
-class Employee
-{
-  position 227 93 125 93;
-  position.association Employee__Shift 0,64 150,39;
-  position.association Employee__Privilege 9,97 30,0;
 }
 
 class Doctor
@@ -85,7 +79,7 @@ class Doctor
 
 class Surgeon
 {
-  position 287 355 109 45;
+  position 272 355 109 45;
 }
 
 class Janitor
@@ -99,13 +93,6 @@ class Patient
   position.association Doctor__Patient 0,0 110,44;
   }
 
-class Ward
-{
-  position 447 105 139 76;
-  position.association Doctor__Ward 0,69 109,19;
-  position.association Employee__Ward 0,30 126,41;
-  position.association Patient__Ward 100,80 60,0;
-}
 
 class Shift
 {
@@ -115,4 +102,18 @@ class Shift
 class Privilege
 {
   position 42 222 126 60;
+}
+
+class Employee
+{
+  position 213 80 124 92;
+  position.association Employee__Shift 0,9 149,57;
+  position.association Employee__Privilege 0,65 30,0;
+}
+
+class Ward
+{
+  position 421 87 139 75;
+  position.association Employee__Ward 0,8 124,13;
+  position.association Patient__Ward 79,75 61,0;
 }

--- a/umpleonline/ump/Hotel.ump
+++ b/umpleonline/ump/Hotel.ump
@@ -52,23 +52,11 @@ class MeetingRoom
   position 358 444 211 76;
 }
 
-class Booking
-{
-  position 101 254 196 170;
-  position.association Booking__ItemOnBill 50,0 126,81;
-  position.association Booking__Booking:subsidiaryBooking 0,140 30,170;
-}
-
 class Event
 {
-  position 124 472 149 62;
+  position 136 471 149 62;
 }
 
-class Person
-{
-  position 209 104 128 79;
-  position.association Booking__Person 47,79 155,0;
-}
 
 class HotelBedroom
 {
@@ -84,13 +72,9 @@ class Suite
 class RentableSpace
 {
   position 477 286 152 79;
-  position.association Booking__RentableSpace 0,15 197,47;
+  position.association Booking__RentableSpace 0,15 201,46;
 }
 
-class ItemOnBill
-{
-  position 25 105 150 81;
-}
 
 class Hotel
 {
@@ -102,4 +86,22 @@ class HotelCompany
 {
   position 393 28 112 58;
   position.association Hotel:owns__HotelCompany 50,62 52,0;
+}
+
+class ItemOnBill
+{
+  position 55 133 148 75;
+}
+
+class Person
+{
+  position 235 133 127 75;
+  position.association Booking__Person 11,75 136,0;
+}
+
+class Booking
+{
+  position 110 255 201 143;
+  position.association Booking__Booking:subsidiaryBooking 20,143 0,118;
+  position.association Booking__ItemOnBill 30,0 85,75;
 }

--- a/umpleonline/ump/InventoryManagement.ump
+++ b/umpleonline/ump/InventoryManagement.ump
@@ -50,20 +50,6 @@ class Product
   position.association Product__ProductSource 100,145 107,0;
 }
 
-class ProductSource
-{
-  position 395 215 223 76;
-  position.association ProductSource__SupplierOrderLineItem 107,76 79,0;
-}
-
-class Supplier
-{
-  position 121 45 128 96;
-  position.association ProductSource__Supplier 129,94 0,0;
-  position.association OrderToSupplier__Supplier 80,96 32,0;
-  position.association ReceivedDelivery__Supplier 24,93 15,0;
-}
-
 class ReceivedLineItem
 {
   position 289 484 195 76;
@@ -85,4 +71,18 @@ class OrderToSupplier
 {
   position 169 215 159 76;
   position.association OrderToSupplier__SupplierOrderLineItem 160,69 0,4;
+}
+
+class ProductSource
+{
+  position 395 230 223 58;
+  position.association ProductSource__SupplierOrderLineItem 107,58 79,0;
+}
+
+class Supplier
+{
+  position 117 39 127 92;
+  position.association ProductSource__Supplier 120,85 0,0;
+  position.association OrderToSupplier__Supplier 84,92 32,0;
+  position.association ReceivedDelivery__Supplier 32,92 19,0;
 }

--- a/umpleonline/ump/Library.ump
+++ b/umpleonline/ump/Library.ump
@@ -64,12 +64,6 @@ class Copy
   position 12 198 180 58;
 }
 
-class PartOfPublication
-{
-  position 85 310 158 100;
-  position.association PPartOfPublication__PartOfPublication:subparts 0,82 15,100;
-}
-
 class IssueOfPeriodical
 {
   position 275 328 123 62;
@@ -81,12 +75,6 @@ class Publication
   position.association EditionOrIssue__Publication 0,58 169,0;
 }
 
-class Author
-{
-  position 53 54 112 58;
-  position.association Author__EditionOrIssue 112,58 0,0;
-}
-
 class Publisher
 {
   position 300 52 112 58;
@@ -96,4 +84,16 @@ class Publisher
 class Book
 {
   position 498 196 109 41;
+}
+
+class Author
+{
+  position 69 53 109 45;
+  position.association Author__EditionOrIssue 102,38 0,10;
+}
+
+class PartOfPublication
+{
+  position 52 298 161 75;
+  position.association PartOfPublication__PartOfPublication:subparts 0,45 19,75;
 }

--- a/umpleonline/ump/OhHellWhist.ump
+++ b/umpleonline/ump/OhHellWhist.ump
@@ -84,16 +84,13 @@ class Game {
    * gameLed -- 0..1 Player currentLead; // the player next to lay down a card
 }
 
+//$?[End_of_model]$?
 //Position information of the display on a diagram of all classes and of their associations
-class Card
-{
-  position 125 15 135 100;
-}
 
 class CardSet
 {
   position 186 153 109 45;
-  position.association Card__CardSet 30,0 31,100;
+  position.association Card__CardSet 30,0 87,92;
 }
 
 class NotDealtCardSet
@@ -122,15 +119,19 @@ class Match
 {
   position 532 48 159 82;
   position.association Match__ScoringTeam 120,82 60,0;
-  position.association Game:games__Match 30,82 72,0;
+  position.association Game:games__Match 29,84 116,0;
+}
+
+
+
+class Card
+{
+  position 75 22 134 92;
 }
 
 class Game
 {
-  position 442 280 123 64;
-  position.association Game__Player:currentLead 11,64 192,11;
-  position.association Card:currentTrickBeingBuilt__Game 0,10 135,50;
-  position.association Game:gameLed__Player:currentLead 24,64 192,30;
-  position.association Game__Player:dealer 0,38 192,10;
+  position 431 258 123 58;
+  position.association Game__Player:dealer 0,33 193,9;
+  position.association Game:gameLed__Player:currentLead 20,58 193,29;
 }
-

--- a/umpleonline/ump/Pizza.ump
+++ b/umpleonline/ump/Pizza.ump
@@ -68,12 +68,6 @@ class Driver
 
 //$?[End_of_model]$?
 
-class Account
-{
-  position 38 46 219 172;
-  position.association Account__Order 37,172 50,0;
-}
-
 class Order
 {
   position 22 271 219 154;
@@ -85,13 +79,6 @@ class OrderItem
   position 429 208 139 82;
 }
 
-class PizzaOrder
-{
-  position 240 465 139 118;
-  position.association PizzaOrder__ToppingType 66,82 40,0;
-  position.association PizzaOrder__ToppingType:toppings 109,20 0,0;
-  position.association PizzaOrder__StandardPizzaSize 0,11 135,7;
-}
 
 class ToppingType
 {
@@ -108,14 +95,27 @@ class DrinkOrder
   position 494 349 109 46;
 }
 
-class Delivery
-{
-  position 270 47 166 82;
-  position.association Delivery__Driver 166,42 0,40;
-  position.association Delivery__Order 133,82 219,11;
-}
-
 class Driver
 {
   position 506 49 109 46;
+}
+
+class Account
+{
+  position 20 46 218 160;
+  position.association Account__Order 32,160 30,0;
+}
+
+class Delivery
+{
+  position 260 47 160 75;
+  position.association Delivery__Driver 160,12 0,10;
+  position.association Delivery__Order 67,75 219,10;
+}
+
+class PizzaOrder
+{
+  position 267 437 109 58;
+  position.association PizzaOrder__StandardPizzaSize 0,43 136,9;
+  position.association PizzaOrder__ToppingType:toppings 109,39 0,10;
 }

--- a/umpleonline/ump/PoliticalEntities.ump
+++ b/umpleonline/ump/PoliticalEntities.ump
@@ -50,6 +50,6 @@ class Country
 
 class Territory
 {
-  position 280 140 109 70;
-  position.association Territory__Territory:borders 0,57 9,70;
+  position 305 139 109 45;
+  position.association Territory__Territory:borders 102,0 109,13;
 }

--- a/umpleonline/ump/WarehouseSystem.ump
+++ b/umpleonline/ump/WarehouseSystem.ump
@@ -21,6 +21,7 @@ class Level{
 }
 
 class LoadingGate{
+  
  Integer number;
  isA MovementLocation;
 }
@@ -108,15 +109,6 @@ class Truck
   position.association DeliverOrShipmentBom__Truck 82,0 121,79;
 }
 
-class RwbmMovement
-{
-  position 39 145 145 98;
-  position.association MovementLocation:to__RwbmMovement:toMovement 112,0 0,21;
-  position.association MovementLocation:from__RwbmMovement:fromMovement 146,20 22,45;
-  position.association BoxOrPallet:movedBox__RwbmMovement 20,98 46,0;
-  position.association Rwbm__RwbmMovement 80,98 45,0;
-}
-
 class Row
 {
   position 552 30 134 76;
@@ -141,7 +133,7 @@ class Slot
 
 class Rwbm
 {
-  position 74 297 109 62;
+  position 87 297 109 62;
 }
 
 class SlotSet
@@ -153,5 +145,14 @@ class SlotSet
 
 class MovementLocation
 {
-  position 323 42 131 45;
+  position 322 32 135 45;
+}
+
+class RwbmMovement
+{
+  position 65 155 145 75;
+  position.association BoxOrPallet:movedBox__RwbmMovement 8,75 60,0;
+  position.association Rwbm__RwbmMovement 66,75 44,0;
+  position.association MovementLocation:from__RwbmMovement:fromMovement 145,17 60,45;
+  position.association MovementLocation:to__RwbmMovement:toMovement 53,0 30,45;
 }


### PR DESCRIPTION
Adjusts the layout information of Umpleonline examples that had incorrect class sizes and association positions on Google Chrome and Safari. 
Does not adjust all examples (the smaller gap that is present between associations starts and classes in almost all examples is mostly still there).