### PR TITLE
Progress on #583 Adds updates to Umpleonline diagram after diagram actions

### DIFF
--- a/umpleonline/scripts/allumple-min.js
+++ b/umpleonline/scripts/allumple-min.js
@@ -1255,9 +1255,9 @@ Page.hideLoading();Action.updateUmpleDiagramForce(false)};Action.updateUmpleDiag
 var errorMessage="";diagramCode=Action.getDiagramCode(response.responseText);errorMessage=Action.getErrorCode(response.responseText);
 if(diagramCode==null||diagramCode==""||diagramCode=="null"){Page.enableDiagram(false);Action.diagramInSync=false;Page.setFeedbackMessage('<a href="#errorClick">See message.</a> To fix: edit model or click undo')
 }else{if(!Action.diagramInSync){Page.enableDiagram(true);Action.diagramInSync=true}Page.setFeedbackMessage("");Page.hideGeneratedCode();
-if(Page.useEditableClassDiagram){var newSystem=Json.toObject(diagramCode);UmpleSystem.merge(newSystem);if(Page.showMethods||!Page.showAttributes){UmpleSystem.update()
-}if(Page.readOnly){jQuery("span.editable").addClass("uneditable")}}else{if(Page.useJointJSClassDiagram){var model=JSON.parse(diagramCode.replace(new RegExp('} { "name": "',"gi"),'}, { "name": "'));
-var umpleCanvas=jQuery("#umpleCanvas");var paper=JJSdiagram.initJJSDiagram(umpleCanvas,model);var MouseWheelHandler=function(event){var delta=Math.max(-1,Math.min(1,(event.wheelDelta||-event.detail)));
+if(Page.useEditableClassDiagram){var newSystem=Json.toObject(diagramCode);UmpleSystem.merge(newSystem);UmpleSystem.update();if(Page.readOnly){jQuery("span.editable").addClass("uneditable")
+}}else{if(Page.useJointJSClassDiagram){var model=JSON.parse(diagramCode.replace(new RegExp('} { "name": "',"gi"),'}, { "name": "'));var umpleCanvas=jQuery("#umpleCanvas");
+var paper=JJSdiagram.initJJSDiagram(umpleCanvas,model);var MouseWheelHandler=function(event){var delta=Math.max(-1,Math.min(1,(event.wheelDelta||-event.detail)));
 if(event.altKey===true){var paperHeight=paper.options.height;var paperWidth=paper.options.width;var scaleFactor=1+(Math.abs(delta)/(delta*10));
 paper.setDimensions(paperWidth*scaleFactor,paperHeight*scaleFactor);if(JJSdiagram.paper){JJSdiagram.paper.setDimensions(jQuery("#umpleCanvas")[0].clientWidth,jQuery("#umpleCanvas")[0].clientHeight)
 }}};var paperHolder=document.getElementById("umpleCanvas");if(paperHolder.addEventListener){paperHolder.addEventListener("mousewheel",MouseWheelHandler,false);
@@ -1379,36 +1379,38 @@ setTimeout(function(){Page.setFeedbackMessage("UML Attributes must be alphanumer
 },2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(c);a.attributes[e].set(b);UmpleSystem.redraw(a);
 var d=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",d),codeChange:true});
 a.resetAttribute(e)}};DiagramEdit.attributeNew=function(d,b){if(!Action.validateAttributeName(b)){Action.updateUmpleDiagram();setTimeout(function(){Page.setFeedbackMessage("UML Attributes must be alphanumeric with an optional type after a colon. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
-},2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(d);var c=a.addAttribute(b);var e=Json.toString(a);
-Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});a.resetAttribute(c);
-UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a)}};DiagramEdit.classDeleted=function(d){var a=true;
-var g=UmpleSystem.find(d);var j=[];var b=[];for(var e=0;e<UmpleSystem.umpleAssociations.length;e++){var f=UmpleSystem.umpleAssociations[e];
-if(f.contains(g)){j.push(f.id)}}for(var e=0;e<UmpleSystem.umpleClasses.length;e++){var c=UmpleSystem.umpleClasses[e];if(c.extendsClass==g.id){b.push(c.id+"_generalization")
-}}for(var e=0;e<j.length;e++){DiagramEdit.associationDeleted(j[e],a)}for(var e=0;e<b.length;e++){DiagramEdit.generalizationDeleted(b[e],a)
-}var k=UmpleSystem.removeClass(d);var h=Json.toString(k);if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();
-Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeClass&actionCode={0}",h),codeChange:true})};DiagramEdit.methodNew=function(d,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();
-setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
+},2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(d);var c=a.addAttribute(b);DiagramEdit.updateHeightClass(a);
+var e=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});
+a.resetAttribute(c);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
+}};DiagramEdit.classDeleted=function(d){var a=true;var g=UmpleSystem.find(d);var j=[];var b=[];for(var e=0;e<UmpleSystem.umpleAssociations.length;
+e++){var f=UmpleSystem.umpleAssociations[e];if(f.contains(g)){j.push(f.id)}}for(var e=0;e<UmpleSystem.umpleClasses.length;e++){var c=UmpleSystem.umpleClasses[e];
+if(c.extendsClass==g.id){b.push(c.id+"_generalization")}}for(var e=0;e<j.length;e++){DiagramEdit.associationDeleted(j[e],a)}for(var e=0;
+e<b.length;e++){DiagramEdit.generalizationDeleted(b[e],a)}var k=UmpleSystem.removeClass(d);var h=Json.toString(k);if(!Page.repeatToolItem){Page.unselectAllToggleTools()
+}Page.showModelLoading();Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeClass&actionCode={0}",h),codeChange:true})
+};DiagramEdit.methodNew=function(d,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
 },2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(d);var c=a.addMethod(b);var e=Json.toString(a);
-Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});a.resetMethod(c);
-UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a)}};DiagramEdit.methodChanged=function(c,e,f,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();
-setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
+Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});DiagramEdit.updateHeightClass(a);
+a.resetMethod(c);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
+}};DiagramEdit.methodChanged=function(c,e,f,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
 },2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(c);a.methods[e].set(b);UmpleSystem.redraw(a);
 var d=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",d),codeChange:true});
-a.resetMethod(e)}};DiagramEdit.methodDelete=function(b,d){var a=UmpleSystem.find(b);a.removeMethod(d);var e=jQuery("#"+a.id);a.position.height=28+17*(a.attributes.size()+a.methods.size());
+a.resetMethod(e)}};DiagramEdit.methodDelete=function(b,d){var a=UmpleSystem.find(b);a.removeMethod(d);var e=jQuery("#"+a.id);a.position.width=UmpleClassFactory.defaultSize.width;
+DiagramEdit.updateHeightClass(a);var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
+a.resetMethod(d);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
+};DiagramEdit.attributeDelete=function(b,d){var a=UmpleSystem.find(b);a.removeAttribute(d);var e=jQuery("#"+a.id);DiagramEdit.updateHeightClass(a);
 a.position.width=UmpleClassFactory.defaultSize.width;var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
-a.resetMethod(d);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a)};DiagramEdit.attributeDelete=function(b,d){var a=UmpleSystem.find(b);
-a.removeAttribute(d);var e=jQuery("#"+a.id);a.position.height=28+17*(a.attributes.size()+a.methods.size());a.position.width=UmpleClassFactory.defaultSize.width;
-var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
-a.resetAttribute(d);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a)};DiagramEdit.associationDeleted=function(a,d){if(d==undefined){d=false
-}var c=UmpleSystem.removeAssociation(a);var b=Json.toString(c);if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();
-Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeAssociation&actionCode={0}",b),codeChange:true})
+a.resetAttribute(d);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
+};DiagramEdit.associationDeleted=function(a,d){if(d==undefined){d=false}var c=UmpleSystem.removeAssociation(a);var b=Json.toString(c);
+if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeAssociation&actionCode={0}",b),codeChange:true})
 };DiagramEdit.generalizationDeleted=function(a,d){if(d==undefined){d=false}var c=UmpleSystem.removeGeneralization(a);var b=Json.toString(c);
 if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeGeneralization&actionCode={0}",b),codeChange:true})
 };DiagramEdit.removeNewClass=function(){if(DiagramEdit.newClass!=null){var a="#"+DiagramEdit.newClass.id;DiagramEdit.newClass=null;jQuery(a).remove();
 return true}return false};DiagramEdit.removeNewAssociation=function(){if(DiagramEdit.newAssociation!=null){var a="#"+DiagramEdit.newAssociation.getElementId();
 jQuery(a).remove();DiagramEdit.newAssociation=null;return true}return false};DiagramEdit.removeNewGeneralization=function(){if(DiagramEdit.newGeneralization!=null){var a="#"+DiagramEdit.newGeneralization.getElementId();
-jQuery(a).remove();DiagramEdit.newGeneralization=null;return true}return false};UmpleAssociationFactory=new Object();UmpleAssociationFactory.create=function(b){var a=new UmpleAssociation();
-a.id=b.id;a.classOneId=b.classOneId;a.classTwoId=b.classTwoId;a.offsetOnePosition=UmplePositionFactory.copy(b.offsetOnePosition);a.offsetTwoPosition=UmplePositionFactory.copy(b.offsetTwoPosition);
+jQuery(a).remove();DiagramEdit.newGeneralization=null;return true}return false};DiagramEdit.updateHeightClass=function(a){a.position.height=20;
+if(Page.showAttributes){a.position.height+=17*(a.attributes.size())}if(Page.showMethods){a.position.height+=17*(a.methods.size())}};UmpleAssociationFactory=new Object();
+UmpleAssociationFactory.create=function(b){var a=new UmpleAssociation();a.id=b.id;a.classOneId=b.classOneId;a.classTwoId=b.classTwoId;
+a.offsetOnePosition=UmplePositionFactory.copy(b.offsetOnePosition);a.offsetTwoPosition=UmplePositionFactory.copy(b.offsetTwoPosition);
 a.multiplicityOne=b.multiplicityOne;a.multiplicityTwo=b.multiplicityTwo;a.name=b.name;a.roleOne=b.roleOne;a.roleTwo=b.roleTwo;a.isSymmetricReflexive=(b.isSymmetricReflexive=="true"||b.isSymmetricReflexive==true)?true:false;
 a.isLeftNavigable=(b.isLeftNavigable=="true"||b.isLeftNavigable==true)?true:false;a.isRightNavigable=(b.isRightNavigable=="true"||b.isRightNavigable==true)?true:false;
 a.isLeftComposition=(b.isLeftComposition=="true"||b.isLeftComposition==true)?true:false;a.isRightComposition=(b.isRightComposition=="true"||b.isRightComposition==true)?true:false;
@@ -1955,7 +1957,7 @@ jQuery(c).mouseover(function(e){Action.associationHover(e,true)});jQuery(c).mous
 UmpleSystem.setDragableAssociationAnchor(b,1)}return d};UmpleSystem.redrawGeneralizationsTo=function(d){for(var c=0;c<this.umpleClasses.length;
 c++){var a=this.umpleClasses[c];if(a.extendsClass==d.id){this.updateClass(a)}else{if(a.interfaces.length>0){for(var b=0;b<a.interfaces.length;
 b++){if(a.interfaces[b]==d.id){this.updateClass(a)}}}}}};UmpleSystem.update=function(){for(var a=0;a<this.umpleClasses.length;++a){var g=this.umpleClasses[a];
-g.position.height=28;if(UmpleSystem.showAttributes){g.position.height+=17*(g.attributes.size())}if(UmpleSystem.showMethods){g.position.height+=17*(g.methods.size())
+g.position.height=20;if(Page.showAttributes){g.position.height+=17*(g.attributes.size())}if(Page.showMethods){g.position.height+=17*(g.methods.size())
 }UmpleSystem.updateClass(g)}for(var a=0;a<this.umpleAssociations.length;++a){var f=UmpleSystem.find(this.umpleAssociations[a].classOneId);
 var h=this.umpleAssociations[a].offsetOnePosition.x+f.position.x+UmpleSystem.position().x;var d=this.umpleAssociations[a].offsetOnePosition.y+f.position.y+UmpleSystem.position().y;
 var k=Action.associationSnapClassReady(h,d,f);var e=UmpleSystem.find(this.umpleAssociations[a].classTwoId);h=this.umpleAssociations[a].offsetTwoPosition.x+e.position.x+UmpleSystem.position().x;

--- a/umpleonline/scripts/allumple-min.js
+++ b/umpleonline/scripts/allumple-min.js
@@ -1379,26 +1379,26 @@ setTimeout(function(){Page.setFeedbackMessage("UML Attributes must be alphanumer
 },2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(c);a.attributes[e].set(b);UmpleSystem.redraw(a);
 var d=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",d),codeChange:true});
 a.resetAttribute(e)}};DiagramEdit.attributeNew=function(d,b){if(!Action.validateAttributeName(b)){Action.updateUmpleDiagram();setTimeout(function(){Page.setFeedbackMessage("UML Attributes must be alphanumeric with an optional type after a colon. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
-},2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(d);var c=a.addAttribute(b);DiagramEdit.updateHeightClass(a);
-var e=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});
-a.resetAttribute(c);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
-}};DiagramEdit.classDeleted=function(d){var a=true;var g=UmpleSystem.find(d);var j=[];var b=[];for(var e=0;e<UmpleSystem.umpleAssociations.length;
-e++){var f=UmpleSystem.umpleAssociations[e];if(f.contains(g)){j.push(f.id)}}for(var e=0;e<UmpleSystem.umpleClasses.length;e++){var c=UmpleSystem.umpleClasses[e];
-if(c.extendsClass==g.id){b.push(c.id+"_generalization")}}for(var e=0;e<j.length;e++){DiagramEdit.associationDeleted(j[e],a)}for(var e=0;
-e<b.length;e++){DiagramEdit.generalizationDeleted(b[e],a)}var k=UmpleSystem.removeClass(d);var h=Json.toString(k);if(!Page.repeatToolItem){Page.unselectAllToggleTools()
-}Page.showModelLoading();Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeClass&actionCode={0}",h),codeChange:true})
-};DiagramEdit.methodNew=function(d,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
+},2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(d);var c=a.addAttribute(b);var e=Json.toString(a);
+Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});a.resetAttribute(c);
+UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()}};DiagramEdit.classDeleted=function(d){var a=true;
+var g=UmpleSystem.find(d);var j=[];var b=[];for(var e=0;e<UmpleSystem.umpleAssociations.length;e++){var f=UmpleSystem.umpleAssociations[e];
+if(f.contains(g)){j.push(f.id)}}for(var e=0;e<UmpleSystem.umpleClasses.length;e++){var c=UmpleSystem.umpleClasses[e];if(c.extendsClass==g.id){b.push(c.id+"_generalization")
+}}for(var e=0;e<j.length;e++){DiagramEdit.associationDeleted(j[e],a)}for(var e=0;e<b.length;e++){DiagramEdit.generalizationDeleted(b[e],a)
+}var k=UmpleSystem.removeClass(d);var h=Json.toString(k);if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();
+Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeClass&actionCode={0}",h),codeChange:true})};DiagramEdit.methodNew=function(d,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();
+setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
 },2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(d);var c=a.addMethod(b);var e=Json.toString(a);
-Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});DiagramEdit.updateHeightClass(a);
-a.resetMethod(c);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
-}};DiagramEdit.methodChanged=function(c,e,f,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
+Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",e),codeChange:true});a.resetMethod(c);
+UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()}};DiagramEdit.methodChanged=function(c,e,f,b){if(!Action.validateMethodName(b)){Action.updateUmpleDiagram();
+setTimeout(function(){Page.setFeedbackMessage("Invalid UML Method. &lt;"+(b.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;"))+"&gt is not valid.")
 },2000);setTimeout(function(){if(true){Page.setFeedbackMessage("")}},10000)}else{var a=UmpleSystem.find(c);a.methods[e].set(b);UmpleSystem.redraw(a);
 var d=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",d),codeChange:true});
 a.resetMethod(e)}};DiagramEdit.methodDelete=function(b,d){var a=UmpleSystem.find(b);a.removeMethod(d);var e=jQuery("#"+a.id);a.position.width=UmpleClassFactory.defaultSize.width;
-DiagramEdit.updateHeightClass(a);var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
+var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
 a.resetMethod(d);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
-};DiagramEdit.attributeDelete=function(b,d){var a=UmpleSystem.find(b);a.removeAttribute(d);var e=jQuery("#"+a.id);DiagramEdit.updateHeightClass(a);
-a.position.width=UmpleClassFactory.defaultSize.width;var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
+};DiagramEdit.attributeDelete=function(b,d){var a=UmpleSystem.find(b);a.removeAttribute(d);var e=jQuery("#"+a.id);a.position.width=UmpleClassFactory.defaultSize.width;
+var c=Json.toString(a);Page.showModelLoading();DiagramEdit.updateUmpleText({actionCode:format("action=editClass&actionCode={0}",c),codeChange:true});
 a.resetAttribute(d);UmpleSystem.updateClass(a);UmpleSystem.redrawGeneralizationsTo(a);UmpleSystem.trimOverlappingAssociations(a);UmpleSystem.update()
 };DiagramEdit.associationDeleted=function(a,d){if(d==undefined){d=false}var c=UmpleSystem.removeAssociation(a);var b=Json.toString(c);
 if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();Page.showLayoutLoading();DiagramEdit.updateUmpleText({actionCode:format("action=removeAssociation&actionCode={0}",b),codeChange:true})
@@ -1407,10 +1407,8 @@ if(!Page.repeatToolItem){Page.unselectAllToggleTools()}Page.showModelLoading();P
 };DiagramEdit.removeNewClass=function(){if(DiagramEdit.newClass!=null){var a="#"+DiagramEdit.newClass.id;DiagramEdit.newClass=null;jQuery(a).remove();
 return true}return false};DiagramEdit.removeNewAssociation=function(){if(DiagramEdit.newAssociation!=null){var a="#"+DiagramEdit.newAssociation.getElementId();
 jQuery(a).remove();DiagramEdit.newAssociation=null;return true}return false};DiagramEdit.removeNewGeneralization=function(){if(DiagramEdit.newGeneralization!=null){var a="#"+DiagramEdit.newGeneralization.getElementId();
-jQuery(a).remove();DiagramEdit.newGeneralization=null;return true}return false};DiagramEdit.updateHeightClass=function(a){a.position.height=20;
-if(Page.showAttributes){a.position.height+=17*(a.attributes.size())}if(Page.showMethods){a.position.height+=17*(a.methods.size())}};UmpleAssociationFactory=new Object();
-UmpleAssociationFactory.create=function(b){var a=new UmpleAssociation();a.id=b.id;a.classOneId=b.classOneId;a.classTwoId=b.classTwoId;
-a.offsetOnePosition=UmplePositionFactory.copy(b.offsetOnePosition);a.offsetTwoPosition=UmplePositionFactory.copy(b.offsetTwoPosition);
+jQuery(a).remove();DiagramEdit.newGeneralization=null;return true}return false};UmpleAssociationFactory=new Object();UmpleAssociationFactory.create=function(b){var a=new UmpleAssociation();
+a.id=b.id;a.classOneId=b.classOneId;a.classTwoId=b.classTwoId;a.offsetOnePosition=UmplePositionFactory.copy(b.offsetOnePosition);a.offsetTwoPosition=UmplePositionFactory.copy(b.offsetTwoPosition);
 a.multiplicityOne=b.multiplicityOne;a.multiplicityTwo=b.multiplicityTwo;a.name=b.name;a.roleOne=b.roleOne;a.roleTwo=b.roleTwo;a.isSymmetricReflexive=(b.isSymmetricReflexive=="true"||b.isSymmetricReflexive==true)?true:false;
 a.isLeftNavigable=(b.isLeftNavigable=="true"||b.isLeftNavigable==true)?true:false;a.isRightNavigable=(b.isRightNavigable=="true"||b.isRightNavigable==true)?true:false;
 a.isLeftComposition=(b.isLeftComposition=="true"||b.isLeftComposition==true)?true:false;a.isRightComposition=(b.isRightComposition=="true"||b.isRightComposition==true)?true:false;

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -1597,7 +1597,6 @@ Action.updateUmpleDiagramCallback = function(response)
     if(Page.useEditableClassDiagram) {
       var newSystem = Json.toObject(diagramCode);
       UmpleSystem.merge(newSystem);
-      if(Page.showMethods || !Page.showAttributes)
       UmpleSystem.update(); 
       
       //Apply readonly styles
@@ -1805,14 +1804,12 @@ Action.toggleAttributes = function()
 {
   Page.showAttributes = !Page.showAttributes;
   Action.redrawDiagram()
-  // UmpleSystem.update();
 }
   
 Action.toggleMethods = function()
 {
   Page.showMethods = !Page.showMethods;
-  Action.redrawDiagram()
-  // UmpleSystem.update();
+  Action.redrawDiagram();
 }
 
 Action.toggleActions = function()

--- a/umpleonline/scripts/umple_action_diagram.js
+++ b/umpleonline/scripts/umple_action_diagram.js
@@ -388,7 +388,7 @@ DiagramEdit.attributeNew = function(diagramId,attributeInput)
     var umpleClass = UmpleSystem.find(diagramId);
     var attributeIndex = umpleClass.addAttribute(attributeInput);
 
-    DiagramEdit.updateHeightClass(umpleClass);
+    
     
     var editClass = Json.toString(umpleClass);
     Page.showModelLoading();
@@ -467,7 +467,7 @@ DiagramEdit.methodNew = function(diagramId, methodInput)
       actionCode: format("action=editClass&actionCode={0}",editClass),
       codeChange: true
     });
-    DiagramEdit.updateHeightClass(umpleClass);
+    
     
     umpleClass.resetMethod(methodIndex);
     UmpleSystem.updateClass(umpleClass);
@@ -515,7 +515,7 @@ DiagramEdit.methodDelete = function(diagramId,index)
 
 //  umpleClass.position.height = UmpleClassFactory.defaultSize.height;
 //  umpleClass.position.width = UmpleClassFactory.defaultSize.width;
-  DiagramEdit.updateHeightClass(umpleClass);
+  
 
   var editClass = Json.toString(umpleClass);
   Page.showModelLoading();
@@ -539,7 +539,7 @@ DiagramEdit.attributeDelete = function(diagramId,index)
   var classObj = jQuery("#" + umpleClass.id);
 //  umpleClass.position.height = Math.round(classObj.height());
 //  umpleClass.position.width = Math.round(classObj.width());
-  DiagramEdit.updateHeightClass(umpleClass);
+  
 // This needs fixing so it picks up the correct width
 // Look trimOverlap, which seems to know the correct width
   umpleClass.position.width = UmpleClassFactory.defaultSize.width;
@@ -632,14 +632,4 @@ DiagramEdit.removeNewGeneralization = function()
     return true;
   }
   return false;
-}
-
-DiagramEdit.updateHeightClass = function(umpleClass) {
-  umpleClass.position.height = 20;
-  if (Page.showAttributes) {
-    umpleClass.position.height += 17*(umpleClass.attributes.size());
-  }
-  if (Page.showMethods) {
-    umpleClass.position.height += 17*(umpleClass.methods.size());
-  }
 }

--- a/umpleonline/scripts/umple_action_diagram.js
+++ b/umpleonline/scripts/umple_action_diagram.js
@@ -388,17 +388,19 @@ DiagramEdit.attributeNew = function(diagramId,attributeInput)
     var umpleClass = UmpleSystem.find(diagramId);
     var attributeIndex = umpleClass.addAttribute(attributeInput);
 
+    DiagramEdit.updateHeightClass(umpleClass);
+    
     var editClass = Json.toString(umpleClass);
     Page.showModelLoading();
     DiagramEdit.updateUmpleText({
       actionCode: format("action=editClass&actionCode={0}",editClass),
       codeChange: true
     });
-
     umpleClass.resetAttribute(attributeIndex);
     UmpleSystem.updateClass(umpleClass);
     UmpleSystem.redrawGeneralizationsTo(umpleClass);
     UmpleSystem.trimOverlappingAssociations(umpleClass);
+    UmpleSystem.update();
   }
 }
 
@@ -465,10 +467,13 @@ DiagramEdit.methodNew = function(diagramId, methodInput)
       actionCode: format("action=editClass&actionCode={0}",editClass),
       codeChange: true
     });
+    DiagramEdit.updateHeightClass(umpleClass);
+    
     umpleClass.resetMethod(methodIndex);
     UmpleSystem.updateClass(umpleClass);
     UmpleSystem.redrawGeneralizationsTo(umpleClass);
     UmpleSystem.trimOverlappingAssociations(umpleClass); 
+    UmpleSystem.update();
   }
 }
 
@@ -504,13 +509,13 @@ DiagramEdit.methodDelete = function(diagramId,index)
   //  umpleClass.position.height = Math.round(classObj.height());
   //  umpleClass.position.width = Math.round(classObj.width());
 
-  umpleClass.position.height = 28+17*(umpleClass.attributes.size()+umpleClass.methods.size());
 // This needs fixing so it picks up the correct width
 // Look trimOverlap, which seems to know the correct width
   umpleClass.position.width = UmpleClassFactory.defaultSize.width;
 
 //  umpleClass.position.height = UmpleClassFactory.defaultSize.height;
 //  umpleClass.position.width = UmpleClassFactory.defaultSize.width;
+  DiagramEdit.updateHeightClass(umpleClass);
 
   var editClass = Json.toString(umpleClass);
   Page.showModelLoading();
@@ -523,6 +528,7 @@ DiagramEdit.methodDelete = function(diagramId,index)
   UmpleSystem.updateClass(umpleClass);
   UmpleSystem.redrawGeneralizationsTo(umpleClass);
   UmpleSystem.trimOverlappingAssociations(umpleClass);
+  UmpleSystem.update();
 }
 
 DiagramEdit.attributeDelete = function(diagramId,index)
@@ -533,8 +539,7 @@ DiagramEdit.attributeDelete = function(diagramId,index)
   var classObj = jQuery("#" + umpleClass.id);
 //  umpleClass.position.height = Math.round(classObj.height());
 //  umpleClass.position.width = Math.round(classObj.width());
-
-  umpleClass.position.height = 28+17*(umpleClass.attributes.size()+umpleClass.methods.size());
+  DiagramEdit.updateHeightClass(umpleClass);
 // This needs fixing so it picks up the correct width
 // Look trimOverlap, which seems to know the correct width
   umpleClass.position.width = UmpleClassFactory.defaultSize.width;
@@ -553,6 +558,7 @@ DiagramEdit.attributeDelete = function(diagramId,index)
   UmpleSystem.updateClass(umpleClass);
   UmpleSystem.redrawGeneralizationsTo(umpleClass);    
   UmpleSystem.trimOverlappingAssociations(umpleClass);
+  UmpleSystem.update();
 }
 
 DiagramEdit.associationDeleted = function(diagramId, addToQueue)
@@ -626,4 +632,14 @@ DiagramEdit.removeNewGeneralization = function()
     return true;
   }
   return false;
+}
+
+DiagramEdit.updateHeightClass = function(umpleClass) {
+  umpleClass.position.height = 20;
+  if (Page.showAttributes) {
+    umpleClass.position.height += 17*(umpleClass.attributes.size());
+  }
+  if (Page.showMethods) {
+    umpleClass.position.height += 17*(umpleClass.methods.size());
+  }
 }

--- a/umpleonline/scripts/umple_system.js
+++ b/umpleonline/scripts/umple_system.js
@@ -366,13 +366,12 @@ UmpleSystem.update = function()
   for(var i = 0; i<this.umpleClasses.length;++i)
   {
     var umpleClass = this.umpleClasses[i];
-    umpleClass.position.height = 28;
-    if(UmpleSystem.showAttributes)
+    umpleClass.position.height = 20;
+    if(Page.showAttributes)
       umpleClass.position.height += 17*(umpleClass.attributes.size());
-    if(UmpleSystem.showMethods)
+    if(Page.showMethods)
       umpleClass.position.height += 17*(umpleClass.methods.size());
     UmpleSystem.updateClass(umpleClass);
-
   }
 
   for(var i = 0; i<this.umpleAssociations.length;++i)


### PR DESCRIPTION
The editable diagram in Umpleonline did not update the classes' size after certain actions, such as removing attributes and methods as well as toggling the visibility of methods.
Adds missing update calls and modifies the size classes are updated to.