### PR TITLE
Fixes #1371 Date initialization validation correction and error message fix in UmpleOnline

### DIFF
--- a/UmpleParser/src/ParseUtilities_Code.ump
+++ b/UmpleParser/src/ParseUtilities_Code.ump
@@ -394,7 +394,7 @@ class ParseResult
       ret += "\"url\" : \"" + url + "\", ";
       ret += "\"line\" : \"" + line + "\", ";
       ret += "\"filename\" : \"" + file + "\", ";
-      ret += "\"message\" : \"" + message + "\"},";
+      ret += "\"message\" : \"" + message.replace("\"", "\'") + "\"},";
       hasOne = true;
     }
 
@@ -433,7 +433,8 @@ class ErrorMessage
     String sev = errorType.getSeverity() <= 2 ? "Error" : "Warning";
     String err = sev + " " + errorType.getErrorCode() + " on line " + this.position.getLineNumber();
     err += " of file \"" + stripLeadingPath(this.position.getFilename()) + "\":\n";
-    return  err + errorType.format(this.parameters);
+    err += errorType.format(this.parameters);
+    return err.replace("\"", "\'");    
   }
 
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -4417,12 +4417,16 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 	setFailedPosition(attributeToken.getPosition(), 142, name, type);
       }
     }
+
+    boolean isList = attributeToken.getValue("list") != null;
         
     if(type != null && value != null)
     {
-      if(!compareTypeToValue(type,value))
-      {
-        setFailedPosition(attributeToken.getPosition(),141,type,value);  
+      if (!isList) { // will check list initializer later
+        if(!compareTypeToValue(type,value))
+        {
+          setFailedPosition(attributeToken.getPosition(),141,type,value);  
+        }
       }
     }
     else if (type == null && value != null)
@@ -4447,7 +4451,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     attribute.setIsUnique(isUnique);
     attribute.setIsLazy(isLazy);
 	attribute.setIsIvar(isIvar);
-    boolean isList = attributeToken.getValue("list") != null;
 
     if (name == null)
     {
@@ -5005,7 +5008,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     {
       inferredType = "Boolean";
     }
-    else if(value.matches("\"\\d{4}-[0-3][0-9]-[0-1][0-9]\""))
+    else if(value.matches("\"\\d{4}-[0-1][0-9]-[0-3][0-9]\""))
     {
       inferredType="Date";
     }

--- a/cruise.umple/test/cruise/umple/compiler/ParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/ParserTest.java
@@ -2090,12 +2090,12 @@ public class ParserTest
 
 	  ErrorMessage em = new ErrorMessage(1002, new Position("filename",0,0,0), "zero", "one");
 
-	  Assert.assertEquals("Warning 1002 on line 0 of file \"filename\":\nThis is a test error zero, one", em.toString());
+	  Assert.assertEquals("Warning 1002 on line 0 of file \'filename\':\nThis is a test error zero, one", em.toString());
 	  
 
 	  ets.addErrorType(new ErrorType(1003, 2, "This is a test error {0}, {1}", "url"));	  
 	  em = new ErrorMessage(1003, new Position("filename",0,0,0), "zero", "one");
-  	  Assert.assertEquals("Error 1003 on line 0 of file \"filename\":\nThis is a test error zero, one",em.toString());
+  	  Assert.assertEquals("Error 1003 on line 0 of file \'filename\':\nThis is a test error zero, one",em.toString());
 
   }
   @Test 
@@ -2112,7 +2112,7 @@ public class ParserTest
 	  pr.addErrorMessage(new ErrorMessage(1002, new Position("file1",0,0,0), " \\' "));
 	  pr.addErrorMessage(new ErrorMessage(1002, new Position("file2",0,0,0), " \" "));
 	  
-	  Assert.assertEquals("{ \"results\" : [ { \"errorCode\" : \"1002\", \"severity\" : \"5\", \"url\" : \"url\", \"line\" : \"0\", \"filename\" : \"file1\", \"message\" : \"Test \\\" \\\\' \\\"\"},{ \"errorCode\" : \"1002\", \"severity\" : \"5\", \"url\" : \"url\", \"line\" : \"0\", \"filename\" : \"file2\", \"message\" : \"Test \\\" \\\" \\\"\"}]}",pr.toJSON());
+	  Assert.assertEquals("{ \"results\" : [ { \"errorCode\" : \"1002\", \"severity\" : \"5\", \"url\" : \"url\", \"line\" : \"0\", \"filename\" : \"file1\", \"message\" : \"Test \\\' \\\\' \\\'\"},{ \"errorCode\" : \"1002\", \"severity\" : \"5\", \"url\" : \"url\", \"line\" : \"0\", \"filename\" : \"file2\", \"message\" : \"Test \\\' \\\' \\\'\"}]}",pr.toJSON());
   }
   
   @Test

--- a/cruise.umple/test/cruise/umple/stats/MetricsCollectorTest.java
+++ b/cruise.umple/test/cruise/umple/stats/MetricsCollectorTest.java
@@ -128,7 +128,7 @@ public class MetricsCollectorTest
     String[] logs = collector.getLogs();
     
     Assert.assertEquals(1,logs.length);
-    Assert.assertEquals("Error 1510 on line 1 of file \"unknown.ump\":\nFile 'unknown.ump' referred to in use statement was not found\n: unknown.ump", logs[0]);
+    Assert.assertEquals("Error 1510 on line 1 of file \'unknown.ump\':\nFile 'unknown.ump' referred to in use statement was not found\n: unknown.ump", logs[0]);
   }
   
 }

--- a/testbed/test/cruise/compiler/expected/Abstract_Method.txt
+++ b/testbed/test/cruise/compiler/expected/Abstract_Method.txt
@@ -1,4 +1,4 @@
-Warning 1008 on line 6 of file "Abstract_Method.ump":
+Warning 1008 on line 6 of file 'Abstract_Method.ump':
 Method syntax could not be processed. It has been considered as Extra Code
 Abstract_Method.ump:6: error: abstract methods cannot have a body
   abstract void foo () 

--- a/testbed/test/cruise/compiler/expected/Constructor.txt
+++ b/testbed/test/cruise/compiler/expected/Constructor.txt
@@ -1,4 +1,4 @@
-Warning 170 on line 8 of file "Constructor.ump":
+Warning 170 on line 8 of file 'Constructor.ump':
 Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.
 Constructor.ump:13: error: incompatible types: String cannot be converted to int
         a = s;

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -494,7 +494,7 @@ function getErrorHtml($errorFilename, $offset = 1)
      
      if($errInfo == null)
      {
-        $errhtml .= "Couldn't read results from the Umple compiler!";
+        $errhtml .= "Couldn't read results from the Umple compiler!<br><pre>".$errorMessage."</pre>";
      }
      else
      {


### PR DESCRIPTION
Fixes #1371 - Dates were validated against yyyy-dd-mm when they were supposed to being validated against yyyy-mm-dd during initialization of attributes. Also this exposed an error in error message output, where double quotes were causing error messages to not be displayed in UmpleOnline when running with certain versions of php due to variations in the json parsing functions. This has been fixed here too.