### PR TITLE
fixes automatically generated ruby comments

### DIFF
--- a/cruise.umple/src/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/GeneratorHelper_CodeClass.ump
@@ -61,9 +61,9 @@ class GeneratorHelper
     {
       for (CodeInjection inject : allCodeInjections)
       {
-	if(inject.hasCodeLabel())
+	      if(inject.hasCodeLabel())
           continue;// handle the case when labels are used. // Do nothing  
-        String comment = "//";//(inject.getSnippet().getCode("Ruby") != null)?"#":"//";
+        String comment = RubyGenerator.class.isInstance(generator)?"#":"//";
         String positionString = "";
         Position p = inject.getPosition();
         Position codeP = inject.getCodePosition();

--- a/cruise.umple/src/util/SampleFileWriter_Code.ump
+++ b/cruise.umple/src/util/SampleFileWriter_Code.ump
@@ -111,7 +111,7 @@ class SampleFileWriter
         }
         actualLine = readLine(actualReader);
         // HACK: To deal with // line # comments
-        while (actualLine != null && actualLine.indexOf("// line") != -1)
+        while (actualLine != null && (actualLine.indexOf("// line") != -1 ||  actualLine.indexOf("# line") != -1))
         { //Ignore the line, go to next
           actualLine = readLine(actualReader);
         }
@@ -196,17 +196,21 @@ class SampleFileWriter
         {
           // Skip past elements that may change in updated code but are not important differences
           while (actualLine != null && (actualLine.indexOf("// line") != -1 ||
+                    actualLine.indexOf("# line") != -1 ||
                     actualLine.indexOf("/* Code from template") != -1 ||
-                    actualLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")))
+                    actualLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION") ||
+                    actualLine.matches("\\s*\\# END OF UMPLE (BEFORE|AFTER) INJECTION")))
           { //Ignore the line, go to next - line found has unimportant difference
             actualLine = actualReader.readLine();
             skippedActualLineDifference = true;
           }
           
           while (expectedLine != null && (expectedLine.indexOf("// line") != -1 ||
+                    actualLine.indexOf("# line") != -1 ||
                     expectedLine.indexOf("/* Code from template") != -1 ||  
                     (skippedActualLineDifference == true && expectedLine.trim().isEmpty()) ||      
-                    expectedLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")))
+                    expectedLine.matches("\\s*\\/\\/ END OF UMPLE (BEFORE|AFTER) INJECTION")||
+                    expectedLine.matches("\\s*\\# END OF UMPLE (BEFORE|AFTER) INJECTION")))
           { 
         	  expectedLine = expectedReader.readLine();
         	  skippedActualLineDifference = false; // Only skip one blank


### PR DESCRIPTION
#1487 
Automatically generated comments in injections in Ruby now use # instead of //
