### PR TITLE
Updating Appveyor php version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ init:
 
 install:
 
-- ps: $env:Path="C:\Ruby21\bin;C:/tools/ruby22/bin;C:\Program Files (x86)\Java\jdk1.8.0\bin;$($env:Path);C:\tools\php72;C:\tools\php;C:\ProgramData\chocolatey\lib\ant"
+- ps: $env:Path="C:\Ruby21\bin;C:/tools/ruby22/bin;C:\Program Files (x86)\Java\jdk1.8.0\bin;$($env:Path);C:\tools\php73;C:\tools\php;C:\ProgramData\chocolatey\lib\ant"
 
 - ps: ant -version
 - ps: pushd build


### PR DESCRIPTION
Appveyor has been failing. Php 3 was being installed, yet the path said php 2.