### PR TITLE
Fix travis.yml syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ nohup.out
 # umple specific
 umpleonline/ump/tmp*
 build/UserManualAndExampleTests_output.txt
+umpleonline/manual
 
 # generated Umple code that is not saved
 src-gen-umple/

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ script:
   # Compile all known Umple examples and verify they compile in Java
   - $ANT_EXAMPLES allUserManualAndExampleTests   
   - $ANT_TESTBED template.resetVersion 
+  
+  # Build the user manual and copy it to a subfolder of UmpleOnline
+  - $ANT_BUILD packageDocs travisCopyManual  
 
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.
   - if [ "$HAVE_DOCKER" ]; then
@@ -75,9 +78,7 @@ after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
         DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-       # docker push "$DOCKER_IMAGE_NAME" &&
         if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-       #     docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
             docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
         elif [ "$TRAVIS_BRANCH" = 'master' ]; then
             docker push "$DOCKER_IMAGE_NAME" &&
@@ -88,7 +89,6 @@ after_success:
         elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
             echo 'The branch name looks like a pull request tag, not pushing branch tag';
         else
-        #    docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
             docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ after_success:
         elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
             echo 'The branch name looks like a pull request tag, not pushing branch tag';
         else
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
+            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH" &&
             docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,32 +64,39 @@ script:
   - $ANT_TESTBED template.resetVersion 
   
   # Build the user manual and copy it to a subfolder of UmpleOnline
-  - $ANT_BUILD packageDocs travisCopyManual  
+  - $ANT_BUILD packageDocs travisCopyManual
 
+  # Figure out the Docker image to build
+  - if [ "$HAVE_DOCKER" ]; then  
+        DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
+        if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
+            DOCKER_IMAGE_NAME="umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
+        elif [ "$TRAVIS_BRANCH" = 'master' ]; then
+            DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT;
+        elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
+            echo 'The branch name is "latest", not using branch tag';
+        elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
+            echo 'The branch name looks like a pull request tag, not using branch tag';
+        else
+             DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_BRANCH";
+        fi
+    fi
+ 
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.
   - if [ "$HAVE_DOCKER" ]; then
         $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline &&
         docker build -t "umple/umpleonline-base:local"
                      -f ../umpleonline/Dockerfile-base ../umpleonline &&
-        docker build -t "umple/umpleonline:$TRAVIS_COMMIT" ../umpleonline;
+        docker build -t "$DOCKER_IMAGE_NAME" ../umpleonline;
     fi
 
 after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
-        DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-        if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-            docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
-        elif [ "$TRAVIS_BRANCH" = 'master' ]; then
-            docker push "$DOCKER_IMAGE_NAME" &&
+        docker push "$DOCKER_IMAGE_NAME" &&        
+        if [ "$TRAVIS_BRANCH" = 'master' ]; then
             docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
             docker push "umple/umpleonline:latest";
-        elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
-            echo 'The branch name is "latest", not pushing branch tag';
-        elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
-            echo 'The branch name looks like a pull request tag, not pushing branch tag';
-        else
-            docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then
             docker tag "umple/umpleonline-base:local" "umple/umpleonline-base:latest" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,12 @@ after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
         DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-        docker push "$DOCKER_IMAGE_NAME" &&
+       # docker push "$DOCKER_IMAGE_NAME" &&
         if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
+       #     docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
             docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
         elif [ "$TRAVIS_BRANCH" = 'master' ]; then
+            docker push "$DOCKER_IMAGE_NAME" &&
             docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
             docker push "umple/umpleonline:latest";
         elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
@@ -87,7 +88,7 @@ after_success:
         elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
             echo 'The branch name looks like a pull request tag, not pushing branch tag';
         else
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
+        #    docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
             docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,38 +65,36 @@ script:
   
   # Build the user manual and copy it to a subfolder of UmpleOnline
   - $ANT_BUILD packageDocs travisCopyManual
-
-  # Figure out the Docker image to build
-  - if [ "$HAVE_DOCKER" ]; then  
-        DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-        if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-            DOCKER_IMAGE_NAME="umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
-        elif [ "$TRAVIS_BRANCH" = 'master' ]; then
-            DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_COMMIT;
-        elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
-            echo 'The branch name is "latest", not using branch tag';
-        elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
-            echo 'The branch name looks like a pull request tag, not using branch tag';
-        else
-             DOCKER_IMAGE_NAME="umple/umpleonline:$TRAVIS_BRANCH";
-        fi
-    fi
  
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.
   - if [ "$HAVE_DOCKER" ]; then
         $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline &&
         docker build -t "umple/umpleonline-base:local"
                      -f ../umpleonline/Dockerfile-base ../umpleonline &&
-        docker build -t "$DOCKER_IMAGE_NAME" ../umpleonline;
+        docker build -t "umple/umpleonline:recentbuild" ../umpleonline;
     fi
 
 after_success:
     if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
-        docker push "$DOCKER_IMAGE_NAME" &&        
-        if [ "$TRAVIS_BRANCH" = 'master' ]; then
+        DOCKER_IMAGE_NAME="umple/umpleonline:recentbuild" &&
+        DOCKER_HASH_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
+        docker push "$DOCKER_IMAGE_NAME" &&
+        if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
+            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
+            docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
+        elif [ "$TRAVIS_BRANCH" = 'master' ]; then
             docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
-            docker push "umple/umpleonline:latest";
+            docker push "umple/umpleonline:latest"; &&
+            docker tag "$DOCKER_IMAGE_NAME" "$DOCKER_HASH_NAME" &&
+            docker push "$DOCKER_HASH_NAME";
+        elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
+            echo 'The branch name is "latest", not pushing branch tag';
+        elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
+            echo 'The branch name looks like a pull request tag, not pushing branch tag';
+        else
+            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH";
+            docker push "umple/umpleonline:$TRAVIS_BRANCH";
         fi &&
         if [ "$TRAVIS_TAG" ]; then
             docker tag "umple/umpleonline-base:local" "umple/umpleonline-base:latest" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ after_success:
             docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
         elif [ "$TRAVIS_BRANCH" = 'master' ]; then
             docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
-            docker push "umple/umpleonline:latest"; &&
+            docker push "umple/umpleonline:latest" &&
             docker tag "$DOCKER_IMAGE_NAME" "$DOCKER_HASH_NAME" &&
             docker push "$DOCKER_HASH_NAME";
         elif [ "$TRAVIS_BRANCH" = 'latest' ]; then

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -357,6 +357,22 @@
     </copy>
   </target>
 
+  <target name="travisCopyManual">
+    <copy todir="umpleonline/manual">
+      <fileset dir="${dist.path}/reference"/>
+    </copy>    
+    <copy todir="umpleonline/manual/files">
+      <fileset dir="build/reference/files"/>
+    </copy>
+    <copy todir="umpleonline/manual/examples">
+      <fileset dir="umplewww/examples"/>
+    </copy>     
+    <copy todir="umpleonline/manual/syntaxhighlighter">
+      <fileset dir="umplewww/syntaxhighlighter"/>
+    </copy>     
+    
+  </target>
+
   <target name="packageUmpleonline" if="${shouldPackageUmpleOnline}">
     <copy file="${dist.dir}/${dist.umple.sync.jar}" tofile="umpleonline/scripts/umplesync.jar" overwrite="true" />
     <copy file="${dist.dir}/${dist.umple.jar}" tofile="umpleonline/scripts/umple.jar" overwrite="true" />


### PR DESCRIPTION
This PR improves Docker builds in two ways:

It ensures a copy of the user manual (when built on Travis for Docker) is in the UmpleOnline directory so the manual can be inspected and earlier versions can be seen along with their release.
It avoids creating Docker images with the commit ID for every branch and PR. It only does this for commits to master.