### PR TITLE
Progress on mixset parsing [location of errors and warning]

### DIFF
--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -348,7 +348,20 @@ class RuleBasedParser
     {
       setupRules();
     }
-    analyzer.init(ruleName, input);
+    analyzer.init(ruleName, input,"temp",null);
+    analyzer.execute();
+    setRootToken(analyzer.getRootToken());
+    setParseResult(analyzer.getParseResult());
+    return getParseResult();
+  }
+  
+  public ParseResult parse(String ruleName, String input,String fileName, Position usePosition)
+  {
+    if(analyzer==null)
+    {
+      setupRules();
+    }
+    analyzer.init(ruleName, input,fileName,usePosition);
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
@@ -615,11 +628,9 @@ class ParserDataPackage
     }
   }
   
-  public void init(String rawinput, Position usePosition){
-    String file = "temp";
-    int offset = 0;
-    int linenumber = 0;
-    linenumbers = new LinkedHashMap<Integer,Integer>();
+  public void init(String rawinput, Position usePosition, int lineNumber, int offset){
+   
+   linenumbers = new LinkedHashMap<Integer,Integer>();
     try {
       for(String line:rawinput.split("\\n"))
       {
@@ -639,7 +650,10 @@ class ParserDataPackage
     }
     couples = new HashMap<String,ParsingCouple>();    
     BalancedRule.initialize(input,this);
+    }
   }
+  public void init(String rawinput, Position usePosition){
+   init(rawinput,usePosition,0,0);
 }
 
 interface RuleBasedParserAction {
@@ -725,12 +739,15 @@ class GrammarAnalyzer {
   }
     
   public void init(String ruleName, String input) {
-    this.input = input;
-    setData(new ParserDataPackage("temp",this));
-    getData().setKeys(keys);
-    getData().init(input,null);  
+    init(ruleName,input,"temp",null);
   }
-
+  
+  public void init(String ruleName, String input, String fileName, Position usePosition) {
+    this.input = input;
+    setData(new ParserDataPackage(fileName,this));
+    getData().setKeys(keys);
+    getData().init(input,usePosition);  
+  }
   /*
     Performs the parsing on the umple file.
   */

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -344,15 +344,7 @@ class RuleBasedParser
 
   public ParseResult parse(String ruleName, String input)
   {
-    if(analyzer==null)
-    {
-      setupRules();
-    }
-    analyzer.init(ruleName, input,"temp",null);
-    analyzer.execute();
-    setRootToken(analyzer.getRootToken());
-    setParseResult(analyzer.getParseResult());
-    return getParseResult();
+    return parse(ruleName,input,"temp",null);
   }
   
   public ParseResult parse(String ruleName, String input,String fileName, Position usePosition)
@@ -362,12 +354,27 @@ class RuleBasedParser
     {
       setupRules();
     }
-    analyzer.init(ruleName, input,fileName,usePosition);
+    analyzer.init(ruleName, input,fileName,usePosition,0,0);
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
   }
+  
+  public ParseResult parse(String ruleName, String input,String fileName,Position position ,int lineNumber, int offset)
+  {
+    if(analyzer==null)
+    {
+      setupRules();
+    }
+    analyzer.init(ruleName, input,fileName,position ,lineNumber, offset) ;   
+    
+    analyzer.execute();
+    setRootToken(analyzer.getRootToken());
+    setParseResult(analyzer.getParseResult());
+    return getParseResult();
+  }
+  
 
   public static boolean evaluate(String hash)
   {
@@ -741,14 +748,14 @@ class GrammarAnalyzer {
   }
     
   public void init(String ruleName, String input) {
-    init(ruleName,input,"temp",null);
+    init(ruleName,input,"temp",null,0,0);
   }
   
-  public void init(String ruleName, String input, String fileName, Position usePosition) {
+  public void init(String ruleName, String input, String fileName, Position usePosition, int lineNumber, int offset) {
     this.input = input;
     setData(new ParserDataPackage(fileName,this));
     getData().setKeys(keys);
-    getData().init(input,usePosition);  
+    getData().init(input,usePosition,lineNumber,offset);  
   }
   /*
     Performs the parsing on the umple file.

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -357,6 +357,7 @@ class RuleBasedParser
   
   public ParseResult parse(String ruleName, String input,String fileName, Position usePosition)
   {
+  
     if(analyzer==null)
     {
       setupRules();
@@ -628,7 +629,7 @@ class ParserDataPackage
     }
   }
   
-  public void init(String rawinput, Position usePosition, int lineNumber, int offset){
+  public void init(String rawinput, Position usePosition, int linenumber, int offset){
    
    linenumbers = new LinkedHashMap<Integer,Integer>();
     try {
@@ -651,11 +652,12 @@ class ParserDataPackage
     couples = new HashMap<String,ParsingCouple>();    
     BalancedRule.initialize(input,this);
     }
-  }
+  
   public void init(String rawinput, Position usePosition){
-   init(rawinput,usePosition,0,0);
+    this.init(rawinput,usePosition,0,0);
 }
 
+}
 interface RuleBasedParserAction {
   public void onSuccess(cruise.umple.parser.Token token);
 }

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -344,21 +344,7 @@ class RuleBasedParser
 
   public ParseResult parse(String ruleName, String input)
   {
-    return parse(ruleName,input,"temp",null);
-  }
-  
-  public ParseResult parse(String ruleName, String input,String fileName, Position usePosition)
-  {
-  
-    if(analyzer==null)
-    {
-      setupRules();
-    }
-    analyzer.init(ruleName, input,fileName,usePosition,0,0);
-    analyzer.execute();
-    setRootToken(analyzer.getRootToken());
-    setParseResult(analyzer.getParseResult());
-    return getParseResult();
+    return parse(ruleName,input,"temp",null,0,0);
   }
   
   public ParseResult parse(String ruleName, String input,String fileName,Position position ,int lineNumber, int offset)
@@ -660,9 +646,6 @@ class ParserDataPackage
     BalancedRule.initialize(input,this);
     }
   
-  public void init(String rawinput, Position usePosition){
-    this.init(rawinput,usePosition,0,0);
-}
 
 }
 interface RuleBasedParserAction {

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -104,7 +104,6 @@ class UmpleInternalParser
     public ParseResult parse(String ruleName, String input, String fileName, Position position, int lineNumber, int offset){
 	setParseResult(parser.parse(ruleName,input,fileName, position,lineNumber,offset));
     setRootToken(parser.getRootToken());
-    SampleFileWriter.destroy(fileName);
     return getParseResult();
   }
 

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -95,17 +95,13 @@ class UmpleInternalParser
   }
 
   public ParseResult parse(String ruleName, String input){
-	//setParseResult(parser.parse(ruleName,input,"temp", ));
-    //setRootToken(parser.getRootToken());
-    //SampleFileWriter.destroy("temp.ump");
-    return this.parse(ruleName,input,"temp", null);
- 
+    return parse(ruleName,input,"temp.ump",null);
   }
   
     public ParseResult parse(String ruleName, String input, String fileName, Position position){
 	setParseResult(parser.parse(ruleName,input,fileName, position));
     setRootToken(parser.getRootToken());
-    SampleFileWriter.destroy("temp.ump");
+    SampleFileWriter.destroy(fileName);
     return getParseResult();
   }
 

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -95,7 +95,7 @@ class UmpleInternalParser
   }
 
   public ParseResult parse(String ruleName, String input){
-    setParseResult(parser.parse(ruleName,input,"temp.ump",null));
+    setParseResult(parser.parse(ruleName,input));
     setRootToken(parser.getRootToken());
     SampleFileWriter.destroy("temp.ump");
     return getParseResult();

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -95,7 +95,15 @@ class UmpleInternalParser
   }
 
   public ParseResult parse(String ruleName, String input){
-	setParseResult(parser.parse(ruleName,input));
+	//setParseResult(parser.parse(ruleName,input,"temp", ));
+    //setRootToken(parser.getRootToken());
+    //SampleFileWriter.destroy("temp.ump");
+    return this.parse(ruleName,input,"temp", null);
+ 
+  }
+  
+    public ParseResult parse(String ruleName, String input, String fileName, Position position){
+	setParseResult(parser.parse(ruleName,input,fileName, position));
     setRootToken(parser.getRootToken());
     SampleFileWriter.destroy("temp.ump");
     return getParseResult();

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -95,11 +95,14 @@ class UmpleInternalParser
   }
 
   public ParseResult parse(String ruleName, String input){
-    return parse(ruleName,input,"temp.ump",null);
+    setParseResult(parser.parse(ruleName,input,"temp.ump",null));
+    setRootToken(parser.getRootToken());
+    SampleFileWriter.destroy("temp.ump");
+    return getParseResult();
   }
   
-    public ParseResult parse(String ruleName, String input, String fileName, Position position){
-	setParseResult(parser.parse(ruleName,input,fileName, position));
+    public ParseResult parse(String ruleName, String input, String fileName, Position position, int lineNumber, int offset){
+	setParseResult(parser.parse(ruleName,input,fileName, position,lineNumber,offset));
     setRootToken(parser.getRootToken());
     SampleFileWriter.destroy(fileName);
     return getParseResult();

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -156,17 +156,30 @@ class UmpleInternalParser
  * This method parses a waiting fragment of a mixset.
  * It should be used after checking existing of a mixset-use-statment.  
  */	
-private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
+  depend cruise.umple.compiler.exceptions.*;
+  
+  private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
   
   if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
   {
     String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getName();
     int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine() - 1;
-    ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragmentFile, null, mixsetFragmentLine,0); 
+    ParseResult result= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragmentFile, null, mixsetFragmentLine,0); 
+    setParseResult(result);
     Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
+    setRootToken(answer);
+    
     analyzeAllTokens(answer);
     mixsetFragment.setIsParsed(true);
-    }
+    
+    if( !result.getWasSuccess() || result.getHasWarnings())
+      {
+      	model.setLastResult(result);
+        throw new UmpleCompilerException(result.toString(),null);
+     
+        
+      }
+   }
    
  }
 

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -223,7 +223,7 @@ private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
 	  }
 	  else
 	    mixsetBody = entityType + " "+entityName + " { "+ mixsetBody + " }";
-	    mixsetFragmentPosition = token.getSubToken("mixsetBody").getPosition();	
+	    mixsetFragmentPosition = token.getSubToken("extraCode").getPosition();	
 	  }
 	else if (oneElementMixset != null) 
 	  {

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -171,17 +171,6 @@ class UmpleInternalParser
     model.setLastResult(result);
     analyzeAllTokens(answer);
     mixsetFragment.setIsParsed(true);
-    
-    
-    /*
-    if( !result.getWasSuccess() || result.getHasWarnings())
-      {
-      	
-        throw new UmpleCompilerException(result.toString(),null);
-     
-        
-      }
-      */
    }
    
  }

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -160,7 +160,9 @@ private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
   
   if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
   {
-    ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragment.getOriginalUmpFile().getName(),null); 
+    String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getName();
+    int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine();
+    ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragmentFile, null, mixsetFragmentLine,0); 
     Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
     analyzeAllTokens(answer);
     mixsetFragment.setIsParsed(true);

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -160,7 +160,7 @@ private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
   
   if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
   {
-    ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody()); 
+    ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragment.getOriginalUmpFile().getName(),null); 
     Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
     analyzeAllTokens(answer);
     mixsetFragment.setIsParsed(true);

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -161,7 +161,7 @@ private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
   if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
   {
     String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getName();
-    int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine();
+    int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine() - 1;
     ParseResult pResult= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragmentFile, null, mixsetFragmentLine,0); 
     Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
     analyzeAllTokens(answer);
@@ -197,7 +197,15 @@ private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
 	  model.addMixsetOrFile(mixset);
 	}
 	
-	String mixsetBody = token.getValue("extraCode");	
+	
+	Position mixsetFragmentPosition = null;
+	int mixsetFragmentLineNumber = 0;
+	
+	String mixsetBody = token.getValue("extraCode");
+	if(mixsetBody != null)
+	{
+	  mixsetFragmentPosition = token.getSubToken("extraCode").getPosition();
+	}		
 	
 	//inline mixset def.
 	String entityType = token.getValue("entityType");
@@ -210,19 +218,24 @@ private void parseMixsetWaitingFragment(MixsetFragment mixsetFragment){
 	  if (oneElementMixset != null)
 	  {
 	    mixsetBody = entityType + " "+entityName + " { "+ oneElementMixset + " }";
+	    mixsetFragmentPosition = token.getSubToken("oneElementMixset").getPosition();
+	    
 	  }
 	  else
-	    mixsetBody = entityType + " "+entityName + " { "+ mixsetBody + " }";	
+	    mixsetBody = entityType + " "+entityName + " { "+ mixsetBody + " }";
+	    mixsetFragmentPosition = token.getSubToken("mixsetBody").getPosition();	
 	  }
-	else 
-	
-	  if (oneElementMixset != null) mixsetBody = oneElementMixset;
+	else if (oneElementMixset != null) 
+	  {
+	    mixsetBody = oneElementMixset;
+	    mixsetFragmentPosition = token.getSubToken("oneElementMixset").getPosition();	  
+	  }
 	  
-	  Position thePosition = token.getPosition();
-	  Position endPosition = token.getEndPosition();
-	  int lineNumber = thePosition.getLineNumber();
+	  
+	  
+	  mixsetFragmentLineNumber = mixsetFragmentPosition.getLineNumber();
 	  UmpleFile mixsetFragmentUmpleFile = model.getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
-	  MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, lineNumber, mixsetBody);
+	  MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, mixsetFragmentLineNumber, mixsetBody);
 	  
 	  // Here the mixset fragmet is considered as waitingFragment (mixsetFragment.isParsed==flase). 
 	  mixset.addMixsetFragment(mixsetFragment);

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -162,23 +162,26 @@ class UmpleInternalParser
   
   if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
   {
-    String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getName();
+    String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getName()+".ump";
     int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine() - 1;
     ParseResult result= parse("MixsetFragmentParsing",  mixsetFragment.getBody(), mixsetFragmentFile, null, mixsetFragmentLine,0); 
     setParseResult(result);
     Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
     setRootToken(answer);
-    
+    model.setLastResult(result);
     analyzeAllTokens(answer);
     mixsetFragment.setIsParsed(true);
     
+    
+    /*
     if( !result.getWasSuccess() || result.getHasWarnings())
       {
-      	model.setLastResult(result);
+      	
         throw new UmpleCompilerException(result.toString(),null);
      
         
       }
+      */
    }
    
  }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -1,8 +1,11 @@
 package cruise.umple.compiler.mixset;
 
 import org.junit.*;
+
 import cruise.umple.UmpleConsoleMain;
+import cruise.umple.compiler.UmpleParserTest;
 import cruise.umple.util.SampleFileWriter;
+import cruise.umple.parser.Position;
 
 public class UmpleMixsetTest {
 	
@@ -96,5 +99,56 @@ public class UmpleMixsetTest {
 				SampleFileWriter.destroy("Inner_2.java");
 			}
 		}
+  
+	@Test
+	public void errorInMixsetBody_Location_1() {
+	
+		//try {
+				UmpleParserTest umpleParserTest = new UmpleParserTest();
+			
+			  umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
+			  umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", 1503);
+
+			//}
+			//finally {
+		//	SampleFileWriter.destroy("mixsetTestA.ump");
+			// all other java classes
+		//	SampleFileWriter.destroy("mixsetTestA.ump");
+
+	//}
+		}
+	@Test
+	public void errorInMixsetBody_Location_2() {
+		
+		//try {
+		UmpleParserTest umpleParserTest = new UmpleParserTest();
+		
+	  umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
+	  //Position(String aFilename, int aLineNumber, int aCharacterOffset, int aOffset)
+	  
+	  umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", new Position("mixsetInnerBodyError.ump",12,1,0),1503);
+
+
+
+		}
+	
+	@Test
+	public void errorInMixsetBody_Location_3() {
+		
+		//try {
+		UmpleParserTest umpleParserTest = new UmpleParserTest();
+		
+	  umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
+	  //Position(String aFilename, int aLineNumber, int aCharacterOffset, int aOffset)
+	  
+	  umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", new Position("mixsetInnerBodyError.ump",12,0,1),1503);
+
+
+
+		}
+	
+
+		
+		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -1,7 +1,6 @@
 package cruise.umple.compiler.mixset;
 
 import org.junit.*;
-
 import cruise.umple.UmpleConsoleMain;
 import cruise.umple.compiler.UmpleParserTest;
 import cruise.umple.util.SampleFileWriter;
@@ -10,86 +9,93 @@ import cruise.umple.compiler.UmpleFile;
 
 
 public class UmpleMixsetTest {
+  
+  UmpleParserTest umpleParserTest;
+ 
+  @Before
+  public void setUp()
+  {
+    umpleParserTest = new UmpleParserTest();
+    umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
+
+  }
 	
   @Test
-	public void mixsetUseInSubsequentFile()
-	{
-		String[] args = new String[] {"first.ump"};
-		SampleFileWriter.createFile("first.ump", " mixset MyMixset { class MyClass {} } use activateMixset.ump; ");
-		SampleFileWriter.createFile	("activateMixset.ump"," use MyMixset; ");
-		try 
-		{
-			UmpleConsoleMain.main(args);
-			SampleFileWriter.assertFileExists("MyClass.java");
-		}	
-		finally 
-		{
-			SampleFileWriter.destroy("first.ump");
-			SampleFileWriter.destroy("MyClass.java");
-			SampleFileWriter.destroy("activateMixset.ump");
-		}
-	}
+  public void mixsetUseInSubsequentFile()
+  {
+	  String[] args = new String[] {"first.ump"};
+	  SampleFileWriter.createFile("first.ump", " mixset MyMixset { class MyClass {} } use activateMixset.ump; ");
+	  SampleFileWriter.createFile	("activateMixset.ump"," use MyMixset; ");
+	  try 
+	  {
+      UmpleConsoleMain.main(args);
+      SampleFileWriter.assertFileExists("MyClass.java");
+    }	
+    finally 
+    {
+      SampleFileWriter.destroy("first.ump");
+      SampleFileWriter.destroy("MyClass.java");
+      SampleFileWriter.destroy("activateMixset.ump");
+    }
+  }
 	
 	@Test
-	public void mixsetUseInCodeTest() {
+  public void mixsetUseInCodeTest() {
     String[] args = new String[] {"mixsetUseInCodeTest.ump"};
-		SampleFileWriter.createFile("mixsetUseInCodeTest.ump", " class Outer_Mix_1{ } mixset Mix { class Inner_Mix {name;} } class Outer_Mix_2{ }"
-				+ "\n"
-				+ " use Mix; "
-				+ "\n");
+    SampleFileWriter.createFile("mixsetUseInCodeTest.ump", " class Outer_Mix_1{ } mixset Mix { class Inner_Mix {name;} } class Outer_Mix_2{ }"
+      + "\n"
+      + " use Mix; "
+      + "\n");
 
-		try 
+    try 
+    {
+      UmpleConsoleMain.main(args);
+      SampleFileWriter.assertFileExists("Inner_Mix.java");
+      SampleFileWriter.assertFileExists("Outer_Mix_1.java");
+      SampleFileWriter.assertFileExists("Outer_Mix_2.java");
+    }	
+    finally 
 		{
-			UmpleConsoleMain.main(args);
-			SampleFileWriter.assertFileExists("Inner_Mix.java");
-			SampleFileWriter.assertFileExists("Outer_Mix_1.java");
-			SampleFileWriter.assertFileExists("Outer_Mix_2.java");
-
-		}	
-		finally 
-		{
-			SampleFileWriter.destroy("mixsetUseInCodeTest.ump");
-			SampleFileWriter.destroy("Inner_Mix.java");
-			SampleFileWriter.destroy("Outer_Mix_1.java");
-			SampleFileWriter.destroy("Outer_Mix_2.java");
-		}
-	}
+      SampleFileWriter.destroy("mixsetUseInCodeTest.ump");
+      SampleFileWriter.destroy("Inner_Mix.java");
+      SampleFileWriter.destroy("Outer_Mix_1.java");
+      SampleFileWriter.destroy("Outer_Mix_2.java");
+    }
+  }
 	
-	@Test
-	public void mixsetUseInConsoleTest() {
-		String[] args = new String[] {"mixsetUseInConsoleTest.ump", "Mx"};
+  @Test
+  public void mixsetUseInConsoleTest() {
+    String[] args = new String[] {"mixsetUseInConsoleTest.ump", "Mx"};
 
-		SampleFileWriter.createFile("mixsetUseInConsoleTest.ump", " class Outer_1{ } mixset Mx { class Inner_M1 {name;} } class Outer_2{ }");
+    SampleFileWriter.createFile("mixsetUseInConsoleTest.ump", " class Outer_1{ } mixset Mx { class Inner_M1 {name;} } class Outer_2{ }");
 
-		try 
-		{
-			UmpleConsoleMain.main(args);
-			SampleFileWriter.assertFileExists("Inner_M1.java");
-			SampleFileWriter.assertFileExists("Outer_1.java");
-			SampleFileWriter.assertFileExists("Outer_2.java");
-
-		}	
-		finally 
-		{
-			SampleFileWriter.destroy("mixsetUseInConsoleTest.ump");
-			SampleFileWriter.destroy("Inner_M1.java");
-			SampleFileWriter.destroy("Outer_1.java");
-			SampleFileWriter.destroy("Outer_2.java");
-		}
-	}
-		
-		
-	@Test
+   try 
+   {
+      UmpleConsoleMain.main(args);
+      SampleFileWriter.assertFileExists("Inner_M1.java");
+      SampleFileWriter.assertFileExists("Outer_1.java");
+      SampleFileWriter.assertFileExists("Outer_2.java");
+    }	
+    finally 
+    {
+      SampleFileWriter.destroy("mixsetUseInConsoleTest.ump");
+      SampleFileWriter.destroy("Inner_M1.java");
+      SampleFileWriter.destroy("Outer_1.java");
+      SampleFileWriter.destroy("Outer_2.java");
+    }
+  }
+			
+  @Test
   public void multipleMixsetUseInConsoleTest() {
-	  String[] args = new String[] {"mixset_1.ump", "M2", "mixset_2.ump", "M1"};
-		SampleFileWriter.createFile("mixset_1.ump", "mixset M1 { class Inner_1 { } }" );
-		SampleFileWriter.createFile("mixset_2.ump", "mixset M2 { class Inner_2 { } }");
+    String[] args = new String[] {"mixset_1.ump", "M2", "mixset_2.ump", "M1"};
+    SampleFileWriter.createFile("mixset_1.ump", "mixset M1 { class Inner_1 { } }" );
+    SampleFileWriter.createFile("mixset_2.ump", "mixset M2 { class Inner_2 { } }");
 
-		try 
-		{
+    try 
+    {
 			UmpleConsoleMain.main(args);
 			SampleFileWriter.assertFileExists("Inner_1.java");
-			SampleFileWriter.assertFileExists("Inner_2.java");
+      SampleFileWriter.assertFileExists("Inner_2.java");
 
 		}	
 		finally 
@@ -103,14 +109,27 @@ public class UmpleMixsetTest {
 	
 	
 	@Test
-	public void errorInMixsetBody_Location() {
-   
-	  UmpleParserTest umpleParserTest = new UmpleParserTest();
-    umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
+  public void errorInMixsetBody() {
+
     UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"mixsetInnerBodyError.ump");
-    umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", new Position(file.getPath()+"/"+file.getFileName(),12,1,12),1503);
+    int line = 12;
+    int errorCode = 1503;
+    int offset= 1;
+		int charOff = 12;
+		umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);		
+		}
+
+  @Test
+  public void warningInNestedMixsetBody() {
+
+    UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"warningInnerMixset.ump");
+    int line = 11;
+    int errorCode = 1007;
+    int offset= 0;
+		int charOff = 12;
+    umpleParserTest.assertHasWarningsParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);			
 		
-	}
+}
 		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -6,10 +6,12 @@ import cruise.umple.UmpleConsoleMain;
 import cruise.umple.compiler.UmpleParserTest;
 import cruise.umple.util.SampleFileWriter;
 import cruise.umple.parser.Position;
+import cruise.umple.compiler.UmpleFile;
+
 
 public class UmpleMixsetTest {
 	
-	@Test
+  @Test
 	public void mixsetUseInSubsequentFile()
 	{
 		String[] args = new String[] {"first.ump"};
@@ -77,78 +79,38 @@ public class UmpleMixsetTest {
 	}
 		
 		
-		@Test
-		public void multipleMixsetUseInConsoleTest() {
-			String[] args = new String[] {"mixset_1.ump", "M2", "mixset_2.ump", "M1"};
-
-			SampleFileWriter.createFile("mixset_1.ump", "mixset M1 { class Inner_1 { } }" );
-			SampleFileWriter.createFile("mixset_2.ump", "mixset M2 { class Inner_2 { } }");
-
-			try 
-			{
-				UmpleConsoleMain.main(args);
-				SampleFileWriter.assertFileExists("Inner_1.java");
-				SampleFileWriter.assertFileExists("Inner_2.java");
-
-			}	
-			finally 
-			{
-				SampleFileWriter.destroy("mixset_1.ump");
-				SampleFileWriter.destroy("mixset_2.ump");
-				SampleFileWriter.destroy("Inner_1.java");
-				SampleFileWriter.destroy("Inner_2.java");
-			}
-		}
-  
 	@Test
-	public void errorInMixsetBody_Location_1() {
+  public void multipleMixsetUseInConsoleTest() {
+	  String[] args = new String[] {"mixset_1.ump", "M2", "mixset_2.ump", "M1"};
+		SampleFileWriter.createFile("mixset_1.ump", "mixset M1 { class Inner_1 { } }" );
+		SampleFileWriter.createFile("mixset_2.ump", "mixset M2 { class Inner_2 { } }");
+
+		try 
+		{
+			UmpleConsoleMain.main(args);
+			SampleFileWriter.assertFileExists("Inner_1.java");
+			SampleFileWriter.assertFileExists("Inner_2.java");
+
+		}	
+		finally 
+		{
+			SampleFileWriter.destroy("mixset_1.ump");
+			SampleFileWriter.destroy("mixset_2.ump");
+			SampleFileWriter.destroy("Inner_1.java");
+			SampleFileWriter.destroy("Inner_2.java");
+		}
+  }
 	
-		//try {
-				UmpleParserTest umpleParserTest = new UmpleParserTest();
-			
-			  umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
-			  umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", 1503);
-
-			//}
-			//finally {
-		//	SampleFileWriter.destroy("mixsetTestA.ump");
-			// all other java classes
-		//	SampleFileWriter.destroy("mixsetTestA.ump");
-
-	//}
-		}
-	@Test
-	public void errorInMixsetBody_Location_2() {
-		
-		//try {
-		UmpleParserTest umpleParserTest = new UmpleParserTest();
-		
-	  umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
-	  //Position(String aFilename, int aLineNumber, int aCharacterOffset, int aOffset)
-	  
-	  umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", new Position("mixsetInnerBodyError.ump",12,1,0),1503);
-
-
-
-		}
 	
 	@Test
-	public void errorInMixsetBody_Location_3() {
+	public void errorInMixsetBody_Location() {
+   
+	  UmpleParserTest umpleParserTest = new UmpleParserTest();
+    umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
+    UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"mixsetInnerBodyError.ump");
+    umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", new Position(file.getPath()+"/"+file.getFileName(),12,1,12),1503);
 		
-		//try {
-		UmpleParserTest umpleParserTest = new UmpleParserTest();
-		
-	  umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
-	  //Position(String aFilename, int aLineNumber, int aCharacterOffset, int aOffset)
-	  
-	  umpleParserTest.assertFailedParse("mixsetInnerBodyError.ump", new Position("mixsetInnerBodyError.ump",12,0,1),1503);
-
-
-
-		}
-	
-
-		
+	}
 		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetInnerBodyError.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetInnerBodyError.ump
@@ -5,7 +5,7 @@ class Y1{}
 
 
 
- mixset M1 {
+mixset M1 {
 
 class A{
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetInnerBodyError.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetInnerBodyError.ump
@@ -1,0 +1,16 @@
+
+
+
+class Y1{}
+
+
+
+ mixset M1 {
+
+class A{
+}
+ Error_at_line_12
+
+class B{}
+}
+use M1;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/warningInnerMixset.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/warningInnerMixset.ump
@@ -1,0 +1,27 @@
+class A{}
+
+mixset M1 {
+
+
+
+mixset InnerMixset{
+
+class B{  
+
+class //Line 11 
+
+}
+
+
+
+}
+
+
+class C{}
+
+
+}
+
+
+use M1;
+use InnerMixset;


### PR DESCRIPTION
This PR refactors some methods in umpleParser to accept a string with a specific line number to start with when parsing the string argument. This is needed for parsing mixset fragments.  

Also, Umple praser is enhanced to stop when it finds an error in a mixset. This is not implemented before even though the prarser detects and shows that there is an error in a specific line in a mixset; it continues as there is any error. 