### PR TITLE
Fixing issue#1467: Inline mixset error 

### DIFF
--- a/build/reference/4102InlineMixsets.txt
+++ b/build/reference/4102InlineMixsets.txt
@@ -1,0 +1,19 @@
+E1511 Inline Mixset Is Not Supported 
+Errors and Warnings 1000+
+noreferences
+
+@@description
+
+<h2> Inline mixset is not supported error reported when the Umple parser can't interpret an inline mixset.</h2>
+
+<p> Umple allows inline mixsets for certain entities in Umple. Inline mixsets accepts classes, traits, and interfaces. If you encounter an error regarding the support of inline mixsets, you can easily add a pair of curly brackets around the code that a mixset introduces. The code bellow shows how to use inline mixsets.  <br/>
+</p>
+
+
+@@example
+@@source manualexamples/E1511InlineMixsetIsNotSupported.ump
+@@endexample
+
+@@syntax
+[[mixsetInlineDefinition]] [[mixsetInnerContent]] [[extraCode]]
+

--- a/build/reference/4102InlineMixsets.txt
+++ b/build/reference/4102InlineMixsets.txt
@@ -6,7 +6,7 @@ noreferences
 
 <h2> Inline mixset is not supported error reported when the Umple parser can't interpret an inline mixset.</h2>
 
-<p> Umple allows inline mixsets for certain entities in Umple. Inline mixsets accepts classes, traits, and interfaces. If you encounter an error regarding the support of inline mixsets, you can easily add a pair of curly brackets around the code that a mixset introduces. The code bellow shows how to use inline mixsets.  <br/>
+<p> Umple allows inline mixsets for certain entities in Umple. Inline mixsets accepts classes, traits, and interfaces. However, empty code classes, interfaces, and traits are allowed for inline mixsets. If you encounter an error regarding the support of inline mixsets, you can easily add a pair of curly brackets around the code that a mixset introduces. The code bellow shows how to use inline mixsets.  <br/>
 </p>
 
 

--- a/build/reference/4102InlineMixsets.txt
+++ b/build/reference/4102InlineMixsets.txt
@@ -4,16 +4,16 @@ noreferences
 
 @@description
 
-<h2> Inline mixset is not supported error reported when the Umple parser can't interpret an inline mixset.</h2>
+<h2> Error reporting that most inline mixsets must have curly brackets around their content.</h2>
 
-<p> Umple allows inline mixsets for certain entities in Umple. Inline mixsets accepts classes, traits, and interfaces. However, empty code classes, interfaces, and traits are allowed for inline mixsets. If you encounter an error regarding the support of inline mixsets, you can easily add a pair of curly brackets around the code that a mixset introduces. The code bellow shows how to use inline mixsets.  <br/>
+<p> An inline mixset is one in a class, interface or trait and where the mixset name is not followed by block denoted by curly brackets. Most of the time to specify a mixset in a class you just specify the keyword mixset, followed by the name of the mixset, followed by the block of items to be included (e.g. attributes, methods, state machines, associations).</p>
+
+<p>However Umple allows inline mixsets for certain entities in Umple. Inline mixsets allow for nested declarations of classes (to create subclasses), traits, and interfaces. However, empty code classes, interfaces, and traits are not allowed for inline mixsets.</p>
+
+<p>If you encounter this error, you can easily add a pair of curly brackets around the code that a mixset introduces. The code bellow shows how to use inline mixsets.  <br/>
 </p>
 
 
 @@example
 @@source manualexamples/E1511InlineMixsetIsNotSupported.ump
 @@endexample
-
-@@syntax
-[[mixsetInlineDefinition]] [[mixsetInnerContent]] [[extraCode]]
-

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -86,7 +86,8 @@ class UmpleInternalParser
     if(mixsetBodyToken == null) 
     { 
       String mixsetName = token.getSubToken("mixsetName").getValue();
-      getParseResult().addErrorMessage(new ErrorMessage(1511,token.getPosition(), mixsetName)); 
+      getParseResult().addErrorMessage(new ErrorMessage(1511,token.getPosition(), mixsetName));
+      return; 
     }
     else 
     mixsetBodyToken.setValue(getMixsetFragmentWithEnclosingElement(token,mixsetBodyToken.getValue()));

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -74,9 +74,7 @@ class UmpleInternalParser
   {
     Token mixsetBodyToken = token.getSubToken("extraCode");
 
-    if(mixsetBodyToken == null || token.getSubToken("entityType") != null) 
-    // the above two conditions filter out inline mixsets; 
-    //they should be formated early in analyzeMixset(..) then become regular mixsets here.
+    if(mixsetBodyToken == null) 
     { 
       String mixsetName = token.getSubToken("mixsetName").getValue();
       getParseResult().addErrorMessage(new ErrorMessage(1511,token.getPosition(), mixsetName)); 

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -79,7 +79,6 @@ class UmpleInternalParser
     {
       Token oneElementToken = token.getSubToken("oneElement");
       oneElementToken.setValue(oneElementToken.getValue()+" ;");
-      //String mixsetExtaCode = getMixsetFragmentWithEnclosingElement(token,oneElementToken.getValue());
       oneElementToken.setName("extraCode");
       mixsetBodyToken = oneElementToken;
     }

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -72,7 +72,16 @@ class UmpleInternalParser
 
   private void analyzeMixsetBodyToken(Token token)
   {
-    Token mixsetBodyToken = token.getSubToken("extraCode");      
+    Token mixsetBodyToken = token.getSubToken("extraCode");
+
+    if(mixsetBodyToken == null || token.getSubToken("entityType") != null) 
+    // the above two conditions filter out inline mixsets; 
+    //they should be formated early in analyzeMixset(..) then become regular mixsets here.
+    { 
+      String mixsetName = token.getSubToken("mixsetName").getValue();
+      getParseResult().addErrorMessage(new ErrorMessage(1511,token.getPosition(), mixsetName)); 
+    }
+    else  
     mixsetBodyToken.setValue(getMixsetFragmentWithEnclosingElement(token,mixsetBodyToken.getValue()));
     analyzeMixset(token);
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -70,16 +70,26 @@ class UmpleInternalParser
     }  
 	}
 
-  private void analyzeMixsetBodyToken(Token token)
+  private void analyzeMixsetBodyToken(Token token) 
   {
     Token mixsetBodyToken = token.getSubToken("extraCode");
-
+    // Code bellow accepts a one element and changes it to be an extraCode
+    // To allow one element mixset that is placed inside a class, trait, etc.
+    if (token.getSubToken("oneElement") != null)
+    {
+      Token oneElementToken = token.getSubToken("oneElement");
+      oneElementToken.setValue(oneElementToken.getValue()+" ;");
+      //String mixsetExtaCode = getMixsetFragmentWithEnclosingElement(token,oneElementToken.getValue());
+      oneElementToken.setName("extraCode");
+      mixsetBodyToken = oneElementToken;
+    }
+    // end
     if(mixsetBodyToken == null) 
     { 
       String mixsetName = token.getSubToken("mixsetName").getValue();
       getParseResult().addErrorMessage(new ErrorMessage(1511,token.getPosition(), mixsetName)); 
     }
-    else  
+    else 
     mixsetBodyToken.setValue(getMixsetFragmentWithEnclosingElement(token,mixsetBodyToken.getValue()));
     analyzeMixset(token);
   }

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -209,7 +209,7 @@
 1503 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
 1510 : 1, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
 
-1511 : 2, "http://manual.umple.org/?E1511InlineMixsetNotSupported.html", Inline syntax is not supported for the mixset : '{0}' . Please enclose its body with curly brackets. ; 
+1511 : 2, "http://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset : '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
 
 
 

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -209,6 +209,8 @@
 1503 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
 1510 : 1, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
 
+1511 : 2, "http://manual.umple.org/?E1511InlineMixsetNotSupported.html", Inline syntax is not supported for the mixset : '{0}' . Please enclose its body with curly brackets. ; 
+
 
 
 # Messages to be emitted when embedded code from another language is compiled and you are passing on the error. These have not yet been activated.

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -209,7 +209,7 @@
 1503 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
 1510 : 1, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
 
-1511 : 2, "http://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset : '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
+1511 : 2, "http://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
 
 
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -525,5 +525,15 @@ public class UmpleMixsetTest {
   {
     umpleParserTest.assertNoWarningsParse("InlineMixsetInsideMixset.ump");
   }
+  @Test
+  public void parseInlineMixsetInsideUmpleEntity()
+  {
+    umpleParserTest.assertNoWarningsParse("inlineMixsetInsideUmpleEntity.ump");
+    UmpleFile umpleFile = new  UmpleFile(umpleParserTest.pathToInput,"inlineMixsetInsideUmpleEntity.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    Assert.assertEquals(umpleClasses.get(0).getAttribute(0).getName(),"attr1");
+  }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -533,6 +533,7 @@ public class UmpleMixsetTest {
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(false);
     model.run();
+    List<UmpleClass> umpleClasses = model.getUmpleClasses();
     Assert.assertEquals(umpleClasses.get(0).getAttribute(0).getName(),"attr1");
   }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/inlineMixsetInsideUmpleEntity.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/inlineMixsetInsideUmpleEntity.ump
@@ -1,0 +1,17 @@
+class X {
+  mixset InlineMixset attr1;
+  mixset InlineMixset abstract;
+}
+
+trait Y 
+{
+ mixset InlineMixset attr2;
+}
+
+
+class Z
+{
+  isA Y;
+}
+
+use InlineMixset;

--- a/umpleonline/ump/manualexamples/E1511InlineMixsetIsNotSupported.ump
+++ b/umpleonline/ump/manualexamples/E1511InlineMixsetIsNotSupported.ump
@@ -1,0 +1,39 @@
+/*
+Example to show how to define inline mixsets. 
+*/
+
+// The mixset M1 has been defined as inline mixset. this because the definition of the mixset is followed by a class definition. 
+mixset M1 class A { 
+  isA B;
+  isA C;
+  x;
+}
+
+// M1 also is inline mixset because it has been followed by a trait definition without curly brackets. 
+// The usuall definition of M1 is: 
+/* 
+mixset M1 
+{ 
+  trait B 
+  { 
+    y;
+  }
+} 
+*/  
+mixset M1 trait B { 
+y;}
+
+
+// M2 is an inline mixset that defines an interface.
+mixset M1 interface C { void method(); }
+
+
+class D {
+ 
+  // M3 adds an attribute for class D. It's an inline mixset since there is no mention to which a class attr1 belongs to.
+  // However, Umple parser understands this implicit definition. Therefore, the attr1 will be added to the class D.   
+  mixset M3 {attr1;}
+  
+  }
+
+use M1; use M2; use M3;

--- a/umpleonline/ump/manualexamples/E1511InlineMixsetIsNotSupported.ump
+++ b/umpleonline/ump/manualexamples/E1511InlineMixsetIsNotSupported.ump
@@ -20,8 +20,10 @@ mixset M1
   }
 } 
 */  
-mixset M1 trait B { 
-y;}
+mixset M1 trait B 
+{ 
+  y;
+}
 
 
 // M2 is an inline mixset that defines an interface.
@@ -29,11 +31,14 @@ mixset M1 interface C { void method(); }
 
 
 class D {
- 
   // M3 adds an attribute for class D. It's an inline mixset since there is no mention to which a class attr1 belongs to.
   // However, Umple parser understands this implicit definition. Therefore, the attr1 will be added to the class D.   
   mixset M3 {attr1;}
   
   }
+
+
+//The line below will cause error since the interface E is empty.
+//Mixset M4 interface E {}
 
 use M1; use M2; use M3;

--- a/umpleonline/ump/manualexamples/traits_example_multifeature.ump
+++ b/umpleonline/ump/manualexamples/traits_example_multifeature.ump
@@ -62,7 +62,7 @@ class C3 {
 
 mixset f4 class C4 {
   isA T4;
-  // Code bellow will cause an error when mixset f4 is used even when mixset f5 is not used.
+  // Commented code bellow will cause an error when mixset f4 is used even when mixset f5 is not used.
   // This because inline mixsets does not support apsect.
   //mixset f5 after custom m2() {System.out.println("m2 occurred");}
   mixset f5 { after custom m2() {System.out.println("m2 occurred");} } 

--- a/umpleonline/ump/manualexamples/traits_example_multifeature.ump
+++ b/umpleonline/ump/manualexamples/traits_example_multifeature.ump
@@ -62,7 +62,10 @@ class C3 {
 
 mixset f4 class C4 {
   isA T4;
-  mixset f5 after custom m2() {System.out.println("m2 occurred");}
+  // Code bellow will cause an error when mixset f4 is used even when mixset f5 is not used.
+  // This because inline mixsets does not support apsect.
+  //mixset f5 after custom m2() {System.out.println("m2 occurred");}
+  mixset f5 { after custom m2() {System.out.println("m2 occurred");} } 
   after e1 {System.out.printlin("event e1 occurred");}
 }//$?[End_of_model]$?
 


### PR DESCRIPTION
This PR fixes the case of an inline mixsetes that consists of one element, which is placed inside Umple classes, traits, or any Umple entities. 
Also, the parser will raise an error for unsupported inline mixsets. An error page has been added to explain the error and the way to solve the error. 