### PR TITLE
Graphviz feature diagram in umple online

### DIFF
--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -28,6 +28,15 @@ digraph FeatureModel {
 
   emit graphStart()(graphStart(UmpleModel.VERSION_NUMBER));
   
+  // Template for what is output if there is no feature diagram 
+  nofeatureDiagram <<! 
+  node [shape=plaintext];
+  message [fixedsize=true label ="No feature found in the umple file." width=4];
+!>>
+  emit nofeatureDiagram()(nofeatureDiagram);
+
+
+
   public void generateFeatureNodeShape(FeatureLink featureLink , StringBuilder code)
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
@@ -77,13 +86,15 @@ digraph FeatureModel {
   public void generate(){
     StringBuilder code = new StringBuilder();
     featureModel = getModel().getFeatureModel(); 
+     // Output basic gv file header
+    _graphStart(0,code);
     if(featureModel == null)
     {
-      code.append("/* Umple code does not have feature diagram. */");
-      return;
+      code.append("// Umple code does not have feature diagram. // \n");
+      _nofeatureDiagram(0,code);
     }
-    // Output basic gv file header
-    _graphStart(0,code);
+    else
+    {
     //display the status of the invariant of FM
     code.append(configurationStatus());
     // Iterate through each root feature. 
@@ -95,6 +106,7 @@ digraph FeatureModel {
         code.append("  "+featureNode.getUniqueFeatureNodeName()+" [label=\""+featureNode.getName()+" \" ]; \n");
         generateFeatureNodeShape(flink,code);
       }		    
+    }
     }
     terminateCode(code);
   }

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -31,7 +31,7 @@ digraph FeatureModel {
   // Template for what is output if there is no feature diagram 
   nofeatureDiagram <<! 
   node [shape=plaintext];
-  message [fixedsize=true label ="No feature found in the umple file." width=4];
+  message [fixedsize=true label ="No require-statement found in the umple file." width=4];
 !>>
   emit nofeatureDiagram()(nofeatureDiagram);
 

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -133,6 +133,7 @@ else if (isset($_REQUEST["umpleCode"]))
   {
      $language = "GvStateDiagram";
      $generatorType = "";
+     $stateDiagram = True;
   }
   else if ($language == "featureDiagram")
   {

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -113,6 +113,7 @@ else if (isset($_REQUEST["umpleCode"]))
 
   $javadoc = false;
   $stateDiagram = false;
+  $featureDiagram = false;
   $classDiagram = false;
   $entityRelationshipDiagram = false;
   $yumlDiagram = false;
@@ -121,6 +122,7 @@ else if (isset($_REQUEST["umpleCode"]))
   $htmlContents = false;
   $generatorType = "";
   
+  //featureDiagram
 
   if ($language == "javadoc")
   {
@@ -131,7 +133,12 @@ else if (isset($_REQUEST["umpleCode"]))
   {
      $language = "GvStateDiagram";
      $generatorType = "";
-     $stateDiagram = True;
+  }
+  else if ($language == "featureDiagram")
+  {
+      $language = "GvFeatureDiagram";
+      $generatorType = "";
+      $featureDiagram = True;
   }
   else if ($language == "classDiagram")
   {
@@ -236,7 +243,7 @@ else if (isset($_REQUEST["umpleCode"]))
     return;      
   } // end html content      
 
-  elseif (!in_array($language,array("Php","Java","Ruby","RTCpp","Cpp","Sql","GvStateDiagram","GvClassDiagram","GvEntityRelationshipDiagram","GvClassTraitDiagram","Yuml")))
+  elseif (!in_array($language,array("Php","Java","Ruby","RTCpp","Cpp","Sql","GvFeatureDiagram","GvStateDiagram","GvClassDiagram","GvEntityRelationshipDiagram","GvClassTraitDiagram","Yuml")))
   {  // If NOT one of the basic languages, then use umplesync.jar
     list($dataname, $dataHandle) = getOrCreateDataHandle();
     $dataHandle->writeData($dataname, $input);
@@ -287,7 +294,7 @@ else if (isset($_REQUEST["umpleCode"]))
   if($toRemove) { exec($rmcommand); }
   
   // The following is a hack. The arguments to umplesync need fixing
-  if (!$stateDiagram && !$classDiagram && !$entityRelationshipDiagram && !$yumlDiagram) {  
+  if (!$stateDiagram && !$classDiagram && !$entityRelationshipDiagram && !$yumlDiagram && !$featureDiagram) {  
     $command = "java -jar umplesync.jar -source {$filename} 2> {$errorFilename}";
   }
   else {
@@ -386,6 +393,25 @@ else if (isset($_REQUEST["umpleCode"]))
       echo "</svg>"; 
     } // end state diagram
 
+    else if ($featureDiagram) {
+      $thedir = dirname($outputFilename);
+      exec("rm -rf " . $thedir . "/featureDiagram.svg");
+      $command = "dot -Tsvg -Gdpi=63 " . $thedir . "/modelGvFeatureDiagram.gv -o " . $thedir .  "/featureDiagram.svg";
+      exec($command);
+      if (!file_exists($thedir . "/featureDiagram.svg") && file_exists("doterr.svg"))
+      {
+        exec("cp " . "./doterr.svg " . $thedir . "/featureDiagram.svg");
+      }
+      $svgcode = readTemporaryFile("{$thedir}/featureDiagram.svg");
+      $svglink = $workDir->makePermalink('featureDiagram.svg');
+      
+      $html = "<a href=\featureDiagram.svg\">Download the GraphViz file for the following</a>&nbsp;<a href=\"$svglink\">Download the SVG file for the following</a>&nbsp;<br/>{$errhtml}&nbsp;
+      <svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" height=\"2000\" width=\"2000\">";
+      echo $html;
+      echo $svgcode;
+      echo "</svg>";   
+    }
+    
     else if ($classDiagram) {
       $thedir = dirname($outputFilename);
       exec("rm -rf " . $thedir . "/classDiagram.svg");

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -277,6 +277,7 @@ function generateMenu($buttonSuffix)
             <option value=\"yumlDiagram:yumlDiagram\">Yuml Class Diagram</option>
             <option value=\"classDiagram:classDiagram\">GraphViz Class Diagram (SVG)</option>
             <option value=\"stateDiagram:stateDiagram\">State Diagram (GraphViz SVG)</option>
+            <option value=\"featureDiagram:featureDiagram\">Feature Diagram (GraphViz SVG)</option>
             <option value=\"entityRelationship:entityRelationshipDiagram\">Entity Relationship Diagram (GraphViz SVG)</option>
             <option id=\"genstatetables\" value=\"html:StateTables\">State Tables</option>
             <option id=\"geneventsequence\" value=\"html:EventSequence\">Event Sequence</option>

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -24,7 +24,6 @@ Action.clicked = function(event)
   
   var obj = event.currentTarget;
   var action = obj.id.substring(6);
-  
   if (action == "PhpCode")
   {
     Action.generateCode("php","Php");
@@ -68,6 +67,10 @@ Action.clicked = function(event)
   else if (action == "StructureDiagram")
   {
     Action.generateCode("structureDiagram","structureDiagram");
+  }
+  else if (action == "FeatureDiagram")
+  {
+    Action.generateCode("featureDiagram","featureDiagram");
   }
   else if (action == "classDiagram")
   {
@@ -161,6 +164,10 @@ Action.clicked = function(event)
   else if (action == "ShowGvClassDiagram")
   {
     Action.changeDiagramType({type:"GVClass"});
+  }
+  else if (action == "ShowGvFeatureDiagram")
+  {
+    Action.changeDiagramType({type:"GVFeature"});//buttonShowGvFeatureDiagram
   }
   else if (action == "ShowGvStateDiagram")
   {
@@ -354,6 +361,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useJointJSClassDiagram = false;
     Page.useGvClassDiagram = false;
     Page.useGvStateDiagram = false;
+    Page.useGvFeatureDiagram = false;
     Page.useStructureDiagram = false;
     changedType = true;
     jQuery("#buttonShowEditableClassDiagram").prop('checked', 'checked');
@@ -364,6 +372,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useJointJSClassDiagram = true;
     Page.useGvClassDiagram = false;
     Page.useGvStateDiagram = false;
+    Page.useGvFeatureDiagram = false;
     Page.useStructureDiagram = false;
     changedType = true;
     jQuery("#buttonShowJointJSClassDiagram").prop('checked', 'checked');
@@ -374,6 +383,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useJointJSClassDiagram = false;
     Page.useGvClassDiagram = true;
     Page.useGvStateDiagram = false;
+    Page.useGvFeatureDiagram = false;
     Page.useStructureDiagram = false;
     changedType = true;
     jQuery("#buttonShowGvClassDiagram").prop('checked', 'checked');
@@ -385,8 +395,20 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvClassDiagram = false;
     Page.useGvStateDiagram = true;
     Page.useStructureDiagram = false;
+    Page.useGvFeatureDiagram = false;
     changedType = true;
     jQuery("#buttonShowGvStateDiagram").prop('checked', 'checked');
+  }
+  else if(newDiagramType.type == "GVFeature") {
+   if(Page.useGvFeatureDiagram) return;
+    Page.useEditableClassDiagram = false;
+    Page.useJointJSClassDiagram = false;
+    Page.useGvClassDiagram = false;
+    Page.useGvStateDiagram = false;
+    Page.useStructureDiagram = false;
+    Page.useGvFeatureDiagram = true;
+    changedType = true;
+    jQuery("#buttonShowGvFeatureDiagram").prop('checked', 'checked');
   }
   else if(newDiagramType.type == "structure") { // Structure Diagram
     if(Page.useGvStructureDiagram) return;
@@ -395,6 +417,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvClassDiagram = false;
     Page.useGvStateDiagram = false;
     Page.useStructureDiagram = true;
+    Page.useGvFeatureDiagram = false;
     changedType = true;
     jQuery("#buttonShowStructureDiagram").prop('checked', 'checked');
   }
@@ -1728,7 +1751,7 @@ Action.updateUmpleDiagramCallback = function(response)
 
     }
     // Display static svg diagram
-    else if(Page.useGvClassDiagram || Page.useGvStateDiagram)
+    else if(Page.useGvClassDiagram || Page.useGvStateDiagram || Page.useGvFeatureDiagram )
     {
       jQuery("#umpleCanvas").html(format('{0}', diagramCode));
     }
@@ -1791,7 +1814,7 @@ Action.getDiagramCode = function(responseText)
     if(output == "null") output = "";
     
   }
-  else if(Page.useGvClassDiagram || Page.useGvStateDiagram)
+  else if(Page.useGvClassDiagram || Page.useGvStateDiagram || Page.useGvFeatureDiagram)
   {
     // The graphviz diagrams are taken from the inner svg tag only. 
     // This allows the website to have a dynamic canvas size around the diagram
@@ -2193,7 +2216,7 @@ Mousetrap.bind(['ctrl+g'], function(e){
 });
 
 Mousetrap.bind(['ctrl+s'], function(e){
-  Page.clickShowGvStateDiagram();
+  Page.clickShowGvFeatureDiagram();
   return false; //equivalent to e.preventDefault();
 });
 
@@ -2405,6 +2428,9 @@ Action.getLanguage = function()
     if(Page.showMethods) language=language+".showmethods";
     if(!Page.showAttributes) language=language+".hideattributes";
   }
+  if(Page.useGvFeatureDiagram) {language="language=featureDiagram"}
+
+
   return language;
 }
 

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -1848,7 +1848,7 @@ Action.getErrorCode = function(responseText)
     
     if(output == "<p>") output = "";
   }
-  else if(Page.useGvClassDiagram || Page.useGvStateDiagram)
+  else if(Page.useGvClassDiagram || Page.useGvStateDiagram || Page.useGvFeatureDiagram)
   {
     var miscStuffAndErrorMessages = responseText.split('<svg width=')[0];
     var prelimparts = miscStuffAndErrorMessages.split('errorRow');

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -2216,7 +2216,7 @@ Mousetrap.bind(['ctrl+g'], function(e){
 });
 
 Mousetrap.bind(['ctrl+s'], function(e){
-  Page.clickShowGvFeatureDiagram();
+  Page.clickShowGvStateDiagram();
   return false; //equivalent to e.preventDefault();
 });
 

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -31,6 +31,7 @@ Page.readOnly = false; // initially allow editing
 Page.useEditableClassDiagram = true;
 Page.useGvClassDiagram = false;
 Page.useGvStateDiagram = false;
+Page.useGvFeatureDiagram = false;
 Page.useStructureDiagram = false;
 Page.showAttributes = true;
 Page.showMethods = false;
@@ -61,6 +62,12 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   {
     Page.useGvClassDiagram = true;
     Page.useEditableClassDiagram = false;
+  }
+  else if(diagramType == "GVFeature")   
+  {
+    Page.useGvFeatureDiagram = true;
+    Page.useEditableClassDiagram = false;
+    Page.useGvStateDiagram = false;
   }
   else if(diagramType == "structureDiagram")
   {
@@ -149,6 +156,7 @@ Page.initPaletteArea = function()
   Page.initAction("buttonShowJointJSClassDiagram");
   Page.initAction("buttonShowGvClassDiagram");
   Page.initAction("buttonShowGvStateDiagram");
+  Page.initAction("buttonShowGvFeatureDiagram");//buttonShowGvFeatureDiagram
   Page.initAction("buttonShowStructureDiagram");
   Page.initAction("buttonShowHideLayoutEditor");
   Page.initAction("buttonManualSync");
@@ -230,6 +238,9 @@ Page.initOptions = function()
    jQuery("#buttonShowJointJSClassDiagram").prop('checked', true);
   if(Page.useGvClassDiagram)
     jQuery("#buttonShowGvClassDiagram").prop('checked', true);
+if(Page.useGvFeatureDiagram)
+    jQuery("#buttonShowGvFeatureDiagram").prop('checked', true);
+
   if(Page.useGvStateDiagram)
     jQuery("#buttonShowGvStateDiagram").prop('checked', true);
   if(Page.useStructureDiagram)
@@ -424,6 +435,9 @@ Page.clickShowGvClassDiagram = function() {
 }
 Page.clickShowGvStateDiagram = function() {
   jQuery('#buttonShowGvStateDiagram').trigger('click');
+}
+Page.clickShowGvFeatureDiagram = function() {
+  jQuery('#buttonShowGvFeatureDiagram').trigger('click');
 }
 Page.clickShowStructureDiagram = function() {
   jQuery('#buttonShowStructureDiagram').trigger('click');

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -537,7 +537,7 @@ $output = $dataHandle->readData('model.ump');
               <input id="buttonShowGvStateDiagram" class="radio" type="radio"  name="buttonCanvasType" value="buttonCanvasTypeGVStateDiagram"/> 
               <a id="labelShowGvStateDiagram" class="buttonExtend">GraphViz State</a> 
             </li>
-			<li id="ttShowGvFeatureDiagram"> 
+	    <li id="ttShowGvFeatureDiagram"> 
               <input id="buttonShowGvFeatureDiagram" class="radio" type="radio"  name="buttonCanvasType" value="buttonCanvasTypeGVFeatureDiagram"/> 
               <a id="labelShowGvFeatureDiagram" class="buttonExtend">GraphViz Feature</a> 
             </li>

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -537,6 +537,10 @@ $output = $dataHandle->readData('model.ump');
               <input id="buttonShowGvStateDiagram" class="radio" type="radio"  name="buttonCanvasType" value="buttonCanvasTypeGVStateDiagram"/> 
               <a id="labelShowGvStateDiagram" class="buttonExtend">GraphViz State</a> 
             </li>
+			<li id="ttShowGvFeatureDiagram"> 
+              <input id="buttonShowGvFeatureDiagram" class="radio" type="radio"  name="buttonCanvasType" value="buttonCanvasTypeGVFeatureDiagram"/> 
+              <a id="labelShowGvFeatureDiagram" class="buttonExtend">GraphViz Feature</a> 
+            </li>
             <li id="ttShowStructureDiagram"> 
               <input id="buttonShowStructureDiagram" class="radio" type="radio" name="buttonCanvasType" value="buttonCanvasTypeStructureDiagram"/> 
               <a id="labelShowStructureDiagram" class="buttonExtend">Composite Structure</a> 


### PR DESCRIPTION
A new **DIAGRAM TYPE** with the name "GraphViz Feature" is added in this PR to show the feature diagram. Its under **OPTIONS** in umple online. It might be better to name it "Feature Diagram" instead of "GraphViz Feature" but the later maintains the consistency with the other diagrams' names.

The GraphViz Feature diagram will look like the below diagram:  

![umpleonlinegvfeaturediagram_example](https://user-images.githubusercontent.com/11878501/53433138-db2ad700-39c1-11e9-921a-0af5a63bc79e.png)
