### PR TITLE
Require-statement Handeling 

### DIFF
--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -24,7 +24,7 @@ class FeatureModel
 
 //A Feature model consists of some FeatureNodels, which can be leaf nodes or fragmentFeature nodes.
 class FeatureNode{
-  abstract;
+  lazy name;
   boolean isLeaf =false;
 }
 
@@ -47,7 +47,7 @@ class FragmentFeatureLeaf
 // A FeatureLink connects a source feature to target feature(s) in the feature diagram.
 class FeatureLink
 {
-  0..1 -- 1 FeatureLeaf sourceFeature;
+  * sourceFeatureLink -- 0..1 FeatureNode sourceFeature; // the sourceFeature can be FeatureLeaf or FeatureNode
   0..* -- * FeatureNode targetFeature;
   boolean isSub =false; // isSub to differentiate between sub-features and include/exclude relationship
   enum FeatureConnectingOpType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
@@ -59,6 +59,8 @@ class FeatureLink
 class MultiplicityFeatureConnectingOpType
 {
   isA FeatureLink;
+  
+  /*
   MultiplicityFeatureConnectingOpType( FeatureLeaf aSourceFeature)
   {
     super(FeatureConnectingOpType.Multiplicity, aSourceFeature);
@@ -66,6 +68,7 @@ class MultiplicityFeatureConnectingOpType
   after constructor(){
     this.setFeatureConnectingOpType(FeatureConnectingOpType.Multiplicity);
   }
+  */
   lazy Multiplicity multiplicity;
 }
 // XORFeatureConnectingOpType is a special type of FeatureLink in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
@@ -73,7 +76,7 @@ class XORFeatureConnectingOpType
 {
   isA MultiplicityFeatureConnectingOpType;
   after constructor(){
-    this.setFeatureConnectingOpType(FeatureConnectingOpType.XOR);
+    //this.setFeatureConnectingOpType(FeatureConnectingOpType.XOR);
     setMultiplicity(new Multiplicity());
    // getMultiplicity.setRange("1","1");
   }

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -51,7 +51,7 @@ class FeatureLink
   0..* -- * FeatureNode targetFeature;
   boolean isSub =false; // isSub to differentiate between sub-features and include/exclude relationship
   enum FeatureConnectingOpType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
-  FeatureConnectingOpType featureConnectingOpType;
+  FeatureConnectingOpType featureConnectingOpType = null;
 
 }
 // MultiplicityFeatureConnectingOpType is a special type of FeatureLink in which there are min and max multiplicity. 
@@ -59,26 +59,20 @@ class FeatureLink
 class MultiplicityFeatureConnectingOpType
 {
   isA FeatureLink;
-  
-  /*
-  MultiplicityFeatureConnectingOpType( FeatureLeaf aSourceFeature)
-  {
-    super(FeatureConnectingOpType.Multiplicity, aSourceFeature);
-  }
+  Multiplicity multiplicity = new Multiplicity();
   after constructor(){
     this.setFeatureConnectingOpType(FeatureConnectingOpType.Multiplicity);
   }
-  */
-  lazy Multiplicity multiplicity;
 }
 // XORFeatureConnectingOpType is a special type of FeatureLink in which lower & upper bounds of the set are limited to 1 (i.e. 1..1). 
 class XORFeatureConnectingOpType 
 {
   isA MultiplicityFeatureConnectingOpType;
   after constructor(){
-    //this.setFeatureConnectingOpType(FeatureConnectingOpType.XOR);
-    setMultiplicity(new Multiplicity());
-   // getMultiplicity.setRange("1","1");
+    this.setFeatureConnectingOpType(FeatureConnectingOpType.XOR);
+    Multiplicity xorMultiplicity = new Multiplicity();
+    xorMultiplicity.setRange("1","1");
+    setMultiplicity(xorMultiplicity);
   }
 }
 

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -54,7 +54,8 @@ class UmpleInternalParser
               return;
             FeatureLeaf targetFeature = new FeatureLeaf(featureModel);
             targetFeature.setMixsetOrFileNode(targetMixset);
-            FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include, sourceFeatureLeaf);        	
+            FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include);
+            edge.setSourceFeature(sourceFeatureLeaf);        	
             edge.addTargetFeature(targetFeature);
             edge.setIsSub(isSubFeature);
             featureModel.addFeaturelink(edge);
@@ -63,11 +64,84 @@ class UmpleInternalParser
       else // has the form of : require [A and B or C]
       {
         TokenTree tree = generateFeatureTreeTokenFromRequireStList(requireTokenList);
+     
+        createFeatureModelSegment(sourceFeatureLeaf,tree,isSubFeature);
         // TO Do: add tree for the feature model 
         // To Do: not and opt implementaion 
         // TO Do:  1..3 of {A, B, C}      
       }
     
+    }
+  }
+
+  public FeatureNode createTargetFeature(TokenTree treeNode, FeatureNode sourceFeature, boolean isSubFeature)
+  {
+    FeatureNode intermediateFeatureNode = new FeatureNode(model.getFeatureModel());
+    intermediateFeatureNode.setName(treeNode.getNodeToken().getName());
+    FeatureLink edge = new FeatureLink(treeNode.getFeatureConnectionOpType());
+    edge.setSourceFeature(sourceFeature);
+    edge.setIsSub(isSubFeature);
+    edge.addTargetFeature(intermediateFeatureNode); 
+    edge.setFeatureModel(model.getFeatureModel());
+    model.getFeatureModel().addFeaturelink(edge);
+    return intermediateFeatureNode;
+  }
+  /*
+  This method takes a require-st as a token tree and then it adds the tree to the feature model 
+  */
+  public void createFeatureModelSegment(FeatureNode sourceFeature, TokenTree tokenTree, boolean isSubFeature)
+  {
+    Token node = tokenTree.getNodeToken();
+    String nodeName = node.getName();
+    TokenTree linkingParent = tokenTree.getParentTokenTree();
+    FeatureLink edge = null;
+    if(! tokenTree.getIsLinkingOperator())
+    {
+      if(node.is("requireTerminal"))
+      {        	
+        Mixset targetMixset = model.getMixset(node.getSubToken("targetMixsetName").getValue());
+        if(targetMixset == null)
+        return; // To Do: should raise warning 
+        
+        FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
+        targetFeature.setMixsetOrFileNode(targetMixset);
+        if(linkingParent == null)
+        {
+          // To Do: even if the parent is null, it may be opt or not or multiplicity
+          edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include);
+          edge.setSourceFeature(sourceFeature); 
+        }
+        else // this is for leaf node as the parent is not null 
+        {
+          edge = new FeatureLink(linkingParent.getFeatureConnectionOpType());
+          edge.setSourceFeature(sourceFeature);       
+        }
+        edge.addTargetFeature(targetFeature);
+        edge.setIsSub(isSubFeature);
+        model.getFeatureModel().addFeaturelink(edge);
+      }
+    }
+    else 
+    {
+        TokenTree rightTokenTree = tokenTree.getRightTokenTree();
+        TokenTree leftTokenTree = tokenTree.getLeftTokenTree();
+        if (rightTokenTree == null || leftTokenTree == null)
+        return; //raise error since a connection node does not have left or right node 
+        //else 
+        FeatureNode intermediateFeatureNode = null;
+        boolean parentTokenEqualsCurrentNodeToken = node.is(linkingParent.getNodeToken().getName());
+        if (!parentTokenEqualsCurrentNodeToken)
+        {
+          intermediateFeatureNode = createTargetFeature(tokenTree, sourceFeature, isSubFeature);
+          createFeatureModelSegment(intermediateFeatureNode,rightTokenTree,isSubFeature);
+          createFeatureModelSegment(intermediateFeatureNode,leftTokenTree,isSubFeature);
+        }
+        else 
+        {
+          createFeatureModelSegment(sourceFeature,rightTokenTree,isSubFeature);
+          createFeatureModelSegment(sourceFeature,leftTokenTree,isSubFeature);
+        }
+
     }
   }
 
@@ -87,7 +161,7 @@ class UmpleInternalParser
         TokenList.add(innerToken);
       }
       else if (innerToken.getSubTokens() != null)
-      	TokenList.addAll(getRequireStatementTokensAsList(innerToken,acceptedTokensList)); 
+      	TokenList.addAll(getRequireStatementTokensAsList(innerToken,acceptedTokensList)); // this to obtain [and] out of [requireLinkingOp] 
     }
     return TokenList;
   }
@@ -110,84 +184,84 @@ This method parses req-statement argument & generates a binary tree representati
 */
 private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
 {
-  TokenTree rootTokenTree = new TokenTree();
-  rootTokenTree.setNodeToken(new Token("ROOT",""));
+  TokenTree rootTokenTree = new TokenTree(new Token("ROOT",""));
   TokenTree currentTree = rootTokenTree;		
   List<String> linkingOpList = Arrays.asList("and","or","xor");
 	
   for(Token token : tokenList)
   {
-    TokenTree rightTokenTree = new TokenTree();
-    rightTokenTree.setNodeToken(token);
+    TokenTree rightTokenTree = new TokenTree(token);
     if(linkingOpList.contains(token.getName()))
     rightTokenTree.setIsLinkingOperator(true);
     currentTree.setRightTokenTree(rightTokenTree);
+    rightTokenTree.setParentTokenTree(currentTree);
     currentTree = rightTokenTree;
   }
   
   currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
   
   TokenTree previousLinkingSubTokenTree = null; 
-	
+		
   while(currentTree.getRightTokenTree() != null)
-  {
-    TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree(); //linking operator on the right of current node 	
+ 	{
+		TokenTree rightLinkingTokenTree = currentTree.getRightTokenTree(); //linking operator on the right of current node 	
     if(rightLinkingTokenTree == null)
     break;
     if(currentTree.getNodeToken() == null || currentTree.getNodeToken().getName() == null ) 
      continue;
-     // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
-     if(currentTree.getNodeToken().is("requireTerminal") && rightLinkingTokenTree.getIsLinkingOperator())
-	{
-	// A and B --> (and A B)
-	if (previousLinkingSubTokenTree == null)
-	{
-          currentTree.setParentTokenTree(rightLinkingTokenTree);
-	  rightLinkingTokenTree.setLeftTokenTree(currentTree);
-	  rightLinkingTokenTree.setParentTokenTree(rootTokenTree);
-	  rootTokenTree.setRightTokenTree(rightLinkingTokenTree);
-	  previousLinkingSubTokenTree = rightLinkingTokenTree;
-	}
-	else
-	{
-        /*
-          this for the case : A and B or C --> (or (and A B))
-        */
-	if(previousLinkingSubTokenTree.getPriority() >= rightLinkingTokenTree.getPriority())
-	{ 
-	  TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
-          while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
-          {
-            if (linkNodeToReplace.getPriority() >= rightLinkingTokenTree.getPriority() )
+    // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
+    if(currentTree.getNodeToken().is("requireTerminal") && rightLinkingTokenTree.getIsLinkingOperator())
+    {
+		// A and B --> (and A B)
+    	if (previousLinkingSubTokenTree == null)
+      {
+      	currentTree.setParentTokenTree(rightLinkingTokenTree);
+        rightLinkingTokenTree.setLeftTokenTree(currentTree);
+        rightLinkingTokenTree.setParentTokenTree(rootTokenTree);
+        rootTokenTree.setRightTokenTree(rightLinkingTokenTree);
+        previousLinkingSubTokenTree = rightLinkingTokenTree;
+      }
+      else
 	    {
-	      previousLinkingSubTokenTree = linkNodeToReplace;
-            }
-            linkNodeToReplace = linkNodeToReplace.getParentTokenTree();
-          }
-          rightLinkingTokenTree.setLeftTokenTree(previousLinkingSubTokenTree);
-          previousLinkingSubTokenTree.getParentTokenTree().setRightTokenTree(rightLinkingTokenTree); 
-          previousLinkingSubTokenTree.setParentTokenTree(rightLinkingTokenTree);
-          previousLinkingSubTokenTree=rightLinkingTokenTree;	
-	}
-	else
-	{
-	  /*
-           this for the case : A or B and C --> or (and A B)
-          */
-          rightLinkingTokenTree.setLeftTokenTree(currentTree);
-          rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
-	  previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
-          previousLinkingSubTokenTree = rightLinkingTokenTree;
-	}
-       }
-      // last step: set right node of terminal to null 
-      currentTree.setRightTokenTree(null);
-     }
-      currentTree = rightLinkingTokenTree; // move to next node of the tree 
-    }
-  
+		    /*
+				this for the case : A and B or C --> (or (and A B))
+		    */
+		    if(previousLinkingSubTokenTree.getPriority() >= rightLinkingTokenTree.getPriority())
+		    { 
+		    	TokenTree linkNodeToReplace = previousLinkingSubTokenTree;
+		      while(linkNodeToReplace != null && ! linkNodeToReplace.getNodeToken().getName().equals("ROOT") )
+		      {
+		      	if (linkNodeToReplace.getPriority() >= rightLinkingTokenTree.getPriority() )
+		        {
+							previousLinkingSubTokenTree = linkNodeToReplace;
+		        }
+						linkNodeToReplace = linkNodeToReplace.getParentTokenTree();
+		      }
+		      rightLinkingTokenTree.setLeftTokenTree(previousLinkingSubTokenTree);
+          rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree.getParentTokenTree());
+		      previousLinkingSubTokenTree.getParentTokenTree().setRightTokenTree(rightLinkingTokenTree); 
+		      previousLinkingSubTokenTree.setParentTokenTree(rightLinkingTokenTree);
+		      previousLinkingSubTokenTree=rightLinkingTokenTree;	
+		    }
+		    else
+			  {
+					/*
+		    	this for the case : A or B and C --> or (and A B)
+		    	*/
+		    	rightLinkingTokenTree.setLeftTokenTree(currentTree);
+					rightLinkingTokenTree.setParentTokenTree(previousLinkingSubTokenTree);
+			  	previousLinkingSubTokenTree.setRightTokenTree(rightLinkingTokenTree);
+		      previousLinkingSubTokenTree = rightLinkingTokenTree;
+		    }
+		  }
+    	// last step: set right node of terminal to null 
+    	currentTree.setRightTokenTree(null);
+  		}
+  	currentTree = rightLinkingTokenTree; // move to next node of the tree 
+		}
+ 
 	return rootTokenTree.getRightTokenTree();	
-  }
+	}
 
 }
 
@@ -202,7 +276,7 @@ Ex: require [A and B or C] will be formed as:
 class TokenTree
 {
   depend cruise.umple.parser.Token;
-  lazy Token nodeToken;
+  Token nodeToken;
   lazy TokenTree parentTokenTree;
   lazy TokenTree leftTokenTree;
   lazy TokenTree rightTokenTree;
@@ -210,7 +284,34 @@ class TokenTree
   boolean isNegated =false;
   boolean isOpt = false;
   boolean isLinkingOperator = false;
+/*
+This method selects the the connection operator type based on the type of the (linking) token.
+If the type is not specified for the linking node, The default is Required.
+It returns null if the node is termainl node.
+*/
+public FeatureLink.FeatureConnectingOpType getFeatureConnectionOpType()
+{
+  if(nodeToken != null )
+  {
+    String operator = nodeToken.getName();
+    switch (operator) {
+		case "and":
+			return FeatureLink.FeatureConnectingOpType.Conjunctive;
+		case "or":
+			return FeatureLink.FeatureConnectingOpType.Disjunctive;
+		case "xor":
+			return FeatureLink.FeatureConnectingOpType.XOR;
+		case "multiplicityTerminal":
+			return FeatureLink.FeatureConnectingOpType.Multiplicity;
+		case "opt":
+			return FeatureLink.FeatureConnectingOpType.Optional;
+    default:
+			return FeatureLink.FeatureConnectingOpType.Required;
+		}
+  }
 
+  return null;
+}
 /*
 This methods returens the priority of a node to move down in the binary tree.
 high priority node moves down & low prioriy moves up 
@@ -232,4 +333,5 @@ not > and > xor > or > ROOT (Top of the tree)
     }
     return -1; // lower priority, leaf nodes should not move 
   }
+
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -298,19 +298,19 @@ public FeatureLink.FeatureConnectingOpType getFeatureConnectionOpType()
   {
     String operator = nodeToken.getName();
     switch (operator) {
-		case "and":
-			return FeatureLink.FeatureConnectingOpType.Conjunctive;
-		case "or":
-			return FeatureLink.FeatureConnectingOpType.Disjunctive;
-		case "xor":
-			return FeatureLink.FeatureConnectingOpType.XOR;
-		case "multiplicityTerminal":
-			return FeatureLink.FeatureConnectingOpType.Multiplicity;
-		case "opt":
-			return FeatureLink.FeatureConnectingOpType.Optional;
-    default:
-			return FeatureLink.FeatureConnectingOpType.Required;
-		}
+      case "and":
+        return FeatureLink.FeatureConnectingOpType.Conjunctive;
+      case "or":
+        return FeatureLink.FeatureConnectingOpType.Disjunctive;
+      case "xor":
+        return FeatureLink.FeatureConnectingOpType.XOR;
+      case "multiplicityTerminal":
+        return FeatureLink.FeatureConnectingOpType.Multiplicity;
+      case "opt":
+        return FeatureLink.FeatureConnectingOpType.Optional;
+      default:
+        return FeatureLink.FeatureConnectingOpType.Required;
+     }
   }
 
   return null;

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -44,89 +44,94 @@ class UmpleInternalParser
       if(requireTokenList.size() == 0 ) // require [ ]
       return;
 
-      firstTokenOfRequireTokenList = requireTokenList.get(0);
-      if (requireTokenList.size() == 1) // require [A]
-      {
-        if(firstTokenOfRequireTokenList.is("requireTerminal"))
-          {        	
-            Mixset targetMixset = model.getMixset(firstTokenOfRequireTokenList.getSubToken("targetMixsetName").getValue());
-            if(targetMixset == null)
-              return;
-            FeatureLeaf targetFeature = new FeatureLeaf(featureModel);
-            targetFeature.setMixsetOrFileNode(targetMixset);
-            FeatureLink edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include);
-            edge.setSourceFeature(sourceFeatureLeaf);        	
-            edge.addTargetFeature(targetFeature);
-            edge.setIsSub(isSubFeature);
-            featureModel.addFeaturelink(edge);
-          }
-      }
-      else // has the form of : require [A and B or C]
+      if (requireTokenList.size() >= 1)  // has the form of : require [A and B or C .... ]
       {
         TokenTree tree = generateFeatureTreeTokenFromRequireStList(requireTokenList);
      
         createFeatureModelSegment(sourceFeatureLeaf,tree,isSubFeature);
-        // TO Do: add tree for the feature model 
+        // TO Do: add tree for the feature model : Done
         // To Do: not and opt implementaion 
-        // TO Do:  1..3 of {A, B, C}      
+        // TO Do:  1..3 of {A, B, C} : Done 
       }
     
     }
   }
-
+  /*
+  this method generates a new feature and links it with a source feature based on its token in the TokenTree.
+  It return null if either treeNode or source feature is null.
+  */
   public FeatureNode createTargetFeature(TokenTree treeNode, FeatureNode sourceFeature, boolean isSubFeature)
   {
-    FeatureNode intermediateFeatureNode = new FeatureNode(model.getFeatureModel());
-    intermediateFeatureNode.setName(treeNode.getNodeToken().getName());
-    FeatureLink edge = new FeatureLink(treeNode.getFeatureConnectionOpType());
+    if (treeNode == null || sourceFeature == null)
+    return null; // To Do : should raise error here 
+    FeatureNode newFeatureNode = new FeatureNode(model.getFeatureModel());
+    newFeatureNode.setName(treeNode.getNodeToken().getName());
+    FeatureLink edge = new FeatureLink();
+    edge.setFeatureConnectingOpType(treeNode.getFeatureConnectionOpType());
     edge.setSourceFeature(sourceFeature);
     edge.setIsSub(isSubFeature);
-    edge.addTargetFeature(intermediateFeatureNode); 
+    edge.addTargetFeature(newFeatureNode); 
     edge.setFeatureModel(model.getFeatureModel());
     model.getFeatureModel().addFeaturelink(edge);
-    return intermediateFeatureNode;
+    return newFeatureNode;
   }
   /*
-  This method takes a require-st as a token tree and then it adds the tree to the feature model 
+  This method takes a require-st as a token tree and then it generates its segment in the feature model 
   */
   public void createFeatureModelSegment(FeatureNode sourceFeature, TokenTree tokenTree, boolean isSubFeature)
   {
     Token node = tokenTree.getNodeToken();
-    String nodeName = node.getName();
     TokenTree linkingParent = tokenTree.getParentTokenTree();
     FeatureLink edge = null;
     if(! tokenTree.getIsLinkingOperator())
     {
-      if(node.is("requireTerminal"))
+      if(node.is("requireTerminal") && node.getSubToken("lowerBound") == null)
       {        	
-        Mixset targetMixset = model.getMixset(node.getSubToken("targetMixsetName").getValue());
-        if(targetMixset == null)
-        return; // To Do: should raise warning 
-        
+        //Mixset targetMixset = model.getMixset(node.getSubToken("targetMixsetName").getValue());
+        //if(targetMixset == null)
+        //return; // To Do: should raise warning 
+        Mixset targetMixset = new Mixset(node.getSubToken("targetMixsetName").getValue());
         FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
         targetFeature.setMixsetOrFileNode(targetMixset);
-        if(linkingParent == null)
-        {
-          // To Do: even if the parent is null, it may be opt or not or multiplicity
-          edge = new FeatureLink(FeatureLink.FeatureConnectingOpType.Include);
-          edge.setSourceFeature(sourceFeature); 
-        }
+        edge = new FeatureLink();
+        
+        if(linkingParent.getNodeToken().is("ROOT"))
+        edge.setFeatureConnectingOpType(FeatureLink.FeatureConnectingOpType.Include);
         else // this is for leaf node as the parent is not null 
-        {
-          edge = new FeatureLink(linkingParent.getFeatureConnectionOpType());
-          edge.setSourceFeature(sourceFeature);       
-        }
+        edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType());
+        
+        edge.setSourceFeature(sourceFeature);       
         edge.addTargetFeature(targetFeature);
         edge.setIsSub(isSubFeature);
         model.getFeatureModel().addFeaturelink(edge);
       }
+      else if(node.is("requireTerminal") && node.getSubToken("lowerBound") != null) //  [lowerBound]..[upperBound] of [A, B, ... ]
+      {
+        edge = new MultiplicityFeatureConnectingOpType();
+		    Multiplicity featureLinkMultiplicity = ((MultiplicityFeatureConnectingOpType) edge).getMultiplicity();
+        featureLinkMultiplicity.setRange(node.getSubToken("lowerBound").getValue(), node.getSubToken("upperBound").getValue());
+        for(Token subToken : node.getSubTokens())
+        {
+          if(subToken.is("targetMixsetName"))
+          {
+            FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
+            Mixset targetMixset = new Mixset(subToken.getValue()); //To Do: check if its a mixset.
+            targetFeature.setMixsetOrFileNode(targetMixset);
+            edge.addTargetFeature(targetFeature);
+          }
+        }
+        edge.setSourceFeature(sourceFeature);       
+        edge.setIsSub(isSubFeature);
+        model.getFeatureModel().addFeaturelink(edge);
+      } 
+ 
     }
     else 
     {
         TokenTree rightTokenTree = tokenTree.getRightTokenTree();
         TokenTree leftTokenTree = tokenTree.getLeftTokenTree();
         if (rightTokenTree == null || leftTokenTree == null)
-        return; //raise error since a connection node does not have left or right node 
+        return; //To Do: raise error since a connection node does not have left or right node 
         //else 
         FeatureNode intermediateFeatureNode = null;
         boolean parentTokenEqualsCurrentNodeToken = node.is(linkingParent.getNodeToken().getName());
@@ -144,8 +149,6 @@ class UmpleInternalParser
 
     }
   }
-
-  
   /*
   This method filters unwanted tokens & changes the form of require-statement argument from 
   nested tokens, as the parser does, to list of tokens.  

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -37,7 +37,7 @@ class UmpleInternalParser
       boolean isSubFeature = t.getSubToken("subfeature") != null; 
 
        //tokens needed for parsing require-statement
-      List<String> acceptedTokensList = Arrays.asList("targetMixsetName","lowerBound","upperBound","and","not","xor","or","opt");
+      List<String> acceptedTokensList = Arrays.asList("requireTerminal","and","not","xor","or","opt");
       ArrayList<Token> requireTokenList = getRequireStatementTokensAsList(t, acceptedTokensList);      
       Token firstTokenOfRequireTokenList;
 
@@ -47,9 +47,9 @@ class UmpleInternalParser
       firstTokenOfRequireTokenList = requireTokenList.get(0);
       if (requireTokenList.size() == 1) // require [A]
       {
-        if(firstTokenOfRequireTokenList.is("targetMixsetName"))
+        if(firstTokenOfRequireTokenList.is("requireTerminal"))
           {        	
-            Mixset targetMixset = model.getMixset(firstTokenOfRequireTokenList.getValue());
+            Mixset targetMixset = model.getMixset(firstTokenOfRequireTokenList.getSubToken("targetMixsetName").getValue());
             if(targetMixset == null)
               return;
             FeatureLeaf targetFeature = new FeatureLeaf(featureModel);
@@ -137,7 +137,7 @@ private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tok
     if(currentTree.getNodeToken() == null || currentTree.getNodeToken().getName() == null ) 
      continue;
      // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
-     if(currentTree.getNodeToken().getName().equals("targetMixsetName") && rightLinkingTokenTree.getIsLinkingOperator())
+     if(currentTree.getNodeToken().is("requireTerminal") && rightLinkingTokenTree.getIsLinkingOperator())
 	{
 	// A and B --> (and A B)
 	if (previousLinkingSubTokenTree == null)

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -16,26 +16,17 @@ mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] |
 
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require ( [=subfeature:sub] )? ( [[requireBody]] | ( [[multiplicity]] of { [[requireTerminal]] [[requireMultiplicityList]] } ) ) 
+requireStatement : require ( [=subfeature:sub] )? [[requireBody]] 
 
 requireBody- : [(([[requireLinkingOptNot]])? [[requireTerminal]] [[requireList]])] 
 
 requireList- : ([[requireLinkingOp]] [[requireTerminal]])*
 
-requireMultiplicityList- : (, [[requireTerminal]])*
-
 requireLinkingOp : ([[requireLinkingOptNot]] | [=and:&|&&|and|,] | [!or:([|][|]?|or|;)] | [=xor:xor|XOR])
 
 requireLinkingOptNot- : ([=opt:opt] | [=not:not] ) 
 
-requireTerminal :  [~targetMixsetName]
+requireTerminal :  [~targetMixsetName] | [[multiplicityTerminal]]
 
-
-
-
-
-
-
-
-
+multiplicityTerminal- : [[multiplicity]] of { [~targetMixsetName] (, [~targetMixsetName] )* }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -308,14 +308,34 @@ public class UmpleMixsetTest {
     model.run();
     FeatureModel featureModel= model.getFeatureModel();
     FeatureLink featureLink = featureModel.getFeaturelink().get(0);
-    FeatureLeaf source = featureLink.getSourceFeature();
+    FeatureLeaf source = ((FeatureLeaf) featureLink.getSourceFeature());
     FeatureNode target = featureLink.getTargetFeature().get(0);
     Assert.assertEquals(featureModel.getFeaturelink().size(),1); // test 
     Assert.assertEquals(false,source.getMixsetOrFileNode().getIsMixset());  // false
     Assert.assertEquals("reqStArgumentParse_oneArgument",source.getMixsetOrFileNode().getName());// == filename 
     Assert.assertTrue (((FeatureLeaf) target).getMixsetOrFileNode().getIsMixset()); // true 
     Assert.assertEquals("M1",((FeatureLeaf) target).getMixsetOrFileNode().getName()); // mixstName 
-	
-  }          
+  }
+
+@Test
+  public void parseMultipleAndsOpReqStArgument()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_MultipleAndsOp.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+		FeatureModel featureModel= model.getFeatureModel();
+		int numOfLinks = featureModel.getFeaturelink().size();// == 6;
+    int numOfFeatures = featureModel.getNode().size();// == 7   
+    Assert.assertEquals(numOfLinks,6); 
+    Assert.assertEquals(numOfFeatures,7); 
+    Assert.assertEquals(false,  ((FeatureLeaf)featureModel.getNode().get(0)).getMixsetOrFileNode().isIsMixset() );  // false: its a file
+    Assert.assertEquals(featureModel.getNode().get(1).getName(), "and");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(2)).getMixsetOrFileNode().getName(),"E");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(3)).getMixsetOrFileNode().getName(), "D");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName(),"C");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(5)).getMixsetOrFileNode().getName(), "B");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"A"); 
+  }                    
   		
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -336,6 +336,30 @@ public class UmpleMixsetTest {
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName(),"C");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(5)).getMixsetOrFileNode().getName(), "B");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"A"); 
-  }                    
+  }
+@Test
+  public void parseMultipleOpReqStArgument()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_MultipleOp.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+		FeatureModel featureModel= model.getFeatureModel();
+		int numOfLinks = featureModel.getFeaturelink().size();
+    int numOfFeatures = featureModel.getNode().size();  
+    Assert.assertEquals(numOfLinks,7); 
+    Assert.assertEquals(numOfFeatures,10); 
+
+    Assert.assertEquals(false,  ((FeatureLeaf)featureModel.getNode().get(0)).getMixsetOrFileNode().isIsMixset() );  // false: its a file
+    Assert.assertEquals(featureModel.getNode().get(1).getName(), "or");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(2)).getMixsetOrFileNode().getName(),"M6");
+		Assert.assertEquals(featureModel.getNode().get(3).getName(), "xor");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName() ,"M5"); 
+		Assert.assertEquals(featureModel.getNode().get(5).getName(), "and");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"M4"); 
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M1");     		    	
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M2");  
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M3");  
+  }                               
   		
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -324,8 +324,8 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		FeatureModel featureModel= model.getFeatureModel();
-		int numOfLinks = featureModel.getFeaturelink().size();// == 6;
+    FeatureModel featureModel= model.getFeatureModel();
+    int numOfLinks = featureModel.getFeaturelink().size();// == 6;
     int numOfFeatures = featureModel.getNode().size();// == 7   
     Assert.assertEquals(numOfLinks,6); 
     Assert.assertEquals(numOfFeatures,7); 
@@ -344,8 +344,8 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		FeatureModel featureModel= model.getFeatureModel();
-		int numOfLinks = featureModel.getFeaturelink().size();
+    FeatureModel featureModel= model.getFeatureModel();
+    int numOfLinks = featureModel.getFeaturelink().size();
     int numOfFeatures = featureModel.getNode().size();  
     Assert.assertEquals(numOfLinks,7); 
     Assert.assertEquals(numOfFeatures,10); 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireStatementNoWarnings.ump
@@ -1,9 +1,9 @@
 
-require [Mixset];
+require [Mixset]; use Mixset; mixset Mixset {}
 
 require [GSMProtocol opt Mp3Recording and Playback and AudioFormat opt Camera ];
 
-require 1..3 of {M1,M2,M3};
+require [ 1..3 of {M1,M2,M3} ];
 
 require [not M2 and m4 ] ;
 
@@ -11,7 +11,7 @@ require [M1 opt M3];
 
 require [M3 or M2];
 
-require 0..1 of {M1}; 
+require [0..1 of {M1}]; 
 
 
 /*

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireSubStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireSubStatementNoWarnings.ump
@@ -1,15 +1,15 @@
 
-require sub [Mixset];
+require sub [Mixset1]; use Mixset1; mixset Mixset1{}
 
 require sub [GSMProtocol opt Mp3Recording and Playback and AudioFormat opt Camera ];
 
-require sub 1..3 of {M1,M2,M3};
+require sub [ 1..3 of {M1,M2,M3 } ];
 
 require sub [M1 opt M3];
 
 require sub [M3 or M2];
 
-require sub 0..1 of {M1}; 
+require sub [0..1 of {M1}]; 
 
 
 /*

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_MultipleAndsOp.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_MultipleAndsOp.ump
@@ -1,0 +1,18 @@
+require [A and B and C and D and E];
+
+mixset D {}
+
+mixset E {}
+
+mixset A {}
+
+mixset B {}
+
+mixset C {}
+
+
+use A;
+use B;
+use C;
+use D;
+use E;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_MultipleOp.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_MultipleOp.ump
@@ -1,0 +1,6 @@
+require [ 1..3 of {M1,M2,M3 } and M4 xor M5 or M6];
+
+mixset M1 {} mixset M2 {} mixset M3 {} mixset M4 {} mixset M5 {} 
+
+use M1 ; use M2 ; use M3 ; use M4 ; use M5 ;use M6;
+


### PR DESCRIPTION
Multiplicity operator has been considered a terminal in the require-statement grammar. So. it will have the following syntax "require [ 1..3 of {A,B,C} ]"  instead of " require 1..3 of {A,B,C}" . This has two advantages: allows multiplicity to be mixed with other linking operators, and it makes processing multiplicity much easier. 

In this PR, complex arguments of require-statement such as "require [ 1..3 of {M1,M2,M3 } and M4 xor M5 or M6];" will be parsed according to its precedence, and then it will be captured by the feature model. More improvement and handling not operator and opt operator will be next step. 

The feature model will capture the require-statement argument, however, it will not check the satisfaction of argument. 
