### PR TITLE
Umple Release 1.29.1

### DIFF
--- a/build/umpleversion.last.txt
+++ b/build/umpleversion.last.txt
@@ -1,1 +1,1 @@
-version :   1.29.0.4179.f58ce0d5e
+version :   1.29.1.4260.b21abf3a3

--- a/build/umpleversion.txt
+++ b/build/umpleversion.txt
@@ -1,1 +1,1 @@
-version : 1.29.0
+version : 1.29.1


### PR DESCRIPTION
Release notes for Umple release 1.29.1

This release includes all updates to Umple From September 2018, including:

Bug fixes including several glitches in Umpleonline, in date initialization, and in constraint code generation.

Support for nested generic types in attributes.

Improvements to NuXMV generation.

Updates to the user manual to allow embedding of YouTube videos (three are so far embedded), and labelling of examples. Additional details have also been added for sections describing 1-1 associations and code injection for custom code.

See
https://github.com/umple/umple/milestone/5?closed=1 for the pull requests completed in this milestone release

The umple-n.n.n-rrrr-hhhhhhhh,jar is the command line compiler
When you do a build a symbolic link is made on linux and mac calling this umple.jar in the dist directory. The hhhhhhhh is the git commit, and the rrrr is an incrementing count of the numer of commits to master.

For the latest Eclipse Plugin see
https://github.com/umple/umple/wiki/InstallEclipsePlugin
(usually released a day after each main release)

When you build Umple, you will also generate other jars including umpledocs, to create the user manual; umplerun, a special tool for simulation, umplesync, an an extended compiler used by Umpleonline.

For details on how to install see http://dl.umple.org

See also http://docker.umple.org for pre-built UmpleOnline environments you can run locally (Click on the Tags tab to see the available releases)