### PR TITLE
Require-statement opt/not operators

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -85,6 +85,21 @@ class UmpleInternalParser
     FeatureLink edge = null;
     if(! tokenTree.getIsLinkingOperator())
     {
+      if(node.is("opt") || node.is("not"))
+      {
+        if(tokenTree.getRightTokenTree().getNodeToken().is("requireTerminal"))
+        {
+          Mixset targetMixset = new Mixset(tokenTree.getRightTokenTree().getNodeToken().getSubToken("targetMixsetName").getValue());
+          FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
+          targetFeature.setMixsetOrFileNode(targetMixset);
+          edge = new FeatureLink();
+          edge.setFeatureConnectingOpType(tokenTree.getFeatureConnectionOpType());
+          edge.setSourceFeature(sourceFeature);
+          edge.addTargetFeature(targetFeature);
+          edge.setIsSub(isSubFeature);
+          model.getFeatureModel().addFeaturelink(edge);          
+        }
+      }
       if(node.is("requireTerminal") && node.getSubToken("lowerBound") == null)
       {        	
         //Mixset targetMixset = model.getMixset(node.getSubToken("targetMixsetName").getValue());
@@ -308,6 +323,8 @@ public FeatureLink.FeatureConnectingOpType getFeatureConnectionOpType()
         return FeatureLink.FeatureConnectingOpType.Multiplicity;
       case "opt":
         return FeatureLink.FeatureConnectingOpType.Optional;
+      case "not":
+        return FeatureLink.FeatureConnectingOpType.Exclude;
       default:
         return FeatureLink.FeatureConnectingOpType.Required;
      }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -46,8 +46,8 @@ class UmpleInternalParser
 
       if (requireTokenList.size() >= 1)  // has the form of : require [A and B or C .... ]
       {
-        TokenTree tree = generateFeatureTreeTokenFromRequireStList(requireTokenList);
-     
+        List<TokenTree> tokenTreeList = generateFeatureTreeTokenFromRequireStList(requireTokenList);
+        for(TokenTree tree: tokenTreeList)
         createFeatureModelSegment(sourceFeatureLeaf,tree,isSubFeature);
         // TO Do: add tree for the feature model : Done
         // To Do: not and opt implementaion 
@@ -200,22 +200,36 @@ class UmpleInternalParser
 This method parses req-statement argument & generates a binary tree representation form the req-statment argument.
 //It returns one node (root node) if there is no argument to parse.
 */
-private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
+private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tokenList)
 {
   TokenTree rootTokenTree = new TokenTree(new Token("ROOT",""));
   TokenTree currentTree = rootTokenTree;		
   List<String> linkingOpList = Arrays.asList("and","or","xor");
-	
-  for(Token token : tokenList)
+	ArrayList<TokenTree> tokenTreeList = new ArrayList<TokenTree>();
+  
+  for (int i=0;i<tokenList.size();i++)
   {
+    Token token = tokenList.get(i);
     TokenTree rightTokenTree = new TokenTree(token);
+    //Start(1): put each [opt/not][terminal] in a separate TokenTree if it was preceded with [terminal]
+    if(token.is("opt") || token.is("not"))
+    {
+      if(currentTree.getNodeToken().is("requireTerminal") && tokenList.get(i+1).is("requireTerminal")) // A opt B
+      {
+        rightTokenTree.setRightTokenTree(new TokenTree(tokenList.get(i+1)));
+        // setParent to rightTokenTree
+        tokenTreeList.add(rightTokenTree);
+        i++; //skip opt terminal 
+        continue;
+      }
+    }
+    //End(1)
     if(linkingOpList.contains(token.getName()))
     rightTokenTree.setIsLinkingOperator(true);
     currentTree.setRightTokenTree(rightTokenTree);
     rightTokenTree.setParentTokenTree(currentTree);
     currentTree = rightTokenTree;
   }
-  
   currentTree = rootTokenTree.getRightTokenTree(); //currentTree points to the first node of the tree
   
   TokenTree previousLinkingSubTokenTree = null; 
@@ -277,8 +291,8 @@ private TokenTree generateFeatureTreeTokenFromRequireStList(ArrayList<Token> tok
   		}
   	currentTree = rightLinkingTokenTree; // move to next node of the tree 
 		}
- 
-	return rootTokenTree.getRightTokenTree();	
+  tokenTreeList.add(rootTokenTree.getRightTokenTree());
+	return tokenTreeList;	
 	}
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -376,7 +376,24 @@ public class UmpleMixsetTest {
     Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
     Assert.assertEquals(featureModel.getFeaturelink(1).getFeatureConnectingOpType().name(), "Exclude");
     
-	 
-  }                               
+  }
+	@Test
+  public void parseTerminalNotOptTerminalReqStArgumet()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_TerminalOpTerminal.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();    
+		//source --> opt B
+    Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false); // false: its the source file
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
+		//source --> and A C
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
+    Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(1).getTargetFeature(0)).getName() ,"and");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
+  }                                                              
   		
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -337,7 +337,7 @@ public class UmpleMixsetTest {
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(5)).getMixsetOrFileNode().getName(), "B");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"A"); 
   }
-@Test
+  @Test
   public void parseMultipleOpReqStArgument()
   {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_MultipleOp.ump");
@@ -360,6 +360,23 @@ public class UmpleMixsetTest {
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M1");     		    	
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M2");  
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M3");  
+  }                               
+  
+  @Test
+  public void parseNotOptSingleReqStArgumet()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_NotOptSingleArg.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();    
+    int numOfLinks = featureModel.getFeaturelink().size();
+    Assert.assertEquals(numOfLinks,2); 
+    Assert.assertEquals(false,  ((FeatureLeaf)featureModel.getNode().get(0)).getMixsetOrFileNode().isIsMixset() );  // false: its a file
+    Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
+    Assert.assertEquals(featureModel.getFeaturelink(1).getFeatureConnectingOpType().name(), "Exclude");
+    
+	 
   }                               
   		
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotOptSingleArg.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotOptSingleArg.ump
@@ -1,0 +1,5 @@
+require [opt MixsetA];
+require [not MixsetB];
+
+// opt and not should be captured by the feature model.
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_TerminalOpTerminal.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_TerminalOpTerminal.ump
@@ -1,0 +1,5 @@
+require [A opt B and C];
+
+mixset A {} mixset B {} mixset C{}
+
+use A; use B; use C;


### PR DESCRIPTION
This PR handles opt/not operators for single mixset such as `require [opt M1]; require [not M2];` . 

When opt/not is mentioned after another mixset name in req-st argument (no any operator to join them), each opt/not will be linked to the source mixset/feature. For example: ` mixset A { require [B opt C and D]; }` will be considered as `mixset A { require [B and D]; require [opt C]; }` . 
