### PR TITLE
Reverts a modification relating to Java main methods made in PR 1347

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -93,8 +93,8 @@ class UmpleToJava {
           }
           properMethodBody = "    Thread.currentThread().setUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+
                              "    Thread.setDefaultUncaughtExceptionHandler(new "+exceptionHandlerPackage+"UmpleExceptionHandler());\n"+properMethodBody;
+          uClass.setHasMainMethod(true);
         }
-        uClass.setHasMainMethod(true);
         
         if (aMethod.numberOfComments() > 0) { append(realSb, "\n\n  {0}", Comment.format("Method Javadoc",aMethod.getComments())); }
         


### PR DESCRIPTION
Reverts a line modification made in PR 1347. The modification did not seem to cause an issue but the logic was off.