### PR TITLE
 Progress on mixset for state machine - stateInternal

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -56,15 +56,42 @@ class UmpleInternalParser
 	depend  java.util.stream.*;
 	
 	// prepare mixsets that are inside a state machine. 
-  private void analyzeMixsetDefinition(Token aToken , StateMachine stateMachine)
-  {
-  	aToken.addSubToken(new Token("entityName",stateMachine.getUmpleClass().getName()) ); 
-    aToken.addSubToken(new Token("entityType","class") );
- 
-    Token mixsetBodyToken = aToken.getSubToken("extraCode");
-    mixsetBodyToken.setValue(" "+stateMachine.getName()+" { "+mixsetBodyToken.getValue() +" } ");
+  private void analyzeMixsetDefinition(List<Token> tokenList , StateMachine stateMachine)
+  {  
+    if (tokenList.size() < 1)
+    return;
     
-    analyzeMixset(aToken);		
+    for(Token aToken : tokenList)
+    {
+      if(stateMachine.getUmpleClass().getName() == null)
+      return;
+      //otherwise
+     	analyzeMixsetBodyToken(aToken);
+    }  
+	}
+
+  private void analyzeMixsetBodyToken(Token token)
+	{
+	  Token mixsetBodyToken = token.getSubToken("extraCode");      
+    mixsetBodyToken.setValue(getMixsetFragmentWithEnclosingElement(token,mixsetBodyToken.getValue()));
+    analyzeMixset(token);
+	}
+	
+	// This method takes a mixset fragment and adds its context. 
+	private String getMixsetFragmentWithEnclosingElement(Token token, String mixsetBody)
+	{
+	  if (token.is("state"))
+	  mixsetBody = " "+ token.getValue("stateName") + " { " + mixsetBody + " } ";
+	  else if (token.is("inlineStateMachine"))
+	  mixsetBody = " "+ token.getValue("name") + " { " + mixsetBody + " } ";
+	  else if (token.is("classDefinition"))
+	  mixsetBody = " class "+ token.getValue("name") + " { " + mixsetBody + " } ";
+	  else if (token.is("ROOT") || token == null)
+	  return mixsetBody ;
+	 
+	 return getMixsetFragmentWithEnclosingElement(token.getParentToken(), mixsetBody) ;
+	  
+	
 	}
 	 
  // prepare mixsets that are inside an Umple class

--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -22,6 +22,7 @@ class UmpleInternalParser
   internal List<Token> stateNames = null;
   internal List<Token> transitionNames = null;
   internal List<Token> ignoredTransitions = new ArrayList<Token>();
+  internal List<Token> innerMixsetTokens = null;
   
   
   //------------------------
@@ -490,8 +491,14 @@ class UmpleInternalParser
                stateNames.add(subToken);
            if((subToken.is("transition")||subToken.is("autoTransition")) && subToken.getValue("stateName") != null)
                transitionNames.add(subToken);
+           if(subToken.is("mixsetDefinition"))
+           {
+             innerMixsetTokens.add(subToken); 
+             
+           }  
            if(subToken.hasSubTokens())
                checkUnclearTransition(subToken);
+               
        }       
    }
 
@@ -506,7 +513,9 @@ class UmpleInternalParser
     
     //Issue 531
     stateNames = new ArrayList<Token>();
-    transitionNames = new ArrayList<Token>();   
+    transitionNames = new ArrayList<Token>();
+    innerMixsetTokens = new ArrayList<Token>();   
+    
     checkUnclearTransition(stateMachineToken);
     for(Token transition : transitionNames){
         numberOfOcurrences = 0;
@@ -725,12 +734,9 @@ class UmpleInternalParser
       }
     }
     
-    Token mixsetToken = stateMachineToken.getSubToken("mixsetDefinition");
-    if(mixsetToken != null)
-    {
-      analyzeMixsetDefinition(mixsetToken, sm);
-    }
-
+    
+    analyzeMixsetDefinition(innerMixsetTokens, sm);
+ 
     return sm;
   }
 

--- a/cruise.umple/src/umple_state_machines.grammar
+++ b/cruise.umple/src/umple_state_machines.grammar
@@ -27,7 +27,7 @@ state : [=final]? [stateName] { [[stateInternal]]* }
 
 //Issue 547 and 148
 stateInternal-# : [[comment]] | [=changeType:+| - |- |*]? [[stateEntity]] | [[standAloneTransition]] |[**extraCode] 
-stateEntity- : [=-||] | [[entryOrExitAction]] | [[autoTransition]] | [[transition]] | [[activity]] | [[state]] | [[trace]] | ;
+stateEntity- : [=-||] | [[mixsetDefinition]] | [[entryOrExitAction]] | [[autoTransition]] | [[transition]] | [[activity]] | [[state]] | [[trace]] | ;
 
 autoTransition : [[activity]]? [[autoTransitionBlock]]
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -242,7 +242,7 @@ public class UmpleMixsetTest {
   }
 
  @Test
-  public void stateMachineStateHasMixset()
+  public void stateMachine_State_HasMixset()
   {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"stateMachineStateHasMixset.ump");
     UmpleModel model = new UmpleModel(umpleFile);
@@ -253,7 +253,21 @@ public class UmpleMixsetTest {
     Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getStates().size(),5);
     Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getAllTransitions().size(), 6);
 
-  }   
+  }
+
+  @Test
+  public void stateMachine_StateEntity_HasMixset()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"stateMachineTransitionHasMixset.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    Assert.assertEquals(umpleClasses.get(0).getName(),"Booking");
+    Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getStates().size(),5);
+    Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getAllTransitions().size(), 6);
+
+  }      
 
  
   		

--- a/cruise.umple/test/cruise/umple/compiler/mixset/stateMachineTransitionHasMixset.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/stateMachineTransitionHasMixset.ump
@@ -1,0 +1,25 @@
+class Booking {
+  state {
+    newBooking { 
+      assignSeat -> seatAssigned;
+      cancel -> cancelled;
+    }
+    seatAssigned {
+      cancel -> cancelled;
+      checkIn -> checkedIn;
+    }
+
+     
+      checkedIn {
+       mixset InnerMixset {  
+         cancel -> cancelled;
+         complete -> completed;
+       }
+  }
+    cancelled {}
+    completed {}
+  }
+}
+
+
+use InnerMixset;


### PR DESCRIPTION
The modifications here allow mixsets definition and use for inner parts of a state. Particularly, state machine's [[stateInternal]] in which [[transition]], [[activity]] etc can be used. The method getMixsetFragmentWithEnclosingElement(..) is used to correctly store a mixset fragment context in which the enclosing element such as umple class or state machine is added to the fragment. The mixset InnerMixset, which is mentioned in the test case, will have the following body after calling getMixsetFragmentWithEnclosingElement(..) :  
```
class Booking {
  state {
      checkedIn {
         cancel -> cancelled;
         complete -> completed;
       }
  }
```
instead of : 

```
  cancel -> cancelled;
  complete -> completed;
```
  
