### PR TITLE
Restoring mixsets grammar

### DIFF
--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -20,11 +20,23 @@ mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] |
 
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require [[requireBody]] 
 
-requireBody- : [targetMixsetName] 
+requireStatement : ( mixsetX [mixsetName] )? require ( ( [ [[requireBody]] ] ) | ( [[multiplicity]] of { [[requireBody]] } ) ) 
 
-//basic case of mixset body 
+//| ( [[multiplicity]] of {[[requireList]]} ) )
 
-//End
-//requireStatement : ( mixset [mixsetName] )? require [[requireBody]] 
+requireBody- : ( ( [[requireLinkingOptNot]] )? [[requireTerminal]] ) [[requireList]] 
+
+requireList- : ( [[requireLinkingOp]] [[requireTerminal]] )*
+
+
+requireLinkingOp : ( [[requireLinkingOptNot]] | [=and:&|&&|and|,] | [!or:([|][|]?|or|;)] )
+
+requireLinkingOptNot : ( opt | not ) 
+
+requireTerminal : [targetMixsetName] 
+
+
+
+
+//requireBody- : [targetMixsetName] ( [[reqLinkingOp]] [[requireBody]] )*


### PR DESCRIPTION
An accidental push to master was done (shouldn't have been allowed, but somehow was). This resets to the previous state fo the mixsets grammar file.