### PR TITLE
Travis Docker and Manual improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ nohup.out
 # umple specific
 umpleonline/ump/tmp*
 build/UserManualAndExampleTests_output.txt
+umpleonline/manual
 
 # generated Umple code that is not saved
 src-gen-umple/

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ script:
   # Compile all known Umple examples and verify they compile in Java
   - $ANT_EXAMPLES allUserManualAndExampleTests   
   - $ANT_TESTBED template.resetVersion 
+  
+  # Build the user manual and copy it to a subfolder of UmpleOnline
+  - $ANT_BUILD packageDocs travisCopyManual  
 
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.
   - if [ "$HAVE_DOCKER" ]; then
@@ -75,9 +78,7 @@ after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
         DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-       # docker push "$DOCKER_IMAGE_NAME" &&
         if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-       #     docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
             docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
         elif [ "$TRAVIS_BRANCH" = 'master' ]; then
             docker push "$DOCKER_IMAGE_NAME" &&
@@ -88,7 +89,6 @@ after_success:
         elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
             echo 'The branch name looks like a pull request tag, not pushing branch tag';
         else
-        #    docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
             docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,12 @@ after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
         DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-        docker push "$DOCKER_IMAGE_NAME" &&
+       # docker push "$DOCKER_IMAGE_NAME" &&
         if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
+       #     docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
             docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
         elif [ "$TRAVIS_BRANCH" = 'master' ]; then
+            docker push "$DOCKER_IMAGE_NAME" &&
             docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
             docker push "umple/umpleonline:latest";
         elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
@@ -87,7 +88,7 @@ after_success:
         elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
             echo 'The branch name looks like a pull request tag, not pushing branch tag';
         else
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
+        #    docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
             docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -357,6 +357,22 @@
     </copy>
   </target>
 
+  <target name="travisCopyManual">
+    <copy todir="umpleonline/manual">
+      <fileset dir="${dist.path}/reference"/>
+    </copy>    
+    <copy todir="umpleonline/manual/files">
+      <fileset dir="build/reference/files"/>
+    </copy>
+    <copy todir="umpleonline/manual/examples">
+      <fileset dir="umplewww/examples"/>
+    </copy>     
+    <copy todir="umpleonline/manual/syntaxhighlighter">
+      <fileset dir="umplewww/syntaxhighlighter"/>
+    </copy>     
+    
+  </target>
+
   <target name="packageUmpleonline" if="${shouldPackageUmpleOnline}">
     <copy file="${dist.dir}/${dist.umple.sync.jar}" tofile="umpleonline/scripts/umplesync.jar" overwrite="true" />
     <copy file="${dist.dir}/${dist.umple.jar}" tofile="umpleonline/scripts/umple.jar" overwrite="true" />


### PR DESCRIPTION
This PR improves Docker builds in two ways:
1. It ensures a copy of the user manual (when built on Travis for Docker) is in the UmpleOnline directory so the manual can be inspected and earlier versions can be seen along with their release.
2. It avoids creating Docker images with the commit ID for every branch and PR. It only does this for commits to master.