### PR TITLE
Php test fix

### DIFF
--- a/testbed/src/TestHarnessPatterns.ump
+++ b/testbed/src/TestHarnessPatterns.ump
@@ -75,7 +75,7 @@ class LanguageSpecificCodeBlock
 
   state{
     allLanguages{
-      applySpecificAction [this.isJava()] / Java {name = "action=java";} Php {$this->name = "actionphp";} -> to;
+      applySpecificAction / Java {name = "action=java";} Php {$this->name = "actionphp";} -> to;
     }
     to{
     }

--- a/testbed/src/TestHarnessPatterns.ump
+++ b/testbed/src/TestHarnessPatterns.ump
@@ -68,7 +68,7 @@ class LanguageSpecificCodeBlock
   name;
 
   before setName Java {String lang = "My lang is ";} Php {$lang = "I am ";}
-  after setName Java {name = lang + "java";} Php {$this->name = $lang + "php";}
+  after setName Java {name = lang + "java";} Php {$this->name = $lang . "php";}
   boolean isJava() Java {return true;} Php {return false;}
 	
   String languageImplementedIn = Java {"Java"} Php {"Php"}

--- a/testbed/test/cruise/compiler/CompilerErrorUtil.java
+++ b/testbed/test/cruise/compiler/CompilerErrorUtil.java
@@ -31,7 +31,9 @@ public class CompilerErrorUtil
 			expectedReader.close();
 		}
 		catch(Exception e) {
-			Assert.fail(e.getMessage());
+			Assert.fail(e.getMessage()+
+			  " Current Dir . =" +Paths.get(".").toAbsolutePath().normalize().toString()+
+			  " Parent Dir .. =" + Paths.get("..").toAbsolutePath().normalize().toString());
 		}
 	}
 	

--- a/testbed/test/cruise/runtime/RuntimeErrorUtil.java
+++ b/testbed/test/cruise/runtime/RuntimeErrorUtil.java
@@ -33,7 +33,9 @@ public class RuntimeErrorUtil
 			expectedReader.close();
 		}
 		catch(Exception e) {
-			Assert.fail(e.getMessage());
+			Assert.fail(e.getMessage()+
+			  " Current Dir . =" +Paths.get(".").toAbsolutePath().normalize().toString()+
+			  " Parent Dir .. =" + Paths.get("..").toAbsolutePath().normalize().toString());
 		}
 	}
 	


### PR DESCRIPTION
A PhP test was giving anomalous that had been corrected incorrectly a long time ago (a + was being used to concatenate strings instead of a .). This corrects the test and removes the bypass.

It also injects some extra diagnostics into the runtime tests, that test for correct handling of Java compilation errors. On the cruise control machine these tests were failing to find a file, although all is OK on other platforms.