### PR TITLE
temporary fix for issue 1483

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -884,6 +884,13 @@ class UmpleInternalParser
 
   private void populateStateMachine(Token stateMachineToken, StateMachine sm, UmpleClassifier uClassifier)
   {
+    //issue1483
+    if(sm.getUmpleClass() == null && sm.getUmpleTrait() == null)
+    {
+      setFailedPosition(stateMachineToken.getPosition(), 1015);
+      return;
+    }
+
     boolean isFirst;
     boolean isFinalState = false;
     String changeType = null;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -203,6 +203,8 @@
 1012: 3, "http://manual.umple.org/?W1012MethodNotFoundInjection.html", Method '{0}' cannot be found. Injection was ignored. ;
 1013: 3, "http://manual.umple.org/?W1013ParameterSpecificationDoesNotApply.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
 1014: 3, "http://manual.umple.org/?W1014ExcludedMethodNotFoundInjection.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
+# Issue 1483
+1015: 3, "http://manual.umple.org/?BasicStateMachines.html", Standalone state machines are not supported. However, state machines can be used in traits or put directly in a class to achieve the same effect. ;
 
 1500 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: '{0}' not understood ; 
 1501 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 


### PR DESCRIPTION
This is a temporary fix for issue #1483 

The current fix checks whether the parsed state machine is associated to a class or a trait or not, if not (standalone state machine), it will show a warning message:

` Warning on line X : Standalone state machines are not supported. However, state machines can be used in traits or put directly in a class to achieve the same effect.. More information (1015)`

and the code for the state machine will be ignored in order to prevent an infinite loop induced when the parser is looking for the class of the state method being analyzed (UmpleInternalParser_CodeStateMachine.ump line 1990)

The generated code will contain no state machines and will possibly result in errors