### PR TITLE
[ci skip] Making dev tools work with multiple clones

### DIFF
--- a/dev-tools/pumple
+++ b/dev-tools/pumple
@@ -6,5 +6,6 @@ cd $UMPLEROOT/build
 echo Copying jars from dist director to the umpleonline scripts directory
 echo Do this after qfbumple when resting umpleonline
 ant -DshouldPackageUmpleOnline=true -Dmyenv=local -f build.umple.xml packageUmpleonline
+cd $UMPLEROOT/umpleonline/scripts
 quitserver
 

--- a/dev-tools/quitserver
+++ b/dev-tools/quitserver
@@ -1,4 +1,7 @@
 #!/bin/csh -fb
-echo Quitting any umpleonline server that is running
-cd ~/umple/umpleonline/scripts
+if ! $?UMPLEROOT then
+  setenv UMPLEROOT ~/umple
+endif
+echo Quitting any umpleonline server that is running in $UMPLEROOT/umpleonline/scripts
+cd $UMPLEROOT/umpleonline/scripts
 php UmpleServerTest.php server -quit 


### PR DESCRIPTION
A couple of the dev-tool scripts weren't designed so they could work with multiple different clones. This checks UMPLE_ROOT and allows these to work in different clones. This allows controlling multiple internal servers.