### PR TITLE
temporary fix for issue 1483

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -1989,11 +1989,20 @@ class UmpleInternalParser
     // Make sure we retrieve the same Umple class for nested children as well
     UmpleClass uClass = null;
     StateMachine smRunner = sm;
-    while (uClass == null)
+    int depth = 0;//issue1483
+
+    while (uClass == null && depth<100)
     {
       uClass = smRunner.getUmpleClass();
       if (smRunner.getParentState() != null)
     	  smRunner = smRunner.getParentState().getStateMachine();
+      depth++;
+    }
+    
+    if(uClass == null)//issue1483
+    {
+      setFailedPosition(methodToken.getPosition(), 1015);
+      return;
     }
 
     // Retrieve method analyzed using the method token

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -203,6 +203,9 @@
 1012: 3, "http://manual.umple.org/?W1012MethodNotFoundInjection.html", Method '{0}' cannot be found. Injection was ignored. ;
 1013: 3, "http://manual.umple.org/?W1013ParameterSpecificationDoesNotApply.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
 1014: 3, "http://manual.umple.org/?W1014ExcludedMethodNotFoundInjection.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
+# Issue 1483
+1015: 3, "http://manual.umple.org/?BasicStateMachines.html", Methods in standalone state machines might not be correctly generated. State machines can be used in traits or put directly in a class to achieve the same effect. ;
+
 
 1500 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: '{0}' not understood ; 
 1501 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 


### PR DESCRIPTION
This is a temporary fix for issue #1483 

The infinite loop occurs whenever there is a method defined inside a standalone state machine.The current fix checks whether the parsed method is associated to a class or not, if not, it will show a warning message:

`Methods in standalone state machines might not be correctly generated. State machines can be used in traits or put directly in a class to achieve the same effect.`

and the code for the state machine might be ignored in order to prevent an infinite loop induced when the parser is looking for the class of the state method being analyzed (UmpleInternalParser_CodeStateMachine.ump line 1990)