### PR TITLE
Issue1442

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/constructor_DeclareOneToOne.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_DeclareOneToOne.ump
@@ -3,6 +3,7 @@ use constructor_AssociationAssignOptionalMany.ump;
 use constructor_AssociationCreateOneToOne.ump;
 use constructor_AttributeAssign.ump;
 use constructor_AttributeAssignAutounique.ump;
+use constructor_AttributeAssignUnique.ump;
 use constructor_AttributeAssignDefaulted.ump;
 use constructor_AttributeAssignLazy.ump;
 use constructor_AttributeAssignList.ump;
@@ -74,6 +75,11 @@ class UmpleToJava {
     {
       hasBody = true;
       #>><<@ UmpleToJava.constructor_AttributeAssignLazy >><<#
+    }
+    else if(av.getIsUnique())
+    {
+      hasBody = true;
+      #>><<@ UmpleToJava.constructor_AttributeAssignUnique >><<#
     }
     else
     {

--- a/UmpleToPhp/UmpleTLTemplates/constructor_DeclareOneToOne.ump
+++ b/UmpleToPhp/UmpleTLTemplates/constructor_DeclareOneToOne.ump
@@ -2,6 +2,7 @@ use constructor_AssociationAssignDefault.ump;
 use constructor_AssociationCreateOneToOne.ump;
 use constructor_AttributeAssign.ump;
 use constructor_AttributeAssignAutounique.ump;
+use constructor_AttributeAssignUnique.ump;
 use constructor_AttributeAssignDefaulted.ump;
 use constructor_AttributeAssignLazy.ump;
 use constructor_AttributeAssignList.ump;
@@ -41,6 +42,11 @@ class UmpleToPhp {
     {
       hasBody = true;
       #>><<@ UmpleToPhp.constructor_AttributeAssignLazy >><<#
+    }
+    else if(av.getIsUnique())
+    {
+      hasBody = true;
+      #>><<@ UmpleToPhp.constructor_AttributeAssignUnique >><<#
     }
     else
     {

--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -1956,21 +1956,26 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
       inject.setIsInternal(true);
       aClass.addCodeInjection(inject);
     }
-      
+
     if (av.getIsUnique())
     {
+      String equals = "| boolean | byte | char | short | int | long | float | double | Integer | Float | Double | Boolean |".contains(av.getFullType())? "{1} == {2}" : "{1} != null && {1}.equals({2})";
       injectIntoUniqueSet(
         av.getType() + " {2} = {3}();" + "\n" +
-        "if ({1} != null && {1}.equals({2})) {" + "\n" + 
+        "if (" + equals + ") {" + "\n" + 
         "return true;" + "\n" +
         "}" + "\n" + 
         "if ({4}({1})) {" + "\n" + 
         "  return wasSet;" + "\n" +
         "}", "before", av, aClass);
-      injectIntoUniqueSet(
-        "if ({2} != null) {" + "\n" +
+
+      String remove = "| boolean | byte | char | short | int | long | float | double | Integer | Float | Double | Boolean |".contains(av.getFullType())?
+      "{5}.remove({2});" + "\n" :
+      "if ({2} != null) {" + "\n" +
         "  {5}.remove({2});" + "\n" +
-        "}" + "\n" +
+        "}" + "\n";
+      injectIntoUniqueSet(
+        remove +
         "{5}.put({1}, this);", "after", av, aClass);
       injectIntoUniqueDelete(
         "{5}.remove({3}());", "before", av, aClass);

--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -1956,26 +1956,21 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
       inject.setIsInternal(true);
       aClass.addCodeInjection(inject);
     }
-
+      
     if (av.getIsUnique())
     {
-      String equals = "| boolean | byte | char | short | int | long | float | double | Integer | Float | Double | Boolean |".contains(av.getFullType())? "{1} == {2}" : "{1} != null && {1}.equals({2})";
       injectIntoUniqueSet(
         av.getType() + " {2} = {3}();" + "\n" +
-        "if (" + equals + ") {" + "\n" + 
+        "if ({2} != null && {2}.equals({1})) {" + "\n" + 
         "return true;" + "\n" +
         "}" + "\n" + 
         "if ({4}({1})) {" + "\n" + 
         "  return wasSet;" + "\n" +
         "}", "before", av, aClass);
-
-      String remove = "| boolean | byte | char | short | int | long | float | double | Integer | Float | Double | Boolean |".contains(av.getFullType())?
-      "{5}.remove({2});" + "\n" :
-      "if ({2} != null) {" + "\n" +
-        "  {5}.remove({2});" + "\n" +
-        "}" + "\n";
       injectIntoUniqueSet(
-        remove +
+        "if ({2} != null) {" + "\n" +
+        "  {5}.remove({2});" + "\n" +
+        "}" + "\n" +
         "{5}.put({1}, this);", "after", av, aClass);
       injectIntoUniqueDelete(
         "{5}.remove({3}());", "before", av, aClass);

--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -1962,7 +1962,7 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
       injectIntoUniqueSet(
         av.getType() + " {2} = {3}();" + "\n" +
         "if ({2} != null && {2}.equals({1})) {" + "\n" + 
-        "return true;" + "\n" +
+        "  return true;" + "\n" +
         "}" + "\n" + 
         "if ({4}({1})) {" + "\n" + 
         "  return wasSet;" + "\n" +

--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -1960,7 +1960,10 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
     if (av.getIsUnique())
     {
       injectIntoUniqueSet(
-        av.getType() + " {2} = {3}();" + "\n" + 
+        av.getType() + " {2} = {3}();" + "\n" +
+        "if ({1} != null && {1}.equals({2})) {" + "\n" + 
+        "return true;" + "\n" +
+        "}" + "\n" + 
         "if ({4}({1})) {" + "\n" + 
         "  return wasSet;" + "\n" +
         "}", "before", av, aClass);

--- a/cruise.umple/src/Generator_CodePhp.ump
+++ b/cruise.umple/src/Generator_CodePhp.ump
@@ -678,8 +678,8 @@ class PhpGenerator
           "if (isset($this->{0})) {" + "\n" +
           "  ${2} = $this->{3}();" + "\n" + 
           "}" + "\n" + 
-          "if (${1} === ${2}) {" + "\n" + 
-          "return true;" + "\n" +
+          "if (isset(${2}) && ${2} === ${1}) {" + "\n" + 
+          "  return true;" + "\n" +
           "}" + "\n" + 
           "if ({6}::{4}(${1})) {" + "\n" + 
           "  return $wasSet;" + "\n" +

--- a/cruise.umple/src/Generator_CodePhp.ump
+++ b/cruise.umple/src/Generator_CodePhp.ump
@@ -678,6 +678,9 @@ class PhpGenerator
           "if (isset($this->{0})) {" + "\n" +
           "  ${2} = $this->{3}();" + "\n" + 
           "}" + "\n" + 
+          "if (${1} === ${2}) {" + "\n" + 
+          "return true;" + "\n" +
+          "}" + "\n" + 
           "if ({6}::{4}(${1})) {" + "\n" + 
           "  return $wasSet;" + "\n" +
           "}", "before", av, aClass);

--- a/cruise.umple/src/Generator_CodeRuby.ump
+++ b/cruise.umple/src/Generator_CodeRuby.ump
@@ -687,7 +687,7 @@ class RubyGenerator
       {
         injectIntoUniqueSet(
           "{2} = {3}();" + "\n" +
-          "if ({1} == {2})" + "\n" + 
+          "if ({2} != nil && {2} == {1})" + "\n" + 
           "  return true" + "\n" +
           "end" + "\n" +
           "if ({6}.{4}?({1}))" + "\n" + 

--- a/cruise.umple/src/Generator_CodeRuby.ump
+++ b/cruise.umple/src/Generator_CodeRuby.ump
@@ -687,6 +687,9 @@ class RubyGenerator
       {
         injectIntoUniqueSet(
           "{2} = {3}();" + "\n" +
+          "if ({1} == {2})" + "\n" + 
+          "  return true" + "\n" +
+          "end" + "\n" +
           "if ({6}.{4}?({1}))" + "\n" + 
           "  return was_set" + "\n" +
           "end", "before", av, aClass);

--- a/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
@@ -72,7 +72,7 @@ public class RegularFlight
     boolean wasSet = false;
     Integer anOldFlightNumber = getFlightNumber();
     if (anOldFlightNumber != null && anOldFlightNumber.equals(aFlightNumber)) {
-    return true;
+      return true;
     }
     if (hasWithFlightNumber(aFlightNumber)) {
       return wasSet;
@@ -91,7 +91,7 @@ public class RegularFlight
     boolean wasSet = false;
     Float anOldFlightNumber3 = getFlightNumber3();
     if (anOldFlightNumber3 != null && anOldFlightNumber3.equals(aFlightNumber3)) {
-    return true;
+      return true;
     }
     if (hasWithFlightNumber3(aFlightNumber3)) {
       return wasSet;
@@ -110,7 +110,7 @@ public class RegularFlight
     boolean wasSet = false;
     Double anOldFlightNumber4 = getFlightNumber4();
     if (anOldFlightNumber4 != null && anOldFlightNumber4.equals(aFlightNumber4)) {
-    return true;
+      return true;
     }
     if (hasWithFlightNumber4(aFlightNumber4)) {
       return wasSet;
@@ -129,7 +129,7 @@ public class RegularFlight
     boolean wasSet = false;
     String anOldLala = getLala();
     if (anOldLala != null && anOldLala.equals(aLala)) {
-    return true;
+      return true;
     }
     if (hasWithLala(aLala)) {
       return wasSet;

--- a/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/RegularFlight.java.txt
@@ -5,6 +5,8 @@
 import java.sql.Time;
 import java.util.*;
 
+// line 2 "model.ump"
+// line 10 "model.ump"
 public class RegularFlight
 {
 
@@ -69,6 +71,9 @@ public class RegularFlight
   {
     boolean wasSet = false;
     Integer anOldFlightNumber = getFlightNumber();
+    if (anOldFlightNumber != null && anOldFlightNumber.equals(aFlightNumber)) {
+    return true;
+    }
     if (hasWithFlightNumber(aFlightNumber)) {
       return wasSet;
     }
@@ -85,6 +90,9 @@ public class RegularFlight
   {
     boolean wasSet = false;
     Float anOldFlightNumber3 = getFlightNumber3();
+    if (anOldFlightNumber3 != null && anOldFlightNumber3.equals(aFlightNumber3)) {
+    return true;
+    }
     if (hasWithFlightNumber3(aFlightNumber3)) {
       return wasSet;
     }
@@ -101,6 +109,9 @@ public class RegularFlight
   {
     boolean wasSet = false;
     Double anOldFlightNumber4 = getFlightNumber4();
+    if (anOldFlightNumber4 != null && anOldFlightNumber4.equals(aFlightNumber4)) {
+    return true;
+    }
     if (hasWithFlightNumber4(aFlightNumber4)) {
       return wasSet;
     }
@@ -117,6 +128,9 @@ public class RegularFlight
   {
     boolean wasSet = false;
     String anOldLala = getLala();
+    if (anOldLala != null && anOldLala.equals(aLala)) {
+    return true;
+    }
     if (hasWithLala(aLala)) {
       return wasSet;
     }
@@ -138,12 +152,12 @@ public class RegularFlight
   {
     return flightNumber;
   }
-
+  /* Code from template attribute_GetUnique */
   public static RegularFlight getWithFlightNumber(int aFlightNumber)
   {
     return regularflightsByFlightNumber.get(aFlightNumber);
   }
-
+  /* Code from template attribute_HasUnique */
   public static boolean hasWithFlightNumber(int aFlightNumber)
   {
     return getWithFlightNumber(aFlightNumber) != null;
@@ -153,12 +167,12 @@ public class RegularFlight
   {
     return flightNumber3;
   }
-
+  /* Code from template attribute_GetUnique */
   public static RegularFlight getWithFlightNumber3(float aFlightNumber3)
   {
     return regularflightsByFlightNumber3.get(aFlightNumber3);
   }
-
+  /* Code from template attribute_HasUnique */
   public static boolean hasWithFlightNumber3(float aFlightNumber3)
   {
     return getWithFlightNumber3(aFlightNumber3) != null;
@@ -168,12 +182,12 @@ public class RegularFlight
   {
     return flightNumber4;
   }
-
+  /* Code from template attribute_GetUnique */
   public static RegularFlight getWithFlightNumber4(double aFlightNumber4)
   {
     return regularflightsByFlightNumber4.get(aFlightNumber4);
   }
-
+  /* Code from template attribute_HasUnique */
   public static boolean hasWithFlightNumber4(double aFlightNumber4)
   {
     return getWithFlightNumber4(aFlightNumber4) != null;
@@ -183,12 +197,12 @@ public class RegularFlight
   {
     return lala;
   }
-
+  /* Code from template attribute_GetUnique */
   public static RegularFlight getWithLala(String aLala)
   {
     return regularflightsByLala.get(aLala);
   }
-
+  /* Code from template attribute_HasUnique */
   public static boolean hasWithLala(String aLala)
   {
     return getWithLala(aLala) != null;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
@@ -6,6 +6,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.util.*;
 
+// line 5 "../../../../ump/tmp12056/model.ump"
 public class Mentor
 {
 
@@ -82,7 +83,7 @@ public class Mentor
   //------------------------
   // INTERFACE
   //------------------------
-
+  /* Code from template attribute_SetImmutable */
   public boolean setStr2(String aStr2)
   {
     boolean wasSet = false;
@@ -145,6 +146,9 @@ public class Mentor
   {
     boolean wasSet = false;
     String anOldId = getId();
+    if (anOldId != null && anOldId.equals(aId)) {
+    return true;
+    }
     if (hasWithId(aId)) {
       return wasSet;
     }
@@ -156,7 +160,7 @@ public class Mentor
     mentorsById.put(aId, this);
     return wasSet;
   }
-
+  /* Code from template attribute_SetDefaulted */
   public boolean setP(String aP)
   {
     boolean wasSet = false;
@@ -180,7 +184,7 @@ public class Mentor
     wasSet = true;
     return wasSet;
   }
-
+  /* Code from template attribute_SetDefaulted */
   public boolean setR(String aR)
   {
     boolean wasSet = false;
@@ -212,7 +216,7 @@ public class Mentor
     wasSet = true;
     return wasSet;
   }
-
+  /* Code from template attribute_SetDefaulted */
   public boolean setV(Date aV)
   {
     boolean wasSet = false;
@@ -228,7 +232,7 @@ public class Mentor
     wasReset = true;
     return wasReset;
   }
-
+  /* Code from template attribute_SetDefaulted */
   public boolean setW(Time aW)
   {
     boolean wasSet = false;
@@ -294,12 +298,12 @@ public class Mentor
   {
     return id;
   }
-
+  /* Code from template attribute_GetUnique */
   public static Mentor getWithId(String aId)
   {
     return mentorsById.get(aId);
   }
-
+  /* Code from template attribute_HasUnique */
   public static boolean hasWithId(String aId)
   {
     return getWithId(aId) != null;
@@ -309,7 +313,7 @@ public class Mentor
   {
     return p;
   }
-
+  /* Code from template attribute_GetDefaulted */
   public String getDefaultP()
   {
     return "robot";
@@ -324,7 +328,7 @@ public class Mentor
   {
     return r;
   }
-
+  /* Code from template attribute_GetDefaulted */
   public String getDefaultR()
   {
     return "";
@@ -349,7 +353,7 @@ public class Mentor
   {
     return v;
   }
-
+  /* Code from template attribute_GetDefaulted */
   public Date getDefaultV()
   {
     return Date.valueOf("1978-12-26");
@@ -359,7 +363,7 @@ public class Mentor
   {
     return w;
   }
-
+  /* Code from template attribute_GetDefaulted */
   public Time getDefaultW()
   {
     return Time.valueOf("12:59:59");
@@ -369,7 +373,7 @@ public class Mentor
   {
     return x;
   }
-
+  /* Code from template attribute_IsBoolean */
   public boolean isLBool()
   {
     return lBool;

--- a/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/ClassTemplateTest_Attributes.java.txt
@@ -147,7 +147,7 @@ public class Mentor
     boolean wasSet = false;
     String anOldId = getId();
     if (anOldId != null && anOldId.equals(aId)) {
-    return true;
+      return true;
     }
     if (hasWithId(aId)) {
       return wasSet;

--- a/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_2.java.txt
@@ -4,6 +4,8 @@
 package example;
 import java.util.*;
 
+// line 4 "../../../../ump/tmp12056/model.ump"
+// line 19 "../../../../ump/tmp12056/model.ump"
 public class X
 {
 
@@ -54,6 +56,9 @@ public class X
   {
     boolean wasSet = false;
     String anOldMyName = getMyName();
+    if (anOldMyName != null && anOldMyName.equals(aMyName)) {
+    return true;
+    }
     if (hasWithMyName(aMyName)) {
       return wasSet;
     }
@@ -78,12 +83,12 @@ public class X
   {
     return myName;
   }
-
+  /* Code from template attribute_GetUnique */
   public static X getWithMyName(String aMyName)
   {
     return xsByMyName.get(aMyName);
   }
-
+  /* Code from template attribute_HasUnique */
   public static boolean hasWithMyName(String aMyName)
   {
     return getWithMyName(aMyName) != null;

--- a/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_2.java.txt
+++ b/cruise.umple/test/cruise/umple/implementation/java/TestUmpleEnumerations_2.java.txt
@@ -57,7 +57,7 @@ public class X
     boolean wasSet = false;
     String anOldMyName = getMyName();
     if (anOldMyName != null && anOldMyName.equals(aMyName)) {
-    return true;
+      return true;
     }
     if (hasWithMyName(aMyName)) {
       return wasSet;

--- a/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_Attributes.php.txt
+++ b/cruise.umple/test/cruise/umple/implementation/php/ClassTemplateTest_Attributes.php.txt
@@ -143,6 +143,9 @@ class Mentor
     if (isset($this->id)) {
       $anOldId = $this->getId();
     }
+    if (isset($anOldId) && $anOldId === $aId) {
+      return true;
+    }
     if (Mentor::hasWithId($aId)) {
       return $wasSet;
     }

--- a/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_Attributes.ruby.txt
+++ b/cruise.umple/test/cruise/umple/implementation/ruby/ClassTemplateTest_Attributes.ruby.txt
@@ -125,6 +125,9 @@ class Mentor
   def set_id(a_id)
     was_set = false
     an_old_id = get_id();
+    if (an_old_id != nil && an_old_id == a_id)
+      return true
+    end
     if (Mentor.has_with_id?(a_id))
       return was_set
     end


### PR DESCRIPTION
Issue #1442 :
- Added check (setAttribute) for the second constructor generated for classes in 1-1 associations with unique attributes to prevent duplicate attribute values.
- setAttribute now returns true if the argument's value is the same as the unique attribute's current value of the same object.
- fixed tests for unique attributes accordingly

I tried also to do control for primitive types in Java (see branch issue1442), added conditions to generate code according to whether the attribute is primitive or not, than found out that Map and Hashmap don't work with primitive types, which means wrappers need to be added conditionally so I stopped working on that until we discuss it's utility and just added control for Umple builtin data types