### PR TITLE
added condition to fix the case when the first code injection languag…

### DIFF
--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -61,21 +61,22 @@ class GeneratorHelper
     {
       for (CodeInjection inject : allCodeInjections)
       {
+        String comment = "//";//(inject.getSnippet().getCode("Ruby") != null)?"#":"//";
         String positionString = "";
         Position p = inject.getPosition();
         Position codeP = inject.getCodePosition();
         String injectFooter = "";
         String injectType = inject.getType();
         if (codeP != null) {
-            positionString =  "// line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+            positionString =  comment + " line " + codeP.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
             if (injectType != null) {
-                injectFooter = "\n// END OF UMPLE " + injectType.toUpperCase() + " INJECTION";
+                injectFooter = "\n"+ comment +" END OF UMPLE " + injectType.toUpperCase() + " INJECTION";
             }
         }
         else if (p != null) {
-            positionString =  "// line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
+            positionString =  comment +" line " + p.getLineNumber() + " \"" + inject.getUmpleClassifier().getRelativePath( p.getFilename(), inject.getUmpleClassifier().getSourceModel().getDefaultGenerate() ) + "\"\n";
             if (injectType != null) {
-                injectFooter = "\n// END OF UMPLE " + injectType.toUpperCase() + " INJECTION";
+                injectFooter = "\n"+ comment +" END OF UMPLE " + injectType.toUpperCase() + " INJECTION";
             }
         }
         if (asCode == null)

--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -84,7 +84,7 @@ class GeneratorHelper
           {
             asCode = positionString + inject.getConstraintCode(generator) + injectFooter;
           }
-          else asCode = positionString + inject.getCode() + injectFooter;
+          else asCode = (inject.getCode()!=null)?positionString + inject.getCode() + injectFooter:positionString + injectFooter;
         }
         else
         {

--- a/cruise.umple/test/cruise/umple/implementation/JavaPhpRubyNoNullMethodInjection.ump
+++ b/cruise.umple/test/cruise/umple/implementation/JavaPhpRubyNoNullMethodInjection.ump
@@ -1,0 +1,68 @@
+class JavaPhpRubyNoNullMethodInjection {
+  
+  // injection 1
+  public void method1 () {
+  } 
+  before method1 Java {
+  //Java
+  }
+  before method1 Php {
+  //Php
+  }
+  before method1 Ruby {
+  #Ruby
+  }
+  after method1 Java {
+  //Java
+  }
+  after method1 Php {
+  //Php
+  }
+  after method1 Ruby {
+  #Ruby
+  }
+   
+  // injection 2
+  public void method2 () {
+  } 
+  before method2 Php {
+  //Php
+  }
+  before method2 Ruby {
+  #Ruby
+  }    
+  before method2 Java {
+  //Java
+  }
+  after method2 Php {
+  //Php
+  }
+  after method2 Ruby {
+  #Ruby
+  }    
+  after method2 Java {
+  //Java
+  }
+      
+  // injection 3
+  public void method3 () {
+  } 
+  before method3 Ruby {
+  #Ruby
+  }    
+  before method3 Java {
+  //Java
+  }
+  before method3 Php {
+  //Php
+  }
+  after method3 Ruby {
+  #Ruby
+  }    
+  after method3 Java {
+  //Java
+  }
+  after method3 Php {
+  //Php
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/JavaPhpRubyNoNullMethodInjectionTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/JavaPhpRubyNoNullMethodInjectionTest.java
@@ -1,0 +1,13 @@
+package cruise.umple.implementation;
+
+import org.junit.*;
+
+public class JavaPhpRubyNoNullMethodInjectionTest extends TemplateTest {
+	
+	@Test
+	public void NoNullMethodInjection()
+	{
+		assertUmpleTemplateFor("JavaPhpRubyNoNullMethodInjection.ump", languagePath + "/JavaPhpRubyNoNullMethodInjection."+ languagePath +".txt", "JavaPhpRubyNoNullMethodInjection");
+	}
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -297,6 +297,11 @@ public class TemplateTest
     // Tear down issue 1444 tests
     SampleFileWriter.destroy(pathToInput + "/Academy.java");
     SampleFileWriter.destroy(pathToInput + "/Registration.java");
+    
+    // Tear down issue 1464 tests
+    SampleFileWriter.destroy(pathToInput + "/JavaPhpRubyNoNullMethodInjection.java");
+    SampleFileWriter.destroy(pathToInput + "/JavaPhpRubyNoNullMethodInjection.php");
+    SampleFileWriter.destroy(pathToInput + "/java_php_ruby_no_null_method_injection.rb");
 
    // destroying the object factory
   }

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaPhpRubyNoNullMethodInjection.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaPhpRubyNoNullMethodInjection.java.txt
@@ -1,5 +1,5 @@
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
 
 
 

--- a/cruise.umple/test/cruise/umple/implementation/java/JavaPhpRubyNoNullMethodInjection.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/JavaPhpRubyNoNullMethodInjection.java.txt
@@ -1,0 +1,109 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!*/
+
+
+
+// line 2 "model.ump"
+public class JavaPhpRubyNoNullMethodInjection
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public JavaPhpRubyNoNullMethodInjection()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+
+  /**
+   * injection 1
+   */
+  // line 6 "model.ump"
+   public void method1(){
+    // line 8 "model.ump"
+    //Java
+    // END OF UMPLE BEFORE INJECTION
+    // line 10 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 13 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 17 "model.ump"
+    //Java
+    // END OF UMPLE AFTER INJECTION
+    // line 19 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 22 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+  }
+
+
+  /**
+   * injection 2
+   */
+  // line 28 "model.ump"
+   public void method2(){
+    // line 29 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 32 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 36 "model.ump"
+    //Java
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 38 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 41 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 45 "model.ump"
+    //Java
+    // END OF UMPLE AFTER INJECTION
+  }
+
+
+  /**
+   * injection 3
+   */
+  // line 50 "model.ump"
+   public void method3(){
+    // line 51 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 55 "model.ump"
+    //Java
+    // END OF UMPLE BEFORE INJECTION
+    // line 57 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 60 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 64 "model.ump"
+    //Java
+    // END OF UMPLE AFTER INJECTION
+    // line 66 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/php/JavaPhpRubyNoNullMethodInjection.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/JavaPhpRubyNoNullMethodInjection.php.txt
@@ -1,6 +1,6 @@
 <?php
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!*/
+/*This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!*/
 
 class JavaPhpRubyNoNullMethodInjection
 {

--- a/cruise.umple/test/cruise/umple/implementation/php/JavaPhpRubyNoNullMethodInjection.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/JavaPhpRubyNoNullMethodInjection.php.txt
@@ -1,0 +1,116 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!*/
+
+class JavaPhpRubyNoNullMethodInjection
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+
+  /**
+   * injection 1
+   */
+   public function method1()
+  {
+
+    // line 8 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 10 "model.ump"
+    //Php
+    // END OF UMPLE BEFORE INJECTION
+    // line 13 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 17 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 19 "model.ump"
+    //Php
+    // END OF UMPLE AFTER INJECTION
+    // line 22 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+  }
+
+
+  /**
+   * injection 2
+   */
+   public function method2()
+  {
+
+    // line 29 "model.ump"
+    //Php
+    // END OF UMPLE BEFORE INJECTION
+    // line 32 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 36 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 38 "model.ump"
+    //Php
+    // END OF UMPLE AFTER INJECTION
+    // line 41 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 45 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+  }
+
+
+  /**
+   * injection 3
+   */
+   public function method3()
+  {
+
+    // line 51 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 55 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 57 "model.ump"
+    //Php
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 60 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 64 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 66 "model.ump"
+    //Php
+    // END OF UMPLE AFTER INJECTION
+  }
+
+}
+?>

--- a/cruise.umple/test/cruise/umple/implementation/php/PhpJavaPhpRubyNoNullMethodInjectionTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/php/PhpJavaPhpRubyNoNullMethodInjectionTest.java
@@ -1,0 +1,17 @@
+package cruise.umple.implementation.php;
+
+import org.junit.*;
+
+import cruise.umple.implementation.JavaPhpRubyNoNullMethodInjectionTest;
+
+public class PhpJavaPhpRubyNoNullMethodInjectionTest extends JavaPhpRubyNoNullMethodInjectionTest
+{
+
+  @Before
+  public void setUp()
+  {
+    super.setUp();
+    language = "Php";
+    languagePath = "php";
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/ruby/JavaPhpRubyNoNullMethodInjection.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/JavaPhpRubyNoNullMethodInjection.ruby.txt
@@ -1,0 +1,103 @@
+# PLEASE DO NOT EDIT THIS CODE
+# This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!
+# NOTE: Ruby generator is experimental and is missing some features available in
+# in other Umple generated languages like Java or PHP
+
+
+
+class JavaPhpRubyNoNullMethodInjection
+
+
+  #------------------------
+  # CONSTRUCTOR
+  #------------------------
+
+  def initialize()
+    @initialized = false
+    @deleted = false
+    @initialized = true
+  end
+
+  #------------------------
+  # INTERFACE
+  #------------------------
+
+  def delete
+    @deleted = true
+  end
+
+
+  # injection 1
+  def method1 ()
+    // line 8 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 10 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 13 "model.ump"
+    #Ruby
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 17 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 19 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 22 "model.ump"
+    #Ruby
+    // END OF UMPLE AFTER INJECTION
+  end
+
+
+  # injection 2
+  def method2 ()
+    // line 29 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 32 "model.ump"
+    #Ruby
+    // END OF UMPLE BEFORE INJECTION
+    // line 36 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 38 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 41 "model.ump"
+    #Ruby
+    // END OF UMPLE AFTER INJECTION
+    // line 45 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+  end
+
+
+  # injection 3
+  def method3 ()
+    // line 51 "model.ump"
+    #Ruby
+    // END OF UMPLE BEFORE INJECTION
+    // line 55 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    // line 57 "model.ump"
+    
+    // END OF UMPLE BEFORE INJECTION
+    
+    // line 60 "model.ump"
+    #Ruby
+    // END OF UMPLE AFTER INJECTION
+    // line 64 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+    // line 66 "model.ump"
+    
+    // END OF UMPLE AFTER INJECTION
+  end
+
+
+
+end

--- a/cruise.umple/test/cruise/umple/implementation/ruby/JavaPhpRubyNoNullMethodInjection.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/JavaPhpRubyNoNullMethodInjection.ruby.txt
@@ -1,5 +1,5 @@
 # PLEASE DO NOT EDIT THIS CODE
-# This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!
+# This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!
 # NOTE: Ruby generator is experimental and is missing some features available in
 # in other Umple generated languages like Java or PHP
 

--- a/cruise.umple/test/cruise/umple/implementation/ruby/RubyJavaPhpRubyNoNullMethodInjectionTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/RubyJavaPhpRubyNoNullMethodInjectionTest.java
@@ -1,0 +1,17 @@
+package cruise.umple.implementation.ruby;
+
+import org.junit.*;
+
+import cruise.umple.implementation.JavaPhpRubyNoNullMethodInjectionTest;
+
+public class RubyJavaPhpRubyNoNullMethodInjectionTest extends JavaPhpRubyNoNullMethodInjectionTest
+{
+
+  @Before
+  public void setUp()
+  {
+    super.setUp();
+    language = "Ruby";
+    languagePath = "ruby";
+  }
+}


### PR DESCRIPTION
After some more testing, I found out that the problem appears whenever the first language specific code snippet is different from the language in which you want to generate your code

For example:

```
class TestMultiLang {
  name;
  public String customGetName () {
  } 
  before customGetName Ruby {
  //Ruby
  }    
  before customGetName Java {
  //Java
  }
  before customGetName Php {
  //Php
  }
}
```

will result in "null" generated for the first code injection if you generate code in Java or Php.

What I understood is that the problem comes from getCode() method of the CodeBlock class (cruise.umple\src\Umple_Code.ump lines 1163 and 1167), returning "null" if the first code specific language (as in customGetName Ruby{}) is different from the generated code language (generate Java code).

What I did is that I added a condition to check wether what getCode() returns is null or not, if it is, it doesn't add it to the generated code (cruise.umple\src\GeneratorHelper_CodeClass.ump line 87). This fixes the problem as the same previous example will now generate:
```
  // line 7 "model.ump"
   public String customGetName(){
    // line 9 "model.ump"
    
    // END OF UMPLE BEFORE INJECTION
    // line 15 "model.ump"
    //Java
    // END OF UMPLE BEFORE INJECTION
    // line 18 "model.ump"
    
    // END OF UMPLE BEFORE INJECTION
    
  }
```
which works, but I think the "header" and "footer" for Php and Ruby injected code (// line 18 "model.ump" and // END OF UMPLE BEFORE INJECTION for example) should not appear in the Java generated code (and vice versa). Should I investigate it more? 