### PR TITLE
fixes #1492 crash in guards

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -1582,7 +1582,7 @@ class UmpleInternalParser
    private Token getExpressionOperator(Token expression, Integer startIndex)
    {
      Integer operatorPosition = startIndex + OPERATOR_POSITION;
-     if (operatorPosition < expression.getSubTokens().size())
+     if (operatorPosition < expression.getSubTokens().size()-1)
      {
        Token operator = expression.getSubToken(operatorPosition);
        String operatorName = operator.getName();

--- a/cruise.umple/test/cruise/umple/compiler/DuplicateGuards.ump
+++ b/cruise.umple/test/cruise/umple/compiler/DuplicateGuards.ump
@@ -1,0 +1,24 @@
+class OtherClass {
+  * -> 1 Another ;
+  Integer row;  
+  Integer row2; 
+}
+
+class Another {
+   Integer junk;
+}
+
+class Statemachine {
+  * -> 1 OtherClass other;
+  Boolean cond; 
+  sm {
+    s1 {
+      event1[other.another.junk == 3] -> s3;
+      event1[other.another.junk == 3] -> s1;
+      event1[cond && other.row > 4] -> s2;
+      event1[cond && other.row == 3] -> s3;
+      event1[cond && other.row == 3] -> s1;
+    }
+    s3 {}
+ }
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserStateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserStateMachineTest.java
@@ -113,6 +113,14 @@ public class UmpleParserStateMachineTest
     Assert.assertEquals("if (((getFlag()!=getFlag())||(getFlag()||getFlag())))\n{\n  {0}\n}", gen.translate("on", t3.getGuard()));
     Assert.assertEquals("if ((!(!getFlag()&&getX())&&(getX()||getX())))\n{\n  {0}\n}", gen.translate("on", t4.getGuard()));
   }
+
+  // Issue 1492
+  @Test
+  public void verifyDuplicateGuards()
+  {
+    assertHasWarning("DuplicateGuards.ump",0,70);
+    assertHasWarning("DuplicateGuards.ump",1,70);
+  }
   
   // Issue 796
   @Test
@@ -2723,6 +2731,10 @@ public class UmpleParserStateMachineTest
     assertHasWarning(filename, -1, -1, null);
   }
 
+  private void assertHasWarning(String filename, int expectedWarningIndex, int expectedError) {
+    assertHasWarning(filename, expectedWarningIndex, expectedError, null);
+  }
+
   private void assertHasWarning(String filename, int expectedWarningIndex, int expectedError, Position expectedPosition)
   {
     File file = new File(pathToInput, filename);
@@ -2755,7 +2767,9 @@ public class UmpleParserStateMachineTest
       Assert.assertNotNull(parser.getParseResult().getErrorMessage(expectedWarningIndex));
       Assert.assertEquals(expectedError, parser.getParseResult().getErrorMessage(expectedWarningIndex).getErrorType().getErrorCode());
       System.out.println(">>" + parser.getParseResult().getErrorMessage(expectedWarningIndex).getPosition().getOffset());
-      Assert.assertEquals(expectedPosition, parser.getParseResult().getErrorMessage(expectedWarningIndex).getPosition());
+      if (expectedPosition != null) {
+        Assert.assertEquals(expectedPosition, parser.getParseResult().getErrorMessage(expectedWarningIndex).getPosition());
+      }
     }
   }
 

--- a/cruise.umplificator/src/Master.ump
+++ b/cruise.umplificator/src/Master.ump
@@ -11,6 +11,7 @@ The following instructs the system to inject comments on every class point to th
 @outputumplesource
 */
 strictness allow 30;
+strictness allow 31;
 strictness allow 1006;
 strictness allow 1007;
 strictness allow 1008;


### PR DESCRIPTION
This fixes #1492

When guards had references to fields in a related class using the dot operator certain comparison operations were not being done correctly. The fix required just two characters (subtracting one in a calculation!). However a test has also been added to prevent regression.