### PR TITLE
Mixset Use Parsing 

### DIFF
--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -60,6 +60,10 @@ class UmpleConsoleConfig {
     return this.linkedFiles.stream().map(p -> new File(p)).collect(Collectors.toList());
   }
 
+ // this method returns mixset names that appear as arguments  
+ public List<String> getLinkedMixsetAsString() {
+    return this.linkedFiles.stream().filter(m-> ! m.endsWith(".ump")).collect(Collectors.toList());
+  }
   public Optional<String> getGenerate() {
     return this.generate;
   }
@@ -164,6 +168,9 @@ class UmpleConsoleMain
     cfg.getLinkedFilesAsFile().stream()
         .filter(File::exists)
         .map(File::getPath)
+        .forEach(umpleFile::addLinkedFiles);
+    //this loop is used to add mixset names as liked umple files.
+    cfg.getLinkedMixsetAsString().stream()
         .forEach(umpleFile::addLinkedFiles);
        
     final UmpleModel model = new UmpleModel(umpleFile);

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -71,7 +71,7 @@ class UmpleInternalParser
     addCouple(braces);
     
     // Set up needed parser actions
-    parser.addParserAction("useStatement", new UseStatementParserAction(model) );
+    parser.addParserAction("useStatement", new UseStatementParserAction() );
         
     parser.setLinkedFileHandler( new UmpleLinkedFileHandler() );
     parser.setAnalyzerGenerator( new UmpleAnalyzerGeneratorHandler() );

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -251,6 +251,7 @@ class UmpleInternalParser
   // Delegate function to analyze a token and send it to the write
   private void analyzeToken(Token t, int analysisStep)
   {
+    analyzeMixsetUseStatement(t, analysisStep);
     analyzeUSE(t, analysisStep);
     analyzeCoreToken(t,analysisStep);
     analyzeEnumerationToken(t, analysisStep);

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -62,7 +62,57 @@ class UmpleInternalParser
 	aToken.addSubToken(new Token("entityType","class") );
 	analyzeMixset(aToken);		
 	}
-
+/*
+ * This method handels mixset use statements appearing in both code and in console. It adds the mixset use statements to umple model in the first round on analysis, 
+ * before other umple elements are added to umple model.  
+ */
+  private void analyzeMixsetUseStatement(Token t, int analysisStep){
+    if (analysisStep != 1) // just for analysisStep == 1. 
+    {
+      return;
+    } 
+    //else
+    
+    if (t.is("useStatement"))
+    {
+       String value = t.getValue("use");
+       
+       // ignore .ump files since they are proccessed in UseStatementParserAction class (UmpleInternalParser_CodeParserHandlers.ump).
+       if (value.endsWith(".ump"))
+       {
+         return;   
+       } 
+       //Otherwise
+       
+       String mixsetName = value;
+       int useLineNumber = t.getPosition().getLineNumber();
+       //UmpleFile mixsetUseFile = model.getUmpleFile(); 
+       String fileName = t.getPosition().getFilename();
+       UmpleFile mixsetUseFile = new UmpleFile(fileName);
+       // check if the mixset was added before 
+       Mixset mixset = model.getMixset(mixsetName);
+       if(mixset == null)
+       {
+         mixset = new Mixset(mixsetName);
+	     mixset.setUseUmpleFile(mixsetUseFile);
+	     mixset.setUseUmpleLine(useLineNumber);
+	     model.addMixsetOrFile(mixset);
+	   }
+	   else if (mixset.getUseUmpleFile() == null)
+	   {
+	     mixset.setUseUmpleFile(mixsetUseFile);
+	     mixset.setUseUmpleLine(useLineNumber);
+	   }
+       
+       
+       
+       
+       
+      
+      
+    }
+  }
+  
 /*
  * This method parses all waiting fragments of a mixset, if there is a mixset-use-statment specified in some of the files.  
  */	

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -63,11 +63,11 @@ class UmpleInternalParser
 	analyzeMixset(aToken);		
 	}
 /*
- * This method handels mixset use statements appearing in both code and in console. It adds the mixset use statements to umple model in the first round on analysis, 
- * before other umple elements are added to umple model.  
+ * This method handles mixset use statements appearing in both code and in the console. The method adds mixset use statements to umple model in the first round on analysis, before
+ * other umple elements are added to umple model. So, there is no issue regarding which line the mixset use statements are mentioned in.   
  */
   private void analyzeMixsetUseStatement(Token t, int analysisStep){
-    if (analysisStep != 1) // just for analysisStep == 1. 
+    if (analysisStep != 1) // the analyze occurs just for analysisStep == 1. 
     {
       return;
     } 
@@ -104,11 +104,6 @@ class UmpleInternalParser
 	     mixset.setUseUmpleLine(useLineNumber);
 	   }
        
-       
-       
-       
-       
-      
       
     }
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeParserHandlers.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeParserHandlers.ump
@@ -30,64 +30,43 @@ class UseStatementParserAction{
   depend cruise.umple.parser.Token;
   
   isA ParserAction;
-  UmpleModel umpleModel;
  
   public void onSuccess(Token token, ParserDataPackage data)
-  {
+  {  
     String value = token.getValue("use");
-  
-    if (! value.endsWith(".ump")) // TO DO : use statement with mixed files and mixsets such as: use a.ump, MixsetA; 
+    // This is the case for the umple file, which ends with .ump
+    // Mixsets will be accepted (e.g use Mixset;) but not be proccessed in this method. 
+    if (value.endsWith(".ump"))  
     {
-      String mixsetName = value;
-      int useLineNumber = token.getPosition().getLineNumber();
-      UmpleFile mixsetUseFile = umpleModel.getUmpleFile(); 
-      // check if the mixset was added before 
-      	
-      Mixset mixset = umpleModel.getMixset(mixsetName);
-      if(mixset  == null)
+      String fileName="";
+	  String path = "";    
+	  int index =-1;
+	  if (data!=null && data.getFullFileAddress()!=null)    index = data.getFullFileAddress().lastIndexOf("/") ;
+	  if (index==-1) index = data.getFullFileAddress().lastIndexOf("\\");  
+	  if (index!=-1){
+	    path = data.getFullFileAddress().substring(0,index+1 );
+	  }
+	  synchronized(data.getHasParsed())
 	  {
-	    mixset  = new Mixset(mixsetName);
-	    mixset.setUseUmpleFile(mixsetUseFile);
-	    mixset.setUseUmpleLine(useLineNumber);
-	    umpleModel.addMixsetOrFile(mixset);
-	  }
-	  else if ( mixset.getUseUmpleFile() == null)
-	  {
-	    mixset.setUseUmpleFile(mixsetUseFile);
-	    mixset.setUseUmpleLine(useLineNumber);
-	  }
-	}
-  else  // This is the case for the umple file, which ends with .ump
-  {
-    String fileName="";
-	String path = "";    
-    int index =-1;
-    if (data!=null && data.getFullFileAddress()!=null)    index = data.getFullFileAddress().lastIndexOf("/") ;
-    if (index==-1) index = data.getFullFileAddress().lastIndexOf("\\");  
-    if (index!=-1){
-    	path = data.getFullFileAddress().substring(0,index+1 );
-    }
-    synchronized(data.getHasParsed())
-    {
-      fileName = data.getAnalyzer().getFile().getAbsoluteFile().getParentFile().getAbsolutePath() + File.separator + value;
-      //I used this technique because I noticed this function is used to several purposes.
-      // The correct implementation is just to set fileName = path +value; and remove the above code.
-      //TODO: this issue must be investigated more. Currently it is working with the following solution. 
-      File f = new File(fileName);
-      if (!f.exists()) fileName = path +value;
-      if(!data.getHasParsed().contains(f.getAbsolutePath()))
-	  {
-	    data.getHasParsed().add(f.getAbsolutePath());
-	    RuleBasedParserThread thread = new RuleBasedParserThread(
-	          data.getAnalyzer().getRules().get("$ROOT$"),
-	          token,
-	          fileName,
-	          data
-	        );
-	    data.getAnalyzer().addThread(thread);
-	    thread.start();
-	  }
-	  }
+	    fileName = data.getAnalyzer().getFile().getAbsoluteFile().getParentFile().getAbsolutePath() + File.separator + value;
+	    //I used this technique because I noticed this function is used to several purposes.
+	    // The correct implementation is just to set fileName = path +value; and remove the above code.
+	    //TODO: this issue must be investigated more. Currently it is working with the following solution. 
+	    File f = new File(fileName);
+	    if (!f.exists()) fileName = path +value;
+	    if(!data.getHasParsed().contains(f.getAbsolutePath()))
+		{
+		  data.getHasParsed().add(f.getAbsolutePath());
+		  RuleBasedParserThread thread = new RuleBasedParserThread(
+		          data.getAnalyzer().getRules().get("$ROOT$"),
+		          token,
+		          fileName,
+		          data
+		        );
+		  data.getAnalyzer().addThread(thread);
+		  thread.start();
+		  }
+		}
     }
   }
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -1,95 +1,82 @@
 package cruise.umple.compiler.mixset;
 
 import org.junit.*;
-import cruise.umple.compiler.*;
-import cruise.umple.*;
-import cruise.umple.compiler.Method.Source;
+import cruise.umple.UmpleConsoleMain;
 import cruise.umple.util.SampleFileWriter;
 
 public class UmpleMixsetTest {
-		String pathToInput;
-    UmpleModel uModel;
-    String defaultPath;
-
-/*
-  @Before
-  public void setup() {
-
-    defaultPath = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset/");
-    String code = "class Outer_1{ } mixset M1 { class Inner_M1 {name;} } Outer_2{ }"
-			+ " use M1;"
-			+ " ";
-    uModel = getRunModel(code);
-  }
-  @Test
-  public void mixsetDetectionTest() {
-		Assert.assertEquals(1, uModel.hasMixsetOrFiles());
-	}
-*/
 	
+	@Test
+	public void mixsetUseInCodeTest() {
+		String[] args = new String[] {"mixsetUseInCodeTest.ump"};
+    
+		SampleFileWriter.createFile("mixsetUseInCodeTest.ump", " class Outer_Mix_1{ } mixset Mix { class Inner_Mix {name;} } class Outer_Mix_2{ }"
+				+ "\n"
+				+ " use Mix; "
+				+ "\n");
 
-  @After
-  public void tearDown() {
-    SampleFileWriter.destroy("mixsetTest.ump");
-  }
+		try 
+		{
+			UmpleConsoleMain.main(args);
+			SampleFileWriter.assertFileExists("Inner_Mix.java");
+			SampleFileWriter.assertFileExists("Outer_Mix_1.java");
+			SampleFileWriter.assertFileExists("Outer_Mix_2.java");
 
+		}	
+		finally 
+		{
+			SampleFileWriter.destroy("mixsetUseInCodeTest.ump");
+			SampleFileWriter.destroy("Inner_Mix.java");
+			SampleFileWriter.destroy("Outer_Mix_2.java");
+			SampleFileWriter.destroy("Outer_Mix_2.java");
+		}
+	}
+	
 	@Test
 	public void mixsetUseInConsoleTest() {
-		String[] args = new String[] {"mixsetTest1.ump", "Mx"};
-		
-		SampleFileWriter.createFile("mixsetTest1.ump", " class Outer_1{ } mixset Mx { class Inner_M1 {name;} } class Outer_2{ }");
+		String[] args = new String[] {"mixsetUseInConsoleTest.ump", "Mx"};
 
-		try {
+		SampleFileWriter.createFile("mixsetUseInConsoleTest.ump", " class Outer_1{ } mixset Mx { class Inner_M1 {name;} } class Outer_2{ }");
+
+		try 
+		{
 			UmpleConsoleMain.main(args);
 			SampleFileWriter.assertFileExists("Inner_M1.java");
+			SampleFileWriter.assertFileExists("Outer_1.java");
+			SampleFileWriter.assertFileExists("Outer_2.java");
+
 		}	
-		catch (Exception e) {
-		} 
-		finally {
-		//	SampleFileWriter.destroy("mixsetTest.ump");
+		finally 
+		{
+			SampleFileWriter.destroy("mixsetUseInConsoleTest.ump");
+			SampleFileWriter.destroy("Inner_M1.java");
+			SampleFileWriter.destroy("Outer_2.java");
+			SampleFileWriter.destroy("Outer_2.java");
 		}
-/*
-
-
-		try {
-		//	UmpleModel m = new UmpleModel(null); m.run();
-			UmpleInternalParser i;
-			RuleBasedParser l;
-			UmpleConsoleMain.main(args);
-			//SampleFileWriter.assertFileExists("mixset/B.java");
-		
-
-		}
-		finally {}
-		
-		//finally {
-			//SampleFileWriter.assertFileExists("CCCInnerClass.java");
-
-			//SampleFileWriter.destroy("mixsetTest.ump.ump");
-			//SampleFileWriter.destroy();
-			SampleFileWriter.destroy("mixset/B.java");
-		//	System.exit(210618);
-
-		//}
-*/
 	}
+		
+		
+		@Test
+		public void multipleMixsetUseInConsoleTest() {
+			String[] args = new String[] {"mixset_1.ump", "M2", "mixset_2.ump", "M1"};
 
+			SampleFileWriter.createFile("mixset_1.ump", "mixset M1 { class Inner_1 { } }" );
+			SampleFileWriter.createFile("mixset_2.ump", "mixset M2 { class Inner_2 { } }");
 
-	// -------------------------------------------------------------------------------------
-	// ----------------------- Functional methods for this test case
-	// -----------------------
-	private UmpleModel getRunModel(String inCode) {
-		SampleFileWriter.createFile("mixsetTest.ump", inCode);
-		UmpleFile uFile = new UmpleFile("mixsetTest.ump");
-		uModel = new UmpleModel(uFile);
-		uModel.setShouldGenerate(true);
-		try {
-			uModel.run();
-		} catch (Exception e) {
-		} finally {
-			SampleFileWriter.destroy("mixsetTest.ump");
+			try 
+			{
+				UmpleConsoleMain.main(args);
+				SampleFileWriter.assertFileExists("Inner_1.java");
+				SampleFileWriter.assertFileExists("Inner_2.java");
+
+			}	
+			finally 
+			{
+				SampleFileWriter.destroy("mixset_1.ump");
+				SampleFileWriter.destroy("mixset_2.ump");
+				SampleFileWriter.destroy("Inner_1.java");
+				SampleFileWriter.destroy("Inner_2.java");
+			}
 		}
-		return uModel;
-	}
-
 }
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -1,0 +1,95 @@
+package cruise.umple.compiler.mixset;
+
+import org.junit.*;
+import cruise.umple.compiler.*;
+import cruise.umple.*;
+import cruise.umple.compiler.Method.Source;
+import cruise.umple.util.SampleFileWriter;
+
+public class UmpleMixsetTest {
+		String pathToInput;
+    UmpleModel uModel;
+    String defaultPath;
+
+/*
+  @Before
+  public void setup() {
+
+    defaultPath = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset/");
+    String code = "class Outer_1{ } mixset M1 { class Inner_M1 {name;} } Outer_2{ }"
+			+ " use M1;"
+			+ " ";
+    uModel = getRunModel(code);
+  }
+  @Test
+  public void mixsetDetectionTest() {
+		Assert.assertEquals(1, uModel.hasMixsetOrFiles());
+	}
+*/
+	
+
+  @After
+  public void tearDown() {
+    SampleFileWriter.destroy("mixsetTest.ump");
+  }
+
+	@Test
+	public void mixsetUseInConsoleTest() {
+		String[] args = new String[] {"mixsetTest1.ump", "Mx"};
+		
+		SampleFileWriter.createFile("mixsetTest1.ump", " class Outer_1{ } mixset Mx { class Inner_M1 {name;} } class Outer_2{ }");
+
+		try {
+			UmpleConsoleMain.main(args);
+			SampleFileWriter.assertFileExists("Inner_M1.java");
+		}	
+		catch (Exception e) {
+		} 
+		finally {
+		//	SampleFileWriter.destroy("mixsetTest.ump");
+		}
+/*
+
+
+		try {
+		//	UmpleModel m = new UmpleModel(null); m.run();
+			UmpleInternalParser i;
+			RuleBasedParser l;
+			UmpleConsoleMain.main(args);
+			//SampleFileWriter.assertFileExists("mixset/B.java");
+		
+
+		}
+		finally {}
+		
+		//finally {
+			//SampleFileWriter.assertFileExists("CCCInnerClass.java");
+
+			//SampleFileWriter.destroy("mixsetTest.ump.ump");
+			//SampleFileWriter.destroy();
+			SampleFileWriter.destroy("mixset/B.java");
+		//	System.exit(210618);
+
+		//}
+*/
+	}
+
+
+	// -------------------------------------------------------------------------------------
+	// ----------------------- Functional methods for this test case
+	// -----------------------
+	private UmpleModel getRunModel(String inCode) {
+		SampleFileWriter.createFile("mixsetTest.ump", inCode);
+		UmpleFile uFile = new UmpleFile("mixsetTest.ump");
+		uModel = new UmpleModel(uFile);
+		uModel.setShouldGenerate(true);
+		try {
+			uModel.run();
+		} catch (Exception e) {
+		} finally {
+			SampleFileWriter.destroy("mixsetTest.ump");
+		}
+		return uModel;
+	}
+
+}


### PR DESCRIPTION
This PR allows parsing and handling of mixset use statements both in code and as arguments in Umple console. 
 
UseStatementParserAction is modified and no longer it receives an instance of UmpleModel as an argument to handle mixset use statements. It is modified to ignore mixset use statemenst such as : "use M1;". UseStatementParserAction is used as a static instance in the RuleBasedParser, which uses singleton design pattern for most of the its (static) instances. 

In this PR, mixset use statements in code are be handled in UmpleInternalParser class (UmpleInternalParser_MixsetCode.ump). UmpleInternalParser has two rounds of analysis. Mixset analysis takes advantage of that by adding mixset use statements to umple model at the first round of token analysis, before other umple elements (e.g. classes,traits, etc) are added to umple model. Therefore, a mixset use statement existing at the last line of an umple file will be parsed first. 

Mixset use statements that appear as arguments in umple console are treated like Umple files; they will be added to the first umple file as use statements. Then they will be tokenized and received by UmpleInternalParser.  