### PR TITLE
Mixset Testing & Require statement intro.

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -92,6 +92,7 @@ class UmpleInternalParser
     parser.addGrammarFile("/umple_filter.grammar"); // TODO Under development
     parser.addGrammarFile("/umple_mixsets.grammar"); // Under development
     
+    
   }
 
   public ParseResult parse(String ruleName, String input){

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -44,7 +44,7 @@ toplevelExtracode : top [top] [[moreCode]]
 namespace- : namespace [namespace] ;
 
 // The main top level elements to be found in an Umple file
-entity- : [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
+entity- : [[mixsetRequireStatement]] | [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
 
 // Comments follow the same conventions as C-family languages. [*UmpleComments*]
 comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -44,7 +44,7 @@ toplevelExtracode : top [top] [[moreCode]]
 namespace- : namespace [namespace] ;
 
 // The main top level elements to be found in an Umple file
-entity- : [[mixsetRequireStatement]] | [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
+entity- : [[requireStatement]] | [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
 
 // Comments follow the same conventions as C-family languages. [*UmpleComments*]
 comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -18,6 +18,10 @@ mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] |
 //mixsetDeclaration- : [[mixsetBasicDeclaration]] | [[mixsetInlineDeclaration]]
 //mixsetBasicDeclaration- : mixset [mixsetName]  [[mixsetInnerContent]] 
 
+// require statement allows adding dependencies on mixsets.
 
+mixsetRequireStatement : require [[requireBody]]  // inline require 
+mixsetRequireStatement : mixset [mixsetName] require [[requireBody]]
 
+requireBody : [mixsetName] //basic case of mixset body 
 

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -18,10 +18,13 @@ mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] |
 //mixsetDeclaration- : [[mixsetBasicDeclaration]] | [[mixsetInlineDeclaration]]
 //mixsetBasicDeclaration- : mixset [mixsetName]  [[mixsetInnerContent]] 
 
-// require statement allows adding dependencies on mixsets.
+// require statement allows adding dependencies between mixsets.
 
-mixsetRequireStatement : require [[requireBody]]  // inline require 
-mixsetRequireStatement : mixset [mixsetName] require [[requireBody]]
+requireStatement : require [[requireBody]] 
 
-requireBody : [mixsetName] //basic case of mixset body 
+requireBody- : [targetMixsetName] 
 
+//basic case of mixset body 
+
+//End
+//requireStatement : ( mixset [mixsetName] )? require [[requireBody]] 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -220,7 +220,21 @@ public class UmpleMixsetTest {
     Assert.assertEquals(umpleClasses.get(0).getAttributes().size(), 0);
     Assert.assertEquals(umpleClasses.get(0).getName(),"OuterClass");
 
+  }
+
+ @Test
+  public void useStatementsDependency()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"UseStatementsDependency.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    Assert.assertEquals(umpleClasses.size(), 1);
+    Assert.assertEquals(umpleClasses.get(0).getName(),"Target");
+
   }   
+   
 
   		
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -234,8 +234,14 @@ public class UmpleMixsetTest {
     Assert.assertEquals(umpleClasses.get(0).getName(),"Target");
 
   }   
-   
+  
+  @Test
+  public void mixsetRequireStatementNoWarnings()
+  {
+    umpleParserTest.assertNoWarningsParse("mixsetRequireStatementNoWarnings.ump");
+  }
 
+ 
   		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -207,7 +207,21 @@ public class UmpleMixsetTest {
     Assert.assertEquals(umpleClasses.get(0).getAttributes().size(), 0);
   	
  }
-   
-		
+
+  @Test
+  public void innerMixsetHasNoEffectWhenParentMixsetNotUsed()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parentMixsetWithNoUseStatement.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    Assert.assertEquals(umpleClasses.size(), 1);
+    Assert.assertEquals(umpleClasses.get(0).getAttributes().size(), 0);
+    Assert.assertEquals(umpleClasses.get(0).getName(),"OuterClass");
+
+  }   
+
+  		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UseStatementsDependency.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UseStatementsDependency.ump
@@ -1,0 +1,31 @@
+mixset OuterMixset_1 {
+
+	use InnerMixset_2;
+  mixset InnerMixset_1 {	
+  class Target {}
+  }
+
+
+}
+
+
+mixset OuterMixset_2 {
+
+	use OuterMixset_1;  
+  mixset InnerMixset_2 {	
+  use InnerMixset_1;
+  }
+
+
+}
+
+use OuterMixset_2;  
+
+
+
+//   use statements activation : OuterMixset_2 
+//																						--> OuterMixset_1 
+//																															--> InnerMixset_2 
+//																																							 --> InnerMixset_1 
+
+// The class Target should be added to umple Model. 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
@@ -1,0 +1,4 @@
+require Mixset;
+
+
+// No issue with require keyword

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
@@ -1,4 +1,7 @@
+
 require Mixset;
+
+//mixset SomeMixset require AnotherMixset; //TODO
 
 
 // No issue with require keyword

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parentMixsetWithNoUseStatement.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parentMixsetWithNoUseStatement.ump
@@ -1,0 +1,19 @@
+class OuterClass {}
+
+mixset OuterMixset {
+  
+  mixset InnerMixset {
+  class InnerClass {}
+  class OuterClass {a;}
+  }
+
+  class OuterClass{b;}
+
+}
+
+
+use InnerMixset;
+// no use statement for parent mixset 'OuterMixset'.
+
+// InnerClass should not added to umple model.
+// should have 0 attributes.


### PR DESCRIPTION
The basic syntax of mixset require statement is introduced in this PR. More progress and enhancements are going to be in next PR.

Also, more test cases are added to the UmpleMixsetTest:
A. Testing that a nested mixset should not affect the umple model if there is a use statement while there is no use statement for its parent mixst.    
B. Test the case when certain mixsets activate other mixsets in a sequential order. 