### PR TITLE
Progress on mixset for state machine

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -54,13 +54,25 @@ class UmpleInternalParser
 {
 	depend cruise.umple.compiler.UmpleFile;
 	depend  java.util.stream.*;
+	
+	// prepare mixsets that are inside a state machine. 
+  private void analyzeMixsetDefinition(Token aToken , StateMachine stateMachine)
+  {
+  	aToken.addSubToken(new Token("entityName",stateMachine.getUmpleClass().getName()) ); 
+    aToken.addSubToken(new Token("entityType","class") );
+ 
+    Token mixsetBodyToken = aToken.getSubToken("extraCode");
+    mixsetBodyToken.setValue(" "+stateMachine.getName()+" { "+mixsetBodyToken.getValue() +" } ");
+    
+    analyzeMixset(aToken);		
+	}
 	 
  // prepare mixsets that are inside an Umple class
   private void analyzeMixsetDefinition(Token aToken , String className)
   {
   	aToken.addSubToken(new Token("entityName",className) );
-	aToken.addSubToken(new Token("entityType","class") );
-	analyzeMixset(aToken);		
+    aToken.addSubToken(new Token("entityType","class") );
+    analyzeMixset(aToken);		
 	}
 /*
  * This method handles mixset use statements appearing in both code and in the console. The method adds mixset use statements to umple model in the first round on analysis, before

--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -725,6 +725,12 @@ class UmpleInternalParser
       }
     }
     
+    Token mixsetToken = stateMachineToken.getSubToken("mixsetDefinition");
+    if(mixsetToken != null)
+    {
+      analyzeMixsetDefinition(mixsetToken, sm);
+    }
+
     return sm;
   }
 

--- a/cruise.umple/src/umple_state_machines.grammar
+++ b/cruise.umple/src/umple_state_machines.grammar
@@ -12,7 +12,7 @@ stateMachine : [[enum]] | [[inlineStateMachine]] | [[referencedStateMachine]] | 
 activeDefinition : [=active] [[codeLangs]] [name]? [[moreCode]]+
 
 //Issue 148
-inlineStateMachine : [=queued]? [=pooled]? [~name] { ( [[comment]] | [[state]] | [[trace]] | [=-||] | [[standAloneTransition]])* }
+inlineStateMachine : [=queued]? [=pooled]? [~name] { ( [[comment]] | [[state]] | [[trace]] | [[mixsetDefinition]] | [=-||] | [[standAloneTransition]])* }
 referencedStateMachine : [name] as [definitionName] ( { [[extendedStateMachine]] } | ; )
 
 //Issue 547 and 148

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -241,6 +241,20 @@ public class UmpleMixsetTest {
     umpleParserTest.assertNoWarningsParse("mixsetRequireStatementNoWarnings.ump");
   }
 
+ @Test
+  public void stateMachineStateHasMixset()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"stateMachineStateHasMixset.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    Assert.assertEquals(umpleClasses.get(0).getName(),"Booking");
+    Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getStates().size(),5);
+    Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getAllTransitions().size(), 6);
+
+  }   
+
  
   		
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/stateMachineStateHasMixset.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/stateMachineStateHasMixset.ump
@@ -1,0 +1,24 @@
+class Booking {
+  state {
+    newBooking { 
+      assignSeat -> seatAssigned;
+      cancel -> cancelled;
+    }
+    seatAssigned {
+      cancel -> cancelled;
+      checkIn -> checkedIn;
+    }
+
+    mixset M1 {   
+      checkedIn {
+        cancel -> cancelled;
+        complete -> completed;
+      }
+  }
+    cancelled {}
+    completed {}
+  }
+}
+
+
+use M1;


### PR DESCRIPTION
This PR allows mixsets definition and use for inlineStateMachine. Therefore, mixset can include optional state(s) trace(s) and standAloneTransition(s). 