### PR TITLE
[SKIP CI] Fixing log.php redirect

### DIFF
--- a/umpleonline/scripts/log.php
+++ b/umpleonline/scripts/log.php
@@ -42,11 +42,11 @@
   if($isSuccess) {
     echo "<p>Successfully established connection to server\n";
    
-    echo "\n<p>php version:";
+    echo "\n<p>php version: ";
     passthru("php -version");
         
-    echo "<p>Java version:";
-    passthru("java -version");
+    echo "<p>Java version: ";
+    passthru("java -version 2>&1");
     
     $numBytesSent= socket_write($theSocket, $commandLine);
     if($numBytesSent === FALSE) {


### PR DESCRIPTION
The version of Java in the log.php was being sent to standard error, and hence was not being shown in the log. This fixes that.