### PR TITLE
Progress on #1027 Adds before/after code injection to get methods for subclasses

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDefaultedSubclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDefaultedSubclass.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+  attribute_GetDefaultedSubclass <<!  /* Code from template attribute_GetDefaultedSubclass */
+<</*attribute_GetDefaultedSubclass*/>>  public <<=gen.translate("type",av)>> <<=gen.translate("getDefaultMethod",av)>>()
+  {
+    <<# if (customGetDefaultPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getDefaultMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetDefaultPrefixCode, "    ")); } #>>
+    <<=gen.translate("type",av)>> <<=gen.translate("parameterOne",av)>> = super.<<= gen.translate("getMethod",av) >>();
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetDefaultPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetDefaultPostfixCode,gen.translate("getDefaultMethod",av));
+      append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetDefaultPostfixCode, "    ")); } #>>    return <<= gen.translate("parameterValue",av) >>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetDerivedSubclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetDerivedSubclass.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+  attribute_GetDerivedSubclass <<!  /* Code from template attribute_GetDerivedSubclass */<</*attribute_GetDerivedSubclass*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}\n", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+      append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("type",av) >> <<= gen.translate("parameterOne",av) >> = super.<<= gen.translate("getMethod",av) >>();
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>    return <<= gen.translate("parameterOne",av) >>;<<#addUncaughtExceptionVariables(gen.translate("getMethod",av),av.getPosition().getFilename(),av.getPosition().getLineNumber(),realSb.toString().split("\\n").length-1,1);#>>
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetManySubclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetManySubclass.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+  attribute_GetManySubclass <<!  /* Code from template attribute_GetManySubclass */
+<</*attribute_GetManySubclass*/>>  public <<=gen.translate("typeMany",av)>> <<=gen.translate("getMethod",av)>>(int index)
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av));
+     append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("typeMany",av)>> <<=gen.translate("parameterOne",av)>> = super.<<=gen.translate("getMethod",av)>>(index);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av));
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>    return <<=gen.translate("parameterOne",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetSubclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetSubclass.ump
@@ -1,0 +1,13 @@
+class UmpleToJava {
+    attribute_GetSubclass <<!<</*attribute_GetSubclass*/>><<# if (av.numberOfComments() > 0) { append(realSb, "\n  {0}", Comment.format("Attribute Javadoc", av.getComments())); } #>><<= umpleSourceFile >>
+  public <<=gen.translate("type",av)>> <<= gen.translate("getMethod",av) >>()
+  {
+    <<# if (customGetPrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPrefixCode,gen.translate("getMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("type",av) >> <<= gen.translate("parameterOne",av) >> =  super.<<= gen.translate("getMethod",av) >>();
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>><<#
+    if (customGetPostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetPostfixCode,gen.translate("getMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    return <<= gen.translate("parameterOne",av) >>;
+  }!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_GetUniqueSubclass.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_GetUniqueSubclass.ump
@@ -1,0 +1,15 @@
+class UmpleToJava {
+  attribute_GetUniqueSubclass <<!  /* Code from template attribute_GetUniqueSubclass */
+<</*attribute_GetUniqueCodeInjection*/>>  public static <<=av.getUmpleClass().getName()>> <<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>)
+  {
+    <<# if (customGetUniquePrefixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePrefixCode,gen.translate("getUniqueMethod",av)); 
+    append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetUniquePrefixCode, "    ")); } #>>
+    <<=av.getUmpleClass().getName()>> <<=gen.translate("parameterGetUnique",av)>> = super.<<=gen.translate("getUniqueMethod",av)>>(<<=gen.translate("type", av)>> <<=gen.translate("parameterOne", av)>>);
+    <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null?traceItem.trace(gen, av,"at_g", uClass):"")>>
+
+
+<<# if (customGetUniquePostfixCode != null) { addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customGetUniquePostfixCode,gen.translate("getUniqueMethod",av)); 
+    append(realSb, "{0}\n",GeneratorHelper.doIndent(customGetUniquePostfixCode, "    ")); } #>>    return <<=gen.translate("parameterGetUnique",av)>>;
+  }
+!>>
+}

--- a/UmpleToJava/UmpleTLTemplates/attribute_Get_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Get_All.ump
@@ -2,14 +2,18 @@ use attribute_Get.ump;
 use attribute_GetCodeInjection.ump;
 use attribute_GetDefaulted.ump;
 use attribute_GetDefaultedCodeInjection.ump;
+use attribute_GetDefaultedSubclass.ump;
 use attribute_GetDerived.ump;
 use attribute_GetDerivedCodeInjection.ump;
+use attribute_GetDerivedSubclass.ump;
 use attribute_GetMany.ump;
+use attribute_GetManySubclass.ump;
 use attribute_GetUnique.ump;
 use attribute_GetUniqueCodeInjection.ump;
+use attribute_GetUniqueSubclass.ump;
+use attribute_GetSubclass.ump;
 use attribute_HasUnique.ump;
 use attribute_HasUniqueCodeInjection.ump;
-
 
 class UmpleToJava {
     attribute_Get_All <<!<</*attribute_Get_All*/>><<#
@@ -125,6 +129,59 @@ class UmpleToJava {
         #>><<@ UmpleToJava.attribute_Get >><<#
       }
       appendln(realSb, "");
+    }
+  }
+  
+  if(uClass.getExtendsClass()!=null)
+  {
+    for(Attribute av:uClass.getExtendsClass().getAttributes())
+    {
+      if (av.isConstant())
+      {
+        continue;
+      }
+
+      List<TraceItem> traceItems = av.getTraced("getMethod", uClass);
+
+      gen.setParameterConstraintName(av.getName());
+
+	  String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+	  String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getMethod",av)));
+
+	  String customGetDefaultPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getDefaultMethod",av)));
+	  String customGetDefaultPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getDefaultMethod",av)));
+
+	  String customGetManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getManyMethod",av)));
+	  String customGetManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getManyMethod",av)));
+	  
+	  String customGetUniquePrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getUniqueMethod",av)));
+	  String customGetUniquePostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getUniqueMethod",av)));
+
+      
+      if (customGetDefaultPrefixCode!=null || customGetDefaultPostfixCode!=null)
+      {
+        #>><<@ UmpleToJava.attribute_GetDefaultedSubclass >><<#
+      }
+      else if (customGetManyPrefixCode!=null || customGetManyPostfixCode!=null)
+      {
+        #>><<@ UmpleToJava.attribute_GetManySubclass >><<#
+      }
+      else if (customGetUniquePrefixCode!=null || customGetUniquePostfixCode!=null)
+      {
+        #>><<@ UmpleToJava.attribute_GetUniqueSubclass >><<#
+      }
+      else if(customGetPrefixCode!=null||customGetPostfixCode!=null)
+      {
+        if (av.getIsDerived())
+        {
+          #>><<@ UmpleToJava.attribute_GetDerivedSubclass >><<#
+        }
+        else
+        {
+          #>><<@ UmpleToJava.attribute_GetSubclass >><<#
+        }
+      }
+              
     }
   }
   gen.setParameterConstraintName("");

--- a/UmpleToPhp/UmpleTLTemplates/attribute_GetManySubclass.ump
+++ b/UmpleToPhp/UmpleTLTemplates/attribute_GetManySubclass.ump
@@ -1,0 +1,11 @@
+class UmpleToPhp {
+    attribute_GetManySubclass <<!<</*attribute_GetManySubclass*/>>
+  public function <<=gen.translate("getMethod",av)>>($index)
+  {
+    <<# if (customGetPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    $<<=gen.translate("parameterOne",av)>> = parent::<<=gen.translate("getMethod",av)>>($index);
+    <<# if (customGetPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    return $<<=gen.translate("parameterOne",av)>>;
+  }
+!>>
+}

--- a/UmpleToPhp/UmpleTLTemplates/attribute_GetSubclass.ump
+++ b/UmpleToPhp/UmpleTLTemplates/attribute_GetSubclass.ump
@@ -1,0 +1,11 @@
+class UmpleToPhp {
+    attribute_GetSubclass <<!<</*attribute_GetSubclass*/>>
+  public function <<=gen.translate("getMethod",av)>>()
+  {
+    <<# if (customGetPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    $<<= gen.translate("parameterOne",av) >> = parent::<<=gen.translate("getMethod",av)>>();
+    <<# if (customGetPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    return $<<= gen.translate("parameterOne",av) >>;
+  }
+  !>>
+}

--- a/UmpleToPhp/UmpleTLTemplates/attribute_Get_All.ump
+++ b/UmpleToPhp/UmpleTLTemplates/attribute_Get_All.ump
@@ -5,10 +5,14 @@ use attribute_GetDefaultedCodeInjection.ump;
 use attribute_GetDerived.ump;
 use attribute_GetDerivedCodeInjection.ump;
 use attribute_GetMany.ump;
+use attribute_GetManySubclass.ump;
 use attribute_GetUnique.ump;
 use attribute_GetUniqueCodeInjection.ump;
 use attribute_HasUnique.ump;
 use attribute_HasUniqueCodeInjection.ump;
+use attribute_GetSubclass.ump;
+
+
 
 
 class UmpleToPhp {
@@ -125,6 +129,37 @@ class UmpleToPhp {
         #>><<@ UmpleToPhp.attribute_Get >><<#
       }
       appendln(realSb, "");
+    }
+  }
+  if(uClass.getExtendsClass()!=null)
+  {
+    for(Attribute av:uClass.getExtendsClass().getAttributes())
+    {
+      if (av.isConstant())
+      {
+        continue;
+      }
+
+      List<TraceItem> traceItems = av.getTraced("getMethod", uClass);
+
+      gen.setParameterConstraintName(av.getName());
+
+	  String customGetPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getMethod",av)));
+	  String customGetPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getMethod",av)));
+	  
+	  String customGetManyPrefixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", gen.translate("getManyMethod",av)));
+      String customGetManyPostfixCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("after", gen.translate("getManyMethod",av)));
+	  
+	  if (customGetManyPrefixCode!=null || customGetManyPostfixCode!=null)
+      {
+        #>><<@ UmpleToPhp.attribute_GetManySubclass >><<#
+      }
+      else if(customGetPrefixCode!=null||customGetPostfixCode!=null)
+      {
+        #>><<@ UmpleToPhp.attribute_GetSubclass >><<#
+      }
+      
+              
     }
   }
   gen.setParameterConstraintName("");

--- a/UmpleToRuby/UmpleTLTemplates/attribute_GetManySubclass.ump
+++ b/UmpleToRuby/UmpleTLTemplates/attribute_GetManySubclass.ump
@@ -1,0 +1,10 @@
+class UmpleToRuby {
+    attribute_GetManySubclass <<!
+  def <<=gen.translate("getMethod",av)>>(index)
+    <<# if (customGetPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<=gen.translate("parameterOne",av)>> = super(index)
+    <<# if (customGetPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    <<=gen.translate("parameterOne",av)>>
+  end
+!>>
+}

--- a/UmpleToRuby/UmpleTLTemplates/attribute_GetSubclass.ump
+++ b/UmpleToRuby/UmpleTLTemplates/attribute_GetSubclass.ump
@@ -1,0 +1,10 @@
+class UmpleToRuby {
+    attribute_GetSubclass <<!
+  def <<= gen.translate("getMethod",av) >>
+    <<# if (customGetPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPrefixCode, "    ")); } #>>
+    <<= gen.translate("parameterOne",av) >> = super
+    <<# if (customGetPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customGetPostfixCode, "    ")); } #>>
+    <<= gen.translate("parameterOne",av) >>
+  end
+  !>>
+}

--- a/UmpleToRuby/UmpleTLTemplates/attribute_Get_All.ump
+++ b/UmpleToRuby/UmpleTLTemplates/attribute_Get_All.ump
@@ -5,10 +5,12 @@ use attribute_GetDefaultedCodeInjection.ump;
 use attribute_GetDerived.ump;
 use attribute_GetDerivedCodeInjection.ump;
 use attribute_GetMany.ump;
+use attribute_GetManySubclass.ump;
 use attribute_GetUnique.ump;
 use attribute_GetUniqueCodeInjection.ump;
 use attribute_HasUnique.ump;
 use attribute_HasUniqueCodeInjection.ump;
+use attribute_GetSubclass.ump;
 
 
 class UmpleToRuby {
@@ -125,6 +127,37 @@ class UmpleToRuby {
         #>><<@ UmpleToRuby.attribute_Get >><<#
       }
       appendln(realSb, "");
+    }
+  }
+  
+  if(uClass.getExtendsClass()!=null)
+  {
+    for(Attribute av:uClass.getExtendsClass().getAttributes())
+    {
+      if (av.isConstant())
+      {
+        continue;
+      }
+
+      List<TraceItem> traceItems = av.getTraced("getMethod", uClass.getExtendsClass());
+
+      gen.setParameterConstraintName(av.getName());
+
+	  String customGetPrefixCode = GeneratorHelper.toCode(gen.getApplicableCodeInjections(uClass, "before", "getMethod", av));
+      String customGetPostfixCode = GeneratorHelper.toCode(gen.getApplicableCodeInjections(uClass, "after", "getMethod", av));
+	  
+	  String customGetManyPrefixCode = GeneratorHelper.toCode(gen.getApplicableCodeInjections(uClass, "before", "getManyMethod", av));
+      String customGetManyPostfixCode = GeneratorHelper.toCode(gen.getApplicableCodeInjections(uClass, "after", "getManyMethod", av));
+	  
+	  if (customGetManyPrefixCode!=null || customGetManyPostfixCode!=null)
+      {
+        #>><<@ UmpleToRuby.attribute_GetManySubclass >><<#
+      }
+      else if(customGetPrefixCode!=null||customGetPostfixCode!=null)
+      {
+        #>><<@ UmpleToRuby.attribute_GetSubclass >><<#
+      }
+              
     }
   }
   gen.setParameterConstraintName("");

--- a/UmpleToRuby/UmpleTLTemplates/attribute_SetMany_subclass.ump
+++ b/UmpleToRuby/UmpleTLTemplates/attribute_SetMany_subclass.ump
@@ -5,11 +5,12 @@ class UmpleToRuby {
     <<# if (customAddPrefixCode != null) { 
       append(realSb, "\n{0}",GeneratorHelper.doIndent(customAddPrefixCode, "    ")); } #>>
       <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPre()?traceItem.trace(gen, av,"at_a", uClass,gen.translate("parameterOne",av)):"")>>
-      was_added = super
+    was_added = super
       <<# for( TraceItem traceItem : traceItems ) #>><<= (traceItem!=null&&traceItem.getIsPost()?traceItem.trace(gen, av,"at_a", uClass):"")>>
     <<# if (customAddPostfixCode != null) { 
       append(realSb, "{0}\n",GeneratorHelper.doIndent(customAddPostfixCode, "    "));
     } #>>
     was_added
-  end!>>
+  end
+  !>>
 }

--- a/cruise.umple/test/cruise/umple/implementation/CodeInjectionTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/CodeInjectionTest.java
@@ -38,4 +38,17 @@ public class CodeInjectionTest extends TemplateTest
 	  assertUmpleTemplateFor("CodeInjectionStateMachineTest.ump",languagePath + "/CodeInjectionStateMachineTest."+ languagePath +".txt","Example");
   }
   
+  @Test
+  public void SubclassInjection()
+  {
+    if (languagePath == "ruby")
+    {
+      assertUmpleTemplateFor("RubyCodeInjectionTestSubclass.ump",languagePath + "/CodeInjectionTestSubclass."+ languagePath +".txt","Example");
+    }
+    else
+    {
+      assertUmpleTemplateFor("CodeInjectionTestSubclass.ump",languagePath + "/CodeInjectionTestSubclass."+ languagePath +".txt","Example");
+    }
+  }
+  
 }

--- a/cruise.umple/test/cruise/umple/implementation/CodeInjectionTestSubclass.ump
+++ b/cruise.umple/test/cruise/umple/implementation/CodeInjectionTestSubclass.ump
@@ -1,0 +1,21 @@
+class Mentor
+{
+  attr;
+  Integer derivedAttr = {1 + 1}
+  String[] listAttr;
+  defaulted defaultedAttr = "value";
+}
+
+class Example
+{
+  isA Mentor;
+  before getAttr {/*before getAttr*/}
+  before getDerivedAttr {/*before getDerivedAttr*/}
+  before getListAttr {/*before getListAttr*/}
+  before getDefaultedAttr {/*before getDefaultedAttr*/}
+  
+  after getAttr {/*after getAttr*/}
+  after getDerivedAttr {/*after getDerivedAttr*/}
+  after getListAttr {/*after getListAttr*/}
+  after getDefaultedAttr {/*after getDefaultedAttr*/}
+}

--- a/cruise.umple/test/cruise/umple/implementation/RubyCodeInjectionTestSubclass.ump
+++ b/cruise.umple/test/cruise/umple/implementation/RubyCodeInjectionTestSubclass.ump
@@ -1,0 +1,21 @@
+class Mentor
+{
+  attr;
+  Integer derivedAttr = {1 + 1}
+  String[] listAttr;
+  defaulted defaultedAttr = "value";
+}
+
+class Example
+{
+  isA Mentor;
+  before getAttr {#before getAttr}
+  before getDerivedAttr {#before getDerivedAttr}
+  before getListAttr {#before getListAttr}
+  before getDefaultedAttr {#before getDefaultedAttr}
+  
+  after getAttr {#after getAttr}
+  after getDerivedAttr {#after getDerivedAttr}
+  after getListAttr {#after getListAttr}
+  after getDefaultedAttr {#after getDefaultedAttr}
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTestSubclass.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/CodeInjectionTestSubclass.java.txt
@@ -1,0 +1,79 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+
+import java.util.*;
+
+// line 9 "A.ump"
+public class Example extends Mentor
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Example(String aAttr)
+  {
+    super(aAttr);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public String getAttr()
+  {
+    // line 12 "A.ump"
+    /*before getAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    String aAttr =  super.getAttr();    // line 17 "A.ump"
+    /*after getAttr*/
+    // END OF UMPLE AFTER INJECTION
+
+    return aAttr;
+  }  /* Code from template attribute_GetDerivedSubclass */
+  public int getDerivedAttr()
+  {
+    // line 13 "A.ump"
+    /*before getDerivedAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    int aDerivedAttr = super.getDerivedAttr();
+    // line 18 "A.ump"
+    /*after getDerivedAttr*/
+    // END OF UMPLE AFTER INJECTION
+    return aDerivedAttr;
+  }
+  /* Code from template attribute_GetManySubclass */
+  public String getListAttr(int index)
+  {
+    // line 14 "A.ump"
+    /*before getListAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    String aListAttr = super.getListAttr(index);
+    // line 19 "A.ump"
+    /*after getListAttr*/
+    // END OF UMPLE AFTER INJECTION
+    return aListAttr;
+  }
+
+  public String getDefaultedAttr()
+  {
+    // line 15 "A.ump"
+    /*before getDefaultedAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    String aDefaultedAttr =  super.getDefaultedAttr();    // line 20 "A.ump"
+    /*after getDefaultedAttr*/
+    // END OF UMPLE AFTER INJECTION
+
+    return aDefaultedAttr;
+  }
+  public void delete()
+  {
+    super.delete();
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/CodeInjectionTestSubclass.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/CodeInjectionTestSubclass.php.txt
@@ -1,0 +1,84 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+class Example extends Mentor
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct($aAttr)
+  {
+    parent::__construct($aAttr);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getAttr()
+  {
+    // line 13 "CodeInjectionTestSubclass.ump"
+    /*before getAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    $aAttr = parent::getAttr();
+    // line 18 "CodeInjectionTestSubclass.ump"
+    /*after getAttr*/
+    // END OF UMPLE AFTER INJECTION
+    return $aAttr;
+  }
+  
+  public function getDerivedAttr()
+  {
+    // line 14 "CodeInjectionTestSubclass.ump"
+    /*before getDerivedAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    $aDerivedAttr = parent::getDerivedAttr();
+    // line 19 "CodeInjectionTestSubclass.ump"
+    /*after getDerivedAttr*/
+    // END OF UMPLE AFTER INJECTION
+    return $aDerivedAttr;
+  }
+  
+  public function getListAttr($index)
+  {
+    // line 15 "CodeInjectionTestSubclass.ump"
+    /*before getListAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    $aListAttr = parent::getListAttr($index);
+    // line 20 "CodeInjectionTestSubclass.ump"
+    /*after getListAttr*/
+    // END OF UMPLE AFTER INJECTION
+    return $aListAttr;
+  }
+
+  public function getDefaultedAttr()
+  {
+    // line 16 "CodeInjectionTestSubclass.ump"
+    /*before getDefaultedAttr*/
+    // END OF UMPLE BEFORE INJECTION
+    $aDefaultedAttr = parent::getDefaultedAttr();
+    // line 21 "CodeInjectionTestSubclass.ump"
+    /*after getDefaultedAttr*/
+    // END OF UMPLE AFTER INJECTION
+    return $aDefaultedAttr;
+  }
+  
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {
+    parent::delete();
+  }
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/implementation/ruby/CodeInjectionTestSubclass.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/CodeInjectionTestSubclass.ruby.txt
@@ -1,0 +1,75 @@
+# PLEASE DO NOT EDIT THIS CODE
+# This code was generated using the UMPLE 1.27.1.3860.40605acef modeling language!
+# NOTE: Ruby generator is experimental and is missing some features available in
+# in other Umple generated languages like Java or PHP
+
+
+
+class Example < Mentor
+
+
+  #------------------------
+  # CONSTRUCTOR
+  #------------------------
+
+  def initialize(a_attr)
+    super(a_attr)
+    @initialized = false
+    @deleted = false
+    @initialized = true
+  end
+
+  #------------------------
+  # INTERFACE
+  #------------------------
+
+  def get_attr
+    // line 13 "A.ump"
+    #before getAttr
+    // END OF UMPLE BEFORE INJECTION
+    a_attr = super
+    // line 18 "A.ump"
+    #after getAttr
+    // END OF UMPLE AFTER INJECTION
+    a_attr
+  end
+  
+  def get_derivedAttr
+    // line 14 "A.ump"
+    #before getDerivedAttr
+    // END OF UMPLE BEFORE INJECTION
+    a_derivedAttr = super
+    // line 19 "A.ump"
+    #after getDerivedAttr
+    // END OF UMPLE AFTER INJECTION
+    a_derivedAttr
+  end
+  
+  def get_listAttr(index)
+    // line 15 "A.ump"
+    #before getListAttr
+    // END OF UMPLE BEFORE INJECTION
+    a_listAttr = super(index)
+    // line 20 "A.ump"
+    #after getListAttr
+    // END OF UMPLE AFTER INJECTION
+    a_listAttr
+  end
+
+  def get_defaultedAttr
+    // line 16 "A.ump"
+    #before getDefaultedAttr
+    // END OF UMPLE BEFORE INJECTION
+    a_defaultedAttr = super
+    // line 21 "A.ump"
+    #after getDefaultedAttr
+    // END OF UMPLE AFTER INJECTION
+    a_defaultedAttr
+  end
+  
+  def delete
+    @deleted = true
+    super
+  end
+
+end


### PR DESCRIPTION
Adds code generation for subclasses using before/after statements for get methods in Java, PHP and Ruby.
Test cases are added, but the Ruby test case is not runnable as the comments added due to before/after statements generating code that does not respect Ruby's syntax... Issues related: #342 and #528 . 