### PR TITLE
Updating Dockerfile-base to deal with php problem

### DIFF
--- a/umpleonline/Dockerfile-base
+++ b/umpleonline/Dockerfile-base
@@ -5,6 +5,6 @@ MAINTAINER Umple umple-help@googlegroups.com
 # give php its own user and install UmpleOnline's dependencies
 RUN adduser -D -H -h /var/cache/php -s /sbin/nologin -G nginx php && \
     apk add --no-cache openjdk8 python py-pip graphviz zip \
-		       php7 php7-fpm php7-sockets php7-zip && \
+		       php7 php7-fpm php7-sockets php7-zip php7-json && \
     pip install supervisor==3.3.3
 


### PR DESCRIPTION
As per #1451 there was a problem loading examples in the Docker-hosted Umpleonline image. This makes sure that php7-json is included