### PR TITLE
Fixes for issue 535.

### DIFF
--- a/umpleonline/scripts/uigu2/app/controllers/main/show_element.php
+++ b/umpleonline/scripts/uigu2/app/controllers/main/show_element.php
@@ -181,13 +181,19 @@ function _show_element($controller) {
           
           $temp_body = $body;
           $stack = new Stack();
+
           for($j = 0; $j < $num_of_attributes; $j++) {
+            //O:15:"EllipticalShape":2:{s:30:"EllipticalShapesemiMajorAxis";s:3:"sss";s:15:"Shape2Dcenter";s:2:"cd";}
             $attribute_separator = strpos($temp_body, ";");
 
             $attribute_string = substr($temp_body, 0, $attribute_separator);
             $attribute_info = explode(":", $attribute_string);
             $attribute_length = intval($attribute_info[1]);
-            $attribute_name = substr($attribute_info[2], $class_name_length + 3, $attribute_length - $class_name_length - 2);
+            //$attribute_name = substr($attribute_info[2], $class_name_length + 3, $attribute_length - $class_name_length - 2);
+
+            $attribute_name = explode(chr(0), $attribute_info[2]);
+            $attribute_name = $attribute_name[2];
+            $attribute_name = substr($attribute_name, 0, strlen($attribute_name) - 1);
 
             $temp_body = substr($temp_body, $attribute_separator + 1);
 

--- a/umpleonline/scripts/uigu2/app/views/layout.php
+++ b/umpleonline/scripts/uigu2/app/views/layout.php
@@ -23,16 +23,17 @@
             <a href="<?php echo WEB_FOLDER ?>">Main Page</a> 
           </td>
           <td> | Pick a class:
-            <form action="<?php echo WEB_FOLDER.'main/show_element'?>" method="POST">
+            <form id="classForm" action="<?php echo WEB_FOLDER.'main/show_element'?>" method="POST">
               <?php 
                 if (isset($element_names) && is_array($element_names)){
+                  $form_id = "classForm";
                   foreach($element_names as $e){
                     if($instantiatable_info[$e]) {
                       // classes that can be instantiated
-                      echo "<button name='element_name' value='$e' onclick='this.form.submit();'><strong>$e &#91;$numbers_of_elements[$e]&#93;</strong></button>";
+                      echo "<a href='javascript:document.getElementById($form_id).submit();'><button name='element_name' value='$e' onclick='javascript:document.getElementById($form_id).submit();'><strong>$e &#91;$numbers_of_elements[$e]&#93;</strong></button></a>";
                     } else {
                       // classes that cannot be instantiated
-                      echo "<button name='element_name' value='$e' onclick='this.form.submit();'>$e &#91;$numbers_of_elements[$e]&#93;</button>";
+                      echo "<a href='javascript:document.getElementById($form_id).submit();'><button name='element_name' value='$e' onclick='javascript:document.getElementById($form_id).submit();'>$e &#91;$numbers_of_elements[$e]&#93;</button></a>";
                     }
                   }
                 }


### PR DESCRIPTION
 Make the buttons in CRUD display a message saying which javacript will be run. Fix a bug that leads to wrong attribute names. Steps to reproduce the bug:
```
1. Click "2DShapes" in EXAMPLES menu.
2. Click "CRUD User Interface" in GENERATE menu.
3. Click "Generate Code".
4. Click "EllipticalShape".
5. Create an object.
6. Look at the "Existing Instances of this Class" form. The name of the "center" attribute does not appear.
The form looks like this:

Object ID   String Representation
0                semiMajorAxis: x axis
                 : (0, 0)
``` 

