### PR TITLE
Progress on #758 Activates PHP compilation of UmpleOnline and manual examples

### DIFF
--- a/UmpleToPhp/UmpleTLTemplates/association_SetOneToManyAssociationClass.ump
+++ b/UmpleToPhp/UmpleTLTemplates/association_SetOneToManyAssociationClass.ump
@@ -4,7 +4,7 @@ class UmpleToPhp {
   {
     $wasSet = false;
     <<# if (customSetPrefixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPrefixCode, "    ")); } #>>
-    if ($<<=gen.translate("parameterOne",av)>>.nil?)
+    if ($<<=gen.translate("parameterOne",av)>> === NULL)
     {
       <<# if (customSetPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "      ")); } #>>
       return wasSet;
@@ -16,7 +16,7 @@ class UmpleToPhp {
     {
       $<<=gen.translate("parameterExisting",av)>>-><<=gen.relatedTranslate("removeMethod",av)>>($this);
     }
-    if !$this-><<=gen.translate("associationOne",av)>>-><<=gen.relatedTranslate("addMethod",av)>>($this)
+    if (!$this-><<=gen.translate("associationOne",av)>>-><<=gen.relatedTranslate("addMethod",av)>>($this))
     {
       $this-><<=gen.translate("associationOne",av)>> = $<<=gen.translate("parameterExisting",av)>>;
       $wasSet = false;
@@ -27,6 +27,6 @@ class UmpleToPhp {
     }
     <<# if (customSetPostfixCode != null) { append(realSb, "\n{0}",GeneratorHelper.doIndent(customSetPostfixCode, "    ")); } #>>
     return $wasSet;
-  end
+  }
 !>>
 }

--- a/UmpleToPhp/UmpleTLTemplates/state_machine_Set.ump
+++ b/UmpleToPhp/UmpleTLTemplates/state_machine_Set.ump
@@ -95,7 +95,14 @@ class UmpleToPhp {
         hasExit = true;
         hasThisExit = true;
         isFirstExit = false;
-        exitActions.append("\n      " + action.getActionCode());
+        if(action.getActionCode() == null) //verify why it returns null
+        {
+          exitActions.append("\n      " + StringFormatter.format("$this->{0}(self::{1});", gen.translate("setMethod",sm), gen.translate("stateNull",sm)));
+        }
+        else
+        {
+          exitActions.append("\n      " + action.getActionCode());
+        }
       }
     }
   

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -226,6 +226,8 @@
       <exclude name="E0*.ump" />
       <exclude name="E1*.ump" />
       <exclude name="E2*.ump" />
+      <exclude name="E3*.ump" />
+      <exclude name="E4*.ump" />
       <exclude name="WE1xxIdentifierInvalid1.ump" />
       <exclude name="WE1xxIdentifierInvalid3.ump" />
       <exclude name="WE1xxIdentifierInvalid5.ump" />
@@ -354,6 +356,8 @@
       <exclude name="E0*.ump" />
       <exclude name="E1*.ump" />
       <exclude name="E2*.ump" />
+      <exclude name="E3*.ump" />
+      <exclude name="E4*.ump" />
       <exclude name="WE1xxIdentifierInvalid1.ump" />
       <exclude name="WE1xxIdentifierInvalid3.ump" />
       <exclude name="WE1xxIdentifierInvalid5.ump" />

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -45,7 +45,7 @@
       <try>
         <antcall target="doJava" />
         <!-- <antcall target="doCpp" />-->
-        <!--<antcall target="doPhp" />-->
+        <antcall target="doPhp" />
         <!--<antcall target="doRuby" />-->
       </try>
       

--- a/umpleonline/ump/manualexamples/HistoryStates1.ump
+++ b/umpleonline/ump/manualexamples/HistoryStates1.ump
@@ -28,3 +28,6 @@ class Machine {
     }
   }
 }
+
+// @@@skipphpcompile Php does not generate proper
+// history state code (see issue 1338)

--- a/umpleonline/ump/manualexamples/TracingAssociations1.ump
+++ b/umpleonline/ump/manualexamples/TracingAssociations1.ump
@@ -10,3 +10,5 @@ class Professor {
   
   trace supervisor;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/TracingAssociations2.ump
+++ b/umpleonline/ump/manualexamples/TracingAssociations2.ump
@@ -10,3 +10,5 @@ class Professor {
   
   trace add supervisor;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/TracingAssociations3.ump
+++ b/umpleonline/ump/manualexamples/TracingAssociations3.ump
@@ -10,3 +10,5 @@ class Professor {
   
   trace remove supervisor;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/TracingAttributes2.ump
+++ b/umpleonline/ump/manualexamples/TracingAttributes2.ump
@@ -4,3 +4,5 @@ class Student
   Integer id;
   trace get id;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/TracingAttributeswithConditions2.ump
+++ b/umpleonline/ump/manualexamples/TracingAttributeswithConditions2.ump
@@ -8,3 +8,5 @@ class Student
   trace name giving [name == "john"];
 }
 
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)
+

--- a/umpleonline/ump/manualexamples/TracingAttributeswithOccurrences2.ump
+++ b/umpleonline/ump/manualexamples/TracingAttributeswithOccurrences2.ump
@@ -8,3 +8,5 @@ class Student
   trace get name for 5;
 }
 
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)
+

--- a/umpleonline/ump/manualexamples/TracingStateMachines1.ump
+++ b/umpleonline/ump/manualexamples/TracingStateMachines1.ump
@@ -18,3 +18,5 @@ class LightBulb
   // report value of attribute v 
   trace exit Off record v;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/TracingStateMachines2.ump
+++ b/umpleonline/ump/manualexamples/TracingStateMachines2.ump
@@ -12,3 +12,5 @@ class LightBulb
   // trace any triggering of event flip
   trace flip;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/TracingStateMachines3.ump
+++ b/umpleonline/ump/manualexamples/TracingStateMachines3.ump
@@ -21,3 +21,5 @@ class GarageDoor
     // trace whole state machine
     trace status;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/W301TracingEntityNotFound1.ump
+++ b/umpleonline/ump/manualexamples/W301TracingEntityNotFound1.ump
@@ -6,3 +6,5 @@ class A {
   
   trace id;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/W301TracingEntityNotFound2.ump
+++ b/umpleonline/ump/manualexamples/W301TracingEntityNotFound2.ump
@@ -6,3 +6,5 @@ class A {
   
   trace identifier;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/W302TracerNotRecognized1.ump
+++ b/umpleonline/ump/manualexamples/W302TracerNotRecognized1.ump
@@ -7,3 +7,5 @@ class A {
   
   trace id;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)

--- a/umpleonline/ump/manualexamples/W302TracerNotRecognized2.ump
+++ b/umpleonline/ump/manualexamples/W302TracerNotRecognized2.ump
@@ -7,3 +7,5 @@ class A {
   
   trace id;
 }
+
+// @@@skipphpcompile See issue 596 (PHP tracing causes issues)


### PR DESCRIPTION
Activates PHP compilation for UO and manual examples.
Skips certain examples that cannot be compiled due to issues ([#596](https://github.com/umple/umple/issues/596) and [#1338](https://github.com/umple/umple/issues/1338)) and corrects some code generation relating to state machines and associations.

A full build takes a few more minutes to complete with PHP compilation activated.