### PR TITLE
Require-statement argument parsing

### DIFF
--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -48,7 +48,7 @@ class FragmentFeatureLeaf
 class FeatureLink
 {
   0..1 -- 1 FeatureLeaf sourceFeature;
-  0..1 -- * FeatureNode targetFeature;
+  0..* -- * FeatureNode targetFeature;
   boolean isSub =false; // isSub to differentiate between sub-features and include/exclude relationship
   enum FeatureConnectingOpType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
   FeatureConnectingOpType featureConnectingOpType;

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -19,6 +19,7 @@ class FeatureModel
 {
   name;
   1--* FeatureNode node;
+  0..1 -- * FeatureLink featurelink;
 }
 
 //A Feature model consists of some FeatureNodels, which can be leaf nodes or fragmentFeature nodes.

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -1,0 +1,84 @@
+/*
+
+Copyright: All contributers to the Umple Project
+
+This file is made available subject to the open source license found at:
+http://umple.org/license
+
+Feature diagram meta-model
+
+*/
+
+// A FeatureDiagram stores information required to build a feature diagram in Umple  
+
+class UmpleModel {
+     0..1 -- 0..1 FeatureModel;
+}
+
+class FeatureModel
+{
+  name;
+  1--* FeatureNode node;
+}
+
+//A Feature model consists of some FeatureNodels, which can be leaf nodes or fragmentFeature nodes.
+class FeatureNode{
+  abstract;
+  boolean isLeaf =false;
+}
+
+// A FeatureLeaf contains a full mixset or a full file. 
+class FeatureLeaf
+{
+  isA FeatureNode;
+  0..1 -- 0..1 MixsetOrFile mixsetOrFileNode;
+  after constructor() { setIsLeaf(true);}
+}
+
+// A FragmentFeatureLeaf consists of one or more mixset fragments.
+class FragmentFeatureLeaf
+{
+  isA FeatureNode;
+  0..1 -- * MixsetFragment mixsetFragment;
+  after constructor() { setIsLeaf(true);}
+}
+
+// A FeatureLink connects a source feature to target feature(s) in the feature diagram.
+class FeatureLink
+{
+  0..1 -- 1 FeatureLeaf sourceFeature;
+  0..1 -- * FeatureNode targetFeature;
+  boolean isSub =false; // isSub to differentiate between sub-features and include/exclude relationship
+  enum FeatureConnectingOpType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
+  FeatureConnectingOpType featureConnectingOpType;
+
+}
+// MultiplicityFeatureConnectingOpType is a special type of FeatureLink in which there are min and max multiplicity. 
+
+class MultiplicityFeatureConnectingOpType
+{
+  isA FeatureLink;
+  MultiplicityFeatureConnectingOpType( FeatureLeaf aSourceFeature)
+  {
+    super(FeatureConnectingOpType.Multiplicity, aSourceFeature);
+  }
+  after constructor(){
+    this.setFeatureConnectingOpType(FeatureConnectingOpType.Multiplicity);
+  }
+  lazy Multiplicity multiplicity;
+}
+// XORFeatureConnectingOpType is a special type of FeatureLink in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
+class XORFeatureConnectingOpType 
+{
+  isA MultiplicityFeatureConnectingOpType;
+  after constructor(){
+    this.setFeatureConnectingOpType(FeatureConnectingOpType.XOR);
+    setMultiplicity(new Multiplicity());
+   // getMultiplicity.setRange("1","1");
+  }
+}
+
+/*
+class MixsetOrFile{}
+class MixsetFragment{}
+*/

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -2,6 +2,12 @@ class UmpleModel {
   // This mixin adds the complete set of Mixsets and files to the
   // model.
      0..1 -- * MixsetOrFile;
+     0..1 -- 1 FeatureDiagram;
+}
+
+class FeatureDiagram
+{
+  1--* FeatureNode node;
 }
 
 // A MixsetOrFile is an umple entity that is subject to require logic
@@ -27,29 +33,55 @@ class UmpleFile {
   }
 }
 
-// 
-// multiplicity linking operator includes XOR operator in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
-enum MixsetLinkingOperatorType { Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude };
+ 
 
-class ReferencedMixset{
-  
-  MixsetLinkingOperatorType mixsetLinkingOperatorType;
-  //0..1 -- * Mixset mixset;
-  0..1 linkingOperator -- * Mixset mixsetNode;
+/*
+A mixset may nest other mixsets, or it may require 
+*/
+class FeatureNode{
+  abstract;
+  boolean isLeaf;
+
 
 }
-
-class ReferencedMultiplicityMixset 
+class FeatureLeaf
 {
-  isA ReferencedMixset;
+  isA FeatureNode;
+  0..1 -- 1 Mixset mixsetNode;
+  0..1 -- * MixsetFragment mixsetFragment;
+}
+class FeatureGroup
+{
+  0..1 -- * FeatureNode innerFeatureNode;
+  isA FeatureNode;
+  boolean isParent =false;// isParent == require sub ... .if not sub, its <<include>>
+  enum FeatureGroupingType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
+  FeatureGroupingType featureGroupingType;
+
+}
+class MultiplicityFeatureGroup 
+{
+  isA FeatureGroup;
   after constructor(){
-    this.setMixsetLinkingOperatorType(MixsetLinkingOperatorType.Multiplicity);
+    this.setFeatureGroupingType(FeatureGroupingType.Multiplicity);
   }
   // min and max attributes required only for mutiplicity. 
   int min; 
   int max;
 }
 
+class XORFeatureGroup 
+{
+  // multiplicity linking operator includes XOR operator in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
+  isA MultiplicityFeatureGroup;
+  after constructor(){
+    this.setFeatureGroupingType(FeatureGroupingType.XOR);
+    this.setMin(1);
+    this.setMax(1);
+
+  }
+
+}
 
 // A mixset is a block of code that may or may not be included by a use statement
 // It consists of one or more fragments that are encountered anywhere in the Umple source
@@ -58,9 +90,6 @@ class Mixset {
   mixsetName; // THe name of the mixset
   isA MixsetOrFile;
   
-  0..1 parentMixset -- * ReferencedMixset childReferencedMixset; // a mixset may have requried, optional, or multiplicity of child mixsets(features) or some included/excluded mixsets
-  
-
 
   after constructor {  
     setIsMixset(true);

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -1,4 +1,3 @@
-
 class UmpleModel {
   // This mixin adds the complete set of Mixsets and files to the
   // model.
@@ -28,6 +27,29 @@ class UmpleFile {
   }
 }
 
+// 
+// multiplicity linking operator includes XOR operator in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
+enum MixsetLinkingOperatorType { Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude };
+
+class ReferencedMixset{
+  
+  MixsetLinkingOperatorType mixsetLinkingOperatorType;
+  //0..1 -- * Mixset mixset;
+  0..1 linkingOperator -- * Mixset mixsetNode;
+
+}
+
+class ReferencedMultiplicityMixset 
+{
+  isA ReferencedMixset;
+  after constructor(){
+    this.setMixsetLinkingOperatorType(MixsetLinkingOperatorType.Multiplicity);
+  }
+  // min and max attributes required only for mutiplicity. 
+  int min; 
+  int max;
+}
+
 
 // A mixset is a block of code that may or may not be included by a use statement
 // It consists of one or more fragments that are encountered anywhere in the Umple source
@@ -36,6 +58,10 @@ class Mixset {
   mixsetName; // THe name of the mixset
   isA MixsetOrFile;
   
+  0..1 parentMixset -- * ReferencedMixset childReferencedMixset; // a mixset may have requried, optional, or multiplicity of child mixsets(features) or some included/excluded mixsets
+  
+
+
   after constructor {  
     setIsMixset(true);
   }

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -1,16 +1,19 @@
+/*
+
+Copyright: All contributers to the Umple Project
+
+This file is made available subject to the open source license found at:
+http://umple.org/license
+
+Mixset meta-model
+
+*/
+
 class UmpleModel {
   // This mixin adds the complete set of Mixsets and files to the
   // model.
      0..1 -- * MixsetOrFile;
-     0..1 -- 0..1 FeatureDiagram;
 }
-
-// A FeatureDiagram stores information required to build a feature diagram 
-class FeatureDiagram
-{
-  1--* FeatureNode node;
-}
-
 // A MixsetOrFile is an umple entity that is subject to require logic
 class MixsetOrFile {
   UmpleFile useUmpleFile = null; // File where the use statement was encountered
@@ -19,8 +22,6 @@ class MixsetOrFile {
   abstract String getName();
 
 }
-
- 
 // This class already exists in the util subdirectory
 // It is used for the main file, and there is code
 // to add linkedfiles. It would seem logical to consider 
@@ -33,71 +34,6 @@ class UmpleFile {
     return getSimpleFileName();
   }
 }
-
- 
-
-
-//A Feature model consists of some FeatureNodels, which can be  leaf nodes and a parent (groupinng) nodes.
-
-class FeatureNode{
-  abstract;
-  boolean isLeaf =false;
-
-
-}
-
-// A FeatureLeaf contains a full mixset or a full file. 
-class FeatureLeaf
-{
-  isA FeatureNode;
-  0..1 -- 0..1 MixsetOrFile mixsetOrFileNode;
-  
-  after constructor() { setIsLeaf(true);}
-
-}
-
-// A FragmentFeatureLeaf consists of one or more mixset fragments.
-class FragmentFeatureLeaf
-{
-  isA FeatureNode;
-  0..1 -- * MixsetFragment mixsetFragment;
-  after constructor() { setIsLeaf(true);}
-}
-// A FeatureGroup is a grouping node in the feature diagram.
-class FeatureGroup
-{
-  0..1 -- * FeatureNode innerFeatureNode;
-  isA FeatureNode;
-  boolean isParent =false;// isParent == require sub ... .if not sub, its <<include>>
-  enum FeatureGroupingType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
-  FeatureGroupingType featureGroupingType;
-
-}
-// MultiplicityFeatureGroup is a special type of FeatureGroup in which there are min and max multiplicity. 
-
-class MultiplicityFeatureGroup 
-{
-  isA FeatureGroup;
-  after constructor(){
-    this.setFeatureGroupingType(FeatureGroupingType.Multiplicity);
-  }
-
-  int min; 
-  int max;
-}
-  // XORFeatureGroup is a special type of MultiplicityFeatureGroup in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
-class XORFeatureGroup 
-{
-  isA MultiplicityFeatureGroup;
-  after constructor(){
-    this.setFeatureGroupingType(FeatureGroupingType.XOR);
-    this.setMin(1);
-    this.setMax(1);
-
-  }
-
-}
-
 // A mixset is a block of code that may or may not be included by a use statement
 // It consists of one or more fragments that are encountered anywhere in the Umple source
 // including in other mixsets

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -2,9 +2,10 @@ class UmpleModel {
   // This mixin adds the complete set of Mixsets and files to the
   // model.
      0..1 -- * MixsetOrFile;
-     0..1 -- 1 FeatureDiagram;
+     0..1 -- 0..1 FeatureDiagram;
 }
 
+// A FeatureDiagram stores information required to build a feature diagram 
 class FeatureDiagram
 {
   1--* FeatureNode node;
@@ -35,21 +36,34 @@ class UmpleFile {
 
  
 
-/*
-A mixset may nest other mixsets, or it may require 
-*/
+
+//A Feature model consists of some FeatureNodels, which can be  leaf nodes and a parent (groupinng) nodes.
+
 class FeatureNode{
   abstract;
-  boolean isLeaf;
+  boolean isLeaf =false;
 
 
 }
+
+// A FeatureLeaf contains a full mixset or a full file. 
 class FeatureLeaf
 {
   isA FeatureNode;
-  0..1 -- 1 Mixset mixsetNode;
-  0..1 -- * MixsetFragment mixsetFragment;
+  0..1 -- 0..1 MixsetOrFile mixsetOrFileNode;
+  
+  after constructor() { setIsLeaf(true);}
+
 }
+
+// A FragmentFeatureLeaf consists of one or more mixset fragments.
+class FragmentFeatureLeaf
+{
+  isA FeatureNode;
+  0..1 -- * MixsetFragment mixsetFragment;
+  after constructor() { setIsLeaf(true);}
+}
+// A FeatureGroup is a grouping node in the feature diagram.
 class FeatureGroup
 {
   0..1 -- * FeatureNode innerFeatureNode;
@@ -59,20 +73,21 @@ class FeatureGroup
   FeatureGroupingType featureGroupingType;
 
 }
+// MultiplicityFeatureGroup is a special type of FeatureGroup in which there are min and max multiplicity. 
+
 class MultiplicityFeatureGroup 
 {
   isA FeatureGroup;
   after constructor(){
     this.setFeatureGroupingType(FeatureGroupingType.Multiplicity);
   }
-  // min and max attributes required only for mutiplicity. 
+
   int min; 
   int max;
 }
-
+  // XORFeatureGroup is a special type of MultiplicityFeatureGroup in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
 class XORFeatureGroup 
 {
-  // multiplicity linking operator includes XOR operator in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
   isA MultiplicityFeatureGroup;
   after constructor(){
     this.setFeatureGroupingType(FeatureGroupingType.XOR);

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1175,3 +1175,4 @@ use StateMachine.ump;
 use Umple_Code.ump;
 use UmpleEnumeration_Code.ump;
 use Mixset.ump;
+use FeatureModel.ump;

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -271,6 +271,7 @@ class UmpleInternalParser
     analyzeFilterToken(t,analysisStep);
     analyzeFIXML(t, analysisStep);
     analyzeMixsetToken(t, analysisStep);
+    analyzeRequireStatement(t, analysisStep);
     
   }
 
@@ -525,3 +526,4 @@ use UmpleInternalParser_CodeFilter.ump;
 use UmpleInternalParser_CodeParserHandlers.ump;
 use UmpleInternalParser_CodeEnumeration.ump;
 use UmpleInternalParser_CodeMixset.ump;
+use UmpleInternalParser_CodeRequireStatement.ump;

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -126,42 +126,39 @@ class UmpleInternalParser
       return;
     } 
     //else
-    
     if (t.is("useStatement"))
     {
-       String value = t.getValue("use");
+      String value = t.getValue("use");
        
        // ignore .ump files since they are proccessed in UseStatementParserAction class (UmpleInternalParser_CodeParserHandlers.ump).
-       if (value.endsWith(".ump"))
-       {
-         return;   
-       } 
+      if (value.endsWith(".ump"))
+      {
+        return;   
+      } 
        //Otherwise
        
-       String mixsetName = value;
-       int useLineNumber = t.getPosition().getLineNumber();
-       //UmpleFile mixsetUseFile = model.getUmpleFile(); 
-       String fileName = t.getPosition().getFilename();
-       UmpleFile mixsetUseFile = new UmpleFile(fileName);
-       // check if the mixset was added before 
-       Mixset mixset = model.getMixset(mixsetName);
-       if(mixset == null)
-       {
-         mixset = new Mixset(mixsetName);
-	     mixset.setUseUmpleFile(mixsetUseFile);
-	     mixset.setUseUmpleLine(useLineNumber);
-	     model.addMixsetOrFile(mixset);
-	   }
-	   else if (mixset.getUseUmpleFile() == null)
-	   {
-	     mixset.setUseUmpleFile(mixsetUseFile);
-	     mixset.setUseUmpleLine(useLineNumber);
-	   }
+      String mixsetName = value;
+      int useLineNumber = t.getPosition().getLineNumber();
+      //UmpleFile mixsetUseFile = model.getUmpleFile(); 
+      String fileName = t.getPosition().getFilename();
+      UmpleFile mixsetUseFile = new UmpleFile(fileName);
+      // check if the mixset was added before 
+      Mixset mixset = model.getMixset(mixsetName);
+      if(mixset == null)
+      {
+        mixset = new Mixset(mixsetName);
+        mixset.setUseUmpleFile(mixsetUseFile);
+        mixset.setUseUmpleLine(useLineNumber);
+        model.addMixsetOrFile(mixset);
+      }
+      else if (mixset.getUseUmpleFile() == null)
+      {
+        mixset.setUseUmpleFile(mixsetUseFile);
+        mixset.setUseUmpleLine(useLineNumber);
+      }
 	   
-	   // this handles the case when a mixset definition is in a file and the mixset use exists in a subsequent file.
-	   parseMixset(mixset);
-       
-      
+	    // this handles the case when a mixset definition is in a file and the mixset use exists in a subsequent file.
+	    parseMixset(mixset); 
     }
   }
   
@@ -201,8 +198,7 @@ class UmpleInternalParser
     if(mixsetFragment.getIsParsed())
     continue;
     //Otherwise
-    parseMixsetWaitingFragment(mixsetFragment);
-    
+    parseMixsetWaitingFragment(mixsetFragment);  
    }
  }
 
@@ -231,6 +227,8 @@ class UmpleInternalParser
     Token answer = parser.getRootToken(); // result of parsing the body of a mixset waitingFragments
     setRootToken(answer);
     model.setLastResult(result);
+    answer.setName("mixsetDefinition"); //attach the mixset name for the fragment instead of ROOT
+    answer.setValue(mixsetFragment.getMixset().getMixsetName());
     analyzeAllTokens(answer);
     mixsetFragment.setIsParsed(true);
    }
@@ -307,7 +305,7 @@ class UmpleInternalParser
 	  
 	  // Here the mixset fragmet is considered as waitingFragment (mixsetFragment.isParsed==flase). 
 	  mixset.addMixsetFragment(mixsetFragment);
-	  
+	  mixsetFragment.setMixset(mixset);
 	  // parse mixset fragments right away if there is a use statment.
 	  // 
 	  if(mixset.getUseUmpleFile() != null)

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -1,0 +1,26 @@
+/*
+Copyright: All contributers to the Umple Project.
+
+This file is made available subject to the open source license found at:
+http://umple.org/license
+
+This file analyzses require statement tokens to populate Requiregraph for Umple model.
+
+Please refer to UmpleInternalParser.ump for more details.
+*/
+
+class UmpleInternalParser
+{
+  depend cruise.umple.compiler.*;
+   
+  public void analyzeRequireStatement(Token t, int analysisStep)
+  {
+    if (analysisStep != 2)
+    {
+      shouldProcessAgain = shouldProcessAgain || (analysisStep == 1);
+      return;
+    }    
+    if (t.is("requireStatement"))
+    {}
+  }
+}

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -110,7 +110,8 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
   rootTokenTree.setNodeToken(new Token("ROOT",""));
 	TokenTree currentTree = rootTokenTree;		
   List<String> acceptedTokensList = Arrays.asList("and","or","xor");
-	for(Token token : tokenList)
+	
+  for(Token token : tokenList)
 	{
 		TokenTree rightTokenTree = new TokenTree();
 		rightTokenTree.setNodeToken(token);
@@ -124,7 +125,6 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
 	currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
 	
   TokenTree previousLinkingSubTokenTree = null;
-  TokenTree rootNode = null;
 	
   while(currentTree.getRightTokenTree() != null)
 	{
@@ -140,69 +140,53 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
       // A and B --> and A B
 			if (previousLinkingSubTokenTree == null)
 			{
-        currentTree.setRightTokenTree(null);
         currentTree.setParentTokenTree(rightLinkingTokenTree);
         rightLinkingTokenTree.setLeftTokenTree(currentTree);
         rightLinkingTokenTree.setParentTokenTree(rootTokenTree);
+        rootTokenTree.setRightTokenTree(rightLinkingTokenTree);
         previousLinkingSubTokenTree = rightLinkingTokenTree;
-        rootNode = rightLinkingTokenTree;// this is the root node 
 			}
-			else if(previousLinkingSubTokenTree != null )
+			else
 			{
         /*
              this for the case : A and B or C --> or (and A B)
-             and.getPriority == 0. or.getPriority ==1
+             and.getPriority == 0. or.getPriority == 1
         */
 				if(previousLinkingSubTokenTree.getPriority() <= rightLinkingTokenTree.getPriority())
 				{ 
          // if(previousLinkingSubTokenTree.getLeftTokenTree() != null)
           //{            
             
-            TokenTree tt = previousLinkingSubTokenTree;
-            while(tt != null && ! tt.getNodeToken().getName().equals("ROOT") )
+            TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
+            while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
             {
-              if (tt.getPriority() <= rightLinkingTokenTree.getPriority() )
+              if (linkNodeToReplace.getPriority() <= rightLinkingTokenTree.getPriority() )
                {
-                previousLinkingSubTokenTree = tt;
+                previousLinkingSubTokenTree = linkNodeToReplace;
                }
-               tt = tt.getParentTokenTree();
+               linkNodeToReplace = linkNodeToReplace.getParentTokenTree();
             }
 
           rightLinkingTokenTree.setLeftTokenTree(previousLinkingSubTokenTree);
           previousLinkingSubTokenTree.getParentTokenTree().setRightTokenTree(rightLinkingTokenTree); 
           previousLinkingSubTokenTree.setParentTokenTree(rightLinkingTokenTree);
-          currentTree.setRightTokenTree(null);
-          previousLinkingSubTokenTree=rightLinkingTokenTree;
-          
-         /* }
-          else 
-          {
-            rightLinkingTokenTree.setLeftTokenTree(currentTree);
-            previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
-            rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
-            rootNode = rightLinkingTokenTree;
-          }*/	
+          previousLinkingSubTokenTree=rightLinkingTokenTree;	
 				}
 				else
 				{   /*
              this for the case : A or B and C --> or (and A B)
              and.getPriority == 0. or.getPriority ==1
             */
-          // last node has low priori
-          rootNode = previousLinkingSubTokenTree;
-          currentTree.setRightTokenTree(null);
           rightLinkingTokenTree.setLeftTokenTree(currentTree);
           rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
         	previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
+          previousLinkingSubTokenTree = rightLinkingTokenTree;
 				}
 			}
-			
+      // to set right node of terminal to null 
+      currentTree.setRightTokenTree(null);
+
 		}
-    
-  //  if (currentTree.getIsLinkingOperator())
-   // {
-   //   previousLinkingSubTokenTree = currentTree;
-   // }
 		currentTree = rightLinkingTokenTree; // move to next node 
 	}
   
@@ -227,6 +211,7 @@ class TokenTree
   boolean isNegated =false;
   boolean isOpt = false;
   boolean isLinkingOperator = false;
+
   public int getPriority()
   {
     String tokenName = nodeToken.getName();

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -29,18 +29,17 @@ class UmpleInternalParser
       Mixset sourceMixset = getMixsetFromToken(t);
       FeatureLeaf sourceFeatureLeaf = new FeatureLeaf(featureModel);
       if (sourceMixset == null) // require-statement comes from umple file 
-      {
-        sourceFeatureLeaf.setMixsetOrFileNode(new UmpleFile(t.getPosition().getFilename()));
-      }
+      sourceFeatureLeaf.setMixsetOrFileNode(new UmpleFile(t.getPosition().getFilename()));
+      boolean isSubFeature = t.getSubToken("subfeature") != null; 
+
        //tokens needed for parsing require-statement
-      List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","sub","opt");
+      List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","subfeature","opt");
       ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
       if(requireTokenList.size() == 0 )
-      return;
-      
+      return;-
       for(Token token : requireTokenList)
       {
-        if ( requireTokenList.size() == 1 )
+        if ( requireTokenList.size() == 2 )
         {
           if(token.is("targetMixsetName"))
           {        	
@@ -53,6 +52,7 @@ class UmpleInternalParser
             targetFeature.setMixsetOrFileNode(targetMixset);
             FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include, sourceFeatureLeaf);        	
             edge.getTargetFeature().add(targetFeature);
+            edge.setIsSub(isSubFeature);
 
           }
        

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -28,35 +28,41 @@ class UmpleInternalParser
 
       Mixset sourceMixset = getMixsetFromToken(t);
       FeatureLeaf sourceFeatureLeaf = new FeatureLeaf(featureModel);
-      if (sourceMixset == null) // require-statement comes from umple file 
+      // require-statement comes from umple file or mixset ?
+      if (sourceMixset == null) 
       sourceFeatureLeaf.setMixsetOrFileNode(new UmpleFile(t.getPosition().getFilename()));
+      else 
+      sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset);
+      
       boolean isSubFeature = t.getSubToken("subfeature") != null; 
 
        //tokens needed for parsing require-statement
       List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","subfeature","opt");
       ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
       if(requireTokenList.size() == 0 )
-      return;-
+      return;
+
       for(Token token : requireTokenList)
       {
-        if ( requireTokenList.size() == 2 )
-        {
+        if ( requireTokenList.size() == 2 ) // need more checking
+         {
           if(token.is("targetMixsetName"))
           {        	
             Mixset targetMixset = model.getMixset(token.getValue());
             if(targetMixset == null)
               return;
-  
-            sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset);
             FeatureLeaf targetFeature = new FeatureLeaf(featureModel);
             targetFeature.setMixsetOrFileNode(targetMixset);
             FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include, sourceFeatureLeaf);        	
-            edge.getTargetFeature().add(targetFeature);
+            edge.addTargetFeature(targetFeature);
             edge.setIsSub(isSubFeature);
 
           }
-       
+          break; // then stop the loop
         }
+
+
+
       }  
        
       
@@ -76,7 +82,9 @@ class UmpleInternalParser
     for(Token innerToken : requireStatementToken.getSubTokens())
     {
       if (! innerToken.getName().equals("") && acceptedTokensList.contains(innerToken.getName()))
-      	TokenList.add(innerToken);
+      {
+        TokenList.add(innerToken);
+      }
       else if (innerToken.getSubTokens() != null)
       	TokenList.addAll(getRequireStatementTokensAsList(innerToken,acceptedTokensList)); 
     }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -38,8 +38,6 @@ class UmpleInternalParser
 
        //tokens needed for parsing require-statement
       List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","opt");
-          
-      //List<String> acceptedTokensList = Arrays.asList("targetMixsetName","and","not","xor","or","opt");
       ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
       Token firstTokenOfRequireTokenList;
 
@@ -62,23 +60,18 @@ class UmpleInternalParser
             featureModel.addFeaturelink(edge);
           }
       }
-      /*
-      else if(firstTokenOfRequireTokenList.is("lowerBound") ) // has a form of: require 1..3 { A, B, C }
-      {
-        //To Do
-      }
-      */
       else // has the form of : require [A and B or C]
       {
         TokenTree tree = generateFeatureTreeTokenFromRequireStList(requireTokenList);
-        // TO Do       
+        // TO Do: add tree for the feature model 
+        // To Do: not and opt implementaion 
+        // TO Do:  1..3 of {A, B, C}      
       }
     
     }
   }
 
   
-
   /*
   This method filters unwanted tokens & changes the form of require-statement argument from 
   nested tokens, as the parser does, to list of tokens.  
@@ -160,14 +153,13 @@ private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tok
 			{
         /*
           this for the case : A and B or C --> (or (and A B))
-           and.getPriority == 0. or.getPriority == 1
         */
-				if(previousLinkingSubTokenTree.getPriority() <= rightLinkingTokenTree.getPriority())
+				if(previousLinkingSubTokenTree.getPriority() >= rightLinkingTokenTree.getPriority())
 				{ 
             TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
             while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
             {
-              if (linkNodeToReplace.getPriority() <= rightLinkingTokenTree.getPriority() )
+              if (linkNodeToReplace.getPriority() >= rightLinkingTokenTree.getPriority() )
                {
                 previousLinkingSubTokenTree = linkNodeToReplace;
                }
@@ -181,7 +173,6 @@ private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tok
 				else
 				{   /*
              this for the case : A or B and C --> or (and A B)
-             and.getPriority == 0. or.getPriority ==1
             */
           rightLinkingTokenTree.setLeftTokenTree(currentTree);
           rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
@@ -195,7 +186,7 @@ private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tok
 		currentTree = rightLinkingTokenTree; // move to next node of the tree 
 	}
   
-	return rootTokenTree.getRightTokenTree;	
+	return rootTokenTree.getRightTokenTree();	
 }
 
 }
@@ -221,9 +212,9 @@ class TokenTree
   boolean isLinkingOperator = false;
 
 /*
-This methods returens the priority of a linking operator to move up in the binary tree.
-high priority node moves up & low prioriy moves down 
-Root > xor > or > and > othter termianl (non linking) nodes.  
+This methods returens the priority of a node to move down in the binary tree.
+high priority node moves down & low prioriy moves up 
+not > and > xor > or > ROOT (Top of the tree)
 */
   public int getPriority()
   {
@@ -231,14 +222,14 @@ Root > xor > or > and > othter termianl (non linking) nodes.
     switch (tokenName)
     {
       case "and":
-      return 0;
-      case "or":
-      return 1;
+      return 3;
       case "xor":
       return 2;
+      case "or":
+      return 1;
       case "ROOT":
-      return 3;
+      return 0;
     }
-    return -1;
+    return -1; // lower priority, leaf nodes should not move 
   }
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -21,6 +21,48 @@ class UmpleInternalParser
       return;
     }    
     if (t.is("requireStatement"))
-    {}
+    {
+      boolean notFlag = false;
+      boolean optFlag = false;
+       
+      String tokenString = t.toString();
+      for (Token token: t.getSubTokens())
+      {
+      
+        String tokenName= token.getName();
+        if(tokenName.equals("not"))
+        {
+          notFlag=true;
+        }
+        else if(tokenName.equals("opt"))
+        {
+          optFlag= true;
+        }
+         else if(tokenName.equals("requireTerminal"))
+        {
+         String mixsetName = token.getValue("targetMixsetName");
+        /*
+         if (notFlag)
+         {}
+         if (optFlag)
+         {}
+         */
+         optFlag=false; notFlag=false;
+        }
+        else if(tokenName.equals("requireLinkingOp"))
+        {
+        
+        }
+      }
+      //List<Token> subTokens = t.getSubTokens();
+      
+      
+      String mixsetName = t.getValue("targetMixsetName");
+      Mixset mixset = model.getMixset(mixsetName);
+       if(mixset != null)
+       {
+       }
+      
+    }
   }
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -37,20 +37,21 @@ class UmpleInternalParser
       boolean isSubFeature = t.getSubToken("subfeature") != null; 
 
        //tokens needed for parsing require-statement
-     // List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","subfeature","opt");
-           List<String> acceptedTokensList = Arrays.asList("targetMixsetName","and","not","xor","or","opt");
-
+      List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","opt");
+          
+      //List<String> acceptedTokensList = Arrays.asList("targetMixsetName","and","not","xor","or","opt");
       ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
-      if(requireTokenList.size() == 0 )
+      Token firstTokenOfRequireTokenList;
+
+      if(requireTokenList.size() == 0 ) // require [ ]
       return;
 
-      for(Token token : requireTokenList)
+      firstTokenOfRequireTokenList = requireTokenList.get(0);
+      if (requireTokenList.size() == 1) // require [A]
       {
-        if ( requireTokenList.size() == 2 ) // need more checking
-         {
-          if(token.is("targetMixsetName"))
+        if(firstTokenOfRequireTokenList.is("targetMixsetName"))
           {        	
-            Mixset targetMixset = model.getMixset(token.getValue());
+            Mixset targetMixset = model.getMixset(firstTokenOfRequireTokenList.getValue());
             if(targetMixset == null)
               return;
             FeatureLeaf targetFeature = new FeatureLeaf(featureModel);
@@ -58,23 +59,26 @@ class UmpleInternalParser
             FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include, sourceFeatureLeaf);        	
             edge.addTargetFeature(targetFeature);
             edge.setIsSub(isSubFeature);
-
+            featureModel.addFeaturelink(edge);
           }
-          break; // then stop the loop
-        }
-
-
-
       }
-      TokenTree tree = getFeatureTreeTokenFromRequireStList(requireTokenList);       
-
-    }
+      else if(firstTokenOfRequireTokenList.is("lowerBound") ) // has a form of: require 1..3 { A, B, C }
+      {
+        //To Do
+      }
+      else // has the form of : require [A and B or C]
+      {
+        TokenTree tree = generateFeatureTreeTokenFromRequireStList(requireTokenList);
+        // TO Do       
+      }
     
+    }
   }
+
   
 
   /*
-  This methods clean unwanted tokens & changes the form of require-statement argument from 
+  This method filters unwanted tokens & changes the form of require-statement argument from 
   nested tokens, as the parser does, to list of tokens.  
   */
   public ArrayList<Token> getRequireStatementTokensAsList(Token requireStatementToken, List<String> acceptedTokensList)
@@ -104,31 +108,34 @@ class UmpleInternalParser
   	return null;
 	}
 
-private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
+/*
+This method parses req-statement argument & generates a binary tree representation form the req-statment argument.
+It returns one node (root node) if there is no argument to parse.
+*/
+private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
 {
 	TokenTree rootTokenTree = new TokenTree();
   rootTokenTree.setNodeToken(new Token("ROOT",""));
 	TokenTree currentTree = rootTokenTree;		
-  List<String> acceptedTokensList = Arrays.asList("and","or","xor");
+  List<String> linkingOpList = Arrays.asList("and","or","xor");
 	
   for(Token token : tokenList)
 	{
 		TokenTree rightTokenTree = new TokenTree();
 		rightTokenTree.setNodeToken(token);
-    if(acceptedTokensList.contains(token.getName()))
+    if(linkingOpList.contains(token.getName()))
     rightTokenTree.setIsLinkingOperator(true);
 		currentTree.setRightTokenTree(rightTokenTree);
-    //rightTokenTree.setParentTokenTree(currentTree);
 		currentTree = rightTokenTree;
 	}
 	
 	currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
 	
-  TokenTree previousLinkingSubTokenTree = null;
+  TokenTree previousLinkingSubTokenTree = null; 
 	
   while(currentTree.getRightTokenTree() != null)
 	{
-		TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree();
+		TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree(); //linking operator on the right of current node 
 		
 		if(rightLinkingTokenTree == null)
 			break;
@@ -137,7 +144,7 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
      // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
 		if(currentTree.getNodeToken().getName().equals("targetMixsetName") && rightLinkingTokenTree.getIsLinkingOperator())
 		{
-      // A and B --> and A B
+      // A and B --> (and A B)
 			if (previousLinkingSubTokenTree == null)
 			{
         currentTree.setParentTokenTree(rightLinkingTokenTree);
@@ -149,14 +156,11 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
 			else
 			{
         /*
-             this for the case : A and B or C --> or (and A B)
-             and.getPriority == 0. or.getPriority == 1
+          this for the case : A and B or C --> (or (and A B))
+           and.getPriority == 0. or.getPriority == 1
         */
 				if(previousLinkingSubTokenTree.getPriority() <= rightLinkingTokenTree.getPriority())
 				{ 
-         // if(previousLinkingSubTokenTree.getLeftTokenTree() != null)
-          //{            
-            
             TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
             while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
             {
@@ -166,7 +170,6 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
                }
                linkNodeToReplace = linkNodeToReplace.getParentTokenTree();
             }
-
           rightLinkingTokenTree.setLeftTokenTree(previousLinkingSubTokenTree);
           previousLinkingSubTokenTree.getParentTokenTree().setRightTokenTree(rightLinkingTokenTree); 
           previousLinkingSubTokenTree.setParentTokenTree(rightLinkingTokenTree);
@@ -183,11 +186,10 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
           previousLinkingSubTokenTree = rightLinkingTokenTree;
 				}
 			}
-      // to set right node of terminal to null 
+      // last step: set right node of terminal to null 
       currentTree.setRightTokenTree(null);
-
 		}
-		currentTree = rightLinkingTokenTree; // move to next node 
+		currentTree = rightLinkingTokenTree; // move to next node of the tree 
 	}
   
 	return rootTokenTree;	
@@ -197,9 +199,12 @@ private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenLis
 
 
 /*
-This class used to represent the binary tree of require-statement
+This class used to represent the binary tree of require-statement argument 
+Ex: require [A and B or C] will be formed as: 
+          ... or...  
+   ... and...      C
+  A           B    
 */
-
 class TokenTree
 {
   depend cruise.umple.parser.Token;
@@ -212,6 +217,11 @@ class TokenTree
   boolean isOpt = false;
   boolean isLinkingOperator = false;
 
+/*
+This methods returens the priority of a linking operator to move up in the binary tree.
+high priority node moves up & low prioriy moves down 
+Root > xor > or > and > othter termianl (non linking) nodes.  
+*/
   public int getPriority()
   {
     String tokenName = nodeToken.getName();

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -62,10 +62,12 @@ class UmpleInternalParser
             featureModel.addFeaturelink(edge);
           }
       }
+      /*
       else if(firstTokenOfRequireTokenList.is("lowerBound") ) // has a form of: require 1..3 { A, B, C }
       {
         //To Do
       }
+      */
       else // has the form of : require [A and B or C]
       {
         TokenTree tree = generateFeatureTreeTokenFromRequireStList(requireTokenList);
@@ -84,6 +86,7 @@ class UmpleInternalParser
   public ArrayList<Token> getRequireStatementTokensAsList(Token requireStatementToken, List<String> acceptedTokensList)
   {
     ArrayList<Token> TokenList =  new ArrayList<Token>();
+    Token terminal;
     for(Token innerToken : requireStatementToken.getSubTokens())
     {
       if (! innerToken.getName().equals("") && acceptedTokensList.contains(innerToken.getName()))
@@ -110,7 +113,7 @@ class UmpleInternalParser
 
 /*
 This method parses req-statement argument & generates a binary tree representation form the req-statment argument.
-It returns one node (root node) if there is no argument to parse.
+//It returns one node (root node) if there is no argument to parse.
 */
 private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
 {
@@ -192,7 +195,7 @@ private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tok
 		currentTree = rightLinkingTokenTree; // move to next node of the tree 
 	}
   
-	return rootTokenTree;	
+	return rootTokenTree.getRightTokenTree;	
 }
 
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -12,7 +12,6 @@ Please refer to UmpleInternalParser.ump for more details.
 class UmpleInternalParser
 {
   depend cruise.umple.compiler.*;
-   
   public void analyzeRequireStatement(Token t, int analysisStep)
   {
     if (analysisStep != 2)
@@ -22,7 +21,78 @@ class UmpleInternalParser
     }    
     if (t.is("requireStatement"))
     {
+      FeatureModel featureModel = model.getFeatureModel();
+      if(featureModel == null)
+        featureModel = new FeatureModel("featureModel");
+      featureModel.setUmpleModel(model);
+
+      Mixset sourceMixset = getMixsetFromToken(t);
+      FeatureLeaf sourceFeatureLeaf = new FeatureLeaf(featureModel);
+      if (sourceMixset == null) // require-statement comes from umple file 
+      {
+        sourceFeatureLeaf.setMixsetOrFileNode(new UmpleFile(t.getPosition().getFilename()));
+      }
+       //tokens needed for parsing require-statement
+      List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","sub","opt");
+      ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
+      if(requireTokenList.size() == 0 )
+      return;
       
+      for(Token token : requireTokenList)
+      {
+        if ( requireTokenList.size() == 1 )
+        {
+          if(token.is("targetMixsetName"))
+          {        	
+            Mixset targetMixset = model.getMixset(token.getValue());
+            if(targetMixset == null)
+              return;
+  
+            sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset);
+            FeatureLeaf targetFeature = new FeatureLeaf(featureModel);
+            targetFeature.setMixsetOrFileNode(targetMixset);
+            FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include, sourceFeatureLeaf);        	
+            edge.getTargetFeature().add(targetFeature);
+
+          }
+       
+        }
+      }  
+       
+      
+
     }
+    
   }
+  
+
+  /*
+  This methods clean unwanted tokens & changes the form of require-statement argument from 
+  nested tokens, as the parser does, to list of tokens.  
+  */
+  public ArrayList<Token> getRequireStatementTokensAsList(Token requireStatementToken, List<String> acceptedTokensList)
+  {
+    ArrayList<Token> TokenList =  new ArrayList<Token>();
+    for(Token innerToken : requireStatementToken.getSubTokens())
+    {
+      if (! innerToken.getName().equals("") && acceptedTokensList.contains(innerToken.getName()))
+      	TokenList.add(innerToken);
+      else if (innerToken.getSubTokens() != null)
+      	TokenList.addAll(getRequireStatementTokensAsList(innerToken,acceptedTokensList)); 
+    }
+    return TokenList;
+  }
+  
+  /*
+  This methods returns the mixset in which require-statement was found.
+  It returns null if the require-statement is in a file (not inside a mixset). 
+	*/
+  private Mixset getMixsetFromToken(Token token) {
+  	Token parentToken = token.getParentToken();
+  	if (parentToken.is("mixsetDefinition"))
+  	  return model.getMixset(parentToken.getValue());
+  	
+  	return null;
+	}
+
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -22,46 +22,6 @@ class UmpleInternalParser
     }    
     if (t.is("requireStatement"))
     {
-      boolean notFlag = false;
-      boolean optFlag = false;
-       
-      String tokenString = t.toString();
-      for (Token token: t.getSubTokens())
-      {
-      
-        String tokenName= token.getName();
-        if(tokenName.equals("not"))
-        {
-          notFlag=true;
-        }
-        else if(tokenName.equals("opt"))
-        {
-          optFlag= true;
-        }
-         else if(tokenName.equals("requireTerminal"))
-        {
-         String mixsetName = token.getValue("targetMixsetName");
-        /*
-         if (notFlag)
-         {}
-         if (optFlag)
-         {}
-         */
-         optFlag=false; notFlag=false;
-        }
-        else if(tokenName.equals("requireLinkingOp"))
-        {
-        
-        }
-      }
-      //List<Token> subTokens = t.getSubTokens();
-      
-      
-      String mixsetName = t.getValue("targetMixsetName");
-      Mixset mixset = model.getMixset(mixsetName);
-       if(mixset != null)
-       {
-       }
       
     }
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -37,7 +37,9 @@ class UmpleInternalParser
       boolean isSubFeature = t.getSubToken("subfeature") != null; 
 
        //tokens needed for parsing require-statement
-      List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","subfeature","opt");
+     // List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","subfeature","opt");
+           List<String> acceptedTokensList = Arrays.asList("targetMixsetName","and","not","xor","or","opt");
+
       ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
       if(requireTokenList.size() == 0 )
       return;
@@ -63,9 +65,8 @@ class UmpleInternalParser
 
 
 
-      }  
-       
-      
+      }
+      TokenTree tree = getFeatureTreeTokenFromRequireStList(requireTokenList);       
 
     }
     
@@ -103,4 +104,143 @@ class UmpleInternalParser
   	return null;
 	}
 
+private TokenTree getFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
+{
+	TokenTree rootTokenTree = new TokenTree();
+  rootTokenTree.setNodeToken(new Token("ROOT",""));
+	TokenTree currentTree = rootTokenTree;		
+  List<String> acceptedTokensList = Arrays.asList("and","or","xor");
+	for(Token token : tokenList)
+	{
+		TokenTree rightTokenTree = new TokenTree();
+		rightTokenTree.setNodeToken(token);
+    if(acceptedTokensList.contains(token.getName()))
+    rightTokenTree.setIsLinkingOperator(true);
+		currentTree.setRightTokenTree(rightTokenTree);
+    //rightTokenTree.setParentTokenTree(currentTree);
+		currentTree = rightTokenTree;
+	}
+	
+	currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
+	
+  TokenTree previousLinkingSubTokenTree = null;
+  TokenTree rootNode = null;
+	
+  while(currentTree.getRightTokenTree() != null)
+	{
+		TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree();
+		
+		if(rightLinkingTokenTree == null)
+			break;
+    if(currentTree.getNodeToken() == null || currentTree.getNodeToken().getName() == null ) 
+     continue;
+     // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
+		if(currentTree.getNodeToken().getName().equals("targetMixsetName") && rightLinkingTokenTree.getIsLinkingOperator())
+		{
+      // A and B --> and A B
+			if (previousLinkingSubTokenTree == null)
+			{
+        currentTree.setRightTokenTree(null);
+        currentTree.setParentTokenTree(rightLinkingTokenTree);
+        rightLinkingTokenTree.setLeftTokenTree(currentTree);
+        rightLinkingTokenTree.setParentTokenTree(rootTokenTree);
+        previousLinkingSubTokenTree = rightLinkingTokenTree;
+        rootNode = rightLinkingTokenTree;// this is the root node 
+			}
+			else if(previousLinkingSubTokenTree != null )
+			{
+        /*
+             this for the case : A and B or C --> or (and A B)
+             and.getPriority == 0. or.getPriority ==1
+        */
+				if(previousLinkingSubTokenTree.getPriority() <= rightLinkingTokenTree.getPriority())
+				{ 
+         // if(previousLinkingSubTokenTree.getLeftTokenTree() != null)
+          //{            
+            
+            TokenTree tt = previousLinkingSubTokenTree;
+            while(tt != null && ! tt.getNodeToken().getName().equals("ROOT") )
+            {
+              if (tt.getPriority() <= rightLinkingTokenTree.getPriority() )
+               {
+                previousLinkingSubTokenTree = tt;
+               }
+               tt = tt.getParentTokenTree();
+            }
+
+          rightLinkingTokenTree.setLeftTokenTree(previousLinkingSubTokenTree);
+          previousLinkingSubTokenTree.getParentTokenTree().setRightTokenTree(rightLinkingTokenTree); 
+          previousLinkingSubTokenTree.setParentTokenTree(rightLinkingTokenTree);
+          currentTree.setRightTokenTree(null);
+          previousLinkingSubTokenTree=rightLinkingTokenTree;
+          
+         /* }
+          else 
+          {
+            rightLinkingTokenTree.setLeftTokenTree(currentTree);
+            previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
+            rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
+            rootNode = rightLinkingTokenTree;
+          }*/	
+				}
+				else
+				{   /*
+             this for the case : A or B and C --> or (and A B)
+             and.getPriority == 0. or.getPriority ==1
+            */
+          // last node has low priori
+          rootNode = previousLinkingSubTokenTree;
+          currentTree.setRightTokenTree(null);
+          rightLinkingTokenTree.setLeftTokenTree(currentTree);
+          rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
+        	previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
+				}
+			}
+			
+		}
+    
+  //  if (currentTree.getIsLinkingOperator())
+   // {
+   //   previousLinkingSubTokenTree = currentTree;
+   // }
+		currentTree = rightLinkingTokenTree; // move to next node 
+	}
+  
+	return rootTokenTree;	
+}
+
+}
+
+
+/*
+This class used to represent the binary tree of require-statement
+*/
+
+class TokenTree
+{
+  depend cruise.umple.parser.Token;
+	lazy Token nodeToken;
+  lazy TokenTree parentTokenTree;
+	lazy TokenTree leftTokenTree;
+	lazy TokenTree rightTokenTree;
+  
+  boolean isNegated =false;
+  boolean isOpt = false;
+  boolean isLinkingOperator = false;
+  public int getPriority()
+  {
+    String tokenName = nodeToken.getName();
+    switch (tokenName)
+    {
+      case "and":
+      return 0;
+      case "or":
+      return 1;
+      case "xor":
+      return 2;
+      case "ROOT":
+      return 3;
+    }
+    return -1;
+  }
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -110,84 +110,84 @@ This method parses req-statement argument & generates a binary tree representati
 */
 private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
 {
-	TokenTree rootTokenTree = new TokenTree();
+  TokenTree rootTokenTree = new TokenTree();
   rootTokenTree.setNodeToken(new Token("ROOT",""));
-	TokenTree currentTree = rootTokenTree;		
+  TokenTree currentTree = rootTokenTree;		
   List<String> linkingOpList = Arrays.asList("and","or","xor");
 	
   for(Token token : tokenList)
-	{
-		TokenTree rightTokenTree = new TokenTree();
-		rightTokenTree.setNodeToken(token);
+  {
+    TokenTree rightTokenTree = new TokenTree();
+    rightTokenTree.setNodeToken(token);
     if(linkingOpList.contains(token.getName()))
     rightTokenTree.setIsLinkingOperator(true);
-		currentTree.setRightTokenTree(rightTokenTree);
-		currentTree = rightTokenTree;
-	}
-	
-	currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
-	
+    currentTree.setRightTokenTree(rightTokenTree);
+    currentTree = rightTokenTree;
+  }
+  
+  currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
+  
   TokenTree previousLinkingSubTokenTree = null; 
 	
   while(currentTree.getRightTokenTree() != null)
-	{
-		TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree(); //linking operator on the right of current node 
-		
-		if(rightLinkingTokenTree == null)
-			break;
+  {
+    TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree(); //linking operator on the right of current node 	
+    if(rightLinkingTokenTree == null)
+    break;
     if(currentTree.getNodeToken() == null || currentTree.getNodeToken().getName() == null ) 
      continue;
      // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
-		if(currentTree.getNodeToken().getName().equals("targetMixsetName") && rightLinkingTokenTree.getIsLinkingOperator())
-		{
-      // A and B --> (and A B)
-			if (previousLinkingSubTokenTree == null)
-			{
-        currentTree.setParentTokenTree(rightLinkingTokenTree);
-        rightLinkingTokenTree.setLeftTokenTree(currentTree);
-        rightLinkingTokenTree.setParentTokenTree(rootTokenTree);
-        rootTokenTree.setRightTokenTree(rightLinkingTokenTree);
-        previousLinkingSubTokenTree = rightLinkingTokenTree;
-			}
-			else
-			{
+     if(currentTree.getNodeToken().getName().equals("targetMixsetName") && rightLinkingTokenTree.getIsLinkingOperator())
+	{
+	// A and B --> (and A B)
+	if (previousLinkingSubTokenTree == null)
+	{
+          currentTree.setParentTokenTree(rightLinkingTokenTree);
+	  rightLinkingTokenTree.setLeftTokenTree(currentTree);
+	  rightLinkingTokenTree.setParentTokenTree(rootTokenTree);
+	  rootTokenTree.setRightTokenTree(rightLinkingTokenTree);
+	  previousLinkingSubTokenTree = rightLinkingTokenTree;
+	}
+	else
+	{
         /*
           this for the case : A and B or C --> (or (and A B))
         */
-				if(previousLinkingSubTokenTree.getPriority() >= rightLinkingTokenTree.getPriority())
-				{ 
-            TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
-            while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
-            {
-              if (linkNodeToReplace.getPriority() >= rightLinkingTokenTree.getPriority() )
-               {
-                previousLinkingSubTokenTree = linkNodeToReplace;
-               }
-               linkNodeToReplace = linkNodeToReplace.getParentTokenTree();
+	if(previousLinkingSubTokenTree.getPriority() >= rightLinkingTokenTree.getPriority())
+	{ 
+	  TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
+          while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
+          {
+            if (linkNodeToReplace.getPriority() >= rightLinkingTokenTree.getPriority() )
+	    {
+	      previousLinkingSubTokenTree = linkNodeToReplace;
             }
+            linkNodeToReplace = linkNodeToReplace.getParentTokenTree();
+          }
           rightLinkingTokenTree.setLeftTokenTree(previousLinkingSubTokenTree);
           previousLinkingSubTokenTree.getParentTokenTree().setRightTokenTree(rightLinkingTokenTree); 
           previousLinkingSubTokenTree.setParentTokenTree(rightLinkingTokenTree);
           previousLinkingSubTokenTree=rightLinkingTokenTree;	
-				}
-				else
-				{   /*
-             this for the case : A or B and C --> or (and A B)
-            */
+	}
+	else
+	{
+	  /*
+           this for the case : A or B and C --> or (and A B)
+          */
           rightLinkingTokenTree.setLeftTokenTree(currentTree);
           rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
-        	previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
+	  previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
           previousLinkingSubTokenTree = rightLinkingTokenTree;
-				}
-			}
+	}
+       }
       // last step: set right node of terminal to null 
       currentTree.setRightTokenTree(null);
-		}
-		currentTree = rightLinkingTokenTree; // move to next node of the tree 
-	}
+     }
+      currentTree = rightLinkingTokenTree; // move to next node of the tree 
+    }
   
 	return rootTokenTree.getRightTokenTree();	
-}
+  }
 
 }
 
@@ -202,10 +202,10 @@ Ex: require [A and B or C] will be formed as:
 class TokenTree
 {
   depend cruise.umple.parser.Token;
-	lazy Token nodeToken;
+  lazy Token nodeToken;
   lazy TokenTree parentTokenTree;
-	lazy TokenTree leftTokenTree;
-	lazy TokenTree rightTokenTree;
+  lazy TokenTree leftTokenTree;
+  lazy TokenTree rightTokenTree;
   
   boolean isNegated =false;
   boolean isOpt = false;

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -16,7 +16,7 @@ mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] |
 
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require ( [[requireBody]] | ( [[multiplicity]] of { [[requireTerminal]] [[requireMultiplicityList]] } ) ) 
+requireStatement : require ( sub )? ( [[requireBody]] | ( [[multiplicity]] of { [[requireTerminal]] [[requireMultiplicityList]] } ) ) 
 
 requireBody- : [(([[requireLinkingOptNot]])? [[requireTerminal]] [[requireList]])] 
 
@@ -24,9 +24,9 @@ requireList- : ([[requireLinkingOp]] [[requireTerminal]])*
 
 requireMultiplicityList- : (, [[requireTerminal]])*
 
-requireLinkingOp : ([[requireLinkingOptNot]] | [=and:&|&&|and|,] | [!or:([|][|]?|or|;)])
+requireLinkingOp : ([[requireLinkingOptNot]] | [=and:&|&&|and|,] | [!or:([|][|]?|or|;)] | [=xor:xor|XOR])
 
-requireLinkingOptNot : (opt | not) 
+requireLinkingOptNot- : ([=opt:opt] | [=not:not] ) 
 
 requireTerminal :  [~targetMixsetName]
 

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -16,7 +16,7 @@ mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] |
 
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require ( sub )? ( [[requireBody]] | ( [[multiplicity]] of { [[requireTerminal]] [[requireMultiplicityList]] } ) ) 
+requireStatement : require ( [=subfeature:sub] )? ( [[requireBody]] | ( [[multiplicity]] of { [[requireTerminal]] [[requireMultiplicityList]] } ) ) 
 
 requireBody- : [(([[requireLinkingOptNot]])? [[requireTerminal]] [[requireList]])] 
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -241,6 +241,12 @@ public class UmpleMixsetTest {
     umpleParserTest.assertNoWarningsParse("mixsetRequireStatementNoWarnings.ump");
   }
 
+  @Test
+  public void mixsetRequireSubStatementNoWarnings()
+  {
+    umpleParserTest.assertNoWarningsParse("mixsetRequireSubStatementNoWarnings.ump");
+  }
+
  @Test
   public void stateMachine_State_HasMixset()
   {

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -9,6 +9,10 @@ import cruise.umple.compiler.UmpleFile;
 import cruise.umple.compiler.UmpleModel;
 import cruise.umple.compiler.UmpleClass;
 import java.util.List;
+import cruise.umple.compiler.FeatureModel;
+import cruise.umple.compiler.FeatureLink;
+import cruise.umple.compiler.FeatureNode;
+import cruise.umple.compiler.FeatureLeaf;
 
 public class UmpleMixsetTest {
   
@@ -295,8 +299,23 @@ public class UmpleMixsetTest {
 		List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getAssociations().length, 2);
   }              
-
- 
+  @Test
+  public void parseOneReqStArgument()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_oneArgument.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    FeatureLink featureLink = featureModel.getFeaturelink().get(0);
+    FeatureLeaf source = featureLink.getSourceFeature();
+    FeatureNode target = featureLink.getTargetFeature().get(0);
+    Assert.assertEquals(featureModel.getFeaturelink().size(),1); // test 
+    Assert.assertEquals(false,source.getMixsetOrFileNode().getIsMixset());  // false
+    Assert.assertEquals("reqStArgumentParse_oneArgument",source.getMixsetOrFileNode().getName());// == filename 
+    Assert.assertTrue (((FeatureLeaf) target).getMixsetOrFileNode().getIsMixset()); // true 
+    Assert.assertEquals("M1",((FeatureLeaf) target).getMixsetOrFileNode().getName()); // mixstName 
+	
+  }          
   		
 }
-

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireSubStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireSubStatementNoWarnings.ump
@@ -1,0 +1,19 @@
+
+require sub [Mixset];
+
+require sub [GSMProtocol opt Mp3Recording and Playback and AudioFormat opt Camera ];
+
+require sub 1..3 of {M1,M2,M3};
+
+require sub [M1 opt M3];
+
+require sub [M3 or M2];
+
+require sub 0..1 of {M1}; 
+
+
+/*
+
+All these forms of require statements should not raise errors .  
+
+*/

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_oneArgument.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_oneArgument.ump
@@ -1,0 +1,13 @@
+
+
+require [M1];
+
+mixset M1 {
+
+class A {}
+
+}
+
+use M1;
+
+


### PR DESCRIPTION
The PR has two major elements:
1. Feature model meta-model
Allows feature modeling in Umple. A feature can be a mixset, a fragment of a mixset, or a file. The require-statement helps to build the feature model.
2. Parsing of require-statement argument
This is an initial step of parsing require statement argument. The parser is now able to process one element in the argument of require-statement such as: require [ A ]. For argument that has a combination of Boolean operators, it builds the right binary tree. Still not operator and opt operator are not fully working, the code needs some modification. This will be in next PR. 
