### PR TITLE
Improve CRUD interface. Replace pulldown with buttons when selecting a class

### DIFF
--- a/cruise.umple/src/Generator_CodeUigu2.ump
+++ b/cruise.umple/src/Generator_CodeUigu2.ump
@@ -247,8 +247,13 @@ class Uigu2ElementGenerator
       String[] constructorParams = constructorSignature.split(", ");
       for(int i = 0; i < constructorParams.length; i++){
         //"$aAttributeName" => "attributeName"
+        //"$allAttributeName" => "attributeName"
         String param = constructorParams[i];
-        param = Character.toLowerCase(param.charAt(2)) + param.substring(3); 
+        if(param.startsWith("$all")) {
+          param = Character.toLowerCase(param.charAt(4)) + param.substring(5);
+        } else {
+          param = Character.toLowerCase(param.charAt(2)) + param.substring(3); 
+        }
         code.append("$constructor_params[] = '" + param + "';").append(NL);
       }
     }

--- a/umpleonline/scripts/uigu2/app/controllers/main/index.php
+++ b/umpleonline/scripts/uigu2/app/controllers/main/index.php
@@ -1,6 +1,64 @@
 <?php
 function _index($controller) {
   $element_names = $controller->get_element_names();
+  
+  $numbers_of_elements = NULL;
+  if(isset($element_names) && is_array($element_names)) {
+  	$numbers_of_elements = array();
+  	foreach($element_names as $e){
+  		$instances = $controller->get_objects($e);
+  		if(empty($instances)) {
+  			$numbers_of_elements[$e] = 0;
+  		} else {
+  			$numbers_of_elements[$e] = count($instances);
+  		}
+    }
+  }
+
   $messages = $controller->get_messages_clear();
-  $controller->get_view()->show($element_names, $messages);
+
+  $instantiatable_info = NULL;
+  if(isset($element_names) && is_array($element_names)) {
+    $instantiatable_info = array();
+    foreach($element_names as $e){
+      if(can_instantiate($controller, $e)) {
+        $instantiatable_info[$e] = true;
+      } else {
+        $instantiatable_info[$e] = false;
+      }
+    }
+  }
+
+  $layout_parameter_map = array('element_names' => $element_names,
+                                'numbers_of_elements' => $numbers_of_elements,
+                                'messages' => $messages,
+                                'instantiatable_info' => $instantiatable_info);
+
+  $controller->get_view()->show_layout($layout_parameter_map);
+  //$controller->get_view()->show($element_names, $messages);
+}
+
+function can_instantiate($controller, $element_name) {
+  if($element = $controller->get_element($element_name)) {
+    if(count($element['constructor_params']) > 0) {
+
+      foreach($element['constructor_params'] as $p) {
+        if(!isset($element['attributes'][$p])) {
+          $field = $element['associations'][$p];
+          //Parameter for an association must be an index ("ID") for an existing instance
+          $instances = $controller->get_objects($field['type']);
+          if(empty($instances) || count($instances) == 0) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+
+    } else {
+      return true;
+    }
+  } else {
+    return false;
+  }
 }

--- a/umpleonline/scripts/uigu2/app/controllers/main/show_element.php
+++ b/umpleonline/scripts/uigu2/app/controllers/main/show_element.php
@@ -285,9 +285,42 @@ function _show_element($controller) {
         $objects_table = "<span class='subtle'> There are no created instances for this Class </span>";
       }
       $view->set('objects_table', $objects_table);
+
       $element_names = $controller->get_element_names();
+
+      $numbers_of_elements = NULL;
+      if(isset($element_names) && is_array($element_names)) {
+        $numbers_of_elements = array();
+        foreach($element_names as $e){
+          $instances = $controller->get_objects($e);
+          if(empty($instances)) {
+            $numbers_of_elements[$e] = 0;
+          } else {
+            $numbers_of_elements[$e] = count($instances);
+          }
+        }
+      }
+
       $messages = $controller->get_messages_clear();
-      $view->show($element_names, $messages);
+
+      $instantiatable_info = NULL;
+      if(isset($element_names) && is_array($element_names)) {
+        $instantiatable_info = array();
+        foreach($element_names as $e){
+          if(can_instantiate($controller, $e)) {
+            $instantiatable_info[$e] = true;
+          } else {
+            $instantiatable_info[$e] = false;
+          }
+        }
+      }
+      
+      $layout_parameter_map = array('element_names' => $element_names,
+                                    'numbers_of_elements' => $numbers_of_elements,
+                                    'messages' => $messages,
+                                    'instantiatable_info' => $instantiatable_info);
+
+      $view->show_layout($layout_parameter_map);
 
     } else{
       $controller->set_message('Error showing Element: '.$element_name.' does not exist', true);
@@ -296,5 +329,30 @@ function _show_element($controller) {
   } else{
     $controller->set_message('Error showing Element: the Element name was not provided', true);
     Uigu2_Controller::redirect('index'); 
+  }
+}
+
+function can_instantiate($controller, $element_name) {
+  if($element = $controller->get_element($element_name)) {
+    if(count($element['constructor_params']) > 0) {
+      
+      foreach($element['constructor_params'] as $p) {
+        if(!isset($element['attributes'][$p])) {
+          $field = $element['associations'][$p];
+          //Parameter for an association must be an index ("ID") for an existing instance
+          $instances = $controller->get_objects($field['type']);
+          if(empty($instances) || count($instances) == 0) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+
+    } else {
+      return true;
+    }
+  } else {
+    return false;
   }
 }

--- a/umpleonline/scripts/uigu2/app/kissmvc_uigu2.php
+++ b/umpleonline/scripts/uigu2/app/kissmvc_uigu2.php
@@ -186,6 +186,16 @@ class Uigu2_View extends KISS_View {
     Uigu2_View::do_dump(VIEW_PATH.'layout.php',$layout_data);
   }
 
+  function show_layout($layout_parameter_map) {
+    // This function is to replace show().
+    $layout_data = array();
+    foreach ($layout_parameter_map as $key => $value) {
+      $layout_data[$key] = $value;
+    }
+    $layout_data['body'][]=$this->fetch();
+    Uigu2_View::do_dump(VIEW_PATH.'layout.php',$layout_data);
+  }
+
   function create_table($array='', $attributes=''){
     if(!is_array($array)||!count($array)){
       return false;

--- a/umpleonline/scripts/uigu2/app/views/layout.php
+++ b/umpleonline/scripts/uigu2/app/views/layout.php
@@ -22,18 +22,36 @@
           <td>
             <a href="<?php echo WEB_FOLDER ?>">Main Page</a> 
           </td>
-          <td> | Show element:
+          <td> | Pick a class:
             <form action="<?php echo WEB_FOLDER.'main/show_element'?>" method="POST">
+              <?php 
+                if (isset($element_names) && is_array($element_names)){
+                  foreach($element_names as $e){
+                    if($instantiatable_info[$e]) {
+                      // classes that can be instantiated
+                      echo "<input type='radio' id='$e' name='element_name' value='$e'>
+                            <label for='$e'><strong>$e &#91;$numbers_of_elements[$e]&#93;</strong></label>";
+                    } else {
+                      // classes that cannot be instantiated
+                      echo "<input type='radio' id='$e' name='element_name' value='$e'>
+                            <label for='$e'>$e &#91;$numbers_of_elements[$e]&#93;</label>";
+                    }
+                  }
+                }
+              ?>
+
+              <!-- 
               <select name="element_name">
                 <option selected>---</option>
                 <?php 
-                if (isset($element_names) && is_array($element_names)){
-                  foreach($element_names as $e){
-                    echo "<option value='$e'>$e</option>";
-                  }
-                }
+                //if (isset($element_names) && is_array($element_names)){
+                //  foreach($element_names as $e){
+                //    echo "<option value='$e'>$e ".$numbers_of_elements[$e]."</option>";
+                //  }
+                //}
                 ?>
-              </select>
+              </select> 
+              -->
               <input type="submit" value="Go"/>
             </form>
           </td>


### PR DESCRIPTION
Improve the CRUD interface. Replace the pulldown with a set of radio buttons when selecting a class. Classes that can be instantiated are in bold. Fix a bug that leads to wrong attribute names in the CRUD interface.