### PR TITLE
Fixes #1327. Makes runtime errors with a string constant parsable

### DIFF
--- a/cruise.umple/src/Generator_SuperCodeGenerator.ump
+++ b/cruise.umple/src/Generator_SuperCodeGenerator.ump
@@ -455,7 +455,10 @@ class SuperCodeGenerator {
       if(constructor.getNumberOfElements()>0)
       {
         constraintWithinConstructor = true;
-        String expr = getExpr(constructor);
+        String expr_generated = getExpr(constructor);	
+		//expr and expr_no_quotes are needed to adjust the format of the Error message we generated(expr_generated)
+		String expr_no_quotes = expr_generated.replace("\"","");
+		String expr = expr_no_quotes.replace("object","");
         constructor.negate();
         String inject = StringFormatter.format(ConstraintLookupMap.get("exception"),getNamedNames(constructor) + " [" + expr + "]");
         String ifstatement = translate("Closed",constructor);

--- a/cruise.umple/src/Generator_SuperCodeGenerator.ump
+++ b/cruise.umple/src/Generator_SuperCodeGenerator.ump
@@ -457,7 +457,7 @@ class SuperCodeGenerator {
         constraintWithinConstructor = true;
         String expr_generated = getExpr(constructor);	
 		//expr and expr_no_quotes are needed to adjust the format of the Error message we generated(expr_generated)
-		String expr_no_quotes = expr_generated.replace("\"","");
+		String expr_no_quotes = expr_generated.replace("\"","\\\"");
 		String expr = expr_no_quotes.replace("object","");
         constructor.negate();
         String inject = StringFormatter.format(ConstraintLookupMap.get("exception"),getNamedNames(constructor) + " [" + expr + "]");

--- a/cruise.umple/test/cruise/umple/compiler/701_ConstraintComparisonWithConstant.ump
+++ b/cruise.umple/test/cruise/umple/compiler/701_ConstraintComparisonWithConstant.ump
@@ -1,0 +1,5 @@
+//expect this to throw an error 
+class X {
+  String s1;
+  [s1 != "cat"] // Constant comparisons
+}

--- a/cruise.umple/test/cruise/umple/compiler/ConstraintX.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/ConstraintX.java.txt
@@ -1,0 +1,62 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
+
+
+
+/**
+ * expect this to throw an error
+ */
+// line 2 "701_ConstraintComparisonWithConstant.ump"
+public class X
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //X Attributes
+  private String s1;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public X(String aS1)
+  {
+    s1 = aS1;
+    if ("cat".equals(aS1))
+    {
+      throw new RuntimeException("Please provide a valid s1 [\"cat\"!=s1]");
+    }
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public boolean setS1(String aS1)
+  {
+    boolean wasSet = false;
+    if (!"cat".equals(aS1))
+    {
+    s1 = aS1;
+    wasSet = true;
+    }
+    return wasSet;
+  }
+
+  public String getS1()
+  {
+    return s1;
+  }
+
+  public void delete()
+  {}
+
+
+  public String toString()
+  {
+    return super.toString() + "["+
+            "s1" + ":" + getS1()+ "]";
+  }
+}

--- a/cruise.umple/test/cruise/umple/compiler/ConstraintX.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/ConstraintX.java.txt
@@ -26,7 +26,7 @@ public class X
     s1 = aS1;
     if ("cat".equals(aS1))
     {
-      throw new RuntimeException("Please provide a valid s1 [cat!=s1]");
+      throw new RuntimeException("Please provide a valid s1 [\"cat\"!=s1]");
     }
   }
 

--- a/cruise.umple/test/cruise/umple/compiler/ConstraintX.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/ConstraintX.java.txt
@@ -26,7 +26,7 @@ public class X
     s1 = aS1;
     if ("cat".equals(aS1))
     {
-      throw new RuntimeException("Please provide a valid s1 [\"cat\"!=s1]");
+      throw new RuntimeException("Please provide a valid s1 [cat!=s1]");
     }
   }
 

--- a/cruise.umple/test/cruise/umple/compiler/JavaGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/JavaGeneratorTest.java
@@ -1314,7 +1314,8 @@ public class JavaGeneratorTest
   
   @Test
   /*
-  PAIN
+  Checks that if constraint contains string constant, double quotes are escaped in error messages. Otherwise, generated code does not compile.
+  Bug #1327
   */
   public void constraintComparisonWithConstant()
   {	
@@ -1323,7 +1324,7 @@ public class JavaGeneratorTest
     model.run();
     String actual = model.getGeneratedCode().get("X");
     File generatedFile = new File(pathToInput+"X.java");
-    //generatedFile.delete();
+    generatedFile.delete();
     File expected = new File(pathToInput + "ConstraintX.java.txt");
     SampleFileWriter.assertFileContent(expected, actual,false);
   }

--- a/cruise.umple/test/cruise/umple/compiler/JavaGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/JavaGeneratorTest.java
@@ -1312,6 +1312,23 @@ public class JavaGeneratorTest
     Assert.assertEquals(1,nestedSm2.numberOfStates());
   }  
   
+  @Test
+  /*
+  PAIN
+  */
+  public void constraintComparisonWithConstant()
+  {	
+	String pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/");
+    model = createModelFromFile(pathToInput, "701_ConstraintComparisonWithConstant.ump");
+    model.run();
+    String actual = model.getGeneratedCode().get("X");
+    File generatedFile = new File(pathToInput+"X.java");
+    //generatedFile.delete();
+    File expected = new File(pathToInput + "ConstraintX.java.txt");
+    SampleFileWriter.assertFileContent(expected, actual,false);
+  }
+  
+  
   private void assertOtherTranslate(UmpleClass c, AssociationVariable av)
   {
     Assert.assertEquals("UNKNOWN ID: blah", generator.relatedTranslate("blah", av));


### PR DESCRIPTION
If constraint included a string constant, generated Java was returning an error. Now the String we are passing as an error message escapes double quotes and does not contain "object" word.