### PR TITLE
Maintain the order of Umple file having mixsets

### DIFF
--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -44,12 +44,17 @@ class Mixset {
   // encountered.
   // If a use statement had been previously encountered, the fragment is parsed and put here
   // directly
-  0..1 usedAsPartOf -- * MixsetFragment usedFragments;
+  // 0..1 usedAsPartOf -- * MixsetFragment usedFragments;
 
   // Waiting ragments are those not yet parsed since no use statement was found yet
   // All new fragments are added here
   // Upon a use statement, all waiting fragments are parsed and put in usedFragments
-  0..1 -- * MixsetFragment waitingFragments;
+  // 0..1 -- * MixsetFragment waitingFragments;
+  
+  // use (parsed) fragments and waiting (unparsed) fragments will be stored as MixsetFragments.
+  // The isParsed filed of MixsetFragment is used to differentiate between them.
+  // The aim is to easly change from waiting fragments to used fragments. Instead of copying and deleteing.  
+  0..1 -- * MixsetFragment mixsetFragments;
   
   String getName() {
     return mixsetName;
@@ -65,6 +70,7 @@ class MixsetFragment {
   UmpleFile originalUmpFile; // where the fragment came from
   Integer originalUmpLine; // line in originaUmpFile
 
+  boolean isParsed = false; // by default a fragment is not parsed, then this will be changed after parsing.
   // This is the text of the fragment
   // Note that it might be prefixed contextually thus:
   // if top level, the body is whatever is found in the curly brackets

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -111,9 +111,6 @@ class UmpleInternalParser
       secondPostTokenAnalysis();
       //add analysis here!!! xx.validateStateMachineGuardConstraints(model);
       checkDefaultedNameConflict();
-      
-    //last thing after analyzing all elements
-    parseMixset();
     
     }
     catch (Exception ex)

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -103,6 +103,9 @@ class UmpleInternalParser
 	     mixset.setUseUmpleFile(mixsetUseFile);
 	     mixset.setUseUmpleLine(useLineNumber);
 	   }
+	   
+	   // this handles the case when a mixset definition is in a file and the mixset use exists in a subsequent file.
+	   parseMixset(mixset);
        
       
     }
@@ -111,6 +114,7 @@ class UmpleInternalParser
 /*
  * This method parses all waiting fragments of a mixset, if there is a mixset-use-statment specified in some of the files.  
  */	
+ /*
  private void parseMixset(){
  
    for (MixsetOrFile mOrF : model.getMixsetOrFiles())
@@ -118,7 +122,7 @@ class UmpleInternalParser
      if(mOrF.getIsMixset() &&  (mOrF.getUseUmpleFile() != null) ) // the second condition is to check if there is a use statement.
      {
        Mixset mixset =(Mixset) mOrF;
-       for(MixsetFragment mixsetWaitingFrag: mixset.getWaitingFragments())
+       for(MixsetFragment mixsetWaitingFrag: mixset.getFragments())
        {  
          //String allMixsetBody = modelMixset.getWaitingFragments().stream().map(mixsetFrag -> mixsetFrag.getBody()).collect(Collectors.joining(" "));
          ParseResult pResult= parse("MixsetFragmentParsing",  mixsetWaitingFrag.getBody()); 
@@ -127,7 +131,42 @@ class UmpleInternalParser
        }
      }
    }
+   
 }
+*/
+
+/*
+ * This method loops through a mixset to parse its waiting fragments.
+ * It should be used after checking existing of a mixset-use-statment.  
+ */	
+
+ private void parseMixset(Mixset mixset){
+   
+   for(MixsetFragment mixsetFragment: mixset.getMixsetFragments())
+   {
+    if(mixsetFragment.getIsParsed())
+    continue;
+    //Otherwise
+    parseMixsetWaitingFragment(mixsetFragment);
+    
+   }
+ }
+
+/*
+ * This method parses a waiting fragment of a mixset.
+ * It should be used after checking existing of a mixset-use-statment.  
+ */	
+private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
+  
+  if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
+  {
+    ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody()); 
+    Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
+    analyzeAllTokens(answer);
+    mixsetFragment.setIsParsed(true);
+    }
+   
+ }
 
  private void analyzeMixsetToken(Token t, int analysisStep)
   {
@@ -183,8 +222,14 @@ class UmpleInternalParser
 	  UmpleFile mixsetFragmentUmpleFile = model.getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
 	  MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, lineNumber, mixsetBody);
 	  
-	  // Here all mixset fragmets are considered as waitingFragment 
-	  mixset.addWaitingFragment(mixsetFragment);
+	  // Here the mixset fragmet is considered as waitingFragment (mixsetFragment.isParsed==flase). 
+	  mixset.addMixsetFragment(mixsetFragment);
+	  
+	  // parse mixset fragments right away if there is a use statment.
+	  // 
+	  if(mixset.getUseUmpleFile() != null)
+	  parseMixsetWaitingFragment(mixsetFragment);
+	  
 	  
 	return  mixset ;
   }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -7,9 +7,27 @@ import cruise.umple.util.SampleFileWriter;
 public class UmpleMixsetTest {
 	
 	@Test
+	public void mixsetUseInSubsequentFile()
+	{
+		String[] args = new String[] {"first.ump"};
+		SampleFileWriter.createFile("first.ump", " mixset MyMixset { class MyClass {} } use activateMixset.ump; ");
+		SampleFileWriter.createFile	("activateMixset.ump"," use MyMixset; ");
+		try 
+		{
+			UmpleConsoleMain.main(args);
+			SampleFileWriter.assertFileExists("MyClass.java");
+		}	
+		finally 
+		{
+			SampleFileWriter.destroy("first.ump");
+			SampleFileWriter.destroy("MyClass.java");
+			SampleFileWriter.destroy("activateMixset.ump");
+		}
+	}
+	
+	@Test
 	public void mixsetUseInCodeTest() {
-		String[] args = new String[] {"mixsetUseInCodeTest.ump"};
-    
+    String[] args = new String[] {"mixsetUseInCodeTest.ump"};
 		SampleFileWriter.createFile("mixsetUseInCodeTest.ump", " class Outer_Mix_1{ } mixset Mix { class Inner_Mix {name;} } class Outer_Mix_2{ }"
 				+ "\n"
 				+ " use Mix; "


### PR DESCRIPTION
This PR allow Umple to maintain the order of mixsets parts when they are activated (by mixset use statements).  The current implementation uses  looping through all mixsets to parse them.

MixsetFragment has a new Boolean field "isParsed" which indicates whether a mixset fragment is parsed or not. Accordingly, mixset will have only one type of mixset fragment instead of the two: waiting and used fragments. This enhancement aims to make easy changing from waiting fragments to used fragments. 

The method parseMixset() is commented and may be used later to raise warnings of mixset use with no actual mixset definitions in the code.