### PR TITLE
fixed extraneous URL_SPLIT message in GraphViz views

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -320,24 +320,30 @@ else if (isset($_REQUEST["umpleCode"]))
   $sourceCode = htmlspecialchars($sourceCode);
   
   $errhtml = getErrorHtml($errorFilename);
-  
+
   if ($sourceCode == "")
   {
     if($input == "//$?[End_of_model]$?") {
-      $html = "
+      $msg = "
         Please create an Umple model textually (on the left side of the screen)
         or visually (on the right side of the screen),
         and then choose Generate Code again.";
     }
     else
     {
-      $html = "
+      $msg = "
         An error occurred interpreting your Umple code, please review it and try again.
         If the problem persists, please email the Umple code to
         the umple-help google group: umple-help@googlegroups.com";
     }
-    echo $errhtml ."<p>URL_SPLIT" . $html;
-    
+    if ($errhtml == ""){
+      $errhtml = "<a href='#' id='errorClick'>Show/Hide errors and warnings</a>";
+      $errhtml .= "<div id='errorRow' colspan='3' >"; 
+      $errhtml .= "<font color=\"red\"> Error : {$msg}.</font></br>";
+      $errhtml .= "<script type=\"text/javascript\">jQuery(\"#errorClick\").click(function(a){a.preventDefault();jQuery(\"#errorRow\").toggle();});</script>";
+      $errhtml .= "</div>";
+    }   
+    echo $errhtml;
   }
   else
   {


### PR DESCRIPTION
An extraneous error message was displayed in GraphViz views in case the result from executing a command was an empty string.

I suspect the extraneous error message was used before the implementation of the current error display system and wasn't updated.

So my solution was that, in case a command execution returns an empty string (which means an error occured), check whether there is no associated error message (which means that the error is not known and there is no error file for it), if so, display the extraneous error message that asks the user to send the code to the Umple team, else, display the predefined error message related to the error.

The difference between Windows and other OS seems to be what executeCommand($command) returns. If there is an error, it returns an empty string, but not in Windows, and thus another message is displayed.