### PR TITLE
Long path install

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -222,10 +222,12 @@ else if (isset($_REQUEST["umpleCode"]))
        }
        // exec("cd $uigu2dir; ln -s ../../scripts/uigu2/app .");    
        $uigu2file = $workDir->makePermalink('index.php');
-       $html = "{$errhtml}
+       // DEBUG - to display as a link Uncomment the following line, and comment out the subsequent 4
+       //  $html = "{$errhtml} <b> <a target=\"otherone\" href=\"" . $uigu2file . "\">$uigu2file</a> </b>";  
+       $html = "{$errhtml} 
       <iframe width=100% height=1000 src=\"" . $uigu2file . "\">This browser does not
       support iframes, so the uigu cannot be displayed</iframe> 
-     ";
+      ";
        echo $html;
     }
     else {

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -166,9 +166,13 @@ class WorkDir{
     Could be used to upload to a dedicated fileserver.
     */
     function makePermalink($path){
-        // assumes the server root is umpleonline/
-        $localpath = $this->root.'/'.$path;
-        $serverpath = substr($localpath, strlen(rootDir()));
+        // assumes the server root is not just umpleonline/
+        $umpsubdirStart = strpos($this->root,"/ump/");
+        $umpsubdir=substr($this->root,$umpsubdirStart);
+        $theURI = $_SERVER['REQUEST_URI'];
+        $choppoint= strlen($theURI)-strlen("/scripts/compiler.php");
+        $serverroot = substr($theURI, 1, $choppoint-1);
+        $serverpath ="/".$serverroot.$umpsubdir."/".$path;
         return $serverpath;
     }
 }

--- a/umpleonline/scripts/uigu2/setup.php
+++ b/umpleonline/scripts/uigu2/setup.php
@@ -11,8 +11,10 @@ define('WEB_DOMAIN_ROOT','http://'.$actualpath);
  *relative to the <DocumentRoot> element of the apache config file 
  *eg.  if <DocumentRoot> is '/var/www/' and the full path is '/var/www/a/b/index.php'
  *use '/a/' (with trailing slash) */
-define('WEB_FOLDER_ROOT','/ump/');
-
+$pathStart=strpos($actualpath,"/umpleonline/");
+$wfr=substr($actualpath,$pathStart);
+define('WEB_FOLDER_ROOT',$wfr);
 define('APP_PATH','app/');
 define('VIEW_PATH',APP_PATH.'views/');
 define('CONTROLLER_PATH',APP_PATH.'controllers/');
+

--- a/umpleonline/scripts/uigu2/setup.php
+++ b/umpleonline/scripts/uigu2/setup.php
@@ -3,8 +3,10 @@
 /*EDIT BELOW: parent URL of the folder where index.php is located
  *eg. to access 'http://a/b/c/index.php', use 'http://a/b/' (with trailing slash) */
 //define('WEB_DOMAIN_ROOT','http://default/');
-define('WEB_DOMAIN_ROOT','http://'.$_SERVER['SERVER_NAME'].'/ump/');
-
+$webPrefix = $_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"];
+$cutoff=strpos($webPrefix,"/ump/");
+$actualpath=substr($webPrefix,0,$cutoff+5);
+define('WEB_DOMAIN_ROOT','http://'.$actualpath);
 /*EDIT BELOW: parent path of the folder where index.php is located,
  *relative to the <DocumentRoot> element of the apache config file 
  *eg.  if <DocumentRoot> is '/var/www/' and the full path is '/var/www/a/b/index.php'


### PR DESCRIPTION
This PR ensures that if UmpleOnline is installed on a server in a directory whose root is something like /umpleonline/2/ it will work. Prior to this it only worked properly if installed as /umpleonline/

The bugs were in downloading zip files and opening the CRUD (uigu2) directory.