### PR TITLE
Progress on require statement grammar

### DIFF
--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -28,7 +28,7 @@ requireLinkingOp : ([[requireLinkingOptNot]] | [=and:&|&&|and|,] | [!or:([|][|]?
 
 requireLinkingOptNot : (opt | not) 
 
-requireTerminal :  [targetMixsetName]
+requireTerminal :  [~targetMixsetName]
 
 
 

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -5,7 +5,7 @@
 // This file is made available subject to the open source license found at:
 // [*http://umple.org/license*]
 
-//mixset allows creation of mixins composed from multiple locations plus some constraints regarding usage of these mixins.
+//mixsets allow creation of mixins composed from multiple locations plus some constraints regarding usage of these mixins.
 // See user manual page [*BasicMixsets*]
 
 mixsetDefinition : mixset [mixsetName] ( [[mixsetInnerContent]] | [[mixsetInlineDefinition]] )

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -5,26 +5,37 @@
 // This file is made available subject to the open source license found at:
 // [*http://umple.org/license*]
 
-//mixsets allow creation of mixins composed from multiple locations plus some constraints regarding usage of these mixins.
+//mixset allows creation of mixins composed from multiple locations plus some constraints regarding usage of these mixins.
 // See user manual page [*BasicMixsets*]
 
 mixsetDefinition : mixset [mixsetName] ( [[mixsetInnerContent]] | [[mixsetInlineDefinition]] )
 mixsetInnerContent- : { [[extraCode]] }
  
-
 mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] | [entityOneElement] ) | [oneElement] )
 
 
-//mixsetDeclaration- : [[mixsetBasicDeclaration]] | [[mixsetInlineDeclaration]]
-//mixsetBasicDeclaration- : mixset [mixsetName]  [[mixsetInnerContent]] 
-
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require [[requireBody]] 
+requireStatement : require ( [[requireBody]] | ( [[multiplicity]] of { [[requireTerminal]] [[requireMultiplicityList]] } ) ) 
 
-requireBody- : [targetMixsetName] 
+requireBody- : [(([[requireLinkingOptNot]])? [[requireTerminal]] [[requireList]])] 
 
-//basic case of mixset body 
+requireList- : ([[requireLinkingOp]] [[requireTerminal]])*
 
-//End
-//requireStatement : ( mixset [mixsetName] )? require [[requireBody]] 
+requireMultiplicityList- : (, [[requireTerminal]])*
+
+requireLinkingOp : ([[requireLinkingOptNot]] | [=and:&|&&|and|,] | [!or:([|][|]?|or|;)])
+
+requireLinkingOptNot : (opt | not) 
+
+requireTerminal :  [targetMixsetName]
+
+
+
+
+
+
+
+
+
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
@@ -1,7 +1,21 @@
 
-require Mixset;
+require [Mixset];
 
-//mixset SomeMixset require AnotherMixset; //TODO
+require [GSMProtocol opt Mp3Recording and Playback and AudioFormat opt Camera ];
+
+require 1..3 of {M1,M2,M3};
+
+require [not M2 and m4 ] ;
+
+require [M1 opt M3];
+
+require [M3 or M2];
+
+require 0..1 of {M1}; 
 
 
-// No issue with require keyword
+/*
+
+All these forms of require statements should not raise errors .  
+
+*/


### PR DESCRIPTION
Here the grammar of requirement statement is enhanced to include:
  A. a list of mixset names such as require [opt M1 or M2].
  B. multiplicity of mixset names separated by a comma as require 1..2 of { M1, M2, M3}.