### PR TITLE
 Progress on #1322 Pooled or queued state machines reaching final state terminating execution (Java)

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/delete_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_All.ump
@@ -353,6 +353,15 @@ class UmpleToJava {
   	hasSomethingToDelete = true;
   }
   
+  for (StateMachine sm : uClass.getStateMachines())
+  {
+    if (sm.isQueued() || sm.isPooled())
+    {
+      append(realSb, "\n   removal.interrupt();");
+      hasSomethingToDelete = true;
+    }
+  }
+  
   if (!uClass.isRoot() && !"external".equals(uClass.getExtendsClass().getModifier()))
   {
     hasSomethingToDelete = true;

--- a/UmpleToJava/UmpleTLTemplates/delete_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/delete_All.ump
@@ -357,8 +357,9 @@ class UmpleToJava {
   {
     if (sm.isQueued() || sm.isPooled())
     {
-      append(realSb, "\n   removal.interrupt();");
+      append(realSb, "\n    removal.interrupt();");
       hasSomethingToDelete = true;
+      break;
     }
   }
   

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_inner_class.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_inner_class.ump
@@ -39,7 +39,10 @@ class UmpleToJava {
     appendln(realSb,"        {");
     appendln(realSb,"          wait();");
     appendln(realSb,"        }");
-    appendln(realSb,"      } catch (InterruptedException e) { e.printStackTrace(); } "); 
+    appendln(realSb,"      } catch (InterruptedException e) {");
+    appendln(realSb,"        Thread.currentThread().interrupt();");
+    appendln(realSb,"        return null;");
+    appendln(realSb,"      }");
     appendln(realSb,"");
     appendln(realSb,"      //The element to be removed");
     appendln(realSb,"      Message m = messages.remove(); "); 
@@ -69,7 +72,10 @@ class UmpleToJava {
     appendln(realSb,"          wait();");
     appendln(realSb,"          message=getNextProcessableMessage();");
     appendln(realSb,"        }");
-    appendln(realSb,"      } catch (InterruptedException e) { e.printStackTrace(); }");
+    appendln(realSb,"      } catch (InterruptedException e) {");
+    appendln(realSb,"        Thread.currentThread().interrupt();");
+    appendln(realSb,"        return null;");
+    appendln(realSb,"      }");
     appendln(realSb,"");
     appendln(realSb,"      // return the message");
     appendln(realSb,"      return (message);");

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_removalThread_run.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_removalThread_run.ump
@@ -12,10 +12,12 @@ class UmpleToJava {
       if(smq.isPooled())
       {
         append(realSb,"      Message m = pool.getNext();");
+        append(realSb,"\n      if(m == null)  return;");
       }
       if(smq.isQueued())
       {
         append(realSb,"      Message m = queue.getNext();");
+        append(realSb,"\n      if(m == null)  return;");
       }
       #>>
       

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods.java.txt
@@ -284,7 +284,9 @@ public class Microwave implements java.io.Serializable, IMicrowaveImpl, Runnable
   }
 
   public void deleteImpl()
-  {}
+  {
+   removal.interrupt();
+  }
 
   protected class Message
   {
@@ -322,7 +324,10 @@ public class Microwave implements java.io.Serializable, IMicrowaveImpl, Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -357,6 +362,7 @@ public class Microwave implements java.io.Serializable, IMicrowaveImpl, Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods.java.txt
@@ -285,7 +285,7 @@ public class Microwave implements java.io.Serializable, IMicrowaveImpl, Runnable
 
   public void deleteImpl()
   {
-   removal.interrupt();
+    removal.interrupt();
   }
 
   protected class Message

--- a/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/Class_DistributableRMI_WithMethods2.java.txt
@@ -284,6 +284,7 @@ public class MicrowaveImpl extends CCImpl implements java.io.Serializable , IMic
 
   public void delete()
   {
+    removal.interrupt();
     super.delete();
   }
 
@@ -323,7 +324,10 @@ public class MicrowaveImpl extends CCImpl implements java.io.Serializable , IMic
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -358,6 +362,7 @@ public class MicrowaveImpl extends CCImpl implements java.io.Serializable , IMic
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventlessStateMachine_PooledStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventlessStateMachine_PooledStateMachine.java.txt
@@ -208,7 +208,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -250,7 +252,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -311,6 +316,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventlessStateMachine_QueuedStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/eventlessStateMachine_QueuedStateMachine.java.txt
@@ -197,7 +197,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -235,7 +237,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -275,6 +280,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachine.java.txt
@@ -158,7 +158,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -200,7 +202,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -261,6 +266,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachine_EventlessStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachine_EventlessStateMachine.java.txt
@@ -265,7 +265,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -307,7 +309,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -384,6 +389,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachine_nestedStates.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachine_nestedStates.java.txt
@@ -333,7 +333,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -375,7 +377,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -468,6 +473,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachines_sameEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multiplePooledStateMachines_sameEvents.java.txt
@@ -206,7 +206,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -248,7 +250,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -319,6 +324,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSM.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSM.java.txt
@@ -232,7 +232,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -270,7 +272,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -320,6 +325,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSM_EventlessStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSM_EventlessStateMachine.java.txt
@@ -252,7 +252,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -290,7 +292,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -340,6 +345,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSM_sameEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSM_sameEvents.java.txt
@@ -194,7 +194,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -232,7 +234,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -282,6 +287,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSMe_nestedStates.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/multipleQSMe_nestedStates.java.txt
@@ -317,7 +317,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -355,7 +357,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -415,6 +420,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/nestedStatesOfQSMwithSameEventNames.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/nestedStatesOfQSMwithSameEventNames.java.txt
@@ -198,7 +198,9 @@ public class NestedStatesWthSameEventNames implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -236,7 +238,10 @@ public class NestedStatesWthSameEventNames implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -266,6 +271,7 @@ public class NestedStatesWthSameEventNames implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine.java.txt
@@ -100,7 +100,9 @@ public class Course implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -142,7 +144,10 @@ public class Course implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -187,6 +192,7 @@ public class Course implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachineWithConcurrentStates_autoTransition.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachineWithConcurrentStates_autoTransition.java.txt
@@ -195,7 +195,9 @@ public class CourseAttempt implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -237,7 +239,10 @@ public class CourseAttempt implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -290,6 +295,7 @@ public class CourseAttempt implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       { 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_UnspecifiedReception.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_UnspecifiedReception.java.txt
@@ -127,7 +127,9 @@ public class PooledSMwithUnspecifiedReception implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -169,7 +171,10 @@ public class PooledSMwithUnspecifiedReception implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -214,6 +219,7 @@ public class PooledSMwithUnspecifiedReception implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_autoTransition.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_autoTransition.java.txt
@@ -90,7 +90,9 @@ public class Light implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -132,7 +134,10 @@ public class Light implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -167,6 +172,7 @@ public class Light implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       { 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents.java.txt
@@ -211,7 +211,9 @@ public class Mentor implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -253,7 +255,10 @@ public class Mentor implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -304,6 +309,7 @@ public class Mentor implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents_and_autoTansitions.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedEvents_and_autoTansitions.java.txt
@@ -171,7 +171,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -213,7 +215,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -256,6 +261,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedTransition_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedTransition_1.java.txt
@@ -209,7 +209,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -251,7 +253,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -309,6 +314,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedTransition_2.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_timedTransition_2.java.txt
@@ -228,7 +228,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -270,7 +272,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -333,6 +338,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
@@ -159,7 +159,9 @@ public class LightFixture implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -201,7 +203,10 @@ public class LightFixture implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -253,6 +258,7 @@ public class LightFixture implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedSM_UnspecifiedRecep.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedSM_UnspecifiedRecep.java.txt
@@ -353,7 +353,9 @@ public class AutomatedTellerMachine implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -391,7 +393,10 @@ public class AutomatedTellerMachine implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -456,6 +461,7 @@ public class AutomatedTellerMachine implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedSMwithConcurrentStatesTest.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedSMwithConcurrentStatesTest.java.txt
@@ -224,7 +224,9 @@ public class QueuedSMwithConcurrentStates implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -262,7 +264,10 @@ public class QueuedSMwithConcurrentStates implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -287,6 +292,7 @@ public class QueuedSMwithConcurrentStates implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedSMwithConcurrentStatesTest_2.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedSMwithConcurrentStatesTest_2.java.txt
@@ -212,7 +212,9 @@ public class QueuedSMwithConcurrentStates_2 implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -250,7 +252,10 @@ public class QueuedSMwithConcurrentStates_2 implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -275,6 +280,7 @@ public class QueuedSMwithConcurrentStates_2 implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine.java.txt
@@ -92,7 +92,9 @@ public class Course implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -130,7 +132,10 @@ public class Course implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -160,6 +165,7 @@ public class Course implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_2.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_2.java.txt
@@ -126,7 +126,9 @@ public class GarageDoor implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -164,7 +166,10 @@ public class GarageDoor implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -199,6 +204,7 @@ public class GarageDoor implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_autoTransition.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_autoTransition.java.txt
@@ -82,7 +82,9 @@ public class Light implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -120,7 +122,10 @@ public class Light implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -140,6 +145,7 @@ public class Light implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       { 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_implementsInterface.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_implementsInterface.java.txt
@@ -74,7 +74,9 @@ public class X implements IX, Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -112,7 +114,10 @@ public class X implements IX, Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -137,6 +142,7 @@ public class X implements IX, Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents.java.txt
@@ -203,7 +203,9 @@ public class Mentor implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -241,7 +243,10 @@ public class Mentor implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -277,6 +282,7 @@ public class Mentor implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents_and_autoTansitions.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedEvents_and_autoTansitions.java.txt
@@ -162,7 +162,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -200,7 +202,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -228,6 +233,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedTransition_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedTransition_1.java.txt
@@ -198,7 +198,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -236,7 +238,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -279,6 +284,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedTransition_2.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_timedTransition_2.java.txt
@@ -217,7 +217,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -255,7 +257,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -303,6 +308,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
@@ -150,7 +150,9 @@ public class LightFixture implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -188,7 +190,10 @@ public class LightFixture implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -225,6 +230,7 @@ public class LightFixture implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
@@ -150,7 +150,9 @@ public class LightFixture implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -188,7 +190,10 @@ public class LightFixture implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -226,6 +231,7 @@ public class LightFixture implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithConcurrensStatesCourseAttempt.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithConcurrensStatesCourseAttempt.java.txt
@@ -179,7 +179,9 @@ public class CourseAttempt implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -217,7 +219,10 @@ public class CourseAttempt implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -237,6 +242,7 @@ public class CourseAttempt implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       { 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithConcurrentStateMachines.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithConcurrentStateMachines.java.txt
@@ -176,7 +176,9 @@ public class QueuedWithConcurrentStateMachines implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -214,7 +216,10 @@ public class QueuedWithConcurrentStateMachines implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -244,6 +249,7 @@ public class QueuedWithConcurrentStateMachines implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithNestedStateMachines.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithNestedStateMachines.java.txt
@@ -158,7 +158,9 @@ public class QueuedWithNestedStateMachines implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -196,7 +198,10 @@ public class QueuedWithNestedStateMachines implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -231,6 +236,7 @@ public class QueuedWithNestedStateMachines implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithNestingStatesATM.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedWithNestingStatesATM.java.txt
@@ -278,7 +278,9 @@ public class AutomatedTellerMachine implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -316,7 +318,10 @@ public class AutomatedTellerMachine implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -381,6 +386,7 @@ public class AutomatedTellerMachine implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/stateMachine_unSpecifiedReception_QSM.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/stateMachine_unSpecifiedReception_QSM.java.txt
@@ -164,7 +164,9 @@ public class QSMwithUnspecifiedRecep implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -202,7 +204,10 @@ public class QSMwithUnspecifiedRecep implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -232,6 +237,7 @@ public class QSMwithUnspecifiedRecep implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testMultipleQSMs.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testMultipleQSMs.java.txt
@@ -230,7 +230,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -268,7 +270,10 @@ public class X implements Runnable
         {
           wait();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); } 
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       //The element to be removed
       Message m = messages.remove(); 
@@ -318,6 +323,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = queue.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates.java.txt
@@ -206,7 +206,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -248,7 +250,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -314,6 +319,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates_2.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates_2.java.txt
@@ -264,7 +264,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -306,7 +308,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -383,6 +388,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates_3.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates_3.java.txt
@@ -359,7 +359,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -401,7 +403,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -499,6 +504,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates_4.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/testPooledwithNestedStates_4.java.txt
@@ -388,7 +388,9 @@ public class X implements Runnable
   }
 
   public void delete()
-  {}
+  {
+    removal.interrupt();
+  }
 
   protected class Message
   {
@@ -430,7 +432,10 @@ public class X implements Runnable
           wait();
           message=getNextProcessableMessage();
         }
-      } catch (InterruptedException e) { e.printStackTrace(); }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
 
       // return the message
       return (message);
@@ -523,6 +528,7 @@ public class X implements Runnable
     while (true) 
     {
       Message m = pool.getNext();
+      if(m == null)  return;
       
       switch (m.type)
       {


### PR DESCRIPTION
This PR fixes state machine behavior for Java in which state machines that are either pooled or queued (with or without regions) would not terminate their running thread. Updates implementation tests with newly generated code. Final state behavior in other languages would need to be tested next.