### PR TITLE
Feature model analysis (Multiplicity)

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -421,7 +421,6 @@ class FeatureModel{
         boolean result = false;
         List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
         for(int i=0 ; i<outgoingLinks.size(); i++){
-          // bitwise xor (^) can not be used here because it does not mean allways only one. Example: (true ^ true ^ true == true) 
           result = result || evaluateFeatureLink(outgoingLinks.get(i));
         }
         return result;
@@ -434,7 +433,7 @@ class FeatureModel{
             List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
             int countOfUsedTarget = 0;
             for(int i=0 ; i < outgoingLinks.size(); i++){
-              if(evaluateFeatureLink(outgoingLinks.get(i)))
+              if(evaluateFeatureLink(outgoingLinks.get(i)))  // bitwise xor (^) can not be used here because it does not mean always only one. Example: (true ^ true ^ true == true) 
               countOfUsedTarget++;
             }
             return (countOfUsedTarget == 1) ? true: false;

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -391,19 +391,23 @@ class FeatureModel{
       if(!featureNode.getIsLeaf())
       {
         List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
-        for(int i=0 ; i<outgoingLinks.size()-1; i++){
-          return evaluateFeatureLink(outgoingLinks.get(i)) && evaluateFeatureLink(outgoingLinks.get(i+1));
+        boolean result = true;
+        for(int i=0 ; i<outgoingLinks.size(); i++){
+          result = result && evaluateFeatureLink(outgoingLinks.get(i));
         }
+        return result;
       }
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Disjunctive))
     {   
       if(!featureNode.getIsLeaf())
       {
+        boolean result = false;
         List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
         for(int i=0 ; i<outgoingLinks.size()-1; i++){
-          return evaluateFeatureLink(outgoingLinks.get(i)) || evaluateFeatureLink(outgoingLinks.get(i+1));
+          result = result || evaluateFeatureLink(outgoingLinks.get(i));
         }
+        return result;
       }
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.XOR))
@@ -411,16 +415,26 @@ class FeatureModel{
       if(!featureNode.getIsLeaf())
           {
             List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
-            for(int i=0 ; i<outgoingLinks.size()-1; i++){
-              return evaluateFeatureLink(outgoingLinks.get(i)) ^ evaluateFeatureLink(outgoingLinks.get(i+1)); // ^: bitwise xor 
+            int countOfUsedTarget = 0;
+            for(int i=0 ; i < outgoingLinks.size(); i++){
+              if(evaluateFeatureLink(outgoingLinks.get(i)))
+              countOfUsedTarget++;
             }
+            return (countOfUsedTarget == 1) ? true: false;
           }
     }
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Multiplicity))
-    { 
-      //To Do
-      // To Do next PR
-      return true;
+    {
+      MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
+      int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
+      int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
+      List<FeatureNode> featureNodes = featureLink.getTargetFeature();
+      int countOfUsedTarget = 0;
+      for(int i=0 ; i < featureNodes.size(); i++){
+        if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(i)))
+        countOfUsedTarget++;
+      }
+      return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
     }
     
     if(featureNode.getIsLeaf())

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -372,20 +372,36 @@ class FeatureModel{
   public boolean evaluateFeatureLink(FeatureLink featureLink)
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
-
-    if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Include))
+    if(featureNode.getIsLeaf())
     {
+      if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Include))
+      {
+        return isUsedFeatureLeaf((FeatureLeaf)featureNode);
+      } 
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Exclude))
+      {
+        return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement, or no def for mixset 
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Optional))
+      {
+        return true;        // opt is allawys has a true value 
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Multiplicity))
+      {
+        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
+        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
+        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
+        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
+        int countOfUsedTarget = 0;
+        for(int i=0 ; i < featureNodes.size(); i++){
+          if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(i)))
+          countOfUsedTarget++;
+        }
+        return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
+      }
+      else 
       return isUsedFeatureLeaf((FeatureLeaf)featureNode);
-    } 
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Exclude))
-    {
-      return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement, or no def for mixset 
-    }
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Optional))
-    {
-      // opt is allawys has a true value 
-      return true;
-    } 
+    } // if not leaf node
     else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Conjunctive))
     { 
       if(!featureNode.getIsLeaf())
@@ -404,7 +420,7 @@ class FeatureModel{
       {
         boolean result = false;
         List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
-        for(int i=0 ; i<outgoingLinks.size()-1; i++){
+        for(int i=0 ; i<outgoingLinks.size(); i++){
           result = result || evaluateFeatureLink(outgoingLinks.get(i));
         }
         return result;
@@ -423,24 +439,7 @@ class FeatureModel{
             return (countOfUsedTarget == 1) ? true: false;
           }
     }
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Multiplicity))
-    {
-      MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
-      int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
-      int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
-      List<FeatureNode> featureNodes = featureLink.getTargetFeature();
-      int countOfUsedTarget = 0;
-      for(int i=0 ; i < featureNodes.size(); i++){
-        if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(i)))
-        countOfUsedTarget++;
-      }
-      return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
-    }
-    
-    if(featureNode.getIsLeaf())
-    {
-      return isUsedFeatureLeaf((FeatureLeaf)featureNode);
-    }
+    //otherwise
     return false;
   }
   /*

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -421,6 +421,7 @@ class FeatureModel{
         boolean result = false;
         List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
         for(int i=0 ; i<outgoingLinks.size(); i++){
+          // bitwise xor (^) can not be used here because it does not mean allways only one. Example: (true ^ true ^ true == true) 
           result = result || evaluateFeatureLink(outgoingLinks.get(i));
         }
         return result;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -452,4 +452,14 @@ public class UmpleMixsetTest {
     FeatureModel featureModel= model.getFeatureModel();
     Assert.assertEquals(false,featureModel.satisfyFeatureModel());
   }
+  @Test
+  public void parseReqStArgumetToSatisfyFeatureModel_6()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_NotvalidBitWiseFeatuerModel.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    Assert.assertEquals(false,featureModel.satisfyFeatureModel());
+  }
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -422,10 +422,30 @@ public class UmpleMixsetTest {
     FeatureModel featureModel= model.getFeatureModel();
     Assert.assertEquals(true,featureModel.satisfyFeatureModel());
   }
-@Test
+  @Test
   public void parseReqStArgumetToSatisfyFeatureModel_3()
   {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_NotValidXorFeatureModel.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    Assert.assertEquals(false,featureModel.satisfyFeatureModel());
+  }
+  @Test
+  public void parseReqStArgumetToSatisfyFeatureModel_4()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_validSetFeatureModel.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    FeatureModel featureModel= model.getFeatureModel();
+    Assert.assertEquals(true,featureModel.satisfyFeatureModel());
+  }
+  @Test
+  public void parseReqStArgumetToSatisfyFeatureModel_5()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"reqStArgumentParse_NotvalidSetFeatureModel.ump");
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotvalidBitWiseFeatuerModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotvalidBitWiseFeatuerModel.ump
@@ -1,0 +1,15 @@
+require [ A xor B xor C];
+
+
+
+mixset A {} mixset B {} mixset C{}
+
+use A; 
+use B; 
+use C;
+
+
+/*
+ This is not valid configuration of feature model. However, using bitwise xor "^" makes the configuration valid.  
+*/
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotvalidSetFeatureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotvalidSetFeatureModel.ump
@@ -1,0 +1,16 @@
+require [ 2..3 of { A, B, C, D}];
+
+
+
+mixset A {} mixset B {} mixset C{}
+mixset D {}
+
+/*
+ use-statements result in not valid configuration of feature model. 
+*/
+
+use A; 
+//use B; 
+//use C;
+//use D; 
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_validSetFeatureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_validSetFeatureModel.ump
@@ -1,0 +1,15 @@
+require [ 2..3 of { A, B, C, D}];
+
+
+
+mixset A {} mixset B {} mixset C{}
+mixset D {}
+
+/*
+ use-statements result in a valid configuration of feature model. 
+*/
+
+use A; use B; 
+use C;
+//use D; 
+


### PR DESCRIPTION
The multiplicity operator has been implemented in this PR. The xor operator has been changed as the bit-wise xor "^" does not always mean only one. 
The test case (parseReqStArgumetToSatisfyFeatureModel_6) shows that xor fails when there are three mixsets and all have use-statements. This is not what we would like to do. 