### PR TITLE
Progress on parsing mixsets inside methods

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -216,7 +216,26 @@ for (StateMachine smq : uClass.getStateMachines())
   {
     #>><<@ UmpleToJava.enumerations_All >><<#
   }
-
+  public void handelMixsetInsideMethod(UmpleModel umodel, MixsetInMethod mixsetInMethod, MethodBody mBody)
+  {
+    if(umodel.getMixset(mixsetInMethod.getMixsetName()) != null) // the mixset has been used.
+    {
+      //first process children
+		  for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
+        handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
+		 //Then ... 
+      String code = mBody.getCodeblock().getCode().replaceFirst("mixset\\s+"+mixsetInMethod.getMixsetName()+"\\s+\\{", ""); // remove def. of mixset + open curly bracket 
+      code = code.substring(0,code.lastIndexOf("}")); // remove last curly bracket.
+      mBody.getCodeblock().setCode(code);
+    }
+    else
+	  {
+		 // delete body of unused mixsets  
+		 String mixsetInMethodCode = mixsetInMethod.getMixsetFragment();
+		 String code = mBody.getCodeblock().getCode().replace(mixsetInMethodCode, "");
+		 mBody.getCodeblock().setCode(code);
+	  } 
+  }
   // This method allows the injection of some code before/after a code label inside a method of an umple class. 
   private void applyCodeInjectionToLabeledMethod(UmpleClass uClass, Method aMethod, String aspectType) {
     List<CodeInjection> uClassCodeInectionList = uClass.getApplicableCodeInjectionsCustomMethod(aspectType, aMethod.getName(), aMethod.getMethodParameters());

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -218,17 +218,31 @@ for (StateMachine smq : uClass.getStateMachines())
   }
   public void handelMixsetInsideMethod(UmpleModel umodel, MixsetInMethod mixsetInMethod, MethodBody mBody)
   {
-    if(umodel.getMixset(mixsetInMethod.getMixsetName()) != null) // the mixset has been used.
+    Mixset mixset = umodel.getMixset(mixsetInMethod.getMixsetName());
+    boolean mixsetIsUsed = false;
+    if(mixset != null) // the mixset has been used. 
     {
-      //first process children
-		  for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
-        handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
-		 //Then ... 
-      String code = mBody.getCodeblock().getCode().replaceFirst("mixset\\s+"+mixsetInMethod.getMixsetName()+"\\s+\\{", ""); // remove def. of mixset + open curly bracket 
-      code = code.substring(0,code.lastIndexOf("}")); // remove last curly bracket.
-      mBody.getCodeblock().setCode(code);
+      if(mixset.getUseUmpleFile() != null)
+      {
+        mixsetIsUsed = true;
+        //first process children
+		    for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
+          handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
+		    //Then ... 
+        String searchFor = "mixset\\s+"+mixsetInMethod.getMixsetName()+"\\s+\\{"; 
+        String code = mBody.getCodeblock().getCode();
+        code = code.replaceFirst(searchFor, ""); // remove def. of mixset + open curly bracket 
+
+        int indexOfMixsetClosingBracket= MethodBody.indexOfMixsetClosingBracket(" { "+code) - 3; // 3 is the added Chars at beginning 
+        String resCode = code.substring(0,indexOfMixsetClosingBracket-1) + " ";
+        if(indexOfMixsetClosingBracket < code.length()) 
+          resCode = resCode + code.substring(indexOfMixsetClosingBracket+1); 
+        mBody.getCodeblock().setCode(resCode);
+
+
+      }
     }
-    else
+    else if(!mixsetIsUsed)
 	  {
 		 // delete body of unused mixsets  
 		 String mixsetInMethodCode = mixsetInMethod.getMixsetFragment();

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -231,8 +231,9 @@ for (StateMachine smq : uClass.getStateMachines())
     ArrayList<Integer> indexToRemoveList = new ArrayList<Integer>();
     for (CodeInjection codeInjectionItem: uClassCodeInectionList)
     {
-    	
-      if(! codeInjectionItem.hasCodeLabel()) // we are concerning with only codeInjection item which has code labels.
+    	// the condition below keeps only codeInjection item(s) which has code labels.
+      // also, codeInjection(s) that has been processed should not be processed again.
+      if(!codeInjectionItem.hasCodeLabel() || codeInjectionItem.getCodeBlockProcessed() ) 
         continue;
       //else 
       String methodLabelToLookat = codeInjectionItem.getInjectionlabel();
@@ -266,6 +267,7 @@ for (StateMachine smq : uClass.getStateMachines())
         resultCode += stringItem ;
       }
       aMethod.getMethodBody().getCodeblock().setCode(codesKey_lang, resultCode);
+      codeInjectionItem.setCodeBlockProcessed(true);
     }
   }
   /*

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -81,13 +81,10 @@ class UmpleToJava {
       // If this is not a constructor, this method should return "void"
       methodType = methodType.equals("") ? "void" : methodType;
     }
-    // check if labels have not been processed for aspect with labels
-    //if(!aMethod.getLabelsProcessed())
-    //{
-      applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
-      applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
-  //    aMethod.setLabelsProcessed(true);
-    //}
+    
+    applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
+    applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
+
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -82,12 +82,12 @@ class UmpleToJava {
       methodType = methodType.equals("") ? "void" : methodType;
     }
     // check if labels have not been processed for aspect with labels
-    if(!aMethod.getLabelsProcessed())
-    {
+    //if(!aMethod.getLabelsProcessed())
+    //{
       applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
       applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
-      aMethod.setLabelsProcessed(true);
-    }
+  //    aMethod.setLabelsProcessed(true);
+    //}
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -84,7 +84,14 @@ class UmpleToJava {
     
     applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
     applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
+   
+   // handle mixsets inside methods(uClass, aMethod);
 
+    ArrayList<MixsetInMethod> mixsetsWithinMethodList = aMethod.getMethodBody().getMixsetsWithinMethod();
+    for(MixsetInMethod mixsetsWithinMethodItem : mixsetsWithinMethodList)
+    {
+      handelMixsetInsideMethod(model, mixsetsWithinMethodItem, aMethod.getMethodBody());
+    }
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -86,12 +86,12 @@ class UmpleToJava {
     applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
    
    // handle mixsets inside methods(uClass, aMethod);
-
     ArrayList<MixsetInMethod> mixsetsWithinMethodList = aMethod.getMethodBody().getMixsetsWithinMethod();
     for(MixsetInMethod mixsetsWithinMethodItem : mixsetsWithinMethodList)
     {
       handelMixsetInsideMethod(model, mixsetsWithinMethodItem, aMethod.getMethodBody());
     }
+    // End 
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -86,7 +86,7 @@ class MixsetFragment {
   body;
 }
 
-class Method
+class MethodBody
 {
   0..1 -- * MixsetInMethod;
 }
@@ -95,8 +95,9 @@ class Method
 class MixsetInMethod
 {
   String mixsetName; 
-	int startPositionIndex; //relative to the original body of the method 
-	int endPositionIndex;
-	MixsetInMethod parentInnerMixset = null; // to determine if its inner mixset
-	MixsetInMethod[] childMixsets ;
+  int startPositionIndex; //relative to the original body of the method 
+  int endPositionIndex;
+  MixsetInMethod parentInnerMixset = null; // to determine if its inner mixset
+  MixsetInMethod[] childMixsets;
+  String mixsetFragment;
 }

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -85,3 +85,18 @@ class MixsetFragment {
   // if class X { mixset Y a; then just there are no curly brackets, and a is wrapped in class X {}
   body;
 }
+
+class Method
+{
+  0..1 -- * MixsetInMethod;
+}
+
+// This class keeps references to mixsets which are iside methods
+class MixsetInMethod
+{
+  String mixsetName; 
+	int startPositionIndex; //relative to the original body of the method 
+	int endPositionIndex;
+	MixsetInMethod parentInnerMixset = null; // to determine if its inner mixset
+	MixsetInMethod[] childMixsets ;
+}

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -400,7 +400,8 @@ class MethodBody
 	}
 	return closeIndex;
 }
-  public static ArrayList<MixsetInMethod> getMixsetsWithinMethod(String codeToLockAt ) { 
+  public ArrayList<MixsetInMethod> getMixsetsWithinMethod() { 
+  String codeToLockAt= this.getCodeblock().getCode(); // the code to look at. 
   ArrayList<MixsetInMethod> mixsetInsideMethodList = new ArrayList<MixsetInMethod>();
   Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{"); // to detect mixset def.
   Matcher matcher = labelPatternToMatch.matcher(codeToLockAt);
@@ -410,7 +411,7 @@ class MethodBody
     int indexOfMixsetClosingBracket = matcher.start() + indexOfMixsetClosingBracket(mixsetDefPlusAfterCode);
     String mixsetBodyWithDef = codeToLockAt.substring(matcher.start(),indexOfMixsetClosingBracket);
     // get the name of the mixset
-    String mixsetName = matcher.group().replace("mixset", "").replace("{", ""); 
+    String mixsetName = matcher.group().replace("mixset", "").replace("{", "").trim(); 
     MixsetInMethod mixsetInsideMethod = new MixsetInMethod(mixsetName,matcher.start(),indexOfMixsetClosingBracket,mixsetBodyWithDef);
     
     // place inner method in their right position.

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -380,7 +380,7 @@ class MethodBody
   depend java.util.regex.Matcher;
   depend java.util.regex.Pattern;
 
-  private static int indexOfMixsetClosingBracket(String strInput) {
+  public static int indexOfMixsetClosingBracket(String strInput) {
 	int closeIndex = 0;
 	int numOfclosingBracket=0;
 	for(int i = 0; i< strInput.length();i++)

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -340,6 +340,7 @@ class UmpleInternalParser
 
 class CodeInjection{
   String injectionlabel = "";
+  boolean codeBlockProcessed = false;
 
   boolean hasCodeLabel()
   {
@@ -372,9 +373,63 @@ class CodeBlock{
     return codeWithLabels;
   }
 
-  class CodeInjection {
-    boolean codeBlockProcessed = false;
-  }
-
 }
 
+class MethodBody
+{
+  depend java.util.regex.Matcher;
+  depend java.util.regex.Pattern;
+
+  private static int indexOfMixsetClosingBracket(String strInput) {
+	int closeIndex = 0;
+	int numOfclosingBracket=0;
+	for(int i = 0; i< strInput.length();i++)
+	{
+		char currentChar = strInput.charAt(i);
+		if(currentChar =='{')
+		numOfclosingBracket++;
+		else if(currentChar == '}')
+			{
+			  numOfclosingBracket--;
+				if(numOfclosingBracket==0)
+			  	{
+					  closeIndex = i+1;
+					  break;
+			  	}
+			}	
+	}
+	return closeIndex;
+}
+  public static ArrayList<MixsetInMethod> getMixsetsWithinMethod(String codeToLockAt ) { 
+  ArrayList<MixsetInMethod> mixsetInsideMethodList = new ArrayList<MixsetInMethod>();
+  Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{"); // to detect mixset def.
+  Matcher matcher = labelPatternToMatch.matcher(codeToLockAt);
+  while (matcher.find()) {
+    String mixsetDefPlusAfterCode = codeToLockAt.substring(matcher.start());
+    // mixset def. + the code after the mixset def.
+    int indexOfMixsetClosingBracket = matcher.start() + indexOfMixsetClosingBracket(mixsetDefPlusAfterCode);
+    String mixsetBodyWithDef = codeToLockAt.substring(matcher.start(),indexOfMixsetClosingBracket);
+    // get the name of the mixset
+    String mixsetName = matcher.group().replace("mixset", "").replace("{", ""); 
+    MixsetInMethod mixsetInsideMethod = new MixsetInMethod(mixsetName,matcher.start(),indexOfMixsetClosingBracket,mixsetBodyWithDef);
+    
+    // place inner method in their right position.
+    for(MixsetInMethod tempMixsetInMethod:mixsetInsideMethodList)
+    {
+      if(mixsetInsideMethod.getStartPositionIndex() > tempMixsetInMethod.getStartPositionIndex()
+    			 & mixsetInsideMethod.getEndPositionIndex() < tempMixsetInMethod.getEndPositionIndex())
+      { 
+        // a nested mixset should be bounded by its close parent mixset 
+        mixsetInsideMethod.setParentInnerMixset(tempMixsetInMethod);
+        tempMixsetInMethod.addChildMixset(mixsetInsideMethod);
+      }
+    }
+    // a nested mixset should not add here. 
+    if(mixsetInsideMethod.getParentInnerMixset() == null) // its not bounded by another mixset 
+    {
+      mixsetInsideMethodList.add(mixsetInsideMethod);
+    }
+  }
+  return mixsetInsideMethodList;
+ }
+}

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -372,8 +372,8 @@ class CodeBlock{
     return codeWithLabels;
   }
 
-  class Method {
-    boolean labelsProcessed = false;
+  class CodeInjection {
+    boolean codeBlockProcessed = false;
   }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -572,9 +572,9 @@ public class UmpleMixsetTest {
     Method aMethod = uClass.getMethod(5);
     String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
 
-		String keyWord = "NewLabel:";
-		String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
-		String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    String keyWord = "NewLabel:";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
 
     Assert.assertEquals(true, beforeLabelCode.contains("code added before the SecondLabel by first Injection"));
     Assert.assertEquals(true, methodBodyCode.contains(keyWord));

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -582,4 +582,74 @@ public class UmpleMixsetTest {
 
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"InjectToLabel.java");
   }
+  @Test
+  public void mixsetInsideMethods_noUseStatement() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "Code after (outside) mixset M1";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("this is aMethod."));
+    Assert.assertEquals(false, beforeLabelCode.contains("code for InnerMixset"));
+    Assert.assertEquals(false, beforeLabelCode.contains("mixset M1 { "));
+    Assert.assertEquals(false, beforeLabelCode.contains("x++;"));
+    Assert.assertEquals(false, beforeLabelCode.contains("extra code for the mixset M1"));
+    //after checks:
+    Assert.assertEquals(false, afterLabelCode.contains("code for mixset M2."));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+  @Test
+  public void mixsetInsideMethods_useM1Statement() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_M1.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "Code after (outside) mixset M1";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("this is aMethod."));
+    Assert.assertEquals(false, beforeLabelCode.contains("code for InnerMixset"));
+    Assert.assertEquals(false, beforeLabelCode.contains("mixset M1 { "));
+    Assert.assertEquals(true, beforeLabelCode.contains("x++;"));
+    Assert.assertEquals(true, beforeLabelCode.contains("extra code for the mixset M1"));
+    //after checks:
+    Assert.assertEquals(false, afterLabelCode.contains("code for mixset M2."));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+  @Test
+  public void mixsetInsideMethods_useM2Statement() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_M2.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "Code after (outside) mixset M1";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("this is aMethod."));
+    Assert.assertEquals(false, beforeLabelCode.contains("code for InnerMixset"));
+    Assert.assertEquals(false, beforeLabelCode.contains("mixset M1 { "));
+    Assert.assertEquals(false, beforeLabelCode.contains("x++;"));
+    Assert.assertEquals(false, beforeLabelCode.contains("extra code for the mixset M1"));
+    //after checks:
+    Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -651,5 +651,74 @@ public class UmpleMixsetTest {
     Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
   }
+  @Test
+  public void mixsetInsideMethods_useM1andInnerMixsetStatement() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_M1_InnerMixset.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "Code after (outside) mixset M1";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("this is aMethod."));
+    Assert.assertEquals(true, beforeLabelCode.contains("code for InnerMixset"));
+    Assert.assertEquals(false, beforeLabelCode.contains("mixset M1 { "));
+    Assert.assertEquals(true, beforeLabelCode.contains("x++;"));
+    Assert.assertEquals(true, beforeLabelCode.contains("extra code for the mixset M1"));
+    //after checks:
+    Assert.assertEquals(false, afterLabelCode.contains("code for mixset M2."));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+ @Test
+  public void mixsetInsideMethods_useM1andM2Statement() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_M1_M2.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "Code after (outside) mixset M1";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("this is aMethod."));
+    Assert.assertEquals(false, beforeLabelCode.contains("code for InnerMixset"));
+    Assert.assertEquals(false, beforeLabelCode.contains("mixset M1 { "));
+    Assert.assertEquals(true, beforeLabelCode.contains("x++;"));
+    Assert.assertEquals(true, beforeLabelCode.contains("extra code for the mixset M1"));
+    //after checks:
+    Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+@Test
+  public void mixsetInsideMethods_useM1andInnerMixsetandM2Statement() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_M1_InnerMixset_M2.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "Code after (outside) mixset M1";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("this is aMethod."));
+    Assert.assertEquals(true, beforeLabelCode.contains("code for InnerMixset"));
+    Assert.assertEquals(false, beforeLabelCode.contains("mixset M1 { "));
+    Assert.assertEquals(true, beforeLabelCode.contains("x++;"));
+    Assert.assertEquals(true, beforeLabelCode.contains("extra code for the mixset M1"));
+    //after checks:
+    Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -561,8 +561,25 @@ public class UmpleMixsetTest {
     {
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"InjectToLabel.java");
     }
-
-
   }
+  @Test
+  public void multipleAspectsForOneLabelMethod() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseLabelsInsideMethod_multpleAspectForOneMethod.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(5);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
 
+		String keyWord = "NewLabel:";
+		String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+		String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+
+    Assert.assertEquals(true, beforeLabelCode.contains("code added before the SecondLabel by first Injection"));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    Assert.assertEquals(true, afterLabelCode.contains("code added before the SecondLabel by second Injection"));
+
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"InjectToLabel.java");
+  }
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
@@ -2,30 +2,27 @@
 class InjectToLabel
 {
 a;b;
-	public static void theStaticMethod( )
-	{
-	  FirstLabel: System.out.println("this is line 1.");
-		System.out.println("this is line 2.");
-		SecondLabel: System.out.println("this is line 3");
-		System.out.println("the end of theStaticMethod().");
-	}
+  public static void theStaticMethod( )
+  {
+    FirstLabel: System.out.println("this is line 1.");
+    System.out.println("this is line 2.");
+    SecondLabel: System.out.println("this is line 3");
+    System.out.println("the end of theStaticMethod().");
+    }
 	
-	before custom SecondLabel:theStaticMethod
-	{	
-	  //Start first Injection.
+
+  before custom SecondLabel:theStaticMethod
+  {	
+    //Start first Injection.
     System.out.println("code added before the SecondLabel by first Injection.");
     NewLabel:
     //End first Injection.
-    
   }
 
-	before custom SecondLabel:theStaticMethod
-	{	
-	  //Start second Injection.
+  before custom SecondLabel:theStaticMethod
+  {	
+    //Start second Injection.
     System.out.println("code added before the SecondLabel by second Injection.");
     //End second Injection. 
-  }
-		
+  }		
 }
-
-

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseLabelsInsideMethod_multpleAspectForOneMethod.ump
@@ -1,0 +1,31 @@
+
+class InjectToLabel
+{
+a;b;
+	public static void theStaticMethod( )
+	{
+	  FirstLabel: System.out.println("this is line 1.");
+		System.out.println("this is line 2.");
+		SecondLabel: System.out.println("this is line 3");
+		System.out.println("the end of theStaticMethod().");
+	}
+	
+	before custom SecondLabel:theStaticMethod
+	{	
+	  //Start first Injection.
+    System.out.println("code added before the SecondLabel by first Injection.");
+    NewLabel:
+    //End first Injection.
+    
+  }
+
+	before custom SecondLabel:theStaticMethod
+	{	
+	  //Start second Injection.
+    System.out.println("code added before the SecondLabel by second Injection.");
+    //End second Injection. 
+  }
+		
+}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod.ump
@@ -1,0 +1,33 @@
+
+//use M2;
+//use M1;
+//use InnerMixset;
+
+class MixsetWithinMethodClass
+{
+	public void aMethod( )
+	{
+	  System.out.println("this is aMethod.");
+	  
+		mixset M1 { 
+		x++;
+		int i = 0;
+		System.out.println("mixset M1 ... ");
+		
+		mixset InnerMixset {
+		 //code for InnerMixset
+		 }
+		//extra code for the mixset M1 
+		}
+		
+		//Code after (outside) mixset M1 
+		
+		mixset M2 {
+		// code for mixset M2.
+		}
+		
+	}
+		
+}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod.ump
@@ -1,4 +1,4 @@
-
+//no use-statement for mixsets 
 //use M2;
 //use M1;
 //use InnerMixset;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1.ump
@@ -5,28 +5,27 @@ use M1;
 
 class MixsetWithinMethodClass
 {
-	public void aMethod( )
-	{
-	  System.out.println("this is aMethod.");
-	  
-		mixset M1 { 
-		x++;
-		int i = 0;
-		System.out.println("mixset M1 ... ");
+  public void aMethod( )
+  {
+    System.out.println("this is aMethod.");
+    mixset M1 { 
+      x++;    
+      int i = 0;
+      System.out.println("mixset M1 ... ");
+      mixset InnerMixset 
+      {
+        //code for InnerMixset
+      }
+    //extra code for the mixset M1 
+    }
+
+    //Code after (outside) mixset M1 
 		
-		mixset InnerMixset {
-		 //code for InnerMixset
-		 }
-		//extra code for the mixset M1 
-		}
+    mixset M2 {
+      // code for mixset M2.
+    }
 		
-		//Code after (outside) mixset M1 
-		
-		mixset M2 {
-		// code for mixset M2.
-		}
-		
-	}
+  }
 		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1.ump
@@ -1,0 +1,33 @@
+
+//use M2;
+use M1;
+//use InnerMixset;
+
+class MixsetWithinMethodClass
+{
+	public void aMethod( )
+	{
+	  System.out.println("this is aMethod.");
+	  
+		mixset M1 { 
+		x++;
+		int i = 0;
+		System.out.println("mixset M1 ... ");
+		
+		mixset InnerMixset {
+		 //code for InnerMixset
+		 }
+		//extra code for the mixset M1 
+		}
+		
+		//Code after (outside) mixset M1 
+		
+		mixset M2 {
+		// code for mixset M2.
+		}
+		
+	}
+		
+}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_InnerMixset.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_InnerMixset.ump
@@ -1,0 +1,33 @@
+
+//use M2;
+use M1;
+use InnerMixset;
+
+class MixsetWithinMethodClass
+{
+	public void aMethod( )
+	{
+	  System.out.println("this is aMethod.");
+	  
+		mixset M1 { 
+		x++;
+		int i = 0;
+		System.out.println("mixset M1 ... ");
+		
+		mixset InnerMixset {
+		 //code for InnerMixset
+		 }
+		//extra code for the mixset M1 
+		}
+		
+		//Code after (outside) mixset M1 
+		
+		mixset M2 {
+		// code for mixset M2.
+		}
+		
+	}
+		
+}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_InnerMixset.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_InnerMixset.ump
@@ -1,32 +1,30 @@
-
 //use M2;
 use M1;
 use InnerMixset;
 
 class MixsetWithinMethodClass
 {
-	public void aMethod( )
-	{
-	  System.out.println("this is aMethod.");
-	  
-		mixset M1 { 
-		x++;
-		int i = 0;
-		System.out.println("mixset M1 ... ");
+  public void aMethod( )
+  {
+    System.out.println("this is aMethod.");
+    mixset M1 { 
+      x++;    
+      int i = 0;
+      System.out.println("mixset M1 ... ");
+      mixset InnerMixset 
+      {
+        //code for InnerMixset
+      }
+    //extra code for the mixset M1 
+    }
+
+    //Code after (outside) mixset M1 
 		
-		mixset InnerMixset {
-		 //code for InnerMixset
-		 }
-		//extra code for the mixset M1 
-		}
+    mixset M2 {
+      // code for mixset M2.
+    }
 		
-		//Code after (outside) mixset M1 
-		
-		mixset M2 {
-		// code for mixset M2.
-		}
-		
-	}
+  }
 		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_InnerMixset_M2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_InnerMixset_M2.ump
@@ -1,6 +1,6 @@
 use M2;
 use M1;
-//use InnerMixset;
+use InnerMixset;
 
 class MixsetWithinMethodClass
 {

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_M2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_M2.ump
@@ -1,0 +1,33 @@
+
+use M2;
+//use M1;
+//use InnerMixset;
+
+class MixsetWithinMethodClass
+{
+	public void aMethod( )
+	{
+	  System.out.println("this is aMethod.");
+	  
+		mixset M1 { 
+		x++;
+		int i = 0;
+		System.out.println("mixset M1 ... ");
+		
+		mixset InnerMixset {
+		 //code for InnerMixset
+		 }
+		//extra code for the mixset M1 
+		}
+		
+		//Code after (outside) mixset M1 
+		
+		mixset M2 {
+		// code for mixset M2.
+		}
+		
+	}
+		
+}
+
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M2.ump
@@ -1,32 +1,30 @@
-
 use M2;
 //use M1;
 //use InnerMixset;
 
 class MixsetWithinMethodClass
 {
-	public void aMethod( )
-	{
-	  System.out.println("this is aMethod.");
-	  
-		mixset M1 { 
-		x++;
-		int i = 0;
-		System.out.println("mixset M1 ... ");
+  public void aMethod( )
+  {
+    System.out.println("this is aMethod.");
+    mixset M1 { 
+      x++;    
+      int i = 0;
+      System.out.println("mixset M1 ... ");
+      mixset InnerMixset 
+      {
+        //code for InnerMixset
+      }
+    //extra code for the mixset M1 
+    }
+
+    //Code after (outside) mixset M1 
 		
-		mixset InnerMixset {
-		 //code for InnerMixset
-		 }
-		//extra code for the mixset M1 
-		}
+    mixset M2 {
+      // code for mixset M2.
+    }
 		
-		//Code after (outside) mixset M1 
-		
-		mixset M2 {
-		// code for mixset M2.
-		}
-		
-	}
+  }
 		
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M2.ump
@@ -1,0 +1,33 @@
+
+use M2;
+//use M1;
+//use InnerMixset;
+
+class MixsetWithinMethodClass
+{
+	public void aMethod( )
+	{
+	  System.out.println("this is aMethod.");
+	  
+		mixset M1 { 
+		x++;
+		int i = 0;
+		System.out.println("mixset M1 ... ");
+		
+		mixset InnerMixset {
+		 //code for InnerMixset
+		 }
+		//extra code for the mixset M1 
+		}
+		
+		//Code after (outside) mixset M1 
+		
+		mixset M2 {
+		// code for mixset M2.
+		}
+		
+	}
+		
+}
+
+


### PR DESCRIPTION
This PR allows methods to handel mixsets within their bodies. Therefore, method-mixsets have two scenarios:  

- When mixsets are not used, the mixsets will be removed from the method's code at generation time.
- When a mixset is used, the body of the mixset, which is inside curly brackets, will be added to the method at generation time.

This applies to nested method-mixsets too. The test cases cover some ways in which nested mixsets are added, or removed, based on the use-statement of mixsets.

Note: inline-mixsets are not supported within methods. It is too complex to allow inline-mixsets inside methods. Therefore, just the regular definition of mixsets such as` mixset <<name>> { <<body>> } ` is expected to be inside a body of a method.  