### PR TITLE
Graphviz feature diagram generator

### DIFF
--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -24,8 +24,11 @@ class FeatureModel
 
 //A Feature model consists of some FeatureNodels, which can be leaf nodes or fragmentFeature nodes.
 class FeatureNode{
+  depend java.util.concurrent.atomic.AtomicInteger ;
+  static AtomicInteger nextId = new AtomicInteger();
+  int id =nextId.incrementAndGet();
   lazy name;
-  boolean isLeaf =false;
+  boolean isLeaf =false; 
 }
 
 // A FeatureLeaf contains a full mixset or a full file. 

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -24,14 +24,14 @@ class FeatureModel
 
 //A Feature model consists of some FeatureNodels, which can be leaf nodes or fragmentFeature nodes.
 class FeatureNode{
+  //This to assign a unique name for each feature node. 
   depend java.util.concurrent.atomic.AtomicInteger ;
   static AtomicInteger nextId = new AtomicInteger();
-  // each FeatureNode has a unique id
+  // each new FeatureNode has a unique id
   int id = nextId.incrementAndGet();
   lazy name;
   boolean isLeaf =false; 
 
-  //This method assign a unique name for each feature node. 
   public String getUniqueFeatureNodeName()
   {
     return name+"_"+id;
@@ -44,7 +44,7 @@ class FeatureLeaf
   isA FeatureNode;
   0..1 -- 0..1 MixsetOrFile mixsetOrFileNode;
   after constructor() { setIsLeaf(true);}
-
+  //a leaf node returns its actual name as a unique name.
   public String getUniqueFeatureNodeName()
   {
     return this.getName();

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -26,9 +26,16 @@ class FeatureModel
 class FeatureNode{
   depend java.util.concurrent.atomic.AtomicInteger ;
   static AtomicInteger nextId = new AtomicInteger();
-  int id =nextId.incrementAndGet();
+  // each FeatureNode has a unique id
+  int id = nextId.incrementAndGet();
   lazy name;
   boolean isLeaf =false; 
+
+  //This method assign a unique name for each feature node. 
+  public String getUniqueFeatureNodeName()
+  {
+    return name+"_"+id;
+  }
 }
 
 // A FeatureLeaf contains a full mixset or a full file. 
@@ -37,6 +44,11 @@ class FeatureLeaf
   isA FeatureNode;
   0..1 -- 0..1 MixsetOrFile mixsetOrFileNode;
   after constructor() { setIsLeaf(true);}
+
+  public String getUniqueFeatureNodeName()
+  {
+    return this.getName();
+  }
 }
 
 // A FragmentFeatureLeaf consists of one or more mixset fragments.

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -35,8 +35,13 @@ class GvFeatureDiagramGenerator {
     {
       if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
       {
-        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
+        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
+        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
+        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();        
+        String minMax =""+lowerBound+".."+upperBound;
+        code.append(sourceFeatureNode.getUniqueFeatureNodeName() + getGvMultiplicityShape(minMax));
         indentLevel+=2;
+        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
         for(int i=0 ; i < featureNodes.size(); i++){
           FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
           appendSpaces(code,indentLevel);
@@ -52,7 +57,7 @@ class GvFeatureDiagramGenerator {
     }
     else //if the node is not leaf node 
     {
-      code.append(""+featureNode.getUniqueFeatureNodeName()+" "+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
+      code.append(getGvNodeShape(featureLink.getFeatureConnectingOpType(),featureNode.getUniqueFeatureNodeName()));
       appendSpaces(code,indentLevel);
       code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getUniqueFeatureNodeName()+" ;"+"\n");
       List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
@@ -104,20 +109,26 @@ class GvFeatureDiagramGenerator {
     }
   }
 
-  public static String getGvNodeShape(FeatureConnectingOpType featureConnectingOpType)
+  public static String getGvMultiplicityShape(String minMax)
+  {
+    return "[label=\""+minMax + "\"]"+ ";"+"\n";
+  }
+  public static String getGvNodeShape(FeatureConnectingOpType featureConnectingOpType , String nodeName)
   { 
+    String end = ";"+"\n";
     switch(featureConnectingOpType)
     {
       case Conjunctive:
-      return "[label=\" and \" ] ";
+      return nodeName+" [label=\" and \" ] "+end;
       case Disjunctive:
-      return "[label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] ";
+      return nodeName+" [label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] "+end;
       case XOR:
-      return "[label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]";
-      case Multiplicity:
-      return "[label=\"multiplicity\"]";
-      default:
+      return nodeName+" [label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]"+end;
+      case Multiplicity://
+      //return nodeName+" [label=\"multiplicity\"]";
       return "";
+      default:
+      return nodeName +end;
     }
   }
 

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -15,11 +15,9 @@ in your umple file, or the command line option
 namespace cruise.umple.compiler;
 
 class GvFeatureDiagramGenerator {
-
-UmpleModel model = null;
-
-
- // Template for what will appear at the start of each graph file
+  depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
+  UmpleModel model = null;
+  // Template for what will appear at the start of each graph file
   graphStart(umpleVersion) <<!digraph FeatureModel{ 
   node [shape=rectangle]  
   edge [arrowhead=none]  
@@ -31,9 +29,36 @@ UmpleModel model = null;
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
     FeatureNode sourceFeatureNode = featureLink.getSourceFeature();
+    
     if(featureNode.getIsLeaf())
     {
-      code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
+
+     if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
+      {
+        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append("["+ "arrowhead=normal color=red constraint=false label=exclude " + "]");
+        code.append(" ;"+"\n");
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
+      {
+        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append("["+ "arrowhead=normal color=blue constraint=false label=include " + "]");
+        code.append(" ;"+"\n");
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Optional))
+      {
+        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append("[arrowhead=odot]");
+        code.append(" ;"+"\n");      
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Conjunctive))
+      {
+        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append("[arrowhead=dot]");
+        code.append(" ;"+"\n");      
+      }
+      else 
+        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
     }
     else 
     {
@@ -68,7 +93,81 @@ UmpleModel model = null;
     terminateCode(code);
     // code.append(" \n } \n");
   }
-
+  /*
+   public boolean evaluateFeatureLink(FeatureLink featureLink)
+  {
+    FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
+    if(featureNode.getIsLeaf())
+    {
+      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
+      {
+        return isUsedFeatureLeaf((FeatureLeaf)featureNode);
+      } 
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
+      {
+        return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement, or no def for mixset 
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Optional))
+      {
+        return true;        // opt is allawys has a true value 
+      }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
+      {
+        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
+        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
+        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
+        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
+        int countOfUsedTarget = 0;
+        for(int i=0 ; i < featureNodes.size(); i++){
+          if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(i)))
+          countOfUsedTarget++;
+        }
+        return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
+      }
+      else 
+      return isUsedFeatureLeaf((FeatureLeaf)featureNode);
+    } // if not leaf node
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Conjunctive))
+    { 
+      if(!featureNode.getIsLeaf())
+      {
+        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+        boolean result = true;
+        for(int i=0 ; i<outgoingLinks.size(); i++){
+          result = result && evaluateFeatureLink(outgoingLinks.get(i));
+        }
+        return result;
+      }
+    }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Disjunctive))
+    {   
+      if(!featureNode.getIsLeaf())
+      {
+        boolean result = false;
+        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+        for(int i=0 ; i<outgoingLinks.size(); i++){
+          result = result || evaluateFeatureLink(outgoingLinks.get(i));
+        }
+        return result;
+      }
+    }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.XOR))
+    { 
+      if(!featureNode.getIsLeaf())
+          {
+            List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+            int countOfUsedTarget = 0;
+            for(int i=0 ; i < outgoingLinks.size(); i++){
+              if(evaluateFeatureLink(outgoingLinks.get(i)))  // bitwise xor (^) can not be used here because it does not mean always only one. Example: (true ^ true ^ true == true) 
+              countOfUsedTarget++;
+            }
+            return (countOfUsedTarget == 1) ? true: false;
+          }
+    }
+    //otherwise
+    return false;
+  }
+*/
   protected void terminateCode(StringBuilder code){ 
     code.append("\n }\n");
     model.setCode(code.toString());

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -57,11 +57,28 @@ class GvFeatureDiagramGenerator {
         code.append("[arrowhead=dot]");
         code.append(" ;"+"\n");      
       }
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
+      {
+        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
+        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
+        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
+        String multip = "_"+lowerBound+"_"+upperBound;
+        
+        code.append(""+sourceFeatureNode.getName()+" -> "+multip + " ;"+"\n");
+        
+        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
+        int countOfUsedTarget = 0;
+        for(int i=0 ; i < featureNodes.size(); i++){
+           FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
+           code.append(multip +" -> "+ fLeaf.getName()+" ;"+"\n");
+        }
+      }
       else 
         code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
     }
-    else 
+    else //if the node is not leaf node 
     {
+      code.append(""+featureNode.getName()+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
       code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
       List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
       for(int i=0 ; i<outgoingLinks.size(); i++){
@@ -92,6 +109,21 @@ class GvFeatureDiagramGenerator {
 
     terminateCode(code);
     // code.append(" \n } \n");
+  }
+
+  public static String getGvNodeShape(FeatureConnectingOpType featureConnectingOpType)
+  { //audioXor [ label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ];
+    switch(featureConnectingOpType)
+    {
+      case Conjunctive:
+      return "";
+      case Disjunctive:
+      return "[ label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] ";
+      case XOR:
+      return "[ label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]";
+      default:
+      return "";
+    }
   }
   /*
    public boolean evaluateFeatureLink(FeatureLink featureLink)

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -33,55 +33,28 @@ class GvFeatureDiagramGenerator {
     appendSpaces(code,indentLevel);
     if(featureNode.getIsLeaf())
     {
-     if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
+      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
       {
-        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
-        code.append("["+ "arrowhead=normal color=red constraint=false label=exclude " + "]");
-        code.append(" ;"+"\n");
-      }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
-      {
-        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
-        code.append("["+ "arrowhead=normal color=blue constraint=false label=include " + "]");
-        code.append(" ;"+"\n");
-      }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Optional))
-      {
-        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
-        code.append("[arrowhead=odot]");
-        code.append(" ;"+"\n");      
-      }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Conjunctive))
-      {
-        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
-        code.append("[arrowhead=dot]");
-        code.append(" ;"+"\n");      
-      }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
-      {
-        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
-        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
-        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
-        String multip = "_"+lowerBound+"_"+upperBound;
-        
-        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+multip + " ;"+"\n");
-        
         List<FeatureNode> featureNodes = featureLink.getTargetFeature();
         indentLevel+=2;
         for(int i=0 ; i < featureNodes.size(); i++){
           FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
           appendSpaces(code,indentLevel);
-          code.append(multip +" -> "+ fLeaf.getName()+" ;"+"\n");
+          code.append(sourceFeatureNode.getUniqueFeatureNodeName() +" -> "+ fLeaf.getName()+" ;"+"\n");
         }
       }
       else 
-        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ;"+"\n");
+      {// link source to leaf node 
+        code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getName()+" ");
+        code.append(getGvTargetShape(featureLink.getFeatureConnectingOpType()));
+        code.append(" ;"+"\n");    
+      }
     }
     else //if the node is not leaf node 
     {
-      code.append(""+featureNode.getName()+featureNode.getId()+" "+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
+      code.append(""+featureNode.getUniqueFeatureNodeName()+" "+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
       appendSpaces(code,indentLevel);
-      code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+featureNode.getId()+" ;"+"\n");
+      code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getUniqueFeatureNodeName()+" ;"+"\n");
       List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
       for(int i=0 ; i<outgoingLinks.size(); i++){
         generateFeatureNodeShape(outgoingLinks.get(i),code);
@@ -105,7 +78,7 @@ class GvFeatureDiagramGenerator {
       List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
       for(FeatureLink flink : featureNodeOutLinks)
       {
-        code.append("  "+featureNode.getName()+featureNode.getId()+" [label=\""+featureNode.getName()+" \" ]; \n");
+        code.append("  "+featureNode.getUniqueFeatureNodeName()+" [label=\""+featureNode.getName()+" \" ]; \n");
         generateFeatureNodeShape(flink,code);
       }		    
     }
@@ -114,8 +87,25 @@ class GvFeatureDiagramGenerator {
     // code.append(" \n } \n");
   }
 
+  public static String getGvTargetShape(FeatureConnectingOpType featureConnectingOpType)
+  { 
+    switch(featureConnectingOpType)
+    {
+      case Exclude:
+      return "["+"arrowhead=normal color=red constraint=false label=exclude "+"]";
+      case Include:
+      return "["+ "arrowhead=normal color=blue constraint=false label=include "+"]";
+      case Optional:
+      return "[arrowhead=odot]";
+      case Conjunctive:
+      return "[arrowhead=dot]";
+      default:
+      return "";
+    }
+  }
+
   public static String getGvNodeShape(FeatureConnectingOpType featureConnectingOpType)
-  { //audioXor [ label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ];
+  { 
     switch(featureConnectingOpType)
     {
       case Conjunctive:
@@ -124,6 +114,8 @@ class GvFeatureDiagramGenerator {
       return "[label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] ";
       case XOR:
       return "[label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]";
+      case Multiplicity:
+      return "[label=\"multiplicity\"]";
       default:
       return "";
     }

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -33,7 +33,6 @@ class GvFeatureDiagramGenerator {
     appendSpaces(code,indentLevel);
     if(featureNode.getIsLeaf())
     {
-
      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
       {
         code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
@@ -106,6 +105,7 @@ class GvFeatureDiagramGenerator {
       List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
       for(FeatureLink flink : featureNodeOutLinks)
       {
+        code.append("  "+featureNode.getName()+featureNode.getId()+" [label=\""+featureNode.getName()+" \" ]; \n");
         generateFeatureNodeShape(flink,code);
       }		    
     }
@@ -119,7 +119,7 @@ class GvFeatureDiagramGenerator {
     switch(featureConnectingOpType)
     {
       case Conjunctive:
-      return "";
+      return "[label=\" and \" ] ";
       case Disjunctive:
       return "[label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] ";
       case XOR:
@@ -128,81 +128,7 @@ class GvFeatureDiagramGenerator {
       return "";
     }
   }
-  /*
-   public boolean evaluateFeatureLink(FeatureLink featureLink)
-  {
-    FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
-    if(featureNode.getIsLeaf())
-    {
-      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
-      {
-        return isUsedFeatureLeaf((FeatureLeaf)featureNode);
-      } 
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
-      {
-        return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement, or no def for mixset 
-      }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Optional))
-      {
-        return true;        // opt is allawys has a true value 
-      }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
-      {
-        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
-        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
-        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
-        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
-        int countOfUsedTarget = 0;
-        for(int i=0 ; i < featureNodes.size(); i++){
-          if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(i)))
-          countOfUsedTarget++;
-        }
-        return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
-      }
-      else 
-      return isUsedFeatureLeaf((FeatureLeaf)featureNode);
-    } // if not leaf node
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Conjunctive))
-    { 
-      if(!featureNode.getIsLeaf())
-      {
-        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
-        boolean result = true;
-        for(int i=0 ; i<outgoingLinks.size(); i++){
-          result = result && evaluateFeatureLink(outgoingLinks.get(i));
-        }
-        return result;
-      }
-    }
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Disjunctive))
-    {   
-      if(!featureNode.getIsLeaf())
-      {
-        boolean result = false;
-        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
-        for(int i=0 ; i<outgoingLinks.size(); i++){
-          result = result || evaluateFeatureLink(outgoingLinks.get(i));
-        }
-        return result;
-      }
-    }
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.XOR))
-    { 
-      if(!featureNode.getIsLeaf())
-          {
-            List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
-            int countOfUsedTarget = 0;
-            for(int i=0 ; i < outgoingLinks.size(); i++){
-              if(evaluateFeatureLink(outgoingLinks.get(i)))  // bitwise xor (^) can not be used here because it does not mean always only one. Example: (true ^ true ^ true == true) 
-              countOfUsedTarget++;
-            }
-            return (countOfUsedTarget == 1) ? true: false;
-          }
-    }
-    //otherwise
-    return false;
-  }
-*/
+
   protected void terminateCode(StringBuilder code){ 
     code.append("\n }\n");
     model.setCode(code.toString());

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -20,8 +20,8 @@ class GvFeatureDiagramGenerator {
   // Template for what will appear at the start of each graph file
   graphStart(umpleVersion) <<!digraph FeatureModel{ 
   node [shape=rectangle]  
-  edge [arrowhead=none]  
-  !>>
+  edge [arrowhead=none] 
+!>>
 
   emit graphStart()(graphStart(UmpleModel.VERSION_NUMBER));
   
@@ -29,7 +29,8 @@ class GvFeatureDiagramGenerator {
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
     FeatureNode sourceFeatureNode = featureLink.getSourceFeature();
-    
+    int indentLevel = 2;
+    appendSpaces(code,indentLevel);
     if(featureNode.getIsLeaf())
     {
 
@@ -67,10 +68,11 @@ class GvFeatureDiagramGenerator {
         code.append(""+sourceFeatureNode.getName()+" -> "+multip + " ;"+"\n");
         
         List<FeatureNode> featureNodes = featureLink.getTargetFeature();
-        int countOfUsedTarget = 0;
+        indentLevel+=2;
         for(int i=0 ; i < featureNodes.size(); i++){
-           FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
-           code.append(multip +" -> "+ fLeaf.getName()+" ;"+"\n");
+          FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
+          appendSpaces(code,indentLevel);
+          code.append(multip +" -> "+ fLeaf.getName()+" ;"+"\n");
         }
       }
       else 
@@ -79,6 +81,7 @@ class GvFeatureDiagramGenerator {
     else //if the node is not leaf node 
     {
       code.append(""+featureNode.getName()+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
+      appendSpaces(code,indentLevel);
       code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
       List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
       for(int i=0 ; i<outgoingLinks.size(); i++){
@@ -208,6 +211,14 @@ class GvFeatureDiagramGenerator {
 
   protected String generatorType() { 
     return "GvFeatureDiagram";
+  }
+  // copied from "Generator_SuperGvGenerator.ump"
+  private void appendSpaces(StringBuilder code, int numSpaces) 
+  {
+    for(int i=0; i<numSpaces; i++) 
+    {
+      code.append(" ");
+    }
   }
 
   /**

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -36,25 +36,25 @@ class GvFeatureDiagramGenerator {
 
      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
       {
-        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
         code.append("["+ "arrowhead=normal color=red constraint=false label=exclude " + "]");
         code.append(" ;"+"\n");
       }
       else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
       {
-        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
         code.append("["+ "arrowhead=normal color=blue constraint=false label=include " + "]");
         code.append(" ;"+"\n");
       }
       else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Optional))
       {
-        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
         code.append("[arrowhead=odot]");
         code.append(" ;"+"\n");      
       }
       else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Conjunctive))
       {
-        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ");
+        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ");
         code.append("[arrowhead=dot]");
         code.append(" ;"+"\n");      
       }
@@ -65,7 +65,7 @@ class GvFeatureDiagramGenerator {
         int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
         String multip = "_"+lowerBound+"_"+upperBound;
         
-        code.append(""+sourceFeatureNode.getName()+" -> "+multip + " ;"+"\n");
+        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+multip + " ;"+"\n");
         
         List<FeatureNode> featureNodes = featureLink.getTargetFeature();
         indentLevel+=2;
@@ -76,13 +76,13 @@ class GvFeatureDiagramGenerator {
         }
       }
       else 
-        code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
+        code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+" ;"+"\n");
     }
     else //if the node is not leaf node 
     {
-      code.append(""+featureNode.getName()+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
+      code.append(""+featureNode.getName()+featureNode.getId()+" "+getGvNodeShape(featureLink.getFeatureConnectingOpType())+" ;"+"\n");
       appendSpaces(code,indentLevel);
-      code.append(""+sourceFeatureNode.getName()+" -> "+featureNode.getName()+" ;"+"\n");
+      code.append(""+sourceFeatureNode.getName()+sourceFeatureNode.getId()+" -> "+featureNode.getName()+featureNode.getId()+" ;"+"\n");
       List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
       for(int i=0 ; i<outgoingLinks.size(); i++){
         generateFeatureNodeShape(outgoingLinks.get(i),code);
@@ -121,9 +121,9 @@ class GvFeatureDiagramGenerator {
       case Conjunctive:
       return "";
       case Disjunctive:
-      return "[ label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] ";
+      return "[label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] ";
       case XOR:
-      return "[ label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]";
+      return "[label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]";
       default:
       return "";
     }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -12,6 +12,8 @@ Please refer to UmpleInternalParser.ump for more details.
 class UmpleInternalParser
 {
   depend cruise.umple.compiler.*;
+  depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
+
   public void analyzeRequireStatement(Token t, int analysisStep)
   {
     if (analysisStep != 2)
@@ -121,7 +123,7 @@ class UmpleInternalParser
         edge = new FeatureLink();
         
         if(linkingParent.getNodeToken().is("ROOT"))
-        edge.setFeatureConnectingOpType(FeatureLink.FeatureConnectingOpType.Include);
+        edge.setFeatureConnectingOpType(FeatureConnectingOpType.Include);
         else // this is for leaf node as the parent is not null 
         edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType());
         
@@ -382,6 +384,7 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(List<Toke
 
 class FeatureModel{
   depend java.util.stream.*;
+  depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
 /*
  * This method returns a leaf node from FeatureModel based on its name.
  * return null if the leaf node is not found.   
@@ -442,19 +445,19 @@ class FeatureModel{
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
     if(featureNode.getIsLeaf())
     {
-      if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Include))
+      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
       {
         return isUsedFeatureLeaf((FeatureLeaf)featureNode);
       } 
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Exclude))
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Exclude))
       {
         return !isUsedFeatureLeaf((FeatureLeaf)featureNode); // return true when there is no use-statement, or no def for mixset 
       }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Optional))
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Optional))
       {
         return true;        // opt is allawys has a true value 
       }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Multiplicity))
+      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
       {
         MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
         int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
@@ -470,7 +473,7 @@ class FeatureModel{
       else 
       return isUsedFeatureLeaf((FeatureLeaf)featureNode);
     } // if not leaf node
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Conjunctive))
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Conjunctive))
     { 
       if(!featureNode.getIsLeaf())
       {
@@ -482,7 +485,7 @@ class FeatureModel{
         return result;
       }
     }
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.Disjunctive))
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Disjunctive))
     {   
       if(!featureNode.getIsLeaf())
       {
@@ -494,7 +497,7 @@ class FeatureModel{
         return result;
       }
     }
-    else if(featureLink.getFeatureConnectingOpType().equals(FeatureLink.FeatureConnectingOpType.XOR))
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.XOR))
     { 
       if(!featureNode.getIsLeaf())
           {
@@ -549,6 +552,8 @@ Ex: require [A and B or C] will be formed as:
 class TokenTree
 {
   depend cruise.umple.parser.Token;
+  depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
+
   Token nodeToken;
   lazy TokenTree parentTokenTree;
   lazy TokenTree leftTokenTree;
@@ -573,26 +578,26 @@ This method selects the the connection operator type based on the type of the (l
 If the type is not specified for the linking node, The default is Required.
 It returns null if the node is termainl node.
 */
-public FeatureLink.FeatureConnectingOpType getFeatureConnectionOpType()
+public FeatureConnectingOpType getFeatureConnectionOpType()
 {
   if(nodeToken != null )
   {
     String operator = nodeToken.getName();
     switch (operator) {
       case "and":
-        return FeatureLink.FeatureConnectingOpType.Conjunctive;
+        return FeatureConnectingOpType.Conjunctive;
       case "or":
-        return FeatureLink.FeatureConnectingOpType.Disjunctive;
+        return FeatureConnectingOpType.Disjunctive;
       case "xor":
-        return FeatureLink.FeatureConnectingOpType.XOR;
+        return FeatureConnectingOpType.XOR;
       case "multiplicityTerminal":
-        return FeatureLink.FeatureConnectingOpType.Multiplicity;
+        return FeatureConnectingOpType.Multiplicity;
       case "opt":
-        return FeatureLink.FeatureConnectingOpType.Optional;
+        return FeatureConnectingOpType.Optional;
       case "not":
-        return FeatureLink.FeatureConnectingOpType.Exclude;
+        return FeatureConnectingOpType.Exclude;
       default:
-        return FeatureLink.FeatureConnectingOpType.Required;
+        return FeatureConnectingOpType.Required;
      }
   }
 

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -143,8 +143,9 @@ class UmpleInternalParser
         edge.addTargetFeature(newFeatureNode); 
         edge.setFeatureModel(model.getFeatureModel());
         
-        FeatureLink intermediateFeatureNodeToTargetEdge = new MultiplicityFeatureConnectingOpType();
+        MultiplicityFeatureConnectingOpType intermediateFeatureNodeToTargetEdge = new MultiplicityFeatureConnectingOpType();
         intermediateFeatureNodeToTargetEdge.setSourceFeature(newFeatureNode);
+        intermediateFeatureNodeToTargetEdge.setMultiplicity(featureLinkMultiplicity);
   
         for(Token subToken : node.getSubTokens())
         {

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -137,6 +137,15 @@ class UmpleInternalParser
         edge = new MultiplicityFeatureConnectingOpType();
 		    Multiplicity featureLinkMultiplicity = ((MultiplicityFeatureConnectingOpType) edge).getMultiplicity();
         featureLinkMultiplicity.setRange(node.getSubToken("lowerBound").getValue(), node.getSubToken("upperBound").getValue());
+        
+        FeatureNode newFeatureNode = new FeatureNode(model.getFeatureModel());
+        newFeatureNode.setName("multiplicityTerminal");
+        edge.addTargetFeature(newFeatureNode); 
+        edge.setFeatureModel(model.getFeatureModel());
+        
+        FeatureLink intermediateFeatureNodeToTargetEdge = new MultiplicityFeatureConnectingOpType();
+        intermediateFeatureNodeToTargetEdge.setSourceFeature(newFeatureNode);
+  
         for(Token subToken : node.getSubTokens())
         {
           if(subToken.is("targetMixsetName"))
@@ -144,7 +153,7 @@ class UmpleInternalParser
             Mixset targetMixset = new Mixset(subToken.getValue()); //To Do: check if its a mixset.
             FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
             targetFeature.setMixsetOrFileNode(targetMixset);
-            edge.addTargetFeature(targetFeature);
+            intermediateFeatureNodeToTargetEdge.addTargetFeature(targetFeature);
           }
         }
         edge.setSourceFeature(sourceFeature);       
@@ -457,19 +466,6 @@ class FeatureModel{
       {
         return true;        // opt is allawys has a true value 
       }
-      else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
-      {
-        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
-        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
-        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
-        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
-        int countOfUsedTarget = 0;
-        for(int i=0 ; i < featureNodes.size(); i++){
-          if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(i)))
-          countOfUsedTarget++;
-        }
-        return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
-      }
       else 
       return isUsedFeatureLeaf((FeatureLeaf)featureNode);
     } // if not leaf node
@@ -510,6 +506,26 @@ class FeatureModel{
             return (countOfUsedTarget == 1) ? true: false;
           }
     }
+    else if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
+      {
+        MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
+        int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
+        int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
+       // List<FeatureNode> featureNodes = featureLink.getTargetFeature(); //featureNode.
+        
+        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+        int countOfUsedTarget = 0;
+        for(int i=0 ; i<outgoingLinks.size(); i++){
+          FeatureLink link = outgoingLinks.get(i);
+          List<FeatureNode> featureNodes = link.getTargetFeature();  
+          for(int k=0 ; k < featureNodes.size(); k++){
+            if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(k)))
+            countOfUsedTarget++;
+          }
+
+        }
+        return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
+      }
     //otherwise
     return false;
   }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -349,7 +349,7 @@ public class UmpleMixsetTest {
     int numOfLinks = featureModel.getFeaturelink().size();
     int numOfFeatures = featureModel.getNode().size();
     Assert.assertEquals(numOfLinks,7);
-    Assert.assertEquals(numOfFeatures,10);
+    Assert.assertEquals(numOfFeatures,11);
 
     Assert.assertEquals(false,  ((FeatureLeaf)featureModel.getNode().get(0)).getMixsetOrFileNode().isIsMixset() );  // false: its a file
     Assert.assertEquals(featureModel.getNode().get(1).getName(), "or");
@@ -357,10 +357,11 @@ public class UmpleMixsetTest {
     Assert.assertEquals(featureModel.getNode().get(3).getName(), "xor");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName() ,"M5");
     Assert.assertEquals(featureModel.getNode().get(5).getName(), "and");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"M4");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M1");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M2");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M3");
+    Assert.assertEquals(featureModel.getNode().get(6).getName(), "multiplicityTerminal");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M4");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M1");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M2");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(10)).getMixsetOrFileNode().getName() ,"M3");
   }
 
   @Test

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -357,8 +357,8 @@ public class UmpleMixsetTest {
     Assert.assertEquals(featureModel.getNode().get(3).getName(), "xor");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(4)).getMixsetOrFileNode().getName() ,"M5");
     Assert.assertEquals(featureModel.getNode().get(5).getName(), "and");
-    Assert.assertEquals(featureModel.getNode().get(6).getName(), "multiplicityTerminal");
-    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(7)).getMixsetOrFileNode().getName() ,"M4");
+    Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(6)).getMixsetOrFileNode().getName() ,"M4");
+    Assert.assertEquals(featureModel.getNode().get(7).getName(), "multiplicityTerminal");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(8)).getMixsetOrFileNode().getName() ,"M1");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(9)).getMixsetOrFileNode().getName() ,"M2");
     Assert.assertEquals(((FeatureLeaf)featureModel.getNode().get(10)).getMixsetOrFileNode().getName() ,"M3");


### PR DESCRIPTION
Shapes of 'or', 'xor','multiplicity', 'opt' and 'exclude' are added to GvFeatureDiagram generator. Also, the generator can now link different parts of the feature model that are encounter in mixsets to one connected tree diagram (if possible).

**Example:**

```
require [ 0..2 of {M1,M2,M3 } xor (M4 and M5) or M6];

mixset M1 {} mixset M2 {} mixset M3 {} mixset M4 {}

mixset M6 { 
 require [opt MixsetA];
}  
mixset MixsetA{
  require [not M4];
}

use M6;
use MixsetA;
```
**will generate the FM diagram:**
![webgraphviz](https://user-images.githubusercontent.com/11878501/52804541-6fa44980-3052-11e9-8b93-48574c444b5a.png)
