### PR TITLE
Feature model analysis

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -118,6 +118,7 @@ class UmpleInternalParser
       secondPostTokenAnalysis();
       //add analysis here!!! xx.validateStateMachineGuardConstraints(model);
       checkDefaultedNameConflict();
+      analyzeFeatureModel(); // lastly to analyze the feature model after all mixsets are added to umple model. 
     
     }
     catch (Exception ex)

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -55,6 +55,8 @@ class UmpleInternalParser
         List<TokenTree> tokenTreeList = generateFeatureTreeTokenFromRequireStList(requireTokenList);
         for(TokenTree tree: tokenTreeList)
         createFeatureModelSegment(sourceFeatureLeaf,tree,isSubFeature);
+        
+        //
         // TO Do: add tree for the feature model : Done
         // To Do: not and opt implementaion 
         // TO Do:  1..3 of {A, B, C} : Done 
@@ -98,9 +100,7 @@ class UmpleInternalParser
         {
           Mixset targetMixset = new Mixset(tokenTree.getRightTokenTree().getNodeToken().getSubToken("targetMixsetName").getValue());
           FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
-          //new FeatureLeaf(model.getFeatureModel());//model.getFeatureModel().
           targetFeature.setMixsetOrFileNode(targetMixset);
-          //targetFeature.setName(targetMixset.getName());
           edge = new FeatureLink();
           edge.setFeatureConnectingOpType(tokenTree.getFeatureConnectionOpType());
           edge.setSourceFeature(sourceFeature);
@@ -251,7 +251,6 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(ArrayList
     break;
     if(currentTree.getNodeToken() == null || currentTree.getNodeToken().getName() == null ) 
      continue;
-    // currentTree.getNodeToken().getName().equals("targetMixsetName") or opt / not
     if(currentTree.getNodeToken().is("requireTerminal") && rightLinkingTokenTree.getIsLinkingOperator())
     {
 		// A and B --> (and A B)
@@ -305,6 +304,11 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(ArrayList
 	return tokenTreeList;	
 	}
 
+  public void analyzeFeatureModel()
+  {
+    if(model.getFeatureModel() != null)
+    model.getFeatureModel().satisfyFeatureModel();
+  }
 }
 
 
@@ -335,6 +339,132 @@ class FeatureModel{
       aNode.setName(name);
     }
     return aNode; 
+  }
+  
+  public boolean evaluateFeatureLink(FeatureLink featureLink)
+  {
+    FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
+
+    if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Include))
+    {
+      FeatureLeaf fNode = ((FeatureLeaf) featureLink.getTargetFeature(0));
+      boolean isMixset = fNode.getMixsetOrFileNode().getIsMixset();
+      if(isMixset)
+      {
+        Mixset mixset = getUmpleModel().getMixset(fNode.getMixsetOrFileNode().getName());
+        if(mixset != null)
+        {
+          if(mixset.getUseUmpleFile() != null)
+          return true;  // this means there is a use-statement here
+          //else there is no use-statement    
+        }
+        else 
+        {
+          return false;//there is no mixset with the specified name. 
+        }
+      }
+    } 
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Exclude))
+    {
+      FeatureLeaf fNode = ((FeatureLeaf) featureLink.getTargetFeature(0));
+      boolean isMixset = fNode.getMixsetOrFileNode().getIsMixset();
+      if(isMixset)
+      {
+        Mixset mixset = getUmpleModel().getMixset(fNode.getMixsetOrFileNode().getName());
+        if(mixset != null)
+        {
+           if(mixset.getUseUmpleFile() == null)
+          return true;  // this means there is no use-statement here
+          //else there is use-statement   
+        }
+        else 
+        {
+          return false;//raise error here ... 
+        }
+      }
+    }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Optional))
+    {
+      // opt is allawys has a true value 
+      return true;
+    } 
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Conjunctive))
+    { 
+      FeatureNode fNode = ((FeatureNode) featureLink.getTargetFeature(0));
+      if(!fNode.getIsLeaf())
+      {
+        List<FeatureLink> outgoingLinks = fNode.getSourceFeatureLink();
+        for(int i=0 ; i<outgoingLinks.size()-1; i++){
+          return evaluateFeatureLink(outgoingLinks.get(i)) && evaluateFeatureLink(outgoingLinks.get(i+1));
+        }
+      }
+    }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Disjunctive))
+    {   
+      FeatureNode fNode = ((FeatureNode) featureLink.getTargetFeature(0));
+      if(!fNode.getIsLeaf())
+      {
+        List<FeatureLink> outgoingLinks = fNode.getSourceFeatureLink();
+        for(int i=0 ; i<outgoingLinks.size()-1; i++){
+          return evaluateFeatureLink(outgoingLinks.get(i)) || evaluateFeatureLink(outgoingLinks.get(i+1));
+        }
+      }
+    }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.XOR))
+    { 
+      FeatureNode fNode = ((FeatureNode) featureLink.getTargetFeature(0));
+      if(!fNode.getIsLeaf())
+          {
+            List<FeatureLink> outgoingLinks = fNode.getSourceFeatureLink();
+            for(int i=0 ; i<outgoingLinks.size()-1; i++){
+              return evaluateFeatureLink(outgoingLinks.get(i)) ^ evaluateFeatureLink(outgoingLinks.get(i+1));
+            }
+          }
+    }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Multiplicity))
+    { //To DO
+      return true;
+    }
+    else if(featureNode.getIsLeaf())
+    {
+      FeatureLeaf featureleaf = (FeatureLeaf) featureNode;
+      boolean isMixset = featureleaf.getMixsetOrFileNode().getIsMixset();
+      if(isMixset)
+      {
+        Mixset mixset = getUmpleModel().getMixset(featureleaf.getMixsetOrFileNode().getName());
+        if(mixset != null)
+        {
+          if(mixset.getUseUmpleFile() != null)
+          return true;  // this means there is a use-statement here
+          //else there is no use-statement    
+        }
+        else 
+        {
+          return false;//there is no mixset with the specified name. 
+        }
+      }
+    }
+    return false;
+  }
+
+  depend java.util.stream.*;
+  public void satisfyFeatureModel()
+  {
+    UmpleModel model = getUmpleModel();
+    //if(featureModel == null)
+    //return ; // there is no any feature model the current umple file.
+    //else
+    //get leaf features that has outgoing links, they are the root of the feature model in this case
+    // check each link based on the type of the link
+    List <FeatureNode> rootFeatures = getNode().stream().filter(n -> (n.hasSourceFeatureLink() && n.getIsLeaf())).collect(Collectors.toList());
+    for(FeatureNode featureNode: rootFeatures)
+    {
+      List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
+      for(FeatureLink flink : featureNodeOutLinks)
+      {
+        evaluateFeatureLink(flink);
+      }
+    }
   }
 
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -313,6 +313,7 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(ArrayList
 
 
 class FeatureModel{
+  depend java.util.stream.*;
 /*
  * This method returns a leaf node from FeatureModel based on its name.
  * return null if the leaf node is not found.   
@@ -378,7 +379,7 @@ class FeatureModel{
     } 
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Exclude))
     {
-      return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement 
+      return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement, or no def for mixset 
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Optional))
     {
@@ -428,7 +429,6 @@ class FeatureModel{
     }
     return false;
   }
-  depend java.util.stream.*;
   /*
   This method checks whether the use-statements plus the feature model results in valid configuration.
   It return true If there is no feature model.

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -340,48 +340,45 @@ class FeatureModel{
     }
     return aNode; 
   }
-  
+  /*
+  This method returns true if the feature leaf has a use-statement.
+  It returns false if there is no use-statement for the mixset.
+  It returns false if there is no mixset or file in the feature leaf.
+  */
+  public boolean isUsedFeatureLeaf(FeatureLeaf featureLeaf){
+    boolean isMixset = featureLeaf.getMixsetOrFileNode().getIsMixset();
+    if(isMixset)
+    {
+      Mixset mixset = getUmpleModel().getMixset(featureLeaf.getMixsetOrFileNode().getName());
+      if(mixset != null)
+      {
+        if(mixset.getUseUmpleFile() != null)
+        return true;  // this means there is a use-statement here
+        //else there is no use-statement    
+      }
+      else 
+      {
+        return false;//there is no mixset with the specified name. 
+      }
+    }
+    return false; 
+  }
+  /*
+  This method takes a feature link (from the feature model) and decides whether the link is satisfied.
+  If the link is not satisfied, it return false.
+  Ex: the link "source--> and" for M1 and M2 is true if there are use-statements for both M1 and M2.   
+  */
   public boolean evaluateFeatureLink(FeatureLink featureLink)
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
 
     if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Include))
     {
-      FeatureLeaf fNode = ((FeatureLeaf) featureLink.getTargetFeature(0));
-      boolean isMixset = fNode.getMixsetOrFileNode().getIsMixset();
-      if(isMixset)
-      {
-        Mixset mixset = getUmpleModel().getMixset(fNode.getMixsetOrFileNode().getName());
-        if(mixset != null)
-        {
-          if(mixset.getUseUmpleFile() != null)
-          return true;  // this means there is a use-statement here
-          //else there is no use-statement    
-        }
-        else 
-        {
-          return false;//there is no mixset with the specified name. 
-        }
-      }
+      return isUsedFeatureLeaf((FeatureLeaf)featureNode);
     } 
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Exclude))
     {
-      FeatureLeaf fNode = ((FeatureLeaf) featureLink.getTargetFeature(0));
-      boolean isMixset = fNode.getMixsetOrFileNode().getIsMixset();
-      if(isMixset)
-      {
-        Mixset mixset = getUmpleModel().getMixset(fNode.getMixsetOrFileNode().getName());
-        if(mixset != null)
-        {
-           if(mixset.getUseUmpleFile() == null)
-          return true;  // this means there is no use-statement here
-          //else there is use-statement   
-        }
-        else 
-        {
-          return false;//raise error here ... 
-        }
-      }
+      return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement 
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Optional))
     {
@@ -390,10 +387,9 @@ class FeatureModel{
     } 
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Conjunctive))
     { 
-      FeatureNode fNode = ((FeatureNode) featureLink.getTargetFeature(0));
-      if(!fNode.getIsLeaf())
+      if(!featureNode.getIsLeaf())
       {
-        List<FeatureLink> outgoingLinks = fNode.getSourceFeatureLink();
+        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
         for(int i=0 ; i<outgoingLinks.size()-1; i++){
           return evaluateFeatureLink(outgoingLinks.get(i)) && evaluateFeatureLink(outgoingLinks.get(i+1));
         }
@@ -401,10 +397,9 @@ class FeatureModel{
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Disjunctive))
     {   
-      FeatureNode fNode = ((FeatureNode) featureLink.getTargetFeature(0));
-      if(!fNode.getIsLeaf())
+      if(!featureNode.getIsLeaf())
       {
-        List<FeatureLink> outgoingLinks = fNode.getSourceFeatureLink();
+        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
         for(int i=0 ; i<outgoingLinks.size()-1; i++){
           return evaluateFeatureLink(outgoingLinks.get(i)) || evaluateFeatureLink(outgoingLinks.get(i+1));
         }
@@ -412,63 +407,48 @@ class FeatureModel{
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.XOR))
     { 
-      FeatureNode fNode = ((FeatureNode) featureLink.getTargetFeature(0));
-      if(!fNode.getIsLeaf())
+      if(!featureNode.getIsLeaf())
           {
-            List<FeatureLink> outgoingLinks = fNode.getSourceFeatureLink();
+            List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
             for(int i=0 ; i<outgoingLinks.size()-1; i++){
-              return evaluateFeatureLink(outgoingLinks.get(i)) ^ evaluateFeatureLink(outgoingLinks.get(i+1));
+              return evaluateFeatureLink(outgoingLinks.get(i)) ^ evaluateFeatureLink(outgoingLinks.get(i+1)); // ^: bitwise xor 
             }
           }
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Multiplicity))
-    { //To DO
+    { 
+      //To Do
+      // To Do next PR
       return true;
     }
     else if(featureNode.getIsLeaf())
     {
-      FeatureLeaf featureleaf = (FeatureLeaf) featureNode;
-      boolean isMixset = featureleaf.getMixsetOrFileNode().getIsMixset();
-      if(isMixset)
-      {
-        Mixset mixset = getUmpleModel().getMixset(featureleaf.getMixsetOrFileNode().getName());
-        if(mixset != null)
-        {
-          if(mixset.getUseUmpleFile() != null)
-          return true;  // this means there is a use-statement here
-          //else there is no use-statement    
-        }
-        else 
-        {
-          return false;//there is no mixset with the specified name. 
-        }
-      }
+      return isUsedFeatureLeaf((FeatureLeaf)featureNode);
     }
     return false;
   }
-
   depend java.util.stream.*;
-  public void satisfyFeatureModel()
+  /*
+  This method checks whether the use-statements plus the feature model results in valid configuration.
+  It return true If there is no feature model.
+  */
+  public boolean satisfyFeatureModel()
   {
     UmpleModel model = getUmpleModel();
-    //if(featureModel == null)
-    //return ; // there is no any feature model the current umple file.
-    //else
-    //get leaf features that has outgoing links, they are the root of the feature model in this case
-    // check each link based on the type of the link
+    boolean isSatisfied = true;
+    // get root features : has outgoing links but no incoming links
     List <FeatureNode> rootFeatures = getNode().stream().filter(n -> (n.hasSourceFeatureLink() && n.getIsLeaf())).collect(Collectors.toList());
     for(FeatureNode featureNode: rootFeatures)
     {
       List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
       for(FeatureLink flink : featureNodeOutLinks)
       {
-        evaluateFeatureLink(flink);
+        isSatisfied = isSatisfied && evaluateFeatureLink(flink);
       }
     }
+    return isSatisfied;
   }
-
 }
-
 /*
 This class used to represent the binary tree of require-statement argument 
 Ex: require [A and B or C] will be formed as: 

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -421,7 +421,8 @@ class FeatureModel{
       // To Do next PR
       return true;
     }
-    else if(featureNode.getIsLeaf())
+    
+    if(featureNode.getIsLeaf())
     {
       return isUsedFeatureLeaf((FeatureLeaf)featureNode);
     }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -402,4 +402,25 @@ public class UmpleMixsetTest {
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(6).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"F");
     Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(7).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"E"); 
   }
+  @Test
+  public void parseReqStArgumetToSatisfyFeatureModel_1()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_featureModel.ump");//reuse ump file from parseReqStArgumetToFeaureModel()
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    Assert.assertEquals(featureModel.satisfyFeatureModel(), false);
+  }
+  @Test
+  public void parseReqStArgumetToSatisfyFeatureModel_2()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_validFeatureModel.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    Assert.assertEquals(featureModel.satisfyFeatureModel(), true);
+  }
+
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -422,5 +422,14 @@ public class UmpleMixsetTest {
     FeatureModel featureModel= model.getFeatureModel();
     Assert.assertEquals(true,featureModel.satisfyFeatureModel());
   }
-
+@Test
+  public void parseReqStArgumetToSatisfyFeatureModel_3()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_NotValidXorFeatureModel.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    Assert.assertEquals(false,featureModel.satisfyFeatureModel());
+  }
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -420,7 +420,7 @@ public class UmpleMixsetTest {
     model.setShouldGenerate(false);
     model.run();
     FeatureModel featureModel= model.getFeatureModel();
-    Assert.assertEquals(featureModel.satisfyFeatureModel(), true);
+    Assert.assertEquals(true,featureModel.satisfyFeatureModel());
   }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotValidXorFeatureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotValidXorFeatureModel.ump
@@ -1,0 +1,18 @@
+require sub [A and B];
+require sub [opt C];
+require [not D];
+require sub [E xor F];
+
+
+mixset A {} mixset B {} mixset C{}
+mixset D {} mixset E {} mixset F{}
+
+/*
+ use-statements result in not valid configuration of feature model. 
+*/
+
+use A; use B; 
+use C;
+//use D; 
+use E; 
+use F;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_validFeatureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_validFeatureModel.ump
@@ -1,0 +1,20 @@
+
+require sub [A and B];
+require sub [opt C];
+require [not D];
+require sub [E xor F];
+
+
+mixset A {} mixset B {} mixset C{}
+mixset D {} mixset E {} mixset F{}
+
+/*
+ use-statements result in valid configuration of feature model. 
+*/
+
+use A; use B; 
+use C;
+//use D; 
+use E; 
+//use F;
+


### PR DESCRIPTION
In this PR, use-statements of mixsets can be checked against the feature model by the method `satisfyFeatureModel`(); of the class `FeatureModel`. The method returns true if all segments of the feature model (require-statements) have been satisfied. The multiplicity operator has not been implemented yet. It will be implemented (and further enhancements) in next PR.   