### PR TITLE
Graphviz Feature diagram generator - coloring used mixsets

### DIFF
--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -17,7 +17,7 @@ namespace cruise.umple.compiler;
 class GvFeatureDiagramGenerator {
   depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
   UmpleModel model = null;
-  // Template for what will appear at the start of each graph file
+  // Template for what will appear at the start of each graphviz file
   graphStart(umpleVersion) <<! /*This code was generated using the UMPLE <<=umpleVersion>> modeling language! */
   
 digraph FeatureModel { 
@@ -48,6 +48,8 @@ digraph FeatureModel {
           FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
           appendSpaces(code,indentLevel);
           code.append(sourceFeatureNode.getUniqueFeatureNodeName() +" -> "+ fLeaf.getName()+" ;"+"\n");
+          fillColorOfFeatureNode(code,fLeaf,indentLevel);
+          
         }
       }
       else 
@@ -55,6 +57,7 @@ digraph FeatureModel {
         code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getName()+" ");
         code.append(getGvTargetShape(featureLink.getFeatureConnectingOpType()));
         code.append(" ;"+"\n");    
+        fillColorOfFeatureNode(code,featureNode,indentLevel);
       }
     }
     else //if the node is not leaf node 
@@ -72,14 +75,14 @@ digraph FeatureModel {
   //This overrides the superclass's method.
   public void generate(){
     StringBuilder code = new StringBuilder();
-    // Output basic gv file header
     if(getModel().getFeatureModel() == null)
     {
       code.append("/* Umple code does not have feature diagram. */");
       return;
     }
+    // Output basic gv file header
     _graphStart(0,code);
-     // Iterate through each root feature. 
+    // Iterate through each root feature. 
     for (FeatureNode featureNode : getModel().getFeatureModel().getRootFeatures())
     {
       List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
@@ -89,9 +92,7 @@ digraph FeatureModel {
         generateFeatureNodeShape(flink,code);
       }		    
     }
-
     terminateCode(code);
-    // code.append(" \n } \n");
   }
 
   public static String getGvTargetShape(FeatureConnectingOpType featureConnectingOpType)
@@ -126,16 +127,29 @@ digraph FeatureModel {
       return nodeName+" [label=\"\" shape=triangle fixedsize=true  color=black width=.3 height=0.3 margin=0 ] "+end;
       case XOR:
       return nodeName+" [label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]"+end;
-      case Multiplicity://
-      //return nodeName+" [label=\"multiplicity\"]";
+      case Multiplicity: // nothing to add here. It will be handled in getGvMultiplicityShape(...)
       return "\n";
       default:
       return nodeName +end;
     }
   }
 
+  //This method fills the background color of a featureLeaf if it is used.
+  public void fillColorOfFeatureNode(StringBuilder code, FeatureNode featureNode, int indentLevel)
+  {
+    if(featureNode.getIsLeaf())
+    {
+      boolean shouldColor = getModel().getFeatureModel().isUsedFeatureLeaf((FeatureLeaf)featureNode);
+      if(shouldColor)
+      { 
+        appendSpaces(code,indentLevel);
+        code.append(featureNode.getName()+" [style=filled fillcolor=\"chartreuse\"]" + "; \n"); 
+      }
+    }
+  }
+
   protected void terminateCode(StringBuilder code){ 
-    code.append("\n }\n");
+    code.append("\n"+"}"+"\n");
     model.setCode(code.toString());
     writeModel();
   }

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -17,6 +17,7 @@ namespace cruise.umple.compiler;
 class GvFeatureDiagramGenerator {
   depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
   UmpleModel model = null;
+  FeatureModel featureModel = null;
   // Template for what will appear at the start of each graphviz file
   graphStart(umpleVersion) <<! /*This code was generated using the UMPLE <<=umpleVersion>> modeling language! */
   
@@ -75,7 +76,8 @@ digraph FeatureModel {
   //This overrides the superclass's method.
   public void generate(){
     StringBuilder code = new StringBuilder();
-    if(getModel().getFeatureModel() == null)
+    featureModel = getModel().getFeatureModel(); 
+    if(featureModel == null)
     {
       code.append("/* Umple code does not have feature diagram. */");
       return;
@@ -83,7 +85,7 @@ digraph FeatureModel {
     // Output basic gv file header
     _graphStart(0,code);
     // Iterate through each root feature. 
-    for (FeatureNode featureNode : getModel().getFeatureModel().getRootFeatures())
+    for (FeatureNode featureNode : featureModel.getRootFeatures())
     {
       List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
       for(FeatureLink flink : featureNodeOutLinks)
@@ -139,7 +141,7 @@ digraph FeatureModel {
   {
     if(featureNode.getIsLeaf())
     {
-      boolean shouldColor = getModel().getFeatureModel().isUsedFeatureLeaf((FeatureLeaf)featureNode);
+      boolean shouldColor = featureModel.isUsedFeatureLeaf((FeatureLeaf)featureNode);
       if(shouldColor)
       { 
         appendSpaces(code,indentLevel);

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -84,6 +84,8 @@ digraph FeatureModel {
     }
     // Output basic gv file header
     _graphStart(0,code);
+    //display the status of the invariant of FM
+    code.append(configurationStatus());
     // Iterate through each root feature. 
     for (FeatureNode featureNode : featureModel.getRootFeatures())
     {
@@ -148,6 +150,19 @@ digraph FeatureModel {
         code.append(featureNode.getName()+" [style=filled fillcolor=\"chartreuse\"]" + "; \n"); 
       }
     }
+  }
+
+  public String configurationStatus()
+  {
+    String result = "  InvariantstatusNode[label=\"  Configuration Status:\" shape=plaintext] \n";
+    if(featureModel.satisfyFeatureModel())
+    {
+      result = result + "  validStatus[label=\"Valid\" shape=plaintext fontcolor=blue];\n";
+    }
+    else 
+    result = result + "  validStatus[label=\"Not Valid  \" shape=plaintext fontcolor=red];\n";
+
+    return result;
   }
 
   protected void terminateCode(StringBuilder code){ 

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -18,7 +18,9 @@ class GvFeatureDiagramGenerator {
   depend cruise.umple.compiler.FeatureLink.FeatureConnectingOpType;
   UmpleModel model = null;
   // Template for what will appear at the start of each graph file
-  graphStart(umpleVersion) <<!digraph FeatureModel{ 
+  graphStart(umpleVersion) <<! /*This code was generated using the UMPLE <<=umpleVersion>> modeling language! */
+  
+digraph FeatureModel { 
   node [shape=rectangle]  
   edge [arrowhead=none] 
 !>>
@@ -126,7 +128,7 @@ class GvFeatureDiagramGenerator {
       return nodeName+" [label=\"\" shape=triangle fixedsize=true style=filled color=black width=.3 height=0.3 margin=0 ]"+end;
       case Multiplicity://
       //return nodeName+" [label=\"multiplicity\"]";
-      return "";
+      return "\n";
       default:
       return nodeName +end;
     }


### PR DESCRIPTION
Here is some enhancement to the feature model: 

1.  Add green color to nodes (mixsets) that are used.
2. Display the status the invariant in the diagram: Is it valid or not valid against the feature model.  In Umple website, the status of the invariant can be a enabled/disabled, or put in a different location.  

Example: 

![phonespl_pr](https://user-images.githubusercontent.com/11878501/53033218-91307700-343e-11e9-83c1-1bcf0a41309e.png)
