### PR TITLE
Require-statement improvement

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -26,14 +26,20 @@ class UmpleInternalParser
         featureModel = new FeatureModel("featureModel");
       featureModel.setUmpleModel(model);
 
+      FeatureLeaf sourceFeatureLeaf;
       Mixset sourceMixset = getMixsetFromToken(t);
-      FeatureLeaf sourceFeatureLeaf = new FeatureLeaf(featureModel);
-      // require-statement comes from umple file or mixset ?
-      if (sourceMixset == null) 
-      sourceFeatureLeaf.setMixsetOrFileNode(new UmpleFile(t.getPosition().getFilename()));
-      else 
-      sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset);
-      
+      if(sourceMixset != null)
+      {
+        sourceFeatureLeaf = featureModel.getOrCreateFeatureLeafNode(sourceMixset.getName());
+        sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset); 
+      }
+      else
+      {
+        UmpleFile ufile = new UmpleFile(t.getPosition().getFilename());
+        sourceFeatureLeaf = featureModel.getOrCreateFeatureLeafNode(ufile.getName()); 
+        sourceFeatureLeaf.setMixsetOrFileNode(ufile);
+      }
+    
       boolean isSubFeature = t.getSubToken("subfeature") != null; 
 
        //tokens needed for parsing require-statement
@@ -55,7 +61,7 @@ class UmpleInternalParser
       }
     
     }
-  }
+  }  
   /*
   this method generates a new feature and links it with a source feature based on its token in the TokenTree.
   It return null if either treeNode or source feature is null.
@@ -83,6 +89,7 @@ class UmpleInternalParser
     Token node = tokenTree.getNodeToken();
     TokenTree linkingParent = tokenTree.getParentTokenTree();
     FeatureLink edge = null;
+    FeatureModel featureModel = model.getFeatureModel();
     if(! tokenTree.getIsLinkingOperator())
     {
       if(node.is("opt") || node.is("not"))
@@ -90,8 +97,10 @@ class UmpleInternalParser
         if(tokenTree.getRightTokenTree().getNodeToken().is("requireTerminal"))
         {
           Mixset targetMixset = new Mixset(tokenTree.getRightTokenTree().getNodeToken().getSubToken("targetMixsetName").getValue());
-          FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
+          FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
+          //new FeatureLeaf(model.getFeatureModel());//model.getFeatureModel().
           targetFeature.setMixsetOrFileNode(targetMixset);
+          //targetFeature.setName(targetMixset.getName());
           edge = new FeatureLink();
           edge.setFeatureConnectingOpType(tokenTree.getFeatureConnectionOpType());
           edge.setSourceFeature(sourceFeature);
@@ -106,8 +115,9 @@ class UmpleInternalParser
         //if(targetMixset == null)
         //return; // To Do: should raise warning 
         Mixset targetMixset = new Mixset(node.getSubToken("targetMixsetName").getValue());
-        FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
+        FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
         targetFeature.setMixsetOrFileNode(targetMixset);
+        //targetFeature.setName(targetMixset.getName());
         edge = new FeatureLink();
         
         if(linkingParent.getNodeToken().is("ROOT"))
@@ -129,8 +139,8 @@ class UmpleInternalParser
         {
           if(subToken.is("targetMixsetName"))
           {
-            FeatureLeaf targetFeature = new FeatureLeaf(model.getFeatureModel());
             Mixset targetMixset = new Mixset(subToken.getValue()); //To Do: check if its a mixset.
+            FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
             targetFeature.setMixsetOrFileNode(targetMixset);
             edge.addTargetFeature(targetFeature);
           }
@@ -297,6 +307,37 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(ArrayList
 
 }
 
+
+class FeatureModel{
+/*
+ * This method returns a leaf node from FeatureModel based on its name.
+ * return null if the leaf node is not found.   
+ */
+  public FeatureLeaf getFeatureLeafNode(String name)
+  {
+    for(FeatureNode aNode: node)
+    {
+      if(aNode.getName().equals(name) && aNode.getIsLeaf()) // isLeaf
+      return ((FeatureLeaf) aNode);
+    }
+    return null;
+  }
+  /*
+  This method does conditional addition for a FeatureLeaf based on the provided name. 
+  It returns a new FeatureLeaf if its not found, or existing FeatureLeaf if the name was found.
+  */
+  public FeatureLeaf getOrCreateFeatureLeafNode(String name)
+  {
+    FeatureLeaf aNode = getFeatureLeafNode(name);
+    if(aNode == null)
+    {
+      aNode = new FeatureLeaf(this);
+      aNode.setName(name);
+    }
+    return aNode; 
+  }
+
+}
 
 /*
 This class used to represent the binary tree of require-statement argument 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -131,18 +131,16 @@ public class UmpleMixsetTest {
 			SampleFileWriter.destroy("Inner_2.java");
 		}
   }
-	
-	
-	@Test
+  @Test
   public void middleOfMixsetBodyError() {
 
     UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"mixsetInnerBodyError.ump");
     int line = 12;
     int errorCode = 1503;
     int offset= 1;
-		int charOff = 12;
-		umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);		
-		}
+    int charOff = 12;
+    umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);		
+  }
 
   @Test
   public void nestedMixsetBodyWarning() {
@@ -152,64 +150,53 @@ public class UmpleMixsetTest {
     int errorCode = 1007;
     int offset= 0;
     int charOff = 12;
-    umpleParserTest.assertHasWarningsParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);			
-		
+    umpleParserTest.assertHasWarningsParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);
   }
 
 	@Test
   public void oneElementMixsetBodyError() {
-    
     UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"oneElementMixsetBodyError.ump");
     int line = 5;
     int errorCode = 1502;
     int offset= 0;
-		int charOff = 0;
-		umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);
-		
+    int charOff = 0;
+    umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);
  }
-  
+
   @Test
   public void lastElementMixsetBodyError() {
-    
     UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"lastElementError.ump");
     int line = 3;
     int errorCode = 1502;
     int offset= 0;
-		int charOff = 14;
-		umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);
+    int charOff = 14;
+    umpleParserTest.assertFailedParse(file.getFileName(), new Position(file.getPath()+"/"+file.getFileName(),line,offset,charOff),errorCode);
 
-		
  }
 
  @Test
   public void fileMaintainItsOrderWithMixset() {
-    
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"mixsetUseUmpleFileOrder.ump");
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getAttribute(0).getName(),"one");
     Assert.assertEquals(umpleClasses.get(0).getAttribute(1).getName(),"two");
     Assert.assertEquals(umpleClasses.get(0).getAttribute(2).getName(),"three");
     Assert.assertEquals(umpleClasses.get(0).getAttribute(3).getName(),"four");
     Assert.assertEquals(umpleClasses.get(0).getAttribute(4).getName(),"five");
-	
-
-		
  }
 
 @Test
   public void mixsetWithNoUseStatementHasNoEffect() {
-    
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"mixsetDefinition.ump"); //mixsetDefinition.ump is reused for a different purpose.
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.size(), 1);
     Assert.assertEquals(umpleClasses.get(0).getAttributes().size(), 0);
-  	
  }
 
   @Test
@@ -233,7 +220,7 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.size(), 1);
     Assert.assertEquals(umpleClasses.get(0).getName(),"Target");
 
@@ -258,7 +245,7 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getName(),"Booking");
     Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getStates().size(),5);
     Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getAllTransitions().size(), 6);
@@ -272,7 +259,7 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getName(),"Booking");
     Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getStates().size(),5);
     Assert.assertEquals(umpleClasses.get(0).getStateMachine("state").getAllTransitions().size(), 6);
@@ -285,7 +272,7 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getName(),"ClassA");
     Assert.assertEquals(umpleClasses.get(0).getAttributes().size(), 2);
   }
@@ -296,9 +283,9 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-		List<UmpleClass> umpleClasses = model.getUmpleClasses();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getAssociations().length, 2);
-  }              
+  }
   @Test
   public void parseOneReqStArgument()
   {
@@ -316,8 +303,7 @@ public class UmpleMixsetTest {
     Assert.assertTrue (((FeatureLeaf) target).getMixsetOrFileNode().getIsMixset()); // true 
     Assert.assertEquals("M1",((FeatureLeaf) target).getMixsetOrFileNode().getName()); // mixstName 
   }
-
-@Test
+  @Test
   public void parseMultipleAndsOpReqStArgument()
   {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_MultipleAndsOp.ump");
@@ -346,22 +332,22 @@ public class UmpleMixsetTest {
     model.run();
     FeatureModel featureModel= model.getFeatureModel();
     int numOfLinks = featureModel.getFeaturelink().size();
-    int numOfFeatures = featureModel.getNode().size();  
-    Assert.assertEquals(numOfLinks,7); 
-    Assert.assertEquals(numOfFeatures,10); 
+    int numOfFeatures = featureModel.getNode().size();
+    Assert.assertEquals(numOfLinks,7);
+    Assert.assertEquals(numOfFeatures,10);
 
     Assert.assertEquals(false,  ((FeatureLeaf)featureModel.getNode().get(0)).getMixsetOrFileNode().isIsMixset() );  // false: its a file
     Assert.assertEquals(featureModel.getNode().get(1).getName(), "or");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(2)).getMixsetOrFileNode().getName(),"M6");
-		Assert.assertEquals(featureModel.getNode().get(3).getName(), "xor");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName() ,"M5"); 
-		Assert.assertEquals(featureModel.getNode().get(5).getName(), "and");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"M4"); 
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M1");     		    	
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M2");  
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M3");  
-  }                               
-  
+    Assert.assertEquals(featureModel.getNode().get(3).getName(), "xor");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName() ,"M5");
+    Assert.assertEquals(featureModel.getNode().get(5).getName(), "and");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"M4");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M1");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M2");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M3");
+  }
+
   @Test
   public void parseNotOptSingleReqStArgumet()
   {
@@ -374,26 +360,47 @@ public class UmpleMixsetTest {
     Assert.assertEquals(numOfLinks,2); 
     Assert.assertEquals(false,  ((FeatureLeaf)featureModel.getNode().get(0)).getMixsetOrFileNode().isIsMixset() );  // false: its a file
     Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
-    Assert.assertEquals(featureModel.getFeaturelink(1).getFeatureConnectingOpType().name(), "Exclude");
-    
+    Assert.assertEquals(featureModel.getFeaturelink(1).getFeatureConnectingOpType().name(), "Exclude"); 
   }
-	@Test
+  @Test
   public void parseTerminalNotOptTerminalReqStArgumet()
   {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_TerminalOpTerminal.ump");
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
-    FeatureModel featureModel= model.getFeatureModel();    
-		//source --> opt B
+    FeatureModel featureModel= model.getFeatureModel();
+    //source --> opt B
     Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false); // false: its the source file
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
-		//source --> and A C
+    //source --> and A C
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
     Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(1).getTargetFeature(0)).getName() ,"and");
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
-  }                                                              
-  		
+  }
+  @Test
+  public void parseReqStArgumetToFeaureModel()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_featureModel.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    // 5 outging links from the source
+
+    Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(0).getTargetFeature(0)).getName() ,"and");
+    /*
+    //source --> opt B
+    Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false); // false: its the source file
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
+    //source --> and A C
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
+
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
+    */ 
+}
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -48,14 +48,14 @@ public class UmpleMixsetTest {
   @Test
   public void mixsetUseInSubsequentFile()
   {
-	  String[] args = new String[] {"first.ump"};
-	  SampleFileWriter.createFile("first.ump", " mixset MyMixset { class MyClass {} } use activateMixset.ump; ");
-	  SampleFileWriter.createFile	("activateMixset.ump"," use MyMixset; ");
-	  try 
-	  {
+    String[] args = new String[] {"first.ump"};
+    SampleFileWriter.createFile("first.ump", " mixset MyMixset { class MyClass {} } use activateMixset.ump; ");
+    SampleFileWriter.createFile	("activateMixset.ump"," use MyMixset; ");
+    try 
+    {
       UmpleConsoleMain.main(args);
       SampleFileWriter.assertFileExists("MyClass.java");
-    }	
+    }
     finally 
     {
       SampleFileWriter.destroy("first.ump");
@@ -63,8 +63,8 @@ public class UmpleMixsetTest {
       SampleFileWriter.destroy("activateMixset.ump");
     }
   }
-	
-	@Test
+
+  @Test
   public void mixsetUseInCodeTest() {
     String[] args = new String[] {"mixsetUseInCodeTest.ump"};
     SampleFileWriter.createFile("mixsetUseInCodeTest.ump", " class Outer_Mix_1{ } mixset Mix { class Inner_Mix {name;} } class Outer_Mix_2{ }"
@@ -80,27 +80,26 @@ public class UmpleMixsetTest {
       SampleFileWriter.assertFileExists("Outer_Mix_2.java");
     }	
     finally 
-		{
+    {
       SampleFileWriter.destroy("mixsetUseInCodeTest.ump");
       SampleFileWriter.destroy("Inner_Mix.java");
       SampleFileWriter.destroy("Outer_Mix_1.java");
       SampleFileWriter.destroy("Outer_Mix_2.java");
     }
   }
-	
+
   @Test
   public void mixsetUseInConsoleTest() {
     String[] args = new String[] {"mixsetUseInConsoleTest.ump", "Mx"};
 
     SampleFileWriter.createFile("mixsetUseInConsoleTest.ump", " class Outer_1{ } mixset Mx { class Inner_M1 {name;} } class Outer_2{ }");
-
    try 
    {
       UmpleConsoleMain.main(args);
       SampleFileWriter.assertFileExists("Inner_M1.java");
       SampleFileWriter.assertFileExists("Outer_1.java");
       SampleFileWriter.assertFileExists("Outer_2.java");
-    }	
+    }
     finally 
     {
       SampleFileWriter.destroy("mixsetUseInConsoleTest.ump");
@@ -109,7 +108,7 @@ public class UmpleMixsetTest {
       SampleFileWriter.destroy("Outer_2.java");
     }
   }
-			
+
   @Test
   public void multipleMixsetUseInConsoleTest() {
     String[] args = new String[] {"mixset_1.ump", "M2", "mixset_2.ump", "M1"};
@@ -118,18 +117,17 @@ public class UmpleMixsetTest {
 
     try 
     {
-			UmpleConsoleMain.main(args);
-			SampleFileWriter.assertFileExists("Inner_1.java");
+      UmpleConsoleMain.main(args);
+      SampleFileWriter.assertFileExists("Inner_1.java");
       SampleFileWriter.assertFileExists("Inner_2.java");
-
-		}	
-		finally 
-		{
-			SampleFileWriter.destroy("mixset_1.ump");
-			SampleFileWriter.destroy("mixset_2.ump");
-			SampleFileWriter.destroy("Inner_1.java");
-			SampleFileWriter.destroy("Inner_2.java");
-		}
+    }	
+    finally 
+    {
+      SampleFileWriter.destroy("mixset_1.ump");
+      SampleFileWriter.destroy("mixset_2.ump");
+      SampleFileWriter.destroy("Inner_1.java");
+      SampleFileWriter.destroy("Inner_2.java");
+    }
   }
   @Test
   public void middleOfMixsetBodyError() {
@@ -388,19 +386,20 @@ public class UmpleMixsetTest {
     model.setShouldGenerate(false);
     model.run();
     FeatureModel featureModel= model.getFeatureModel();
-    // 5 outging links from the source
-
+    //source --> (and A B)
     Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(0).getTargetFeature(0)).getName() ,"and");
-    /*
-    //source --> opt B
-    Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false); // false: its the source file
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
-    //source --> and A C
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
-
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
-    */ 
-}
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
+    //source --> opt C
+    Assert.assertEquals(featureModel.getFeaturelink(3).getFeatureConnectingOpType().name(), "Optional");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
+    //source --> not D
+    Assert.assertEquals(featureModel.getFeaturelink(4).getFeatureConnectingOpType().name(), "Exclude");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(4).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"D");
+    //source --> (xor F E)
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(5).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
+    Assert.assertEquals(featureModel.getFeaturelink(5).getFeatureConnectingOpType().name(), "XOR");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(6).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"F");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(7).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"E"); 
+  }
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_featureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_featureModel.ump
@@ -1,0 +1,15 @@
+/*
+map the require-statement to feature model. 
+*/
+require sub [A and B];
+require sub [opt C];
+require [not D];
+require sub [E xor F];
+
+
+mixset A {} mixset B {} mixset C{}
+mixset D {} mixset E {} mixset F{}
+
+use A; use B; use C;
+use D; use E; use F;
+


### PR DESCRIPTION
This PR allows several segments of the feature model in different locations to be linked together based on the name of the source feature. For Example, the feature model that results from: `require [A]; require [opt B]` will have one source feature (the source file) and two target features (with different linking types)