### PR TITLE
[CI SKIP] Add End_of-Model to hide skipcompile

### DIFF
--- a/umpleonline/ump/manualexamples/RE001ImmutabilityException1.ump
+++ b/umpleonline/ump/manualexamples/RE001ImmutabilityException1.ump
@@ -26,7 +26,7 @@ class Path
       }    
     }
 }
-
+//$?[End_of_model]$?
 // @@@skipcppcompile - Has Java code
 // @@@skipphpcompile - Has Java code
 // @@@skiprubycompile - Has Java code


### PR DESCRIPTION
The skipcompile directives were supposed to be hidden in the manual

The manual example for the immutability runtime exception had extraneous skipcompile directives visible