### PR TITLE
Fixes #1279 Compiler error caused by constraint with non-existing child

### DIFF
--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -4695,12 +4695,15 @@ class ModelConstraintSuperClass
       }
       else
       {
-        for(UmpleInterface i:child.getParentInterface())
+        if (child != null)
         {
-          if(i.getName().equals(getSource()))
-          {
-             return ModelConstraint.SUCCESS;
-          }
+		  for(UmpleInterface i:child.getParentInterface())
+		  {
+			if(i.getName().equals(getSource()))
+			{
+			   return ModelConstraint.SUCCESS;
+			}
+		  }
         }
       }
       return new ModelConstraintResult(getPosition(),93,getTarget(),getSource());

--- a/cruise.umple/test/cruise/umple/compiler/150_inexistentSuperClassConstrainted.ump
+++ b/cruise.umple/test/cruise/umple/compiler/150_inexistentSuperClassConstrainted.ump
@@ -1,0 +1,3 @@
+class Foo {
+  [model: Foo parent Y]
+}

--- a/cruise.umple/test/cruise/umple/compiler/ModelConstraintTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/ModelConstraintTest.java
@@ -34,6 +34,7 @@ public class ModelConstraintTest {
 		assertFailedParse("150_badMultiLayerSubClassConstrained.ump", 92);
 		assertFailedParse("150_badSuperClassConstrained.ump", 93);
 		assertFailedParse("150_badMultiLayerSuperClassConstrained.ump", 93);
+		assertFailedParse("150_inexistentSuperClassConstrainted.ump", 93);
 		assertFailedParse("150_badAssociationToConstrained.ump", 94);
 		assertFailedParse("150_badAssociationInvalidMultiplicityConstrained.ump", 94);
 	}


### PR DESCRIPTION
Fixes the compiler error by having error 93 (constraint not respected) be raised if the constraint in a superclass cannot be verified due to the child not being found. Adds a test.