### PR TITLE
Fixes #1341 Improper Java exception handling in main method corrected

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -402,7 +402,7 @@ for (StateMachine smq : uClass.getStateMachines())
   <<=uClass.getExtraCode()>>
   
 
-<<# } #>><<@ UmpleToJava.trace >><<#if(uClass!=mainMainClass){#>>
+<<# } #>><<@ UmpleToJava.trace >><<#if(model.getMainClassName() != uClass.getName()){#>>
 }<<#}
   return realSb.toString();
 }

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -402,11 +402,11 @@ for (StateMachine smq : uClass.getStateMachines())
   <<=uClass.getExtraCode()>>
   
 
-<<# } #>><<@ UmpleToJava.trace >><<#if(model.getMainClassName() != uClass.getName()){#>>
+<<# } #>><<@ UmpleToJava.trace >><<#if(model.getMainClass() == null || model.getMainClass().getName() != uClass.getName()){#>>
 }<<#}
   return realSb.toString();
 }
-#>><<@ UmpleToJava.uncaught_exception >><<#
+#>><<@ UmpleToJava.uncaught_exception >><<#}
 
 
 

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -81,17 +81,16 @@ class UmpleToJava {
           &&paramType.equals("String")&&isList.equals(" [] "))
         {
           String exceptionHandlerPackage = "";
-          if(mainMainClass!=null)
+          if(model.getMainClassName() != null)
           {
-            exceptionHandlerPackage = mainMainClass.getPackageName()+"."+mainMainClass.getName()+".";
+            exceptionHandlerPackage = model.getMainClassName()+".";
           }
           else
           {
-            mainMainClass = uClass;
+            model.setMainClassName(uClass.getName());
           }
           properMethodBody = "    Thread.currentThread().setUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+
                              "    Thread.setDefaultUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+properMethodBody;
-          uClass.setHasMainMethod(true);
         }
     
         if (aMethod.numberOfComments() > 0) { append(realSb, "\n\n  {0}", Comment.format("Method Javadoc",aMethod.getComments())); }

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -81,18 +81,21 @@ class UmpleToJava {
           &&paramType.equals("String")&&isList.equals(" [] "))
         {
           String exceptionHandlerPackage = "";
-          if(model.getMainClassName() != null)
+          if(model.getMainClass() != null)
           {
-            exceptionHandlerPackage = model.getMainClassName()+".";
+            if (model.getMainClass().getPackageName() != "")  exceptionHandlerPackage = model.getMainClass().getPackageName() + ".";
+            
+            exceptionHandlerPackage += model.getMainClass().getName()+".";
           }
           else
           {
-            model.setMainClassName(uClass.getName());
+            model.setMainClass(uClass);
           }
           properMethodBody = "    Thread.currentThread().setUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+
                              "    Thread.setDefaultUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+properMethodBody;
         }
-    
+        uClass.setHasMainMethod(true);
+        
         if (aMethod.numberOfComments() > 0) { append(realSb, "\n\n  {0}", Comment.format("Method Javadoc",aMethod.getComments())); }
         
         append(realSb,"\n");

--- a/UmpleToJava/UmpleTLTemplates/uncaught_exception.ump
+++ b/UmpleToJava/UmpleTLTemplates/uncaught_exception.ump
@@ -1,7 +1,6 @@
 class UmpleToJava {
     uncaught_exception <<!<</*uncaught_exception*/>><<#
 java.util.regex.Pattern lineNumberPattern = java.util.regex.Pattern.compile("// line ([0|1|2|3|4|5|6|7|8|9]*) \"(.*)\"");
-public static UmpleClass mainMainClass = null;
 private void addUncaughtExceptionVariables(int javaline, String code, String methodname)
 {
   String[] lines = code.split("\\n");

--- a/UmpleToJava/UmpleTLTemplates/uncaught_exception.ump
+++ b/UmpleToJava/UmpleTLTemplates/uncaught_exception.ump
@@ -31,8 +31,9 @@ private void addUncaughtExceptionVariables(String methodname, String filename, i
   uncaughtExceptions.get(methodname).addUncaughtJavaLine(javaline+1);
   uncaughtExceptions.get(methodname).addUncaughtLength(length);
 }
-public String getExceptionHandler(String exceptions) { 
-  StringBuilder realSb = new StringBuilder();#>>
+public String getExceptionHandler(String exceptions, UmpleClass uClass, UmpleModel model) { 
+  StringBuilder realSb = new StringBuilder();
+  if(model.getMainClass() != null && model.getMainClass().getName() == uClass.getName()){#>>
   public static class UmpleExceptionHandler implements Thread.UncaughtExceptionHandler
   {
     public void uncaughtException(Thread t, Throwable e)
@@ -148,8 +149,10 @@ public String getExceptionHandler(String exceptions) {
     public int size(){
       return umpleFileNames.length;
     }
-  } 
-}<<#
+  }
+}
+<<#
+  }
   return realSb.toString();
-}#>>!>>
+#>>!>>
 }

--- a/cruise.umple.eclipse/src/cruise/umple/ui/eclipse/UmpleAction.java
+++ b/cruise.umple.eclipse/src/cruise/umple/ui/eclipse/UmpleAction.java
@@ -60,7 +60,6 @@ public class UmpleAction implements IWorkbenchWindowActionDelegate
 	  boolean successfulCompilation;
 	    UmpleModel model;
 	    String pjName ;
-	    JavaClassGenerator.mainMainClass = null;
     try
     {
     	MessageConsole umpleConsole = findConsole("Umple Compile");

--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -125,7 +125,10 @@ class JavaGenerator
     
     if(mainClasses.size()>0)
     {
-      writeUncaughtExceptionFile(mainClasses.get(0));
+      for(UmpleClass uClass : mainClasses)
+      {
+        writeUncaughtExceptionFile(uClass);
+      }
     }
 	  if(getModel().getDistributed())
     {
@@ -3198,7 +3201,7 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
     file.mkdirs();
 
     BufferedWriter bw = new BufferedWriter(new FileWriter(filename,true));
-    String contents = new JavaClassGenerator().getExceptionHandler(uncaughtExceptions.toString());
+    String contents = new JavaClassGenerator().getExceptionHandler(uncaughtExceptions.toString(), aClass, getModel());
     getModel().getGeneratedCode().put(aClass.getName(),getModel().getGeneratedCode().get(aClass.getName())+contents);
     try
     {

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -50,6 +50,7 @@ class UmpleModel
   Glossary glossary = new Glossary();
   String defaultNamespace = null;
   String code = null;
+  String mainClassName = null;
   Boolean debugMode = false;
   ParseResult lastResult = null;
   public static final String[] validLanguages = findValidLanguages();

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -50,7 +50,7 @@ class UmpleModel
   Glossary glossary = new Glossary();
   String defaultNamespace = null;
   String code = null;
-  String mainClassName = null;
+  UmpleClass mainClass = null;
   Boolean debugMode = false;
   ParseResult lastResult = null;
   public static final String[] validLanguages = findValidLanguages();

--- a/cruise.umple/test/cruise/umple/implementation/DistributedClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/DistributedClassTest.java
@@ -173,11 +173,7 @@ public class DistributedClassTest extends TemplateTest
 
   @After
   public void tearDown() {
-	/* Nullify mainMainClass. It's a static variable, if we don't do this the state will
-	 * affect the next set of JUnit tests that use mainMainClass.
-	 */
 	super.tearDown();
-	JavaClassGenerator.mainMainClass = null;
   }	
 	
   @Test

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated.java.txt
@@ -146,5 +146,5 @@ public class Mentor
     public int size(){
       return umpleFileNames.length;
     }
-  } 
+  }
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.java.txt
@@ -27,8 +27,8 @@ public class Mentor
 
   // line 13 "ClassTemplateTest_Generated5.ump"
    public static  void main(String [] args){
-    Thread.currentThread().setUncaughtExceptionHandler(new Student.UmpleExceptionHandler());
-    Thread.setDefaultUncaughtExceptionHandler(new Student.UmpleExceptionHandler());
+    Thread.currentThread().setUncaughtExceptionHandler(new example.Student.UmpleExceptionHandler());
+    Thread.setDefaultUncaughtExceptionHandler(new example.Student.UmpleExceptionHandler());
     /* Class Teacher main */
   }
 

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.java.txt
@@ -1,0 +1,35 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+package example;
+
+// line 9 "ClassTemplateTest_Generated5.ump"
+public class Mentor
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Mentor()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+  // line 13 "ClassTemplateTest_Generated5.ump"
+   public static  void main(String [] args){
+    Thread.currentThread().setUncaughtExceptionHandler(new Student.UmpleExceptionHandler());
+    Thread.setDefaultUncaughtExceptionHandler(new Student.UmpleExceptionHandler());
+    /* Class Teacher main */
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.ump
@@ -2,7 +2,7 @@ namespace example;
 
 class Student
 {
-  public static void main(String[] args)
+  public static void main(String[] args)
   {
     /* Class Student main */
   }

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Generated5.ump
@@ -1,0 +1,17 @@
+namespace example;
+
+class Student
+{
+  public static void main(String[] args)
+  {
+    /* Class Student main */
+  }
+}
+
+class Mentor
+{
+  public static void main(String[] args)
+  {
+    /* Class Teacher main */
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaClassTemplateTest.java
@@ -146,6 +146,7 @@ public class JavaClassTemplateTest extends ClassTemplateTest
 	 * and that the correct threading code is generated when "public static void main(String[] args)" is specified
 	 */
     assertUmpleTemplateFor("java/ClassTemplateTest_Generated.ump","java/ClassTemplateTest_Generated.java.txt","Mentor");
+    assertUmpleTemplateFor("java/ClassTemplateTest_Generated5.ump", "java/ClassTemplateTest_Generated5.java.txt", "Mentor");
     /*
      *  Check that a "main" function (in the Java sense) is only detected (and accompanying threading code generated)
      *  when a function matches the "public static void main(String[] args)" format exactly.
@@ -155,8 +156,6 @@ public class JavaClassTemplateTest extends ClassTemplateTest
     
     // Check that void is not added twice if the user explicitly includes it in the .ump file
     assertUmpleTemplateFor("java/ClassTemplateTest_Generated3.ump","java/ClassTemplateTest_Generated3.java.txt","Mentor");
-
-    
   }
   
   @Test

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestParseValidation.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestParseValidation.java
@@ -52,8 +52,6 @@ public class TestParseValidation {
 		if (!(new File(checkFile).exists())) { 
 			Assert.fail("Unable to locate umple file: " + checkFile);
 		}
-		// Nullify mainMainClass
-		JavaClassGenerator.mainMainClass = null;
 		UmpleFile umpFile = new UmpleFile(getPath());
 		umpleModel = new UmpleModel(umpFile);
 	}

--- a/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
+++ b/cruise.umple/test/cruise/umple/test/harness/resource/TestResource.java
@@ -89,8 +89,6 @@ public class TestResource {
 			}
 		}
 		
-		// Nullify mainMainClass
-		JavaClassGenerator.mainMainClass = null;
 		UmpleFile umpFile = new UmpleFile(getPath(), getModelFilename());
 		umpleModel = new UmpleModel(umpFile);
 		umpleModel.setShouldGenerate(false);
@@ -236,8 +234,6 @@ public class TestResource {
 				SampleFileWriter.destroy(filePath);
 			}
 		}
-		// Nullify mainMainClass
-		JavaClassGenerator.mainMainClass = null;
 	}
 
 	public void setPath(String aPath) {


### PR DESCRIPTION
UmpleModel was modified to add a reference to the class in the model containing the exception handling classes (used to replace a previous static variable that created erroneous results when adding a main method in UmpleOnline or when using more than one main method in an Umple file when using the command line tool). A test was added.