### PR TITLE
Deleting files leftover from #1405 #552

### DIFF
--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -89,6 +89,8 @@ public class TemplateTest
     SampleFileWriter.destroy(pathToInput + "/Light.php");
     SampleFileWriter.destroy(pathToInput + "/LightFixture.php");
     SampleFileWriter.destroy(pathToInput + "/LightFixture.java");
+    SampleFileWriter.destroy(pathToInput + "/Window.php");
+    SampleFileWriter.destroy(pathToInput + "/Window.java");    
     SampleFileWriter.destroy(pathToInput + "/A_Guard.php");
     SampleFileWriter.destroy(pathToInput + "/B.php");
     


### PR DESCRIPTION
Deleting two files that were generated during testing by PR #1405 (fixing issue #552). These were being left around and were causing problems with subsequent builds.