### PR TITLE
Display the total number of commands run in UmpleOnline and log.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ umpleonline/ump/tmp*
 build/UserManualAndExampleTests_output.txt
 umpleonline/manual
 umpleonline/countlog.txt
+umpleonline/commandcount.txt
 umpleonline/scripts/specialPort.txt
 
 # generated Umple code that is not saved

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ umpleonline/ump/tmp*
 build/UserManualAndExampleTests_output.txt
 umpleonline/manual
 umpleonline/countlog.txt
-umpleonline/commandcount.txt
+umpleonline/scripts/commandcount.txt
 umpleonline/scripts/specialPort.txt
 
 # generated Umple code that is not saved

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -703,6 +703,9 @@ class PlaygroundMain
               +"  JsonMixed: " +generateJsonMixedCommandsRun
               +"\n\n", client);          
 
+          returnCommandResult("Number of commands run since July 2019: "
+            +commandsEverRun+"\n\n", client);
+
           returnCommandResult("Number of clients queued: "
             +getClientConnections().length+"\n\n", client);
 
@@ -910,13 +913,12 @@ class PlaygroundMain
     returnCommandResult(answer, client);
   }
   
-
-  protected boolean saveCommandsCount(){
+  private boolean saveCommandsCount(){
     boolean saved = false;
 
     try {
-        FileWriter writer = new FileWriter("commandcount.txt", true);
-        writer.write(commandsEverRun);
+        FileWriter writer = new FileWriter("commandcount.txt", false);
+        writer.write(Integer.toString(commandsEverRun));
         writer.close();
         saved = true;
     } catch (IOException e) {
@@ -926,7 +928,7 @@ class PlaygroundMain
     return saved;
   }
 
-  protected boolean loadCommandsCount(){
+  private boolean loadCommandsCount(){
     boolean loaded = false;
     try {
       BufferedReader myReader = new BufferedReader(new FileReader("commandcount.txt"));
@@ -963,7 +965,6 @@ class PlaygroundMain
   protected void serverStopped() {
     // Uncomment the following to debug
     // System.err.println("Umple server stopped accepting connections "+getPort());
-    saveCommandsCount();
   }
   
   protected void serverClosed() {

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -794,6 +794,7 @@ class PlaygroundMain
     if ("-quit".equals(args[0])) {
       if(isServer) {
         try {
+          saveCommandsCount();
           this.close();
         }
         catch (IOException e) {

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -484,6 +484,7 @@ class PlaygroundMain
 
   Boolean isServer=false;
   int commandsRun = 0;
+  int commandsEverRun = 0;
   int checkpointCommandsRun = 0;
   int checkpoint2CommandsRun = 0;
   int cpDiffCmds = 0;
@@ -590,6 +591,7 @@ class PlaygroundMain
   {
     String answer = "";
     commandsRun++;
+    commandsEverRun++;
     
     if(commandsRun%100==0) { // We have hit a checkpoint
       checkpoint2CommandsRun = checkpointCommandsRun;
@@ -598,6 +600,11 @@ class PlaygroundMain
       checkpointTime = System.currentTimeMillis();
       checkpoint2MaxElapsed = checkpointMaxElapsed;
       checkpointMaxElapsed = 0; // start counting max again
+    }
+
+    if(commandsEverRun%1000==0) {
+      //write commandcount.txt with commandsEverRun (to allow for crashes)
+      saveCommandsCount();
     }
     
     previousCommand = lastCommand;
@@ -903,15 +910,60 @@ class PlaygroundMain
     returnCommandResult(answer, client);
   }
   
+
+  protected boolean saveCommandsCount(){
+    boolean saved = false;
+
+    try {
+        FileWriter writer = new FileWriter("commandcount.txt", true);
+        writer.write(commandsEverRun);
+        writer.close();
+        saved = true;
+    } catch (IOException e) {
+        System.err.println(e.getMessage());
+    }
+
+    return saved;
+  }
+
+  protected boolean loadCommandsCount(){
+    boolean loaded = false;
+    try {
+      BufferedReader myReader = new BufferedReader(new FileReader("commandcount.txt"));
+
+      int number = 0;
+      String token;
+      if ((token = myReader.readLine()) != null) {
+        try {
+            number = Integer.parseInt(token);
+        } catch (NumberFormatException ex) {
+            System.err.println(token + " is not a number");
+        } 
+      } 
+      myReader.close();
+      commandsEverRun = number;
+      loaded = true;
+
+    } catch(FileNotFoundException e){
+      System.err.println(e.getMessage());
+
+    } catch(IOException e){
+      System.err.println(e.getMessage());
+    }
+    return loaded;
+  }
+
   protected void serverStarted() {
     // Uncomment the following to debug
     // System.err.println("Umple server started on port "+getPort());
     // System.err.println("Working directory "+System.getProperty("user.dir"));
+    loadCommandsCount();
   }
   
   protected void serverStopped() {
     // Uncomment the following to debug
     // System.err.println("Umple server stopped accepting connections "+getPort());
+    saveCommandsCount();
   }
   
   protected void serverClosed() {

--- a/umpleonline/counter.php
+++ b/umpleonline/counter.php
@@ -28,7 +28,7 @@ if(file_exists($logpath)){
 }
 
 if(file_exists($commandlogpath)){
-	if(!is_writable($commandlogpath)||!is_readable($commandlogpath)) {
+	if(!is_readable($commandlogpath)) {
 		chmod($commandlogpath, 0755);
 	}
 	$log = fopen($commandlogpath, "r");

--- a/umpleonline/counter.php
+++ b/umpleonline/counter.php
@@ -9,6 +9,7 @@ http://justintadlock.com/web-design/counter
 //opens countlog.txt to read the number of hits
 $dir = dirname(__FILE__);
 $logpath = $dir."/countlog.txt";
+$commandlogpath = $dir."/scripts/commandcount.txt";
 if(file_exists($logpath)){
 	if(!is_writable($logpath)||!is_readable($logpath)) {
 		chmod($logpath, 0755);
@@ -24,6 +25,16 @@ if(file_exists($logpath)){
 	$log = fopen($logpath,"w");
 	fwrite($log, $count);
 	fclose($log);
+}
+
+if(file_exists($commandlogpath)){
+	if(!is_writable($commandlogpath)||!is_readable($commandlogpath)) {
+		chmod($commandlogpath, 0755);
+	}
+	$log = fopen($commandlogpath, "r");
+	$count = fgets($log,1000);
+	fclose($log);
+	echo " | $count commands run since July 2019" ;
 }
 
 


### PR DESCRIPTION
The total number of commands run is now loaded from and saved in commandcount.txt found in umpleonline/scripts/. The number of commands run is displayed in UmpleOnline:

` 148150 visits since October 2018 | 854110 commands run since July 2019`

 and in log.php. commandcount.txt should be added to the diretory.


 