### PR TITLE
Trying to fix appveyor fail

### DIFF
--- a/build/build.deps.xml
+++ b/build/build.deps.xml
@@ -147,8 +147,10 @@
     <mkdir dir="${user.home.ant}"/>
 
     <echo>Installing Ivy v${ivy.install.version}</echo>
-    <get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+    <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
          dest="${ivy.jar.file}" usetimestamp="true" />
+    <!-- COMMENTED OUT AS WAS GETTING 503 ERROR get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+         dest="${ivy.jar.file}" usetimestamp="true" / -->
 
     <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpath="${ivy.jar.file}" />
 


### PR DESCRIPTION
Appveyor is failing with a 403 error (Forbidden) when downloading Ivy from Maven. This is an attempt to see if switching to https will solve the problem.