### PR TITLE
Progress on parsing labeled methods

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -231,8 +231,9 @@ for (StateMachine smq : uClass.getStateMachines())
     ArrayList<Integer> indexToRemoveList = new ArrayList<Integer>();
     for (CodeInjection codeInjectionItem: uClassCodeInectionList)
     {
-    	
-      if(! codeInjectionItem.hasCodeLabel()) // we are concerning with only codeInjection item which has code labels.
+    	// the condition below keeps only codeInjection item(s) which has code labels.
+      // also, codeInjection(s) that has been processed should not be processed again.
+      if(!codeInjectionItem.hasCodeLabel() || codeInjectionItem.getCodeBlockProcessed() ) 
         continue;
       //else 
       String methodLabelToLookat = codeInjectionItem.getInjectionlabel();
@@ -266,6 +267,7 @@ for (StateMachine smq : uClass.getStateMachines())
         resultCode += stringItem ;
       }
       aMethod.getMethodBody().getCodeblock().setCode(codesKey_lang, resultCode);
+      codeInjectionItem.setCodeBlockProcessed(true);
     }
   }
   /*

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -81,13 +81,10 @@ class UmpleToJava {
       // If this is not a constructor, this method should return "void"
       methodType = methodType.equals("") ? "void" : methodType;
     }
-    // check if labels have not been processed for aspect with labels
-    //if(!aMethod.getLabelsProcessed())
-    //{
-      applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
-      applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
-  //    aMethod.setLabelsProcessed(true);
-    //}
+    
+    applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
+    applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
+
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -82,12 +82,12 @@ class UmpleToJava {
       methodType = methodType.equals("") ? "void" : methodType;
     }
     // check if labels have not been processed for aspect with labels
-    if(!aMethod.getLabelsProcessed())
-    {
+    //if(!aMethod.getLabelsProcessed())
+    //{
       applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
       applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
-      aMethod.setLabelsProcessed(true);
-    }
+  //    aMethod.setLabelsProcessed(true);
+    //}
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -372,8 +372,8 @@ class CodeBlock{
     return codeWithLabels;
   }
 
-  class Method {
-    boolean labelsProcessed = false;
+  class CodeInjection {
+    boolean codeBlockProcessed = false;
   }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -572,9 +572,9 @@ public class UmpleMixsetTest {
     Method aMethod = uClass.getMethod(5);
     String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
 
-		String keyWord = "NewLabel:";
-		String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
-		String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    String keyWord = "NewLabel:";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
 
     Assert.assertEquals(true, beforeLabelCode.contains("code added before the SecondLabel by first Injection"));
     Assert.assertEquals(true, methodBodyCode.contains(keyWord));

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -561,8 +561,25 @@ public class UmpleMixsetTest {
     {
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"InjectToLabel.java");
     }
-
-
   }
+  @Test
+  public void multipleAspectsForOneLabelMethod() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseLabelsInsideMethod_multpleAspectForOneMethod.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(5);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
 
+		String keyWord = "NewLabel:";
+		String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+		String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+
+    Assert.assertEquals(true, beforeLabelCode.contains("code added before the SecondLabel by first Injection"));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    Assert.assertEquals(true, afterLabelCode.contains("code added before the SecondLabel by second Injection"));
+
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"InjectToLabel.java");
+  }
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
@@ -2,30 +2,27 @@
 class InjectToLabel
 {
 a;b;
-	public static void theStaticMethod( )
-	{
-	  FirstLabel: System.out.println("this is line 1.");
-		System.out.println("this is line 2.");
-		SecondLabel: System.out.println("this is line 3");
-		System.out.println("the end of theStaticMethod().");
-	}
+  public static void theStaticMethod( )
+  {
+    FirstLabel: System.out.println("this is line 1.");
+    System.out.println("this is line 2.");
+    SecondLabel: System.out.println("this is line 3");
+    System.out.println("the end of theStaticMethod().");
+    }
 	
-	before custom SecondLabel:theStaticMethod
-	{	
-	  //Start first Injection.
+
+  before custom SecondLabel:theStaticMethod
+  {	
+    //Start first Injection.
     System.out.println("code added before the SecondLabel by first Injection.");
     NewLabel:
     //End first Injection.
-    
   }
 
-	before custom SecondLabel:theStaticMethod
-	{	
-	  //Start second Injection.
+  before custom SecondLabel:theStaticMethod
+  {	
+    //Start second Injection.
     System.out.println("code added before the SecondLabel by second Injection.");
     //End second Injection. 
-  }
-		
+  }		
 }
-
-

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
@@ -1,0 +1,31 @@
+
+class InjectToLabel
+{
+a;b;
+	public static void theStaticMethod( )
+	{
+	  FirstLabel: System.out.println("this is line 1.");
+		System.out.println("this is line 2.");
+		SecondLabel: System.out.println("this is line 3");
+		System.out.println("the end of theStaticMethod().");
+	}
+	
+	before custom SecondLabel:theStaticMethod
+	{	
+	  //Start first Injection.
+    System.out.println("code added before the SecondLabel by first Injection.");
+    NewLabel:
+    //End first Injection.
+    
+  }
+
+	before custom SecondLabel:theStaticMethod
+	{	
+	  //Start second Injection.
+    System.out.println("code added before the SecondLabel by second Injection.");
+    //End second Injection. 
+  }
+		
+}
+
+


### PR DESCRIPTION
Multiple aspects that target one labeled method are not parsed properly, only the first will be processed while the rest will be ignored. This PR fixes this issue and adds a test case for it.  

The order of parsing of multiple labeled aspect follows the order of their locations in umple file. 