### PR TITLE
Adding ability to run internal server on custom port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ umpleonline/ump/tmp*
 build/UserManualAndExampleTests_output.txt
 umpleonline/manual
 umpleonline/countlog.txt
+umpleonline/scripts/specialPort.txt
 
 # generated Umple code that is not saved
 src-gen-umple/

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -745,7 +745,19 @@ class PlaygroundMain
       // Start server on port 5556 if in a test environment, otherwise use port 5555
       // Test environment means that the directory has 'test' in it
       int port = 5555;
-      if(System.getProperty("user.dir").contains("test")) {
+      File specialPort = new File(System.getProperty("user.dir")+File.separator+"specialPort.txt");
+      if(specialPort.exists()) {
+        try {
+          FileReader reader = new FileReader(specialPort);
+          BufferedReader in = new BufferedReader(reader);
+          port = Integer.parseInt(in.readLine());
+          in.close();
+        }
+        catch (IOException e) {
+          System.err.println("Could not read the contents of specialPort.txt. Should be a port number. Using 5555.");
+        } 
+      }
+      else if(System.getProperty("user.dir").contains("test")) {
         port = 5556;
       }
       
@@ -823,6 +835,10 @@ class PlaygroundMain
     else
     {
       // All other commands have filename at second argument
+      if(args.length == 1) {
+        System.err.println("Filename argument required after command. Quitting");
+        System.exit(1);
+      }
       String filename = args[1];
       umpleFile = new UmpleFile(filename);
       model = new UmpleModel(umpleFile);

--- a/umpleonline/scripts/UmpleServerTest.php
+++ b/umpleonline/scripts/UmpleServerTest.php
@@ -6,11 +6,7 @@
     exit(0);
   }
 
-  // run on port 5556 if in a directory with 'test' as a substring, otherwise use 5555
-  $portnumber = 5555;
-  if(strpos(getcwd(),"test") !== false) {
-    $portnumber = 5556;
-  }  
+  require_once ("setPortNumber.php");
   
   $argCount = 1;
   $commandLine = "";

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -738,12 +738,8 @@ function execRun($command) {
 function serverRun($commandLine,$rawcommand=null) {
 
   $originalCommandLine = $commandLine; // save in case we have to fall back to it
-  
-  // run on port 5556 if in a directory with 'test' as a substring, otherwise use 5555
-  $portnumber = 5555;
-  if(strpos(getcwd(),"test") !== false) {
-    $portnumber = 5556;
-  }
+
+  require_once ("setPortNumber.php");  
   
   // Some output is error output -- save to a file
   $errorFile = null;
@@ -807,7 +803,7 @@ function serverRun($commandLine,$rawcommand=null) {
     if ($output === FALSE) {
       @socket_close($theSocket);;
       // This usually happens at moments of overload; run as exec but give server much higher priority
-      execRun("nice -10 java -jar umplesync.jar ".$originalCommandLine);
+      execRun("nice -n 10 java -jar umplesync.jar ".$originalCommandLine);
       return;
     }
     if(strlen($output) == 0) {

--- a/umpleonline/scripts/log.php
+++ b/umpleonline/scripts/log.php
@@ -2,11 +2,7 @@
   // Calls log on the server for testing purposes
   // Also see UmpleServerTest.php for command line use
 
-  // run on port 5556 if in a directory with 'test' as a substring, otherwise use 5555
-  $portnumber = 5555;
-  if(strpos(getcwd(),"test") !== false) {
-    $portnumber = 5556;
-  }  
+  require_once ("setPortNumber.php"); 
 
   $commandLine = "-log";
 ?>

--- a/umpleonline/scripts/setPortNumber.php
+++ b/umpleonline/scripts/setPortNumber.php
@@ -1,0 +1,13 @@
+<?php
+  // run on port 5556 if in a directory with 'test' as a substring, otherwise use 5555
+  $portnumber = 5555;
+  $specialPortFile = getcwd()."/specialPort.txt";
+  if (file_exists($specialPortFile) && is_readable($specialPortFile) ) {
+    $specialPortOpenFile = fopen($specialPortFile, "r");
+    $portnumber = fgets($specialPortOpenFile,5);
+    fclose($specialPortOpenFile);
+  }
+  else if(strpos(getcwd(),"test") !== false) {
+    $portnumber = 5556;
+  }
+?>


### PR DESCRIPTION
Previously in UmpleOnline php would connects to the Java VM using port 5555 by default, or 5556 if the path had the word 'test' in it.

However there is a need to set up special branch testing servers, and so we need to be able to specify the port.

Following merging of this PR, if the file specialPort.txt exists in the umpleonline/scripts directory, it will be read to determine the port to use. If the file is not present the previous rules will still apply. The specialPort.txt file should simply contain as a string the port number to use, if a custom port is needed.