### PR TITLE
Prep for #1374 Captions and Videos

### DIFF
--- a/build/reference/3001basicStateMachines.txt
+++ b/build/reference/3001basicStateMachines.txt
@@ -33,22 +33,24 @@ Details of each state can include:
 
 <p>Note that, in addition, you can specify code to be executed whenever an event is processed by using <a href="CodeInjectioninEventMethods.html">before or after directives.</a></p>
 
-<p>The following diagram shows a garage door state machine as a UML diagram. The Umple code for this is at the bottom of this page. Note that UmpleOnline currently cannot draw state machines.
+<p>The following diagram shows a garage door state machine as a UML diagram. The Umple code for this is in the second example shown, and is further explained in the video below. <br/> &nbsp; <br/>
 
 <img  width=480 src="examples/GarageStateMachine.png" alt="state machne for garage door"/>
 
 &nbsp;<br/>
+
+@@videoURL https://www.youtube.com/embed/mFczzVkTZ9g
 
 @@syntax
 
 [[stateMachine]] [[enum]] [[inlineStateMachine]] [[state]] [[stateInternal]] [[stateEntity]] [[transition]] [[entryOrExitAction]] [[autoTransition]] [[autoTransitionBlock]] [[activity]] [[guard]] [[eventDefinition]] [[eventWithArgs]] [[action]] [[afterEveryEvent]] [[afterEvent]]
 
 
-@@example
+@@example @@caption Basic Garage Door Example @@endcaption
 @@source manualexamples/BasicStateMachines1.ump &diagramtype=state
 @@endexample
 
 
-@@example
+@@example @@caption Garage Door Example with Actions @@endcaption
 @@source manualexamples/BasicStateMachines2.ump &diagramtype=state
 @@endexample

--- a/cruise.umple/src/Documenter.ump
+++ b/cruise.umple/src/Documenter.ump
@@ -54,11 +54,15 @@ class Content
 
   // Short samples of Umple code
   0..1 -> * ManualExample examples;
+  
+  // URL of Youtube Video (if any)
+  videoURL = null;
 }
 
 class ManualExample {
   text;
   url = "";
+  caption = ""; // If empty, then default caption will be used Example, Another Example
 }
 
 /*
@@ -96,6 +100,7 @@ class Template
   const HtmlTemplate = htmlTemplate();
   const ExampleTemplate = exampleTemplate();
   const SyntaxTemplate = syntaxTemplate();
+  const VideoURLTemplate = videoURLTemplate();  
   const NavigationHeaderTemplate = navigationHeaderTemplate();
   const NavigationItemTemplate = navigationItemTemplate();
   const NavigationItemTemplateNoAnchor = navigationItemTemplateNoAnchor();

--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -323,6 +323,18 @@ class Documenter
         "<span class=\"notranslate\" translate=\"no\">" +
         syntaxHtml+ "</span>");
     }
+
+    if (selectedContent.getVideoURL() == null)
+    {
+      htmlOutput = htmlOutput.replace("@@VIDEOURL@@", "");
+    }
+    else
+    {
+      String videoURLHtml = Template.VideoURLTemplate.replace("@@VIDEO_URL@@",selectedContent.getVideoURL());
+      htmlOutput = htmlOutput.replace("@@VIDEOURL@@", 
+        "<span class=\"notranslate\" translate=\"no\">" +
+        videoURLHtml+ "</span>");
+    }
     
     String exampleOutput = "";
     for (ManualExample manualExample : selectedContent.getExamples())
@@ -330,7 +342,14 @@ class Documenter
       String example = manualExample.getText();
       String url = manualExample.getUrl();
       String nextExample = Template.ExampleTemplate;
-      String exampleHeader = exampleOutput.length() == 0 ? "Example" : "Another Example";
+      String caption = manualExample.getCaption();
+      String exampleHeader = "";
+      if(caption != null && !caption.equals("")) {
+        exampleHeader = caption;
+      }
+      else {
+        exampleHeader = exampleOutput.length() == 0 ? "Example" : "Another Example";
+      }
       nextExample = nextExample.replace("@@EXAMPLE_NUMBER@@",exampleHeader);
       
       endOfExampleBeforePosition = example.indexOf("//$?[End_of_model]$?");
@@ -443,8 +462,8 @@ class ContentParser
   private int init()
   {
     addRule("groupOrder : ( [**group] ; )*");
-    addRule("content : [*title] [*group] [=noreferences]? @@description [**description] (@@syntax [**syntax])? [[example]]* @@Filename [*filename]");
-    addRule("example- : @@example [**example] @@endexample");
+    addRule("content : [*title] [*group] [=noreferences]? @@description [**description] (@@videoURL [**videoURL])? (@@syntax [**syntax])? [[example]]* @@Filename [*filename]");
+    addRule("example- : @@example ( @@caption [**caption] @@endcaption )? [**example] @@endexample");
     init += 1;
     return init;
   }
@@ -472,11 +491,15 @@ class ContentParser
         Group g = getGroup(t.getValue("group"));
         Content content = new Content(t.getValue("title"), t.getValue("description"), t.getValue("syntax"), t.getValue("filename"));
         
+        if(t.getValue("videoURL") != null) {
+          content.setVideoURL(t.getValue("videoURL"));
+        }
+        
         if (t.getValue("noreferences") != null)
         {
           content.setShouldIncludeReferences(false);
         }
-        
+        ManualExample newEx = null;
         for (Token exampleToken : t.getSubTokens())
         {
           if (exampleToken.is("example"))
@@ -502,9 +525,20 @@ class ContentParser
                   +exampleText.substring(9).trim();
               }
             }
-            ManualExample newEx = new ManualExample(exampleText);
+            // If we have an example without finding a caption first, then create a plain example
+            if(newEx == null) {
+              newEx = new ManualExample(exampleText);
+            }
+            else {
+              newEx.setText(exampleText);
+            }
             newEx.setUrl(exampleURL);
             content.addExample(newEx);
+            newEx = null; // any subsequent caption or example starts a new example
+          }
+          else if (exampleToken.is("caption")) {
+            newEx = new ManualExample(""); // Empty for now pending finding example token
+            newEx.setCaption(exampleToken.getValue());
           }
         }
         g.addContent(content);
@@ -569,6 +603,18 @@ class Template
         "" + "\n";
     return template;
   }
+  
+  private static String videoURLTemplate()
+  {
+    String template = "" +
+ "      <h3>YouTube Video with Additional Explanation</h3>" + "\n" +     
+      "  <iframe width=\"560\" height=\"315\"\n"+
+      "     src=\"@@VIDEO_URL@@?rel=0\" frameborder=\"0\"\n"+
+      "     allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>\n" +
+      "&nbsp; <br/> &nbsp; <br/>" + "\n";
+    return template;
+  }  
+  
 
   private static String htmlTemplate()
   {
@@ -696,6 +742,7 @@ class Template
         "      <p class=\"description\">@@DESCRIPTION@@</p>" + "\n" +
         "" + "\n" +
         "@@EXAMPLE@@" + "\n" +
+        "@@VIDEOURL@@" + "\n" +
         "@@SYNTAX@@" + "\n";
     return template;
   }


### PR DESCRIPTION
This adds syntax to user manual page domain-specific language to allow examples to have captions. After the @@example keyword add @@caption Put the Caption Here @@endcaption. 

This also adds syntax to allow embedding YouTube videos in manual pages. Just specify @@videoURL with the URL following. This goes before the @@syntax (if present).

The Basic  State Machines page has been updated with both of these features. Issue #1374 can be completed later by applying the new syntax to other manual pages.