### PR TITLE
[skip CI] fix older java version command in log

### DIFF
--- a/umpleonline/scripts/log.php
+++ b/umpleonline/scripts/log.php
@@ -46,7 +46,7 @@
     passthru("php -version");
         
     echo "<p>Java version:";
-    passthru("java --version");
+    passthru("java -version");
     
     $numBytesSent= socket_write($theSocket, $commandLine);
     if($numBytesSent === FALSE) {


### PR DESCRIPTION
Current java uses --version to determine the version. The log.php issues that command to display the version.

But if an UmpleOnline instance is running on Java 8 (as is our main server), ht requires -version. This makes this adjustment for backward compatibility