### PR TITLE
[ci skip] bad links in umplificator man page

### DIFF
--- a/build/reference/5202UmplificationTooling.txt
+++ b/build/reference/5202UmplificationTooling.txt
@@ -9,10 +9,10 @@ The <b> Umplificator </b> is a reverse engineering tool for the incremental auto
 <p>To transform a program written in Java into Umple you can use one of the following tools: </p>
 <ul>
 
-<li><b>Eclipse</b>: To use the Umplificator with Eclipse, you need to load the the Umplificator plugin (cruise.umplificator.eclipse.X.X.X.jar). This can be obtained from our <a href="http:/dl.umple.org">downloads site</a>. </li>
+<li><b>Eclipse</b>: To use the Umplificator with Eclipse, you need to load the the Umplificator plugin (cruise.umplificator.eclipse.X.X.X.jar). You can build this from sources or contact the Umple team for a fresh build. </li>
 <br />
 
-<li><b>Command-line based compiler</b>: You can use the Umplificator from the command line.  Simply download the latest officially released version of the <a href="http:/dl.umple.org"> umplificator jar</a>, and run it as "java -jar umplificator.jar *.java". </li>
+<li><b>Command-line based compiler</b>: This can be run as "java -jar umplificator.jar *.java". </li>
 Note that it is also possible to umplify files with extension ".ump". 
 </ul>
 


### PR DESCRIPTION
Removing bad links to the umplificator manual page