### PR TITLE
Fixes #884 Adds annotations that pass through from Umple to generated code

### DIFF
--- a/UmpleToPhp/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToPhp/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -59,7 +59,7 @@ class UmpleToPhp {
         }
         
 				appendln(realSb, "");
-				if (aMethod.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Method Javadoc",aMethod.getComments())); }
+				if (aMethod.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Method Javadoc",aMethod.getComments(),false)); }
 				
   			//appendln(realSb,override);
   			append(realSb, "  {0}{1} {2} {3}({4})", methodModifier, methodImplementationModifier, methodType, methodName, finalParams);

--- a/UmpleToPhp/UmpleTLTemplates/members_AllAssociations.ump
+++ b/UmpleToPhp/UmpleTLTemplates/members_AllAssociations.ump
@@ -20,7 +20,7 @@ class UmpleToPhp {
     appendln(realSb, "");
     String lookup = av.isOne() ? "associationOne" : "associationMany";
     
-    if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Association Javadoc", av.getComments())); }
+    if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Association Javadoc", av.getComments()),false); }
     
     if (av.isOptionalOne() && av.getRelatedAssociation().isMandatory() && !av.isImmutable())
     {

--- a/UmpleToPhp/UmpleTLTemplates/members_AllAttributes.ump
+++ b/UmpleToPhp/UmpleTLTemplates/members_AllAttributes.ump
@@ -31,7 +31,7 @@ class UmpleToPhp {
 
     appendln(realSb, "");
     
-    if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); }
+    if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments(),false)); }
     
     append(realSb, "  private ${0};", attribute);
   }

--- a/UmpleToPhp/UmpleTLTemplates/phpClassGenerator.ump
+++ b/UmpleToPhp/UmpleTLTemplates/phpClassGenerator.ump
@@ -78,7 +78,7 @@ class PhpClassGenerator {
 #>><?php<<@ UmpleToPhp.UmpleNotice >>
 
 
-<<# if (uClass.numberOfComments() > 0) { if (!uClass.getComments().get(0).getIsInline()) {append(realSb, "\n{0}", Comment.format("Multiline",uClass.getComments()));} else {append(realSb, "\n{0}", Comment.format("Slashes",uClass.getComments())); } } #>>
+<<# if (uClass.numberOfComments() > 0) { if (!uClass.getComments().get(0).getIsInline()) {append(realSb, "\n{0}", Comment.format("Multiline",uClass.getComments(),false));} else {append(realSb, "\n{0}", Comment.format("Slashes",uClass.getComments(),false)); } } #>>
 <<# append(realSb, System.lineSeparator()); #>>
 <<# if (uClass.getIsAbstract()) { append(realSb, "{0} ", "abstract"); } #>>class <<= uClass.getName() >><<= gen.translate("isA",uClass) >>
 {<<@ UmpleToPhp.members_AllStatics >><<@ UmpleToPhp.members_AllAttributes >><<@ UmpleToPhp.members_AllStateMachines >><<@ UmpleToPhp.members_AllDoActivities >><<@ UmpleToPhp.members_AllAssociations >><<@ UmpleToPhp.members_AllHelpers >>

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1104,6 +1104,7 @@ class Comment
 
   // The text associated with the comment.
   text;
+  Boolean annotation = false;
 }
 
 class UmpleTemplate {

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -340,6 +340,7 @@ class UmpleInternalParser
    */
   private void analyzeComment(Token token, boolean isAnnotation)
   {
+  
     String theValue = "";
     // Special comment directive to force umpleoutput directives to be added
     // In every class

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -102,9 +102,14 @@ class UmpleInternalParser
     }
     else if (t.is("inlineComment"))
     {
-      analyzeComment(t);
+      analyzeComment(t, false);
       shouldConsumeComment = addToLastAttributeOrAssociation(t);
-    } 
+    }
+    else if (t.is("annotationComment"))
+    {
+      analyzeComment(t, true);
+      shouldConsumeComment = addToLastAttributeOrAssociation(t);
+    }     
     else if (t.is("multilineComment"))
     {
       analyzeMultilineComment(t);
@@ -218,7 +223,12 @@ class UmpleInternalParser
     }
     else if (token.is("inlineComment"))
     {
-      analyzeComment(token);
+      analyzeComment(token, false);
+      shouldConsumeComment = addToLastAttributeOrAssociation(token);
+    }
+    else if (token.is("annotationComment"))
+    {
+      analyzeComment(token, true);
       shouldConsumeComment = addToLastAttributeOrAssociation(token);
     }
     else if (token.is("multilineComment"))
@@ -328,7 +338,7 @@ class UmpleInternalParser
    * 
    * @param token The current token which has been flagged to be a comment to analyze, containing its value.
    */
-  private void analyzeComment(Token token)
+  private void analyzeComment(Token token, boolean isAnnotation)
   {
     String theValue = "";
     // Special comment directive to force umpleoutput directives to be added
@@ -340,10 +350,14 @@ class UmpleInternalParser
     if (!token.getValue().equals("$?[End_of_model]$?")) 
     {
       theValue = token.getValue();
-      lastComments.add(new Comment(theValue));
+      Comment theComment = new Comment(theValue);
+      if(isAnnotation) {
+        theComment.setAnnotation(true);
+      }
+      lastComments.add(theComment);
     }
   }
-
+  
   /**
    * Analyzes a comment to determine if it should be added into the list of currently parsed comments waiting to be added to
    * a class, attribute, association, method or otherwise.

--- a/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTrait.ump
@@ -208,7 +208,12 @@ class UmpleInternalParser
     }
     else if (token.is("inlineComment"))
     {
-      analyzeComment(token);
+      analyzeComment(token, false);
+      shouldConsumeComment = addToLastAttributeOrAssociation(token);
+    }
+    else if (token.is("annotationComment"))
+    {
+      analyzeComment(token, true);
       shouldConsumeComment = addToLastAttributeOrAssociation(token);
     }
     else if (token.is("multilineComment"))

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -4024,6 +4024,11 @@ class Comment
    */
   public static String format(String type,List<Comment> allComments)
   {
+    return format(type, allComments, true);
+  }
+
+  public static String format(String type,List<Comment> allComments, boolean allowAnnotations)
+  {
     //String commentDelimiter = type == "Hash" ? "# " : (type == "Javadoc") ? " * " : (type == "Attribute Javadoc") ? "   * " : (type == "Association Javadoc") ? "   * " : (type == "Method Javadoc") ? "   * " : (type == "RubyMultiline") ? "  " : (type == "Multiline") ? "" : "// ";
 
     String commentDelimiter;
@@ -4077,7 +4082,7 @@ class Comment
 
     for (Comment c : allComments)
     {
-      boolean couldTreatAsAnnotation = true;
+      boolean couldTreatAsAnnotation = allowAnnotations;
       
       if (type == "RubyMultiline" || type == "RubyMultiline Internal") {
         couldTreatAsAnnotation = false;

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -4027,6 +4027,7 @@ class Comment
     //String commentDelimiter = type == "Hash" ? "# " : (type == "Javadoc") ? " * " : (type == "Attribute Javadoc") ? "   * " : (type == "Association Javadoc") ? "   * " : (type == "Method Javadoc") ? "   * " : (type == "RubyMultiline") ? "  " : (type == "Multiline") ? "" : "// ";
 
     String commentDelimiter;
+    List<String> deferredAnnotations = new ArrayList<String>();
 
     // Set the comment delimiter based on the type of the comment. (ex. For Javadoc prepend "*" before every comment line)
     if (type == "Hash")
@@ -4072,9 +4073,16 @@ class Comment
     }
 
     String output = "";
+    Boolean foundComment = false;
 
     for (Comment c : allComments)
     {
+      boolean couldTreatAsAnnotation = true;
+      
+      if (type == "RubyMultiline" || type == "RubyMultiline Internal") {
+        couldTreatAsAnnotation = false;
+      }
+      
       if (type == "Javadoc" || type == "Attribute Javadoc" || type == "Association Javadoc" || type == "Method Javadoc" || type == "RubyMultiline" || type == "RubyMultiline Internal")
       {
         int startIndex = 0;
@@ -4103,59 +4111,80 @@ class Comment
           c.setText(c.getText().substring(startIndex));
         }
       }
-      output += commentDelimiter + c.getText() + "\n";
+      
+      // If it is an annotation, add at end
+      if(c.isAnnotation() && couldTreatAsAnnotation) {
+        deferredAnnotations.add(c.getText());
+      }
+      else
+      {
+        foundComment = true;
+        output += commentDelimiter + c.getText() + "\n";
+      }
     }
 
     // Finalize the comment based on what type it was. (ex. For Javadoc place the "/**" and "*/" around the comment)
-    if (type == "Javadoc")
-    {
-      output = "/**\n" + output + " */";
-    }
-    else if (type == "Attribute Javadoc")
-    {
-      output = "  /**\n" + output + "   */";
-    }
-    else if (type == "Association Javadoc")
-    {
-      output = "  /**\n" + output + "   */";
-    }
-    else if (type == "Method Javadoc")
-    {
-      output = "  /**\n" + output + "   */";
-    }
-    else if (type == "RubyMultiline")
-    {
-      // initialize sb at least as large as the output with 1 comment
-      StringBuilder sb = new StringBuilder( output.length() + 2 ); 
-      sb.append("#");
-      char c;
-      for( int i=0; i < output.length(); ++i ){
-        c = output.charAt(i);
-        sb.append(c);
-        if( (c == '\n') && (i != output.length()-1) ){
-          sb.append("#");
-        }
+    if(foundComment) {
+      if (type == "Javadoc")
+      {
+        output = "/**\n" + output + " */";
       }
-      output = sb.toString();
-    }
-    else if (type == "RubyMultiline Internal")
-    {
-      // initialize sb at least as large as the output with 1 comment
-      StringBuilder sb = new StringBuilder( output.length() + 2 ); 
-      sb.append("#");
-      char c;
-      for( int i=0; i < output.length(); ++i ){
-        c = output.charAt(i);
-        sb.append(c);
-        if( (c == '\n') && (i != output.length()-1) ){
-          sb.append("  #");
-        }
+      else if (type == "Attribute Javadoc")
+      {
+        output = "  /**\n" + output + "   */";
       }
-      output = sb.toString();
+      else if (type == "Association Javadoc")
+      {
+        output = "  /**\n" + output + "   */";
+      }
+      else if (type == "Method Javadoc")
+      {
+        output = "  /**\n" + output + "   */";
+      }
+      else if (type == "RubyMultiline")
+      {
+        // initialize sb at least as large as the output with 1 comment
+        StringBuilder sb = new StringBuilder( output.length() + 2 ); 
+        sb.append("#");
+        char c;
+        for( int i=0; i < output.length(); ++i ){
+          c = output.charAt(i);
+          sb.append(c);
+          if( (c == '\n') && (i != output.length()-1) ){
+            sb.append("#");
+          }
+        }
+        output = sb.toString();
+      }
+      else if (type == "RubyMultiline Internal")
+      {
+        // initialize sb at least as large as the output with 1 comment
+        StringBuilder sb = new StringBuilder( output.length() + 2 ); 
+        sb.append("#");
+        char c;
+        for( int i=0; i < output.length(); ++i ){
+          c = output.charAt(i);
+          sb.append(c);
+          if( (c == '\n') && (i != output.length()-1) ){
+            sb.append("  #");
+          }
+        }
+        output = sb.toString();
+      }
+      else if (type == "Multiline")
+      {
+        output = "/*\n" + output + "*/";
+      }
     }
-    else if (type == "Multiline")
-    {
-      output = "/*\n" + output + "*/";
+    
+    // Process all deferred annotations if any
+    boolean firstAnnotation = true;
+    for (String d: deferredAnnotations) {
+      if(firstAnnotation) {
+        output = output + "\n";
+        firstAnnotation = false;
+      }
+      output = output + "  "+ d + "\n";
     }
 
     return output.trim();

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -50,8 +50,9 @@ entity- : [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[f
 comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]
 inlineComment- : // [*inlineComment]
 multilineComment- : /* [**multilineComment] */
-annotationComment- : [!annotationComment:@[a-zA-Z_][a-zA-Z0-9_-]*]
-//( OPEN_ROUND_BRACKET **annotationContents** CLOSE_ROUND_BRACKET )?
+
+//Matches all forms of Java annotations including those with parentheses and values in quotes
+annotationComment- : [!annotationComment:@[a-zA-Z_][a-zA-Z0-9_-]*(\((("(\w|\s|-)*")|\w|\s|=|,|\.)*\))?]
 
 // The Debug statement turns on debugging in code generation. For developer use only
 debug- : [=debug] ;

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -47,9 +47,11 @@ namespace- : namespace [namespace] ;
 entity- : [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
 
 // Comments follow the same conventions as C-family languages. [*UmpleComments*]
-comment- : [[inlineComment]] | [[multilineComment]]
+comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]
 inlineComment- : // [*inlineComment]
 multilineComment- : /* [**multilineComment] */
+annotationComment- : [!annotationComment:@[a-zA-Z_][a-zA-Z0-9_-]*]
+//( OPEN_ROUND_BRACKET **annotationContents** CLOSE_ROUND_BRACKET )?
 
 // The Debug statement turns on debugging in code generation. For developer use only
 debug- : [=debug] ;

--- a/cruise.umple/test/cruise/umple/implementation/Annotations.ump
+++ b/cruise.umple/test/cruise/umple/implementation/Annotations.ump
@@ -1,0 +1,24 @@
+// Class comment 1
+@dddddr
+// Class comment 2
+class X {
+  @wwwww
+  a; @xxxxx
+  b; // zzzzz
+  c;
+  // rrrr
+  @ssss
+  internal String i; @iiiii
+  g;
+
+  @mmmm
+  m1() {}
+  
+  @nnnn
+  // This is a method comment
+  public void m2 (int x) {
+      return;
+  }
+  q;
+  r;
+}

--- a/cruise.umple/test/cruise/umple/implementation/AnnotationsTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/AnnotationsTest.java
@@ -1,0 +1,12 @@
+package cruise.umple.implementation;
+
+import org.junit.*;
+
+public class AnnotationsTest extends TemplateTest {
+	
+	@Test
+	public void Annotations1()
+	{
+		assertUmpleTemplateFor("Annotations.ump", languagePath + "/Annotations_X."+ languagePath +".txt", "X");
+	}
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/Annotations_X.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Annotations_X.java.txt
@@ -1,0 +1,168 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+
+
+/**
+ * Class comment 1
+ * Class comment 2
+ */
+  @dddddr
+// line 5 "model.ump"
+// line 27 "model.ump"
+public class X
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //X Attributes
+  private String a;
+  private String b;
+  private String c;
+
+  /**
+   * rrrr
+   */
+  @ssss
+  @iiiii
+  private String i;
+  private String g;
+  private String q;
+  private String r;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public X(String aA, String aB, String aC, String aI, String aG, String aQ, String aR)
+  {
+    a = aA;
+    b = aB;
+    c = aC;
+    i = aI;
+    g = aG;
+    q = aQ;
+    r = aR;
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public boolean setA(String aA)
+  {
+    boolean wasSet = false;
+    a = aA;
+    wasSet = true;
+    return wasSet;
+  }
+
+  public boolean setB(String aB)
+  {
+    boolean wasSet = false;
+    b = aB;
+    wasSet = true;
+    return wasSet;
+  }
+
+  public boolean setC(String aC)
+  {
+    boolean wasSet = false;
+    c = aC;
+    wasSet = true;
+    return wasSet;
+  }
+
+  public boolean setG(String aG)
+  {
+    boolean wasSet = false;
+    g = aG;
+    wasSet = true;
+    return wasSet;
+  }
+
+  public boolean setQ(String aQ)
+  {
+    boolean wasSet = false;
+    q = aQ;
+    wasSet = true;
+    return wasSet;
+  }
+
+  public boolean setR(String aR)
+  {
+    boolean wasSet = false;
+    r = aR;
+    wasSet = true;
+    return wasSet;
+  }
+
+  @wwwww
+  @xxxxx
+  public String getA()
+  {
+    return a;
+  }
+
+  /**
+   * zzzzz
+   */
+  public String getB()
+  {
+    return b;
+  }
+
+  public String getC()
+  {
+    return c;
+  }
+
+  public String getG()
+  {
+    return g;
+  }
+
+  public String getQ()
+  {
+    return q;
+  }
+
+  public String getR()
+  {
+    return r;
+  }
+
+  public void delete()
+  {}
+
+
+  @mmmm
+  // line 16 "model.ump"
+  public void m1(){
+    
+  }
+
+
+  /**
+   * This is a method comment
+   */
+  @nnnn
+  // line 21 "model.ump"
+   public void m2(int x){
+    return;
+  }
+
+
+  public String toString()
+  {
+    return super.toString() + "["+
+            "a" + ":" + getA()+ "," +
+            "b" + ":" + getB()+ "," +
+            "c" + ":" + getC()+ "," +
+            "g" + ":" + getG()+ "," +
+            "q" + ":" + getQ()+ "," +
+            "r" + ":" + getR()+ "]";
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/Annotations_X.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/Annotations_X.php.txt
@@ -1,0 +1,162 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+// Class comment 1
+// @dddddr
+// Class comment 2
+class X
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //X Attributes
+
+  /**
+   * @wwwww
+   * @xxxxx
+   */
+  private $a;
+
+  /**
+   * zzzzz
+   */
+  private $b;
+  private $c;
+
+  /**
+   * rrrr
+   * @ssss
+   * @iiiii
+   */
+  private $i;
+  private $g;
+  private $q;
+  private $r;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct($aA, $aB, $aC, $aI, $aG, $aQ, $aR)
+  {
+    $this->a = $aA;
+    $this->b = $aB;
+    $this->c = $aC;
+    $this->i = $aI;
+    $this->g = $aG;
+    $this->q = $aQ;
+    $this->r = $aR;
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function setA($aA)
+  {
+    $wasSet = false;
+    $this->a = $aA;
+    $wasSet = true;
+    return $wasSet;
+  }
+
+  public function setB($aB)
+  {
+    $wasSet = false;
+    $this->b = $aB;
+    $wasSet = true;
+    return $wasSet;
+  }
+
+  public function setC($aC)
+  {
+    $wasSet = false;
+    $this->c = $aC;
+    $wasSet = true;
+    return $wasSet;
+  }
+
+  public function setG($aG)
+  {
+    $wasSet = false;
+    $this->g = $aG;
+    $wasSet = true;
+    return $wasSet;
+  }
+
+  public function setQ($aQ)
+  {
+    $wasSet = false;
+    $this->q = $aQ;
+    $wasSet = true;
+    return $wasSet;
+  }
+
+  public function setR($aR)
+  {
+    $wasSet = false;
+    $this->r = $aR;
+    $wasSet = true;
+    return $wasSet;
+  }
+
+  public function getA()
+  {
+    return $this->a;
+  }
+
+  public function getB()
+  {
+    return $this->b;
+  }
+
+  public function getC()
+  {
+    return $this->c;
+  }
+
+  public function getG()
+  {
+    return $this->g;
+  }
+
+  public function getQ()
+  {
+    return $this->q;
+  }
+
+  public function getR()
+  {
+    return $this->r;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+
+  /**
+   * @mmmm
+   */
+  public function m1()
+  {
+    
+  }
+
+
+  /**
+   * @nnnn
+   * This is a method comment
+   */
+   public function m2(int $x)
+  {
+    return;
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/ruby/Annotations_X.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/Annotations_X.ruby.txt
@@ -1,0 +1,131 @@
+# PLEASE DO NOT EDIT THIS CODE
+# This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!
+# NOTE: Ruby generator is experimental and is missing some features available in
+# in other Umple generated languages like Java or PHP
+
+
+
+# Class comment 1
+# Class comment 2
+
+  @dddddr
+class X
+
+
+  #------------------------
+  # MEMBER VARIABLES
+  #------------------------
+
+  #X Attributes - for documentation purposes
+
+  # @wwwww
+  # @xxxxx
+  #attr_reader :a, :b, :c, :i, :g, :q, :r
+
+  #------------------------
+  # CONSTRUCTOR
+  #------------------------
+
+  def initialize(a_a, a_b, a_c, a_i, a_g, a_q, a_r)
+    @initialized = false
+    @deleted = false
+    @a = a_a
+    @b = a_b
+    @c = a_c
+    @i = a_i
+    @g = a_g
+    @q = a_q
+    @r = a_r
+    @initialized = true
+  end
+
+  #------------------------
+  # INTERFACE
+  #------------------------
+
+  def set_a(a_a)
+    was_set = false
+    @a = a_a
+    was_set = true
+    was_set
+  end
+
+  def set_b(a_b)
+    was_set = false
+    @b = a_b
+    was_set = true
+    was_set
+  end
+
+  def set_c(a_c)
+    was_set = false
+    @c = a_c
+    was_set = true
+    was_set
+  end
+
+  def set_g(a_g)
+    was_set = false
+    @g = a_g
+    was_set = true
+    was_set
+  end
+
+  def set_q(a_q)
+    was_set = false
+    @q = a_q
+    was_set = true
+    was_set
+  end
+
+  def set_r(a_r)
+    was_set = false
+    @r = a_r
+    was_set = true
+    was_set
+  end
+
+  def get_a
+    @a
+  end
+
+  def get_b
+    @b
+  end
+
+  def get_c
+    @c
+  end
+
+  def get_g
+    @g
+  end
+
+  def get_q
+    @q
+  end
+
+  def get_r
+    @r
+  end
+
+  def delete
+    @deleted = true
+  end
+
+
+  # @mmmm
+  def m1 ()
+    
+  end
+
+
+  # @nnnn
+  # This is a method comment
+  def m2 (x)
+    return;
+  end
+
+
+
+end


### PR DESCRIPTION
This PR allows all Java annotations starting with @ to be passed through to generated code if they are present in Umple source. When generating php and Ruby they appear as comments. Users can use annotations on methods in order to use Umple with tools that process annotations, or to mark a method as @Deprecated etc. Annotations on classes also appear before the generated class. Annotations on attributes appear before the get method. Annotations on internal attributes appear before the private variable.

An annotation can appear in Umple anywhere a comment can appear. In fact, they are treated just like comments, except that in Java they are output without being wrapped in a comment.

This feature has been requested by several people in the end-user community.
