### PR TITLE
Updating test parser

### DIFF
--- a/UmpleTToJunit/UmpleTLTemplates/members_AllAssertions.ump
+++ b/UmpleTToJunit/UmpleTLTemplates/members_AllAssertions.ump
@@ -3,25 +3,25 @@ class UmpleTToJUnit {
 members_AllAssertions <<!<</*members_AllAssertions*/>><<#
 
 
-		if(as.getType().equals("AssertTrue"))
+		if(as.getType().equals("assertTrue"))
 		{		
 		#>>		 
 		 			 Assert.assertTrue (<<=as.getAssertCode()>>);
 		<<#}
 		
-		if(as.getType().equals("AssertFalse"))
+		if(as.getType().equals("assertFalse"))
 		{#>>
 		 			 Assert.assertFalse (<<=as.getAssertCode()>>);<<#}
 		
-		if(as.getType().equals("AssertEqual"))
+		if(as.getType().equals("assertEqual"))
 		{#>>
 		 			 Assert.assertEqual (<<=as.getAssertCode()>>);<<#}
 		
-		if(as.getType().equals("AssertNull"))
+		if(as.getType().equals("assertNull"))
 		{#>>
 		 			 Assert.assertNull (<<=as.getAssertCode()>>);<<#}
 		
-		if(as.getType().equals("AssertMethod"))
+		if(as.getType().equals("assertMethod"))
 		{#>>
 		 			 UmpleAssert.assertMethod (<<=as.getAssertCode()>>);<<#}
 #>>

--- a/UmpleTToJunit/UmpleTLTemplates/members_AllTestCases.ump
+++ b/UmpleTToJunit/UmpleTLTemplates/members_AllTestCases.ump
@@ -32,9 +32,10 @@ for (TestCase tc : model.getTestSuite(0).getTestcases())
 	  		for ( Action act : tc.getActions())
 	  		{
 				if (act.getLocOrder() == i)
-				{
-					#>> //include Action Code if there is actions in a TestCAse 
-					  <<=act.getCode()>><<#
+				{//include Action Code if there is actions in a TestCAse 
+					#>> 
+					  <<=act.getCode()>>
+					  <<#
 				}
 				
 			}

--- a/UmpleTToPhpUnit/UmpleTLTemplates/members_AllAssertions.ump
+++ b/UmpleTToPhpUnit/UmpleTLTemplates/members_AllAssertions.ump
@@ -3,25 +3,25 @@ class UmpleTToPhpUnit {
 members_AllAssertions <<!<</*members_AllAssertions*/>><<#
 
 
-		if(as.getType().equals("AssertTrue"))
+		if(as.getType().equals("assertTrue"))
 		{		
 		#>>		 
 		 			 $this->assertTrue(<<=as.getAssertCode()>>);
 		<<#}
 		
-		if(as.getType().equals("AssertFalse"))
+		if(as.getType().equals("assertFalse"))
 		{#>>
 		 			 $this->assertFalse(<<=as.getAssertCode()>>);<<#}
 		
-		if(as.getType().equals("AssertEqual"))
+		if(as.getType().equals("assertEqual"))
 		{#>>
 		 			 $this->assertEqual(<<=as.getAssertCode()>>);<<#}
 		
-		if(as.getType().equals("AssertNull"))
+		if(as.getType().equals("assertNull"))
 		{#>>
 		 			 $this->assertNull(<<=as.getAssertCode()>>);<<#}
 		
-		if(as.getType().equals("AssertMethod"))
+		if(as.getType().equals("assertMethod"))
 		{#>>
 		 			 $this->assertMethod(<<=as.getAssertCode()>>);<<#}
 #>>

--- a/UmpleTToPhpUnit/UmpleTLTemplates/members_AllTestCases.ump
+++ b/UmpleTToPhpUnit/UmpleTLTemplates/members_AllTestCases.ump
@@ -32,7 +32,7 @@ for (TestCase tc : model.getTestSuite(0).getTestcases())
 	  		{
 				if (act.getLocOrder() == i)
 				{
-					#>> //include Action Code if there is actions in a TestCAse 
+					#>>		  
 					  <<=act.getCode()>><<#
 				}
 				
@@ -42,7 +42,7 @@ for (TestCase tc : model.getTestSuite(0).getTestcases())
 		  
 		  
 		  if (tc.hasAssertions())
-		  {
+		  {		  
 			  for (Assertion as: tc.getAssertions())
 			  {
 				  if (as.getLocOrder() ==i)

--- a/UmpleTToRubyUnit/UmpleTLTemplates/members_AllAssertions.ump
+++ b/UmpleTToRubyUnit/UmpleTLTemplates/members_AllAssertions.ump
@@ -2,23 +2,23 @@
 class UmpleTToRubyUnit {
  members_AllAssertions <<!<</*members_AllAssertions*/>> <<#
 
-		if(as.getType().equals("AssertTrue"))
+		if(as.getType().equals("assertTrue"))
 		{#>>		 
 		 			 assert(<<=as.getAssertCode()>>)<<#}
 		
-		if(as.getType().equals("AssertFalse"))
+		if(as.getType().equals("assertFalse"))
 		{#>>
 		 			 assert(!<<=as.getAssertCode()>>)<<#}
 		
-		if(as.getType().equals("AssertEqual"))
+		if(as.getType().equals("assertEqual"))
 		{#>>
 		 			 assert_equal (<<=as.getAssertCode()>>)<<#}
 		
-		if(as.getType().equals("AssertNull"))
+		if(as.getType().equals("assertNull"))
 		{#>>
 		 			 assert_nil(<<=as.getAssertCode()>>)<<#}
 		
-		if(as.getType().equals("AssertMethod"))
+		if(as.getType().equals("assertMethod"))
 		{#>>
 		 			 assert_method (<<=as.getAssertCode()>>)<<#}
 #>>

--- a/UmpleToTest/UmpleTLTemplates/members_AllTestCases.ump
+++ b/UmpleToTest/UmpleTLTemplates/members_AllTestCases.ump
@@ -6,6 +6,9 @@ members_AllTestCases <<!<</*members_AllTestCases*/>><<#
 		{
 		boolean hasBeforeAssertions=false;
 		boolean hasAfterAssertions=false;
+		String concreteLang="";
+		
+		
 		
 		
 		
@@ -13,10 +16,13 @@ members_AllTestCases <<!<</*members_AllTestCases*/>><<#
 		appendln(realSb, "     //------------------");
 	    appendln(realSb, "      //User-defined Tests");
 	    appendln(realSb, "      //------------------");
-		for (UmpleTestCase uTestCase :uClass.getUmpleTestCases())
-		{#>>
+		for (UmpleTestCase uTestCase :uClass.getUmpleTestCases())			
+		{
+		if(uTestCase.getIsConcrete())
+		{ concreteLang = uTestCase.getConcreteLang()+" ";   }
+		#>>
 			
-			test <<=uTestCase.getName()>> {
+			<<=concreteLang>>test <<=uTestCase.getName()>> {
 			  <<#
 			  
 			for (UmpleAssertion uAssert : uTestCase.getUmpleAssertions())

--- a/build/build.testgenerator.xml
+++ b/build/build.testgenerator.xml
@@ -25,7 +25,7 @@
 		  		</java>
 		  		<java jar="${umple.stable.jar}" fork="true" failonerror="true">
 		  		  <arg value="UmpleTToRubyUnit/UmpleTLTemplates/Master.ump"/>
-		  		</java>
+		  		</java>				
       
 		      </parallel>
 		  </target>
@@ -55,11 +55,26 @@
 	  		
 	      </parallel>
 	  </target>
+	  	  
 		  
 	  <target name="CompilingUmpleTestParser">
 		  <echo message="Compiling Umple Test Parser !"/>
 	 
 	 </target>
+	 
+     <!-- 
+       Build
+       Compile Umple files for Mutation test generator
+      -->
+	 
+    <target name="GeneratingMutationTestGenerator">  
+	  <echo message="Generating Umple Mutation Test Generator !"/>
+      <parallel>
+        <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+          <arg value="cruise.umple.mutation/src/Master.ump"/>
+        </java>  		
+      </parallel>
+  </target>
 		
 		
 	 
@@ -70,8 +85,7 @@
 	 </copy>
      <copy todir="cruise.umple.test-parser/src-gen/cruise/umple/testparser/" overwrite="true">
 	  <fileset dir="cruise.umple.test-parser/src/src-gen/cruise/umple/testparser/" excludes=".git* UmpleTToRubyUnit.java" />
-	 </copy>
-	 				  
+	 </copy>	 				  
     </target>
 	
 	
@@ -93,6 +107,7 @@
 				   <antcall target="CopyingXUnitGenerators" />
 			       <antcall target="GeneratingTestParser" />
 				   <antcall target="CompilingUmpleTestParser" />
+				   <antcall target="GeneratingMutationTestGenerator" />
    				   <antcall target="CopyingTestParserFiles" />
 				   <antcall target="testXUnitTemplateTest" />
 				   

--- a/cruise.umple.mutation/model.ump
+++ b/cruise.umple.mutation/model.ump
@@ -1,0 +1,28 @@
+use model2.ump;
+
+class A {
+
+String id;
+Integer number;
+Float number3;
+Double numer2;
+
+}
+
+class B {
+
+0..1 -- * A;
+
+1 -- * C;
+
+}
+
+
+class C {
+	
+1 -- 2..4 D;
+	
+	
+}
+
+class D {}

--- a/cruise.umple.mutation/model2.ump
+++ b/cruise.umple.mutation/model2.ump
@@ -1,0 +1,39 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telesystem.core;
+
+class PhoneCall{ 
+ String isOnHold;
+ String startTime;
+ duration;
+ 0..1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 0..1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ double location;
+ double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/src/Master.ump
+++ b/cruise.umple.mutation/src/Master.ump
@@ -1,0 +1,8 @@
+generate Java "../src-gen-umple";
+
+namespace cruise.umple.mutation;
+
+use Mutant.ump;
+use MutationMetamodel.ump;
+use MutationSuite_code.ump;
+use MutationConsoleMain.ump;

--- a/cruise.umple.mutation/src/MutationConsoleMain.ump
+++ b/cruise.umple.mutation/src/MutationConsoleMain.ump
@@ -1,0 +1,171 @@
+namespace cruise.umple.mutation;
+
+
+
+
+class MutationConsoleMain{
+depend java.io.File;
+depend java.net.URISyntaxException;
+depend java.nio.file.Paths;
+depend java.util.Arrays;
+
+depend cruise.umple.UmpleConsoleMain;
+depend joptsimple.*;
+			
+	public static void main(String[] args) {
+		
+		
+		MutationSuite ms = new MutationSuite(null,0, "", "");
+		OptionParser parser = new OptionParser();
+		OptionSpec<Void> help = parser.acceptsAll(Arrays.asList("h","help"),"show help").forHelp();
+        OptionSpec<String> generate = parser.accepts("generate").withRequiredArg();        
+        OptionSpec<String> mutant = parser.accepts("mutant").withOptionalArg();
+        OptionSpec<String> mutationType = parser.accepts("t").withRequiredArg();
+        OptionSpec<String> mutationOperator = parser.accepts("p").withRequiredArg();
+        OptionSpec<String> lang = parser.accepts("l").withRequiredArg();
+        
+        //OptionSet options = parser.parse("generate", "-t", "random", "-p", "full");
+        OptionSet options = null;
+        try {
+         options = parser.parse(args);
+        }
+        catch(Exception e) {
+        	if (e.toString().contains("generate"))
+        	{
+        		System.out.println(" Missing Umple model file! example: <umple_file>.ump");
+        		return;
+        	}
+        	
+        	if (e.toString().contains("l"))
+        	{
+        		System.out.println(" Missing language ! example: Java, Php, Ruby ..etc");
+        		return;
+        	}
+        	
+        	if (e.toString().contains("t"))
+        	{
+        		System.out.println(" Missing replacement type ! example: random, OneOptionalToMany, Integer ..etc , runy -h for more help !");
+        		return;
+        	}
+        	
+        	if (e.toString().contains("p"))
+        	{
+        		System.out.println(" Missing mutation operator ! example: full, OneOptionalToMany, Integer ..etc , runy -h for more help !");
+        		return;
+        	}
+        		
+        }
+        
+        try {
+        options.valueOf(generate).equals(null);
+    	
+    		//System.out.println(" Missing Umple model file! example: <umple_file>.ump");    		    	
+        }
+        catch(Exception e) {
+        	System.out.println(" Missing Umple model file! example: <umple_file>.ump");
+        }
+    	
+        try {
+            options.valueOf(lang).equals(null);
+        	
+        		//System.out.println(" Missing Umple model file! example: <umple_file>.ump");    		    	
+            }
+            catch(Exception e) {
+            	System.out.println(" Missing language ! example: Java, Php, Ruby ..etc");
+            	return;
+            }
+    	
+        try {
+            options.valueOf(mutationType).equals(null);
+        	
+        		//System.out.println(" Missing Umple model file! example: <umple_file>.ump");    		    	
+            }
+            catch(Exception e) {
+            	System.out.println(" Missing replacement type ! example: random, OneOptionalToMany, Integer ..etc , runy -h for more help !");
+        		return;
+            }
+    	
+    	
+        try {
+            options.valueOf(mutationOperator).equals(null);
+        	
+        		//System.out.println(" Missing Umple model file! example: <umple_file>.ump");    		    	
+            }
+            catch(Exception e) {
+            	System.out.println(" Missing mutation operator ! example: full, OneOptionalToMany, Integer ..etc , runy -h for more help !");
+        		return;
+            }
+               
+        //OptionSet options = parser.parse("-a", "apple", "-a", "berries", "-a", "mango");
+        /*System.out.println("model name: ");
+        System.out.println(options.valuesOf(generate));
+        System.out.println(options.has(generate));
+        System.out.println("Opetions: ");
+        System.out.println(options.valueOf(mutationType));
+        System.out.println(options.has(mutationType));
+        System.out.println("Operator: ");
+        System.out.println(options.valueOf(mutationOperator));
+        System.out.println(options.has(mutationOperator));
+        //# FIXME: improve commandline messages;
+        System.out.println("Language: ");
+        System.out.println(options.valueOf(lang));
+        System.out.println(options.has(lang));*/
+        if(options.has(help)) {
+        	System.out.println("Please specify <umple_file> to process for mutation");
+        	System.out.println("For more detailed information visit http://manual.umple.org");
+        	System.out.println("#############################################################################################");
+        	System.out.println("Example: java -jar umple.mutation.jar -generate model.ump -t random -p OneToMany -l Java   ");
+        	System.out.println("#############################################################################################");
+        	System.out.println("Option	    Description");
+        	System.out.println("------	    -----------");
+        	System.out.println("-help		Print help message");
+        	System.out.println("-t			indicate the type of replacement for the  \n" + 
+        					   "		          mutation : random, specific element: OptionalOneToMany, OneToMany, OptionalOneToOne, ManyToMany,\n"+
+        					   "			  direction, Integer, String, Double, Float");
+        	System.out.println("-p		 	indicate the targeted element to be mutated: ‘full’ or specific element.");
+        	System.out.println("-l			the output language of the system to be generated: Java, ruby, Php (any system Umple accepts)  ");
+        	
+
+        }
+        
+        else {
+        	      
+        String path = "";
+        path = Paths.get(".").toAbsolutePath().normalize().toString()+File.separator;
+			//path = System.getProperty("user.dir")+File.separator+"cruise/umple/mutation/";
+        	//path=(MutationConsoleMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getPath();		
+        String modelName =options.valueOf(generate);
+        String aLang=options.valueOf(lang);
+        String replacementType = "";
+        String muOperator = "";
+        
+        replacementType = (options.valueOf(mutationType)).toString();
+        muOperator = (options.valueOf(mutationOperator)).toString();
+        
+                
+        System.out.println("Replacement type used: "+replacementType);
+        System.out.println("Targeted mutation operator : "+muOperator);
+        try {
+        ms.prepare(path, modelName, aLang,replacementType,muOperator);
+        System.out.println("Model mutated successfully !");
+        
+        }
+        catch(Exception e) {
+        	System.out.println("Failed to mutate: "+ e.getMessage());
+        	
+        }
+        /*****
+        // Run Diff on original model against the mutated one to find changes.
+        try {
+         
+			Runtime.getRuntime().exec("diff " + modelName +" "+ mutationType+File.separator+mutationType+"Mutation_"+modelName);
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		*/
+        }
+		
+	}
+
+}

--- a/cruise.umple.mutation/src/MutationMetamodel.ump
+++ b/cruise.umple.mutation/src/MutationMetamodel.ump
@@ -1,0 +1,46 @@
+//////class UmpleClass{}
+//// Mutation model
+
+class MutationSuite{
+  depend cruise.umple.compiler.*;
+//  attriute
+   UmpleModel originalModel;
+   int score;
+   String uFileName;
+   int unprocessedFiles = 0 ;
+   String path;
+   List<String> muFiles = new ArrayList<String>();
+   boolean hasMultipleFiles= false;
+   ArrayList<String> randomReplacements_association = new ArrayList<String>(Arrays.asList("OneToMany","OptionalOneToMany","OneToNN","ManyToMany")) ;
+   ArrayList<String> randomReplacements_typedAttribute = new ArrayList<String>(Arrays.asList("String","Integer","Float","Double")) ;
+  //private ArrayList<String> replacementsCode = new ArrayList<String>(Arrays.asList("1..*","0..1--*","1--2..4")) ;
+    
+  0..1 -- * Replacement;
+  1 -- * Mutant;  
+}
+
+class Mutant{
+  depend cruise.umple.compiler.*;
+  UmpleModel muModel;
+  type;
+    
+  1--* MutationFragment mf;  
+  
+}
+
+
+
+class Replacement{
+replacementCode;
+replacementType;
+
+}
+
+class MutationFragment {
+ code;
+ location;
+ type;
+}
+
+
+

--- a/cruise.umple.mutation/src/MutationSuite_code.ump
+++ b/cruise.umple.mutation/src/MutationSuite_code.ump
@@ -1,0 +1,1623 @@
+
+
+class MutationSuite {
+
+depend java.util.*;
+depend java.util.regex.*;
+depend cruise.umple.parser.*;
+depend cruise.umple.parser.analysis.RuleBasedParser;
+depend java.io.*;
+	
+ public Boolean mutate(Mutant mu, String modelCode , String muType, String muOperator, String replacementType, String lang){
+	   
+	   
+	   if (muType .equals( "random"))
+	   {		   
+		   if (muOperator .equals( "OneToMany"))
+		   {
+			   mutateAssociationOneToMany(mu, modelCode, replacementType,lang);
+			   return true;
+		   }
+		   
+		   if (muOperator .equals( "OneToOptionalOne"))
+		   {
+			   mutateAssociationOneToOptionalOne(mu, modelCode, replacementType,lang);
+			   return true;
+		   }
+		   
+		   if (muOperator .equals( "OptionalOneToMany"))
+		   {
+			   mutateAssociationOptionalOneToMany(mu, modelCode,replacementType, lang);
+			   return true;
+		   }
+		   
+		   if (muOperator .equals( "OneToNN"))
+		   {
+			   mutateAssociationOneToNN(mu, modelCode,replacementType, lang);
+			   return true;
+		   }
+		   
+		   if (muOperator .equals( "direction"))
+		   {
+			   mutateAssociationDirectionality(mu, modelCode,replacementType, lang);
+			   return true;
+		   }
+		   
+		   if (muOperator .equals( "ConstraintBiggerEq"))
+		   {
+			   mutateConstraintsBiggerEq(mu, modelCode,replacementType, lang);
+			   return true;
+		   }
+		   
+		   if (muOperator .equals( "ConstraintBigger"))
+		   {
+			   mutateConstraintsBigger(mu, modelCode,replacementType, lang);
+			   return true;
+		   }
+	   }
+	   
+	   if (muOperator.equals( "full"))
+	   {
+		   mutateAssociationOneToMany(mu, modelCode,replacementType,lang);
+		   mutateAssociationOptionalOneToMany(mu, modelCode,replacementType, lang);
+		   mutateAssociationOneToNN(mu, modelCode,replacementType, lang);
+		   mutateAssociationDirectionality(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedString(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedInteger(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedFloat(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedDouble(mu, modelCode,replacementType, lang);
+		   mutateAssociationOneToOptionalOne(mu, modelCode, replacementType,lang);
+		   mutateConstraintsBiggerEq(mu, modelCode,replacementType, lang);
+		   mutateConstraintsBigger(mu, modelCode,replacementType, lang);
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "direction"))
+	   {
+		   mutateAssociationDirectionality(mu, modelCode,replacementType, lang);
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "Association"))
+	   {
+		   mutateAssociationOneToMany(mu, modelCode,replacementType,lang);
+		   mutateAssociationOptionalOneToMany(mu, modelCode,replacementType, lang);
+		   mutateAssociationOneToNN(mu, modelCode,replacementType, lang);
+		   mutateAssociationDirectionality(mu, modelCode,replacementType, lang);
+		   return true;
+		   
+	   }
+	   
+	   if (muOperator .equals( "Attribute"))
+	   {
+		   mutateAttributeTypedString(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedInteger(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedFloat(mu, modelCode,replacementType, lang);
+		   mutateAttributeTypedDouble(mu, modelCode,replacementType, lang);
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "AttributeInt"))
+	   {
+		   
+		   mutateAttributeTypedInteger(mu, modelCode,replacementType, lang);
+		   
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "AttributeString"))
+	   {
+		   
+		   mutateAttributeTypedString(mu, modelCode,replacementType, lang);
+		   
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "AttributeFloat"))
+	   {
+		   
+		   mutateAttributeTypedFloat(mu, modelCode,replacementType, lang);
+		   
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "AttributeDouble"))
+	   {
+		   
+		   mutateAttributeTypedDouble(mu, modelCode,replacementType, lang);
+		   
+		   return true;
+	   }
+	   
+	   
+	   if (muOperator .equals( "OneToMany"))
+	   {
+		   mutateAssociationOneToMany(mu, modelCode,replacementType,lang);
+		   return true;
+	   }
+	   if (muOperator .equals( "OptionalOneToMany"))
+	   {
+		   mutateAssociationOptionalOneToMany(mu, modelCode,replacementType, lang);
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "OneToNN"))
+	   {
+		   mutateAssociationOneToNN(mu, modelCode,replacementType,lang);
+		   return true;
+	   }
+	   
+	   
+	   if (muOperator .equals( "ConstraintBiggerEq"))
+	   {
+		   mutateConstraintsBiggerEq(mu, modelCode,replacementType,lang);
+		   return true;
+	   }
+	   
+	   if (muOperator .equals( "ConstraintBigger"))
+	   {
+		   mutateConstraintsBiggerEq(mu, modelCode,replacementType,lang);
+		   return true;
+	   }
+	   
+	   
+	   
+	   
+    return false;
+  }
+
+   public Boolean generateMuCode(Mutant mu){
+    return null;
+  }
+
+
+   public Boolean mutateAssociationOneToMany(Mutant mu, String modelCode,String replacementType,String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+	   
+		  //String regex = "[^0..]1\\s*\\w*\\s*--\\s*\\*\\s+\\w(\\s+\\w*)?";
+	   String regex = "[^0..]1\\s*\\w*\\s*--\\s*\\*\\s+\\w(\\s+\\w*)?";
+		  String replacement = " 0..1 ";
+		  
+		  if (replacementType .equals( "random"))
+		  {
+			  Collections.shuffle(randomReplacements_association);
+			  replacementType = randomReplacements_association.get(0);
+		  }
+		  
+		  if (replacementType .equals( "OptionalOneToMany"))
+		  {
+			  replacement = " 0..1 ";
+		  }
+		  
+		  if (replacementType .equals( "ManyToMany"))
+		  {
+			  replacement = " * ";
+		  }
+		  
+		  if (replacementType .equals( "OneToOne"))
+		  {
+			  replacement = " 1 ";
+		  }
+		  		  		  		  		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement, "OneToMany");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  
+		  modelFileName =this.writeMutatedFile(path, uFileName, "OneToMany", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"OneToMany", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "OneToManyMutation_"+ uFileName, lang,"OneToMany");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  
+		  
+		  
+	  //mutatedModel.setCode(muModelCode);  
+	  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this);
+	  //this.addMutant(aMutant);
+	   
+	   return null;
+  }
+   
+   
+   public Boolean mutateAssociationOneToOptionalOne(Mutant mu, String modelCode,String replacementType,String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+	   
+		  //String regex = "[^0..]1\\s*\\w*\\s*--\\s*\\*\\s+\\w(\\s+\\w*)?";
+	   String regex = "[^0..]1\\s*\\w*\\s*--\\s*0..1\\s+\\w(\\s+\\w*)?";
+		  String replacement = " 1 -- 0..1 ";
+		  
+		  if (replacementType .equals( "random"))
+		  {
+			  Collections.shuffle(randomReplacements_association);
+			  replacementType = randomReplacements_association.get(0);
+		  }
+		  
+		  if (replacementType .equals( "OptionalOneToMany"))
+		  {
+			  replacement = " 0..1 -- * ";
+		  }
+		  
+		  if (replacementType .equals( "ManyToMany"))
+		  {
+			  replacement = " * -- * ";
+		  }
+		  
+		  if (replacementType .equals( "OneToOne"))
+		  {
+			  replacement = " 1 -- 1 ";
+		  }
+		  if (replacementType .equals( "OneToMany"))
+		  {
+			  replacement = " 1 -- * ";
+		  }
+		  
+		  
+		  		  		  		  		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement, "OneToOptionalOne");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  
+		  modelFileName =this.writeMutatedFile(path, uFileName, "OneToOptionalOne", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"OneToOptionalOne", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "OneToOptionalOneMutation_"+ uFileName, lang,"OneToOptionalOne");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  
+		  
+		  
+	  //mutatedModel.setCode(muModelCode);  
+	  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this);
+	  //this.addMutant(aMutant);
+	   
+	   return null;
+  }
+
+  
+   public Boolean mutateAssociationOptionalOneToMany(Mutant mu, String modelCode,String replacementType, String lang){
+	      
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+ 
+	   String regex = "\\s0..1\\s*\\w*\\s*--\\s*\\*\\s+\\w(\\s+\\w*)?";
+	   String replacement = " 0..1 -- * ";
+		  
+		  if (replacementType .equals( "random"))
+		  {
+			  Collections.shuffle(randomReplacements_association);
+			  replacementType = randomReplacements_association.get(0);
+		  }
+		  
+		  if (replacementType .equals( "OneToMany"))
+		  {
+			  replacement = " 1 -- * ";
+		  }
+		  
+		  if (replacementType .equals( "ManyToMany"))
+		  {
+			  replacement = " * -- * ";
+		  }
+		  
+		  if (replacementType .equals( "OneToOne"))
+		  {
+			  replacement = " 1 -- 1 ";
+		  }
+		  
+		  if (replacementType .equals( "ManyToMany"))
+		  {
+			  replacement = " * -- * ";
+		  }
+		  
+		  if (replacementType .equals( "OneToOne"))
+		  {
+			  replacement = " 1 -- 1 ";
+		  }
+		  
+		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement,"OptionalOneToMany");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  
+		  modelFileName =this.writeMutatedFile(path, uFileName, "OptionalOneToMany", muModelCode);
+		  modelFile = new File (modelFileName);
+		  //UmpleFile umpleFile = new UmpleFile (modelFile);
+		  UmpleModel muModel = new UmpleModel(null);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  
+		  try {
+			
+			 muModel = this.createUmpleMutationSystem(path, "OptionalOneToManyMutation_"+ uFileName, lang,"OptionalOneToMany");
+			 this.addMutant(new Mutant(muModel,"OptionalOneToMany", this));
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  
+		  
+		  
+	  //mutatedModel.setCode(muModelCode);  
+	  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this);
+	  //this.addMutant(aMutant);
+	   
+	   return null;
+  
+  }
+
+   public Boolean mutateAssociationDirectionality(Mutant mu, String modelCode,String replacementType, String lang){
+ 	  
+	   String muModelCode = "";
+	   StringBuffer muCode = new StringBuffer(modelCode);
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+	   Random ran = new Random();
+	   
+	   
+			
+	   	  
+	   
+	   String regex = "\\s?--\\s?";
+	   String replacement = " -> ";
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  /*
+		  Pattern pattern = Pattern.compile(regex);
+		  Matcher matcher = pattern.matcher(modelCode);
+		  
+		  //matcher.find();
+		  //muModelCode= modelCode.replace(matcher.group(), matcher.group().replace("0..1",replacement));
+		   
+		  muModelCode = modelCode;
+		  int numberOfOccurences = 0;
+		  while(matcher.find()) {
+			  numberOfOccurences++;
+		  }		
+		  
+		  matcher.reset();	
+		  
+		  	   
+		  int random = ran.nextInt(numberOfOccurences);
+		   
+		  System.out.println("Number of Occurences: "+numberOfOccurences);
+		  System.out.println("random: "+ (random+1));
+		  
+		  matcher.reset();		  
+		  //matcher
+		  int x=0;
+		  
+		  
+		  //System.out.println(matcher.groupCount());
+		  while(matcher.find())		  
+		  //for ( x = 0;x>numberOfOccurences;x++)
+		  {
+			  			  
+		      if(x == random){
+			  System.out.println(matcher.group().toString());			  
+			  muCode = muCode.replace(matcher.start(), matcher.end(), replacement);
+			  System.out.println(muModelCode.indexOf(matcher.group()))	;
+			  
+			  System.out.println("indexes: ");
+		      System.out.println(matcher.start());
+		      System.out.println(matcher.end());
+		      
+		      }		      
+		      x++;		                  
+		  }
+		  */
+	   
+	      
+		  //System.out.println(muCode.toString());
+		  //muModelCode = muCode.toString();
+		  muModelCode = modifyModelCode(modelCode, regex, replacement,"AssociationDirectionality");
+		  
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName,  "AssociationDirectionality", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"AssociationDirectionality", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "AssociationDirectionalityMutation_"+uFileName, lang,"AssociationDirectionality");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  
+		  
+	  //mutatedModel.setCode(muModelCode);  
+	  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this);
+	  //this.addMutant(aMutant);
+	   
+	   return null;
+  
+  }
+   public Boolean mutateAssociationOneToN(Mutant mu, String modelCode,String replacementType, String lang){
+    String muModelCode="";
+	  String regex = "1\\s*\\w*\\s*--\\s*\\d\\s+\\w\\s+\\w*";
+	  String replacement = "";
+	  UmpleModel mutatedModel = originalModel;
+	  mutatedModel.getCode().replaceAll(regex, replacement);
+	  //Mutant aMutant = new Mutant(mutatedModel, "OnetoN", this,"");
+	  //this.addMutant(aMutant);
+  return null;
+  }
+     
+	  public Boolean mutateAssociationOneToNN(Mutant mu, String modelCode,String replacementType, String lang){
+    
+	   String regex = "[2-9]..[2-9]";
+	   Pattern pattern = Pattern.compile(regex);
+	   Matcher matcher = pattern.matcher(modelCode);
+		  String muModelCode = "";
+		  
+		  String replacement = "REPCODE_OneToNN_1";
+		  String replacement2 = "REPCODE_OneToNN_2";
+		  String replacement3 = "REPCODE_OneToNN_3";
+		  String replacement4 = "REPCODE_OneToNN_4";
+		  
+		  
+		  muModelCode = modelCode.replaceAll(regex, replacement);
+		  		 
+		  matcher.find();
+		  int upperBound = Integer.parseInt(matcher.group().substring(matcher.group().length()-1,matcher.group().length()));
+		  int lowerBound = Integer.parseInt(matcher.group().substring(0,1));
+		  String codeFragement = matcher.group().substring(1, matcher.group().length());
+		//Mutation above Lower Bound
+		  
+		  //System.out.println(codeFragement);
+		  //System.out.println(lowerBound);
+		  String replacementFragmentCode = lowerBound+1 +codeFragement;
+		  //System.out.println(replacementFragmentCode);
+		  muModelCode = modelCode.replaceAll(regex, replacementFragmentCode);
+		  this.writeMutatedFile(path, uFileName,  "OneToNN_aboveLowerBound", muModelCode);
+		  
+		//Mutation below Lower Bound
+		  //matcher.find();
+		  lowerBound = Integer.parseInt(matcher.group().substring(0,1));
+		  //System.out.println(codeFragement);
+		  //System.out.println(lowerBound);
+		  replacementFragmentCode = lowerBound-1 +codeFragement;
+		  //System.out.println(replacementFragmentCode);
+		  muModelCode = modelCode.replaceAll(regex, replacementFragmentCode);
+		  this.writeMutatedFile(path, uFileName,  "OneToNN_belowLowerBound", muModelCode);
+		  
+		//Mutation below Lower Bound
+		  //matcher.find();		  
+		  codeFragement = matcher.group().substring(0, matcher.group().length()-1);;
+		  //System.out.println(codeFragement);
+		  //System.out.println(lowerBound);
+		  replacementFragmentCode = codeFragement +( upperBound-1);
+		  //System.out.println(replacementFragmentCode);
+		  muModelCode = modelCode.replaceAll(regex, replacementFragmentCode);
+		  this.writeMutatedFile(path, uFileName,  "OneToNN_belowUpperBound", muModelCode);
+		  
+		//Mutation above Lower Bound
+		  //matcher.find();		  
+		  codeFragement = matcher.group().substring(0, matcher.group().length()-1);;
+		  //System.out.println(codeFragement);
+		  //System.out.println(lowerBound);
+		  replacementFragmentCode = codeFragement + (upperBound+1);
+		  //System.out.println(replacementFragmentCode);
+		  muModelCode = modelCode.replaceAll(regex, replacementFragmentCode);
+		  this.writeMutatedFile(path, uFileName,  "OneToNN_aboveUpperBound", muModelCode);
+		  
+		  
+		  
+	  return null;
+  }
+   
+   
+   
+   public Boolean mutateAttributeTypedString(Mutant mu, String modelCode,String replacementType, String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+
+	   String regex = "String\\s*";
+		  String replacement = "";
+		  
+		  if (replacementType == "random")
+		  {
+			  Collections.shuffle(randomReplacements_typedAttribute);
+			  replacementType = randomReplacements_typedAttribute.get(0);
+		  }
+		  
+		  if (replacementType == "Integer")
+		  {
+			  replacement = "Integer";
+		  }
+		  
+		  if (replacementType == "Float")
+		  {
+			  replacement = "Float";
+		  }
+		  
+		  if (replacementType == "Double")
+		  {
+			  replacement = "Double";
+		  }
+		  
+		  if (replacementType == "String")
+		  {
+			  replacement = "String";
+		  }
+		  
+		  
+		  
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement, "TypedAttributeString");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName,  "TypedAttributeString", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"TypedAttributeString", this));
+		  try {
+			 
+			 this.createUmpleMutationSystem(path, "TypedAttributeStringMutation_"+ uFileName, lang,"TypedAttributeString");
+			 
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  return null;
+	  }
+
+   public Boolean mutateAttributeTypedInteger(Mutant mu, String modelCode,String replacementType, String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+			
+	   	  
+	   
+	   String regex = "Integer\\s";
+		  String replacement = "Integer";
+		  
+		  if (replacementType == "random")
+		  {
+			  Collections.shuffle(randomReplacements_typedAttribute);
+			  replacementType = randomReplacements_typedAttribute.get(0);
+		  }
+		  
+		  if (replacementType == "Integer" || replacementType == "int")
+		  {
+			  replacement = "Integer";
+		  }
+		  
+		  if (replacementType == "Float")
+		  {
+			  replacement = "Float";
+		  }
+		  
+		  if (replacementType == "Double")
+		  {
+			  replacement = "Double";
+		  }
+		  
+		  if (replacementType == "String")
+		  {
+			  replacement = "String";
+		  }
+		  
+		  
+		  
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement, "TypedAttributeInt");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName, "TypedAttributeInteger", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"TypedAttributeInteger", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path,"TypedAttributeIntegerMutation_"+ uFileName, lang,"TypedAttributeInteger");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  return null;
+	  }
+   
+   public Boolean mutateAttributeTypedFloat(Mutant mu, String modelCode,String replacementType, String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+			
+	   	  
+	   
+	    String regex = "Float\\s";
+		  String replacement = "";
+		  
+		  if (replacementType == "random")
+		  {
+			  Collections.shuffle(randomReplacements_typedAttribute);
+			  replacementType = randomReplacements_typedAttribute.get(0);
+		  }
+		  
+		  if (replacementType == "Integer")
+		  {
+			  replacement = "Integer";
+		  }
+		  
+		  if (replacementType == "Float")
+		  {
+			  replacement = "Float";
+		  }
+		  
+		  if (replacementType == "Double")
+		  {
+			  replacement = "Double";
+		  }
+		  
+		  if (replacementType == "String")
+		  {
+			  replacement = "String";
+		  }
+		  
+		  
+		  
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  
+		  Pattern pattern = Pattern.compile(regex);
+		  Matcher matcher = pattern.matcher(modelCode);
+		  
+		  
+		  //matcher.find();
+		  //muModelCode= modelCode.replace(matcher.group(), matcher.group().replace("0..1",replacement));
+		   
+		  muModelCode = modelCode;
+		  while(matcher.find())		  		  		  
+		  { 
+			  //System.out.println(matcher.group().toString());			  
+			  muModelCode= muModelCode.replace(matcher.group(), matcher.group().replace("Float",replacement));
+		  
+		  }
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName,  "TypedAttributeFloat", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"TypedAttributeFloat", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "TypedAttributeFloatMutation_"+ uFileName, lang,"TypedAttributeFloat");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  return null;
+	  }
+   
+   public Boolean mutateAttributeTypedDouble(Mutant mu, String modelCode,String replacementType, String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+			
+	   	  
+	   
+	   String regex = "\\s*Double\\s*";
+		  String replacement = "";
+		  
+		  if (replacementType == "random")
+		  {
+			  Collections.shuffle(randomReplacements_typedAttribute);
+			  replacementType = randomReplacements_typedAttribute.get(0);
+		  }
+		  
+		  if (replacementType == "Integer")
+		  {
+			  replacement = "Integer";
+		  }
+		  
+		  if (replacementType == "Float")
+		  {
+			  replacement = "Float";
+		  }
+		  
+		  if (replacementType == "Double")
+		  {
+			  replacement = "Double";
+		  }
+		  
+		  if (replacementType == "String")
+		  {
+			  replacement = "String";
+		  }
+		  
+		  
+		  
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  
+		  Pattern pattern = Pattern.compile(regex);
+		  Matcher matcher = pattern.matcher(modelCode);
+		  
+		  
+		  //matcher.find();
+		  //muModelCode= modelCode.replace(matcher.group(), matcher.group().replace("0..1",replacement));
+		   
+		  muModelCode = modelCode;
+		  while(matcher.find())		  		  		  
+		  { 
+			  //System.out.println(matcher.group().toString());			  
+			  muModelCode= muModelCode.replace(matcher.group(), matcher.group().replace("Double",replacement));
+		  
+		  }
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName,  "TypedAttributeDouble", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"TypedAttributeDouble", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "TypedAttributeDoubleMutation_"+ uFileName, lang,"TypedAttributeDouble");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  return null;
+	  }
+   
+   public Boolean mutateConstraintsBiggerEq(Mutant mu, String modelCode,String replacementType, String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+			
+	   	  
+	   
+	   String regex = "pre:\\s*\\w*\\s*>=";
+		  String replacement = "";
+		  
+		  if (replacementType == "random")
+		  {
+			  Collections.shuffle(randomReplacements_typedAttribute);
+			  replacementType = randomReplacements_typedAttribute.get(0);
+		  }
+		  
+		  if (replacementType == "<")
+		  {
+			  replacement = "<";
+		  }
+		  
+		  if (replacementType == "<=")
+		  {
+			  replacement = "<=";
+		  }
+		  
+		  if (replacementType == ">")
+		  {
+			  replacement = ">";
+		  }
+		  
+		  if (replacementType == "==")
+		  {
+			  replacement = "==";
+		  }
+		  
+		  
+		  
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  
+		  Pattern pattern = Pattern.compile(regex);
+		  Matcher matcher = pattern.matcher(modelCode);
+		  
+		  
+		  //matcher.find();
+		  //muModelCode= modelCode.replace(matcher.group(), matcher.group().replace("0..1",replacement));
+		   
+		  muModelCode = modelCode;
+		  
+		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement, "ConstraintBiggerEq");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName,  "ConstraintsBiggerEq", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"ConstraintsBiggerEq", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "ConstraintsBiggerEqMutation_"+ uFileName, lang,"ConstraintsBiggerEq");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  return null;
+	  }
+   
+   public Boolean mutateConstraintsBigger(Mutant mu, String modelCode,String replacementType, String lang){
+	   String muModelCode = "";
+	   String modelFileName="";
+	   File modelFile;
+	   UmpleModel mutatedModel = new UmpleModel(null); 
+			
+	   	  
+	   
+	   String regex = "pre:\\s*\\w*\\s*>";
+		  String replacement = "";
+		  
+		  if (replacementType == "random")
+		  {
+			  Collections.shuffle(randomReplacements_typedAttribute);
+			  replacementType = randomReplacements_typedAttribute.get(0);
+		  }
+		  
+		  if (replacementType == "<")
+		  {
+			  replacement = "<";
+		  }
+		  
+		  if (replacementType == "<=")
+		  {
+			  replacement = "<=";
+		  }
+		  
+		  if (replacementType == ">=")
+		  {
+			  replacement = ">=";
+		  }
+		  
+		  if (replacementType == "==")
+		  {
+			  replacement = "==";
+		  }
+		  
+		  
+		  
+		  
+		  
+		  //muModelCode = modelCode.replaceAll(regex, replacement);
+		  
+		  Pattern pattern = Pattern.compile(regex);
+		  Matcher matcher = pattern.matcher(modelCode);
+		  
+		  
+		  //matcher.find();
+		  //muModelCode= modelCode.replace(matcher.group(), matcher.group().replace("0..1",replacement));
+		   
+		  muModelCode = modelCode;
+		  
+		  
+		  muModelCode = modifyModelCode(modelCode, regex, replacement, "ConstraintBiggerEq");
+		  //System.out.println(matcher.group());
+		  //System.out.println("Mutated Code  ");
+		  //System.out.println(muModelCode);
+		  //muModelCode= "namespace OptionalOneToMany;\n"+muModelCode;
+		  modelFileName =this.writeMutatedFile(path, uFileName,  "ConstraintsBiggerEq", muModelCode);
+		  modelFile = new File (modelFileName);
+		  UmpleFile umpleFile = new UmpleFile (modelFile);
+		  //System.out.println("ModelFILENAME  ");
+		  //System.out.println(modelFileName);
+		  this.addMutant(new Mutant(new UmpleModel(umpleFile),"ConstraintsBiggerEq", this));
+		  try {
+			
+			 this.createUmpleMutationSystem(path, "ConstraintsBiggerEqMutation_"+ uFileName, lang,"ConstraintsBiggerEq");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		  return null;
+	  }
+   
+   public Boolean mutateAttributeLazy(Mutant mu, String modelCode,String replacementType, String lang){
+	    String muModelCode = "";
+			  String regex = "0..1\\s*\\w*\\s*--\\s*\\*\\s+\\w\\s+\\w*";
+			  String replacement = "REPCODE_OptionalOneToMany";
+			  
+			  /*if (replacementType== "OneToMany" && replacementType!="OptionalOneToMany")
+			  {
+				  replacement = "1--*";
+			  }*/
+			  
+			  muModelCode = modelCode.replaceAll(regex, replacement);
+			  
+			  //System.out.println("Mutated Code  ");
+			  //System.out.println(muModelCode);
+			  this.writeMutatedFile(path, uFileName,  "AttributeLazy", muModelCode);
+		  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this,"");
+		  //this.addMutant(aMutant);
+	  return null;
+	  }
+   
+   public Boolean mutateAttributeImmutable(Mutant mu, String modelCode,String replacementType, String lang){
+	    String muModelCode = "";
+			  String regex = "0..1\\s*\\w*\\s*--\\s*\\*\\s+\\w\\s+\\w*";
+			  String replacement = "REPCODE_OptionalOneToMany";
+			  
+			  /*if (replacementType== "OneToMany" && replacementType!="OptionalOneToMany")
+			  {
+				  replacement = "1--*";
+			  }*/
+			  
+			  muModelCode = modelCode.replaceAll(regex, replacement);
+			  
+			  //System.out.println("Mutated Code  ");
+			  //System.out.println(muModelCode);
+			  this.writeMutatedFile(path, uFileName,  "AttributeImmutable", muModelCode);
+		  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this,"");
+		  //this.addMutant(aMutant);
+	  return null;
+	  }
+   
+   
+   public Boolean mutateExtraCodeOperatorBiggerThan(Mutant mu, String modelCode,String replacementType, String lang){
+	    String muModelCode = "";
+			  String regex = "0..1\\s*\\w*\\s*--\\s*\\*\\s+\\w\\s+\\w*";
+			  String replacement = "REPCODE_OptionalOneToMany";
+			  
+			  /*if (replacementType== "OneToMany" && replacementType!="OptionalOneToMany")
+			  {
+				  replacement = "1--*";
+			  }*/
+			  
+			  muModelCode = modelCode.replaceAll(regex, replacement);
+			  
+			  //System.out.println("Mutated Code  ");
+			  //System.out.println(muModelCode);
+			  this.writeMutatedFile(path, uFileName,  "AttributeImmutable", muModelCode);
+		  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this,"");
+		  //this.addMutant(aMutant);
+	  return null;
+	  }
+   
+   public Boolean mutateExtraCodeOperatorSmallerThan(Mutant mu, String modelCode,String replacementType, String lang){
+	    String muModelCode = "";
+			  String regex = "0..1\\s*\\w*\\s*--\\s*\\*\\s+\\w\\s+\\w*";
+			  String replacement = "REPCODE_OptionalOneToMany";
+			  
+			  /*if (replacementType== "OneToMany" && replacementType!="OptionalOneToMany")
+			  {
+				  replacement = "1--*";
+			  }*/
+			  
+			  muModelCode = modelCode.replaceAll(regex, replacement);
+			  
+			  //System.out.println("Mutated Code  ");
+			  //System.out.println(muModelCode);
+			  this.writeMutatedFile(path, uFileName,  "AttributeImmutable", muModelCode);
+		  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this,"");
+		  //this.addMutant(aMutant);
+	  return null;
+	  }
+   
+   public Boolean mutateExtraCodeOperatorEqual(Mutant mu, String modelCode,String replacementType, String lang){
+	    String muModelCode = "";
+			  String regex = "0..1\\s*\\w*\\s*--\\s*\\*\\s+\\w\\s+\\w*";
+			  String replacement = "REPCODE_OptionalOneToMany";
+			  
+			  /*if (replacementType== "OneToMany" && replacementType!="OptionalOneToMany")
+			  {
+				  replacement = "1--*";
+			  }*/
+			  
+			  muModelCode = modelCode.replaceAll(regex, replacement);
+			  
+			  //System.out.println("Mutated Code  ");
+			  //System.out.println(muModelCode);
+			  this.writeMutatedFile(path, uFileName,  "AttributeImmutable", muModelCode);
+		  //Mutant aMutant = new Mutant(mutatedModel, "OptionalOneToMany", this,"");
+		  //this.addMutant(aMutant);
+	  return null;
+	  }
+	  
+	  
+public UmpleModel createUmpleMutationSystem(String pathToInput, String filename, String lang, String muType) throws IOException{
+	   
+	   //pathToInput= SampleFileWriter.rationalize("");
+	   //filename = SampleFileWriter.rationalize(filename);
+	   //System.out.println("filename::::");
+	   //System.out.println(pathToInput+muType+"/"+filename);
+	   BufferedReader br = new BufferedReader(new FileReader(pathToInput+muType+"/"+filename));
+	   String modelCode = "";
+	   String line = "";
+	   File file = new File(pathToInput,muType+"/"+ filename);
+	   String umpleParserName="UmpleInternalParser";
+	   String language = lang;
+	   RuleBasedParser rbp = new RuleBasedParser();	   
+	   UmpleFile uFile = new UmpleFile (file);
+	   
+	   System.out.println(uFile.getPath());
+	   UmpleModel model = new UmpleModel(uFile);
+	   model.setShouldGenerate(true);
+	   while ((line = br.readLine()) != null) {
+		     //System.out.println(line);
+		     modelCode += line+"\n";
+		   }
+	   //br.close();
+	   //originalModel.setCode(modelCode);	   
+	   model.setCode(modelCode);
+	   
+	   //model.addGenerate("");
+	   
+	   
+	   UmpleParser uiParser = new UmpleInternalParser("cruise.umple.compiler",model,rbp);
+	   //uiParser.analyze(true);
+	   
+	   ParseResult result = rbp.parse(file); 	   
+	   model.extractAnalyzersFromParser(rbp);
+	   model.setLastResult(result);
+	   
+	   //rbp.addGrammarFile("");
+	   
+//	   model.setUmpleFile(new UmpleFile(new File(pathToInput, filename)));
+	   model.addGenerate(language);
+	   ;
+	   //model.setDefaultNamespace(pathToInput);
+	   
+	   //System.out.println("PATHTHTTHTHTH");
+	   //System.out.println(model.getDefaultGeneratePath());
+	   
+	   result = uiParser.analyze(true);
+	   
+	   //System.out.println("PackaGE::::");
+	   //model.setDefaultPackage(model.getDefaultNamespace());
+	   //model.setDefaultNamespace(model.getDefaultPackage());
+	   //model.getDefaultGenerate()
+	   //System.out.println(model.getDefaultNamespace());
+	   
+	   //System.out.println(file.getAbsolutePath());
+	   //System.out.println(file.getName());
+	   //System.out.println(rbp.getRootToken());
+	   
+	   
+	   
+	   //System.out.println(result.getErrorMessages().toString());
+	   System.out.println("Generting files for: "+ filename);
+	   model.generate();
+	   //System.out.println("GENCODEDEDEDE");
+	   //System.out.println(model.getGeneratedCode());
+	   
+	   
+	   
+	    
+	    /*model.setShouldGenerate(false);
+	    //if( aTracer != null )
+	    //	model.setTracer(new TracerDirective(aTracer));
+	    
+		   
+	    
+	    
+	    
+	    model = uiParser.getModel();*/
+	    
+	    //System.out.println(model.getUmpleFile());
+	    
+	    
+	   // System.out.println(result.toString());
+	    
+	    //System.out.println(model.getAssociation(0).toString());
+	    	    	    
+	    
+	    return model;
+	   
+	  }
+   
+   public String writeMutatedFile(String path, String modelName, String muType, String code){
+    //File file= new File (path, filename);
+	    
+	   
+	   //System.out.println("USEFILE WRITING");
+	    code = modifyModelNameSpace(code, muType);
+	    File file = new File(path+muType);
+	    file.mkdirs();   
+	    String filename = path +muType+ File.separator + muType + "Mutation_" + modelName ;
+	    	    
+	    
+	    BufferedWriter bw = null;
+		try {
+			bw = new BufferedWriter(new FileWriter(filename));
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}	   
+		
+		if(this.muFiles.size()>0)
+		{
+			code = modifyModelUseStatements(code, muType);
+		}
+
+	    try
+	    {	
+	      System.out.println("Wrtitng file: "+ filename);
+	      bw.write(code);
+	      bw.flush();	      
+	    } catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	    finally
+	    {
+	      try {
+			bw.close();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	    }
+	    
+	    //originalModel.getUmpleFile().addLinkedFiles("model2.ump");
+	    
+	    if(hasMultipleFiles)
+	    {
+	    	writeMutatedUseFiles(path, muType, code);
+	    }
+	    
+	    
+	    return filename;
+	    
+  }
+   
+   
+   public String readUseFilesCode (String filename)   
+   {
+	   String code= "";
+	   
+	   BufferedReader br = null;
+		try {
+			br = new BufferedReader(new FileReader(path+uFileName));
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		   String line = null;
+		   
+		   try {
+			while ((line = br.readLine()) != null) {
+			     //System.out.println(line);
+			     code += line+"\n";			     
+			   }
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	   
+	   
+	   return code;
+	   
+   }
+   
+   public void writeMutatedUseFiles(String path, String muType, String code) {
+	// TODO Auto-generated method stub
+	   
+	   for(String filename : muFiles)
+	   {
+		   //writeMutatedFile(path, filename, muType, code);
+		   //System.out.println("muFileXXXXX:"+ filename);
+		   
+	   }
+	
+}
+
+public boolean analyzeModelFiles (String path, String modelName, String modelCode)
+   {
+	   String regex = "use\\s\\w*.ump;";
+	   modelCode = originalModel.getCode(); 
+	   //String muModelCode = "";
+	   StringBuffer muCode = new StringBuffer(modelCode);	   
+	   Random ran = new Random();	   		  		  		  
+	   Pattern pattern = Pattern.compile(regex);
+	   Matcher matcher = pattern.matcher(modelCode);	   
+	   //muModelCode = modelCode;
+	   int numberOfOccurences = 0;
+	   int random=0;
+	   String filename="";
+	   
+	   while(matcher.find()) {
+		   numberOfOccurences++;
+		   filename = matcher.group().substring(4, matcher.group().length()-1);
+		   
+		   //System.out.println(filename);
+		   this.muFiles.add(filename.toString());
+		   
+	   }	   
+	   
+	   //System.out.println("Code: "+modelCode);
+	   System.out.println("Number of linked model files: "+numberOfOccurences);	   
+	   matcher.reset();		  
+	   
+	   int x = 0;
+	   //String filename = "";
+
+
+	   //System.out.println(matcher.groupCount());	   
+	   //System.out.println("muFles: "+x);
+	   //System.out.println("MODEL FILENAME: "+filename);
+	   
+	   
+	   
+	 unprocessedFiles = muFiles.size();  
+	   	   	   	   
+	 if (numberOfOccurences>0)
+	 {
+		 return true;
+	 }
+		 
+	   
+	 else return false;
+	   
+   }
+   
+   
+   public String modifyModelCode (String modelCode, String regex, String replacement, String muOperator)
+   {
+	   
+	   String muModelCode = "";
+	   StringBuffer muCode = new StringBuffer(modelCode);	   
+	   Random ran = new Random();	   		  		  		  
+	   Pattern pattern = Pattern.compile(regex);
+	   Matcher matcher = pattern.matcher(modelCode);	   
+	   muModelCode = modelCode;
+	   int numberOfOccurences = 0;
+	   int random=0;
+	   
+	   while(matcher.find()) {
+		   numberOfOccurences++;
+		   
+	   }	   
+	   
+	   try {
+		   random = ran.nextInt(numberOfOccurences);
+	   }
+	   catch (Exception e ){
+		   System.out.println(e.getMessage());
+	   }
+	   System.out.println("Number of occurences: "+numberOfOccurences);
+	   System.out.println("random element number: "+ (random+1));
+	   matcher.reset();		  
+	   int x = 0;
+
+
+	   //System.out.println(matcher.groupCount());
+	   while(matcher.find())		  
+		   //for ( x = 0;x>numberOfOccurences;x++)
+	   {
+
+		   if(x == random){
+			   
+			   if(muOperator == "OneToMany")
+			   {
+				   muCode = muCode.replace(matcher.start(), matcher.start()+3, replacement);
+			   }
+			   
+			   if(muOperator.equals("ConstraintBiggerEq"))
+			   {
+				   System.out.println(matcher.group().toString());
+				   muCode = muCode.replace(matcher.end()-2, matcher.end(), replacement);
+			   }
+			   else {
+				   //System.out.println(matcher.group());
+				   muCode = muCode.replace(matcher.start(), matcher.end()-1, replacement);			   
+			   }
+		   }		      
+		   x++;		                  
+	   }
+
+	   muModelCode = muCode.toString();
+	   return  muModelCode;
+	   
+   }
+   
+   public String modifyModelNameSpace (String model, String muType)
+   {
+	   String regex = "namespace\\s\\w+[.\\w]*";
+	   Pattern pattern = Pattern.compile(regex);
+	   Matcher matcher = pattern.matcher(model);	   
+	   try{
+		   matcher.find();
+		   model = model.replaceAll(regex, matcher.group()+"."+muType);
+	   }
+	   catch(Exception e)
+	   {
+		   
+	   }
+	   
+	   
+	   return model;
+	   
+   }
+   
+   public String modifyModelUseStatements (String model, String muType)
+   {
+	   String regex = "use";
+	   Pattern pattern = Pattern.compile(regex);
+	   Matcher matcher = pattern.matcher(model);	   
+	   //matcher.find();	   
+	   model = model.replaceAll("use ", "use "+muType+"Mutation"+"_");
+	   
+	   return model;
+	   
+   }
+   
+   public void prepare (String aPath, String aUFileName, String aLang, String replacementType, String muOperator)
+   {
+	   //MutationSuite muSuite = new MutationSuite(null, 0, null);
+	   
+	    path = aPath;	    
+	    uFileName = aUFileName;
+	    String randomElement = "";
+	    
+	   File aFile = new File(path+uFileName);
+	   UmpleFile uFile = new UmpleFile(path+uFileName);
+	   //UmpleModel umpleModel = new UmpleModel(uFile);
+	   originalModel= new UmpleModel(uFile);
+	   String lang = aLang;
+	   String repType = replacementType;
+	   String mutationOperator = muOperator;
+	   //System.out.println("FRESHHSHSHS");
+	   //System.out.println(umpleModel.);
+	   String modelCode = "";	   
+	   String muModelCode = "";	   	   
+	   
+	   BufferedReader br = null;
+	try {
+		br = new BufferedReader(new FileReader(path+uFileName));
+	} catch (FileNotFoundException e) {
+		// TODO Auto-generated catch block
+		System.out.println("Unable to read model file !");
+		e.printStackTrace();
+	}
+	   String line = null;
+	   originalModel.setCode("");
+	   try {
+		while ((line = br.readLine()) != null) {
+		     //System.out.println(line);
+		     modelCode += line+"\n";
+		     originalModel.setCode(originalModel.getCode()+line+"\n");
+		   }
+	} catch (IOException e) {
+		// TODO Auto-generated catch block
+		e.printStackTrace();
+	}
+	   
+	  if(repType == "random")
+	  {
+	   //System.out.println("unshuffled collection of replacements:");
+	   //System.out.println(randomReplacements_association);
+	   //System.out.println("Shuffled collection:");
+	   Collections.shuffle(randomReplacements_association);
+	   //System.out.println(randomReplacements_association);
+	   //System.out.println("Shuffle again collection:");
+	   Collections.shuffle(randomReplacements_association);
+	   //System.out.println(randomReplacements_association);
+	   
+	   //System.out.println("getting Random replacement:");
+	   Collections.shuffle(randomReplacements_association);
+	   //System.out.println(randomReplacements_association.get(0));	   	   	   	   
+	   //System.out.println(aFile.getAbsolutePath());
+	   //System.out.println(aFile.getPath());
+	   //System.out.println(aFile.exists());
+	   //System.out.println(modelCode);
+	   	   
+	   //System.out.println("Find a random Replacement and generate mutant: ");
+	   randomElement = randomReplacements_association.get(0);
+	   System.out.println("Randomly generated mutant with the following change: "+randomElement);
+	  }
+	   
+	   // public Boolean mutate(Mutant mu, String modelCode , String muType, String muOperator, String replacementType, String lang){
+	  analyzeModelFiles(aPath, aUFileName, muModelCode); 
+	  
+	  if (this.muFiles.size()>0)
+	  {
+		  
+		  
+		  for(String useModelFile : this.muFiles) {
+			  uFileName = useModelFile;
+			  String useFileCode = readUseFilesCode(uFileName);
+			  System.out.println("Mutating linked file:  ");
+			  System.out.println(useModelFile);
+			  
+			  //System.out.println(mutationOperator);
+			  mutate(null, useFileCode, "random",mutationOperator,repType, lang);
+			  //this.prepare(aPath, useModelFile, aLang, replacementType, muOperator);
+		  }
+		  /*int processedFiles = 0;
+		  while(unprocessedFiles>0)
+		  {
+			  String useModelFile = muFiles.get(processedFiles);
+			  //uFileName = muFiles;
+			  String useFileCode = readUseFilesCode(uFileName);
+			  System.out.println("Mutating linked file:  ");
+			  System.out.println(useModelFile);
+			  
+			  //System.out.println(mutationOperator);
+			  //mutate(null, useFileCode, "random",mutationOperator,repType, lang);
+			  this.prepare(aPath, useModelFile, aLang, replacementType, muOperator);
+			  unprocessedFiles--;
+			  processedFiles++;
+			  
+		  }*/
+		  
+		  
+	  }
+	  
+	  uFileName = aUFileName;	  
+	  mutate(null, modelCode, "random",mutationOperator,repType, lang);
+	   
+	   
+	   
+   }
+
+  // line 220 "../../../../src/MutationSuite_code.ump"
+   /*public static void main(String [] args) throws IOException{
+    Thread.currentThread().setUncaughtExceptionHandler(new UmpleExceptionHandler());
+    Thread.setDefaultUncaughtExceptionHandler(new UmpleExceptionHandler());
+    
+    //prepare("src-gen-umple/cruise/umple/mutation/","model2.ump", "java","full","random");
+       /*
+       String path = "src-gen-umple/cruise/umple/mutation/";
+        
+	   File aFile = new File("src-gen-umple/cruise/umple/mutation/model2.ump");
+	   UmpleFile uFile = new UmpleFile(aFile);
+	   //UmpleModel umpleModel = new UmpleModel(uFile);
+	   originalModel= new UmpleModel(uFile);
+	   //System.out.println("FRESHHSHSHS");
+	   //System.out.println(umpleModel.);
+	   String modelCode = "";	   
+	   String muModelCode = "";	   	   
+	   
+	   BufferedReader br = new BufferedReader(new FileReader("src-gen-umple/cruise/umple/mutation/model2.ump"));
+	   String line = null;
+	   originalModel.setCode("");
+	   while ((line = br.readLine()) != null) {
+	     //System.out.println(line);
+	     modelCode += line+"\n";
+	     originalModel.setCode(originalModel.getCode()+line+"\n");
+	   }
+	   	 
+	   
+	   //UmpleFile file = new UmpleFile ("src-gen-umple/cruise/umple/mutation/model.ump");
+	   
+	   
+	   
+	   //UmpleModel aOriginalModel = new UmpleModel (new  UmpleFile ("src-gen-umple/cruise/umple/mutation/model.ump"));
+	   //aOriginalModel.setShouldGenerate(false);
+	   
+	   
+	   //aOriginalModel.setUmpleFile(file);
+	   MutationSuite muSuite = new MutationSuite(null, 0, null);
+	   
+	   System.out.println("unshuffled collection of replacements:");
+	   System.out.println(muSuite.randomReplacements_association);
+	   System.out.println("Shuffled collection:");
+	   Collections.shuffle(muSuite.randomReplacements_association);
+	   System.out.println(muSuite.randomReplacements_association);
+	   System.out.println("Shuffle again collection:");
+	   Collections.shuffle(muSuite.randomReplacements_association);
+	   System.out.println(muSuite.randomReplacements_association);
+	   
+	   System.out.println("getting Random replacement:");
+	   Collections.shuffle(muSuite.randomReplacements_association);
+	   System.out.println(muSuite.randomReplacements_association.get(0));
+	   
+	   
+	   
+	   
+	   //System.out.println(aFile.getAbsolutePath());
+	   //System.out.println(aFile.getPath());
+	   //System.out.println(aFile.exists());
+	   //System.out.println(modelCode);
+	   	   
+	   System.out.println("Find a random Replacement and generate mutant: ");
+	   String randomElement = muSuite.randomReplacements_association.get(0);
+	   
+	   muSuite.mutate(null, modelCode, randomElement,"full","random", "Java");
+	   
+	   System.out.println("Generated the following mutant: "+randomElement);
+	   
+	   
+	   //muSuite.mutateAssociationOptionalOneToMany(null, modelCode);
+	   //Mutant mutant = new Mutant(null,"OneToMany",muSuite,modelCode);
+	   //System.out.println(muSuite.getMutants().toString());
+	   
+	   //muSuite.processReplacements();
+	   //muSuite.mutateAssociationOptionalOneToMany(null, modelCode);
+	   //muSuite.mutateAssociationOneToMany(null, modelCode);
+	   //muSuite.mutateAssociationOneToNN(null, modelCode);
+	   //muSuite.mutateRandom(null, modelCode);
+	   //
+	  //String muModelCodel="";
+	  //String regex = "0..1 -- *";
+	  //String replacement = "REPCODE";	  
+	  //muModelCode = modelCode.replaceAll(regex, replacement);
+	  
+	  //System.out.println("Mutated Code  ");
+	  //System.out.println(muModelCode);
+	  //muSuite.writeMutatedFile("src-gen-umple/cruise/umple/mutation/", "model.ump", "OptionalOneToMany", muModelCode);
+	  
+	  
+	  //UmpleModel muModel = muSuite.createUmpleMutationSystem("src-gen-umple/cruise/umple/mutation", "OptionalOneToManyMutation_model.ump", "Ruby");	  
+	  //System.out.println(muSuite.getMutants().size());
+	  
+	  /*for ( int i = 0 ; i <= muSuite.muFiles.size(); i ++)		  
+	  {
+		  
+		  muSuite.createUmpleMutationSystem("", muSuite.muFiles.get(i), "java");
+	  }*/
+	  
+	  /*for (Mutant mu : muSuite.getMutants())
+	  {
+		  System.out.println("This is Umplefile from main list: ");
+		  mu.getMuModel().getUmpleFile();
+	  }
+    
+  }*/
+
+
+}

--- a/cruise.umple.mutation/src/evaluator.ump
+++ b/cruise.umple.mutation/src/evaluator.ump
@@ -1,0 +1,1 @@
+//to be updated

--- a/cruise.umple.mutation/src/mutant.ump
+++ b/cruise.umple.mutation/src/mutant.ump
@@ -1,0 +1,1 @@
+//to be updated for extra code 

--- a/cruise.umple.mutation/src/mutantClass.ump
+++ b/cruise.umple.mutation/src/mutantClass.ump
@@ -1,0 +1,1 @@
+//to be updated

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/MutationTest.java
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/MutationTest.java
@@ -1,0 +1,480 @@
+/**
+ * 
+ */
+package cruise.umple.mutation.test;
+import cruise.umple.mutation.*;
+import cruise.umple.util.SampleFileWriter;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.junit.*;
+
+public class MutationTest {
+	MutationSuite ms = new MutationSuite(null,0,"","");
+	String path = "";
+	String uFileName = "";
+	File aFile = null;
+	
+	
+	
+	@Before
+	public void setup (){
+		
+		
+		
+	}
+	
+	@Test
+	  public void avoidJunitError()
+	  {}
+	
+	///// Association Mutation tests
+	
+	@Test 
+	public void mutateAssociation_OneToManyWithOptionalOneToMany(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel.ump";
+	     
+		ms.prepare(path, uFileName,"Java","OptionalOneToMany","OneToMany");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		
+		
+		
+		assertMutatedModelEqualFalse(path+uFileName, path+"OneToMany/"+"OneToManyMutation_" +uFileName);
+		/*if (assertMutatedModelEqualTrue(path+uFileName, path+"OneToMany/"+"OneToManyMutation_" +uFileName))
+		{	
+			Assert.fail("generated mutation model is identical to original");
+		
+		}
+		else 
+		{
+			//some code 
+		}*/
+		
+		
+	
+	}
+	
+	
+	@Test
+	public void mutateAssociation_OneToManyWithOptionalOneToMany_GeneratedFiles(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel.ump";
+	     
+	    ms.prepare(path, uFileName,"Java","OptionalOneToMany","OneToMany");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);		
+		 SampleFileWriter.assertFileExists(path + "OneToMany");
+						
+	}
+	
+	@Test
+	public void mutateAssociation_OptionalOneToManyWithOneToMany(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel.ump";
+	     
+		ms.prepare(path, uFileName,"Java","OneToMany","OptionalOneToMany");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		assertMutatedModelEqualFalse(path+uFileName, path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName);
+		/*if (assertMutatedModelEqualFalse(path+uFileName, path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName))
+		{	
+			Assert.fail("New mutation is identical");
+		
+		}*/
+		
+		
+				
+	}
+	
+	@Test
+	public void mutateAssociation_OptionalOneToManyWithOneToMany_GeneratedFiles(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel.ump";
+	     
+		ms.prepare(path, uFileName,"Java","OneToMany","OptionalOneToMany");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileExists(path + "OptionalOneToMany");	
+	}
+	
+	@Test
+	public void mutateAssociation_Directionality(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel.ump";
+	     
+		ms.prepare(path, uFileName,"Java","","direction");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		
+		assertMutatedModelEqualFalse(path+uFileName, path+"AssociationDirectionality/"+"AssociationDirectionalityMutation_" +uFileName);
+		/*if (AssertMutatedModel(path+uFileName, path+"AssociationDirectionality/"+"AssociationDirectionalityMutation_" +uFileName))
+		{	
+			Assert.fail("New mutation is identical");
+		
+		}*/
+		
+		//System.out.println(ms.getMutant(0).getMuModel().getUmpleClass("PhoneCall").toString());
+		 
+						
+	}
+	
+	@Test
+	public void mutateAssociation_DirectionalityGeneratedFiles(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel.ump";
+	     
+		ms.prepare(path, uFileName,"Java","","direction");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);		
+		 SampleFileWriter.assertFileExists(path + "AssociationDirectionality");
+						
+	}
+	
+	///// Name space and directives
+	
+	@Test
+	public void mutate_namespace(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_namespace.ump";
+	     
+		ms.prepare(path, uFileName,"Java","","direction");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_namespace_expected.ump.txt"), new File(path + "AssociationDirectionality/AssociationDirectionalityMutation_uModel_namespace.ump"), false);
+		
+		
+		 
+						
+	}
+	
+	///// Attribute Mutation tests
+	@Test
+	public void mutate_attributeTyped_intWithFloat(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_int.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Float","AttributeInt");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_int_expectedFloat.ump.txt"), new File(path + "TypedAttributeInteger/TypedAttributeIntegerMutation_uModel_attributeTyped_int.ump"), false);	 
+						
+	}
+	
+	@Test
+	public void mutate_attributeTyped_intWithString(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_int.ump";
+	     
+		ms.prepare(path, uFileName,"Java","String","AttributeInt");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_int_expectedString.ump.txt"), new File(path + "TypedAttributeInteger/TypedAttributeIntegerMutation_uModel_attributeTyped_int.ump"), false);	 
+						
+	}
+	@Test
+	public void mutate_attributeTyped_intWithDouble(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_int.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Double","AttributeInt");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_int_expectedDouble.ump.txt"), new File(path + "TypedAttributeInteger/TypedAttributeIntegerMutation_uModel_attributeTyped_int.ump"), false);	 
+						
+	}
+	
+	@Test
+	public void mutate_attributeTyped_floatWithDouble(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_float.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Double","AttributeFloat");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_float_expectedDouble.ump.txt"), new File(path + "TypedAttributeFloat/TypedAttributeFloatMutation_uModel_attributeTyped_float.ump"), false);	 
+						
+	}
+	
+	
+	@Test
+	public void mutate_attributeTyped_floatWithInt(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_float.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Integer","AttributeFloat");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_float_expectedInt.ump.txt"), new File(path + "TypedAttributeFloat/TypedAttributeFloatMutation_uModel_attributeTyped_float.ump"), false);	 
+						
+	}
+	
+	@Test
+	public void mutate_attributeTyped_floatWithString(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_float.ump";
+	     
+		ms.prepare(path, uFileName,"Java","String","AttributeFloat");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_float_expectedString.ump.txt"), new File(path + "TypedAttributeFloat/TypedAttributeFloatMutation_uModel_attributeTyped_float.ump"), false);	 
+						
+	}
+	
+	
+	@Test
+	public void mutate_attributeTyped_stringWithDouble(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_string.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Double","AttributeString");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_string_expectedDouble.ump.txt"), new File(path + "TypedAttributeString/TypedAttributeStringMutation_uModel_attributeTyped_string.ump"), false);	 
+						
+	}
+	
+	
+	@Test
+	public void mutate_attributeTyped_stringWithInt(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_string.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Integer","AttributeString");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_string_expectedInt.ump.txt"), new File(path + "TypedAttributeString/TypedAttributeStringMutation_uModel_attributeTyped_string.ump"), false);	 
+						
+	}
+	
+	@Test
+	public void mutate_attributeTyped_stringWithFloat(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_attributeTyped_string.ump";
+	     
+		ms.prepare(path, uFileName,"Java","Float","AttributeString");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		SampleFileWriter.assertFileContent(new File(path+"uModel_attributeTyped_string_expectedFloat.ump.txt"), new File(path + "TypedAttributeString/TypedAttributeStringMutation_uModel_attributeTyped_string.ump"), false);	 
+						
+	}
+	
+	
+	@Test
+	public void mutate_AssertMutateModelTest_True(){	
+		path = "test/cruise/umple/mutation/test/";
+		String model1 = "uModel_mutateAssert_model.ump";
+		String model2 = "uModel_mutateAssert_model_identical.ump";		
+		String model3 = "uModel_mutateAssert_model_mutated.ump";
+		//Assert.assertFalse(assertMutatedModel(path+model1,path+model3));
+		Assert.assertTrue("AssertMethod: AssertMutateModell failed! @ identical",assertMutatedModelEqualTrue(path+model1,path+ model2));
+						
+	}
+	@Test
+	public void mutate_AssertMutateModelTest_False(){	
+		path = "test/cruise/umple/mutation/test/";
+		String model1 = "uModel_mutateAssert_model.ump";
+		String model2 = "uModel_mutateAssert_model_identical.ump";		
+		String model3 = "uModel_mutateAssert_model_mutated.ump";
+		//Assert.assertFalse(assertMutatedModel(path+model1,path+model3));
+		Assert.assertTrue("AssertMethod: AssertMutateModell failed @ mutated!",assertMutatedModelEqualFalse(path+model1,path+model3));
+						
+	}
+	
+	
+	@Test
+	public void mutate_constraint(){
+	    path = "test/cruise/umple/mutation/test/";
+	    uFileName = "uModel_mutateConstraint.ump";
+	     
+		ms.prepare(path, uFileName,"Java","<","ConstraintBiggerEq");
+	    
+		//SampleFileWriter.assertFileContent(new File(path+uFileName),new File (path+"OptionalOneToMany/"+"OptionalOneToManyMutation_" +uFileName), true);
+		//SampleFileWriter.assertFileContent(new File(path+"uModel_mutateConstraint.ump.txt"), new File(path + "ConstraintsBiggerEqMutation_uModel_mutateConstraint.ump"), false);	 
+						
+	}
+	
+	
+	
+	/// use model Files
+	
+	@Test
+	public void mutate_useFiles(){	
+		path = "test/cruise/umple/mutation/test/";
+		String model1 = "uModel_useFiles.ump";
+		//String model2 = "uModel_mutateAssert_model_identical.ump";		
+		//String model3 = "uModel_mutateAssert_model_mutated.ump";
+		//Assert.assertFalse(assertMutatedModel(path+model1,path+model3));
+		//Assert.assertTrue("AssertMethod: AssertMutateModell failed! @ identical",assertMutatedModelEqualTrue(path+model1,path+ model2));
+		//Assert.assertTrue("AssertMethod: AssertMutateModell failed @ mutated!",assertMutatedModelEqualFalse(path+model1,path+model3));
+		ms.prepare(path, model1, "Java", "", "direction");
+	}
+	
+	
+	////// Regex testing for several cases 
+	
+	
+	
+	////// Test for the paper 
+	
+	@Test
+	public void mutate_telephoneSystem(){	
+		path = "test/cruise/umple/mutation/test/";
+		String model1 = "uModel_telephone.ump";
+		//String model2 = "uModel_mutateAssert_model_identical.ump";		
+		//String model3 = "uModel_mutateAssert_model_mutated.ump";
+		//Assert.assertFalse(assertMutatedModel(path+model1,path+model3));
+		//Assert.assertTrue("AssertMethod: AssertMutateModell failed! @ identical",assertMutatedModelEqualTrue(path+model1,path+ model2));
+		//Assert.assertTrue("AssertMethod: AssertMutateModell failed @ mutated!",assertMutatedModelEqualFalse(path+model1,path+model3));
+		ms.prepare(path, model1, "Java", "random", "full");
+	}
+	
+	
+	///Utilities 
+	
+	public Boolean assertMutatedModelEqualTrue (String file1, String file2)
+	
+	{   
+		String modelCode1="";
+		String modelCode2= "";
+		
+		
+		System.out.println(file1);
+		BufferedReader br1 = null;
+		try {
+			br1 = new BufferedReader(new FileReader(file1));
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		   String line = null;
+		   
+		   try {
+			while ((line = br1.readLine()) != null) {
+			     //System.out.println(line);
+			     modelCode1 += line+"\n";			     
+			   }
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		   System.out.println(file2);
+		   
+		   BufferedReader br2 = null;
+			try {
+				br2 = new BufferedReader(new FileReader(file2));
+			} catch (FileNotFoundException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			   line = null;
+			   
+			   try {
+				while ((line = br2.readLine()) != null) {
+				     //System.out.println(line);
+				     modelCode2 += line+"\n";			     
+				   }
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+  
+			   
+			   Assert.assertTrue(modelCode1.equals(modelCode2));
+			   /*if( modelCode1.equals(modelCode2))
+			   {
+				   //Assert.assertTrue(condition);
+				   return true;
+			   }*/
+		return true;
+		
+	}
+	
+	
+public Boolean assertMutatedModelEqualFalse (String file1, String file2)
+	
+	{   
+		String modelCode1="";
+		String modelCode2= "";
+		
+		
+		System.out.println(file1);
+		BufferedReader br1 = null;
+		try {
+			br1 = new BufferedReader(new FileReader(file1));
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		   String line = null;
+		   
+		   try {
+			while ((line = br1.readLine()) != null) {
+			     //System.out.println(line);
+			     modelCode1 += line+"\n";			     
+			   }
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		   System.out.println(file2);
+		   
+		   BufferedReader br2 = null;
+			try {
+				br2 = new BufferedReader(new FileReader(file2));
+			} catch (FileNotFoundException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			   line = null;
+			   
+			   try {
+				while ((line = br2.readLine()) != null) {
+				     //System.out.println(line);
+				     modelCode2 += line+"\n";			     
+				   }
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+  
+			   
+			   
+			   Assert.assertFalse(modelCode1.equals(modelCode2));
+			   /*if( modelCode1.equals(modelCode2))
+			   {
+				   return false;
+			   }*/
+		return true;
+		
+	}
+	
+	@After
+	public void teardown() {
+		path = "test/cruise/umple/mutation/test/";
+		//System.out.println(path + "cruise/umple/mutation/test/mutation/Direction/Feature.java");
+		SampleFileWriter.destroy(path + "AssociationDirectionality");
+		SampleFileWriter.destroy(path + "OneToMany");
+		SampleFileWriter.destroy(path + "OneToOptionalOne");
+		SampleFileWriter.destroy(path + "OptionalOneToMany");
+		SampleFileWriter.destroy(path + "OneToNN_aboveLowerBound");
+		SampleFileWriter.destroy(path + "OneToNN_belowUpperBound");
+		SampleFileWriter.destroy(path + "OneToNN_belowLowerBound");
+		SampleFileWriter.destroy(path + "OneToNN_aboveUpperBound");
+		SampleFileWriter.destroy(path + "TypedAttributeFloat");
+	    SampleFileWriter.destroy(path + "TypedAttributeString");
+		SampleFileWriter.destroy(path + "TypedAttributeInteger");
+		SampleFileWriter.destroy(path + "TypedAttributeDouble");
+		SampleFileWriter.destroy(path + "ConstraintsBiggerEq");
+		
+		
+		
+	}
+	
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel.ump
@@ -1,0 +1,39 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class PhoneCall{ 
+ String isOnHold;
+ String startTime;
+ duration;
+ 1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ double location;
+ double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float.ump
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class A{
+
+Float x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float_expectedDouble.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float_expectedDouble.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeFloat;
+
+class A{
+
+Double x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float_expectedInt.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float_expectedInt.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeFloat;
+
+class A{
+
+Integer x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float_expectedString.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_float_expectedString.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeFloat;
+
+class A{
+
+String x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int.ump
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class A{
+
+Integer x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int_expectedDouble.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int_expectedDouble.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeInteger;
+
+class A{
+
+Double x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int_expectedFloat.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int_expectedFloat.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeInteger;
+
+class A{
+
+Float x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int_expectedString.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_int_expectedString.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeInteger;
+
+class A{
+
+String x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string.ump
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class A{
+
+String x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string_expectedDouble.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string_expectedDouble.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeString;
+
+class A{
+
+Double x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string_expectedFloat.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string_expectedFloat.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeString;
+
+class A{
+
+Float x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string_expectedInt.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_attributeTyped_string_expectedInt.ump.txt
@@ -1,0 +1,12 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.TypedAttributeString;
+
+class A{
+
+Integer x;
+
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateAssert_model.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateAssert_model.ump
@@ -1,0 +1,39 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class PhoneCall{ 
+ String isOnHold;
+ String startTime;
+ duration;
+ 1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ double location;
+ double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateAssert_model_identical.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateAssert_model_identical.ump
@@ -1,0 +1,39 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class PhoneCall{ 
+ String isOnHold;
+ String startTime;
+ duration;
+ 1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ double location;
+ double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateAssert_model_mutated.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateAssert_model_mutated.ump
@@ -1,0 +1,39 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.SomeNamespace;
+
+class PhoneCall{ 
+ String isOnHold;
+ Double startTime;
+ duration;
+ 1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ double location;
+ double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateConstraint.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateConstraint.ump
@@ -1,0 +1,10 @@
+class PotentialVoter {
+  Integer age;
+  
+  int vote(int candidate) {
+    [pre: age >= 18]
+    [pre: candidate > 0]
+    // rest of stuff that we do not interpret
+     return 0;
+  }
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateConstraint.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_mutateConstraint.ump.txt
@@ -1,0 +1,10 @@
+class PotentialVoter {
+  Integer age;
+  
+  int vote(int candidate) {
+    [pre: age < 18]
+    [pre: candidate > 0]
+    // rest of stuff that we do not interpret
+     return 0;
+  }
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_namespace.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_namespace.ump
@@ -1,0 +1,9 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class A{
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_namespace_expected.ump.txt
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_namespace_expected.ump.txt
@@ -1,0 +1,9 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone.AssociationDirectionality;
+
+class A{
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_telephone.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_telephone.ump
@@ -1,0 +1,39 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace paper;
+
+class PhoneCall{ 
+ String isOnHold;
+ String startTime;
+ duration;
+ 1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ Double location;
+ Double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_useFiles.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_useFiles.ump
@@ -1,0 +1,43 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+use uModel_useFiles1.ump;
+use uModel_useFiles2.ump;
+
+class PhoneCall{ 
+ String isOnHold;
+ String startTime;
+ duration;
+ 1 call -- * TelephoneNumber originator;
+ 0..1 -- * TelephoneNumber parties;
+}
+class TelephoneNumber{
+ digits;
+ Float num;
+ 0..1 number -- * TelephoneNumber voicemail;
+}
+class VoiceMailBox{
+ 0..1 -- * VoiceMailMessage; 
+ 1 -- * TelephoneNumber;
+}
+class VoiceMailMessage {
+ Integer digitizedSound;
+}
+class Feature {
+ Integer description;
+ * -- * TelephoneNumber;
+}
+class Telephone {
+ model;
+}
+class PhoneLine {
+ double location;
+ double poCode;
+ Integer digOrAnalog;
+ * -- * TelephoneNumber;
+ 1 -- 0..1 Telephone;
+}

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_useFiles1.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_useFiles1.ump
@@ -1,0 +1,15 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class A{
+
+1 -- * C;
+
+}
+
+class C{}
+

--- a/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_useFiles2.ump
+++ b/cruise.umple.mutation/test/cruise/umple/mutation/test/uModel_useFiles2.ump
@@ -1,0 +1,8 @@
+/*
+ Telephone System- sample UML class diagram in Umple 
+  Last updated: June 8, 2010
+*/
+//Namespace for core of the system.
+namespace telecome.telephone;
+
+class B{}

--- a/cruise.umple.test-parser/src-gen/cruise/umple/testgenerator/Util.java
+++ b/cruise.umple.test-parser/src-gen/cruise/umple/testgenerator/Util.java
@@ -1,11 +1,13 @@
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This code was generated using the UMPLE 1.25.0-963d2bd modeling language!*/
+/*This code was generated using the UMPLE 1.29.1.4657.40ea68fec modeling language!*/
 
 package cruise.umple.testgenerator;
 import java.util.Random;
-import cruise.umple.*;
+import java.lang.reflect.Method;
+import cruise.umple.testparser.TestParser;
+import java.io.File;
 
-// line 3 "../../../Utility.ump"
+// line 3 "../../../../ump/Utility.ump"
 public class Util
 {
 
@@ -51,7 +53,7 @@ public class Util
    * Random String Generator
    * ------------------------
    */
-  // line 17 "../../../Utility.ump"
+  // line 20 "../../../../ump/Utility.ump"
    public String randomGenerator(Random random, String characters, int length){
     char[] text = new char[length];
     for (int i = 0; i < length; i++)
@@ -60,9 +62,6 @@ public class Util
     }
     return new String(text);
   }
-   
- 
-   
 
 
   /**
@@ -70,11 +69,92 @@ public class Util
    * Random Int Generator
    * ------------------------
    */
-  // line 30 "../../../Utility.ump"
+  // line 33 "../../../../ump/Utility.ump"
    public int randomGenerator(int range){
     int text = random.nextInt(range);
 	  	
 	return text;
+  }
+
+
+  /**
+   * ------------------------
+   * AssertMethod // check if a method is present in a class using reflection, example: assertMethod(foo.class, "methodName")
+   * ------------------------
+   */
+  // line 45 "../../../../ump/Utility.ump"
+   public Boolean assertMethod(Class cls, String methodName){
+    Boolean hasMethod = false;
+    	Method[] methods = cls.getMethods();
+    	for (Method m : methods )
+    	{
+    		if ( m.getName() == methodName)
+    		{ hasMethod = true; }
+    	}
+    	return hasMethod;
+  }
+
+  // line 61 "../../../../ump/Utility.ump"
+   public TestModel createUmpleTestSystem(String path, String filename, String lang){
+    String language =lang;
+     //File file = new File(pathToInput+"/" + path, filename);
+     File file = new File(path+filename);
+     String grName = "";
+     TestModel aTestModel = new TestModel(null, null, null, null, null,null, null, language);
+     TestParser parser = new TestParser(null, "", file, 0);
+     //ParseResult result = new ParseResult(false);
+     //InputStream is = this.getClass().getResourceAsStream("mbt_parsing.grammar");
+     //ClassLoader classLoader = getClass().getClassLoader();
+     //File grammarFile = new File(classLoader.getResource("mbt_parsing.grammar").getFile());
+     ////system.out.println(grammarFile.tos);
+     //parser.setGrammarFile(path+"src/ump/mbt_parsing.grammar");
+     //InputStream in = getClass().getResourceAsStream("/mbt_parsing.grammar"); 
+     //BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+     //File grFile = new File (getClass().getResource("mbt_parsing.grammar").getPath().replace("file:", ""));
+     //File grFile = new File ();
+     //grName = file.getName();
+     
+     //grName = getClass().getResource("mbt_parsing.grammar").getFile();
+     ////system.out.println(Util.class.getResource("mbt_parsing.grammar").getFile());
+     //parser.setGrammarFile(Util.class.getResource("mbt_parsing.grammar").getFile().toString());
+     ////system.out.println(parser.getGrammarFile());
+     parser.setTestModelFile(file);
+     //parser.setTestModelFile(file);
+     
+     
+     ////system.out.println(path);
+     parser.prepare();
+     aTestModel = parser.getATestModel();
+     //system.out.println(file.getAbsoluteFile());
+     aTestModel.setCodeLang(language);
+     //system.out.println(aTestModel.getCodeLang());
+     if(aTestModel.getCodeLang().equals("JUnit"))
+     {
+     
+     //language = lang;
+     TestCaseJUnitGenerator junitGenerator = new TestCaseJUnitGenerator(null, null, null, null, null);
+	     junitGenerator.setTestModel(aTestModel);
+	     junitGenerator.setPath(path);
+	     junitGenerator.writeFile();
+     }
+     if(aTestModel.getCodeLang().equals("PhpUnit"))
+     {
+     	TestCasePhpUnitGenerator phpGenerator = new TestCasePhpUnitGenerator(null, null, null, null, null); 
+         phpGenerator.setTestModel(aTestModel);
+         phpGenerator.setPath(path);
+         phpGenerator.writeFile();
+   }
+     if(aTestModel.getCodeLang().equals("RubyUnit"))
+     {
+     	TestCaseRubyUnitGenerator rubyGenerator = new TestCaseRubyUnitGenerator(null, null, null, null, null); 
+         rubyGenerator.setTestModel(aTestModel);
+         rubyGenerator.setPath(path);
+         rubyGenerator.writeFile();
+     }
+     
+     
+     
+     return aTestModel;
   }
 
 

--- a/cruise.umple.test-parser/src/ump/Master.ump
+++ b/cruise.umple.test-parser/src/ump/Master.ump
@@ -7,7 +7,9 @@ use TestCaseTemplate_model.ump;
 use TestCaseTemplate_JUnitGenerator.ump;
 use TestCaseTemplate_PhpUnitGenerator.ump;
 use TestCaseTemplate_RubyUnitGenerator.ump;
-use TestCaseTemplate_Generator.ump; 
+use TestCaseTemplate_Generator.ump;
+use TestGeneratorConsoleMain.ump ;
+use Utility.ump ;
 
 namespace cruise.umple.testparser;
 

--- a/cruise.umple.test-parser/src/ump/TestGeneratorConsoleMain.ump
+++ b/cruise.umple.test-parser/src/ump/TestGeneratorConsoleMain.ump
@@ -1,0 +1,115 @@
+
+
+
+
+class TestGeneratorConsoleMain {
+ depend java.io.File;
+depend java.nio.file.Paths;
+depend joptsimple.OptionParser;
+depend joptsimple.OptionSet;
+depend joptsimple.OptionSpec;
+depend java.util.Arrays;	
+	
+	public static void main(String[] args) {
+		
+		Util util = new Util();
+		OptionParser parser = new OptionParser();
+		//OptionSpec<String> help = parser.accepts("help").withOptionalArg();
+		OptionSpec<Void> help = parser.acceptsAll(Arrays.asList("h","help"),"show help").forHelp();
+		OptionSpec<String> generate = parser.accepts("generate").withOptionalArg();        
+        OptionSpec<String> mutant = parser.accepts("unit-test").withOptionalArg();
+        //OptionSpec<String> mutationType = parser.accepts("t").withRequiredArg();
+        //OptionSpec<String> mutationOperator = parser.accepts("p").withRequiredArg();
+        OptionSpec<String> lang = parser.accepts("l").withRequiredArg();
+        
+        //OptionSet options = parser.parse("generate", "-t", "random", "-p", "full");
+        OptionSet options = parser.parse(args);
+               
+        //OptionSet options = parser.parse("-a", "apple", "-a", "berries", "-a", "mango");
+        /*System.out.println("model name: ");
+        System.out.println(options.valuesOf(generate));
+        System.out.println(options.has(generate));
+        System.out.println("Opetions: ");
+        System.out.println(options.valueOf(mutationType));
+        System.out.println(options.has(mutationType));
+        System.out.println("Operator: ");
+        System.out.println(options.valueOf(mutationOperator));
+        System.out.println(options.has(mutationOperator));
+        
+        System.out.println("Language: ");
+        System.out.println(options.valueOf(lang));
+        System.out.println(options.has(lang));*/
+        String path = "";
+        String languagePath="";
+        
+        
+        if(options.has(help)) {
+        	System.out.println("Please specify <umple_file.umpt> to process for unit-test generation");
+        	System.out.println("For more detailed information visit http://manual.umple.org");
+        	System.out.println("#############################################################################################");
+        	System.out.println("Example: java -jar umple.unit-test.jar -generate model.umpt -l JUnit   ");
+        	System.out.println("#############################################################################################");
+        	System.out.println("Option	    Description");
+        	System.out.println("------	    -----------");
+        	System.out.println("-help		Print help message");
+        	/*System.out.println("-t			indicate the type of replacement for the  \n" + 
+        					   "		          mutation : random, specific element: OptionalOneToMany, OneToMany, OptionalOneToOne, ManyToMany,\n"+
+        					   "			  direction, Integer, String, Double, Float");
+        	System.out.println("-p		 	indicate the targeted element to be mutated: ‘full’ or specific element.");*/
+        	System.out.println("-l			the output language of the unit system to be generated: JUnit, RubyUnit, PhpUnit");
+        	
+
+        }
+        
+        else {
+        
+        languagePath= options.valueOf(lang);
+        
+        path = Paths.get(".").toAbsolutePath().normalize().toString()+File.separator;
+			//path = System.getProperty("user.dir")+File.separator+"cruise/umple/mutation/";
+        	//path=(MutationConsoleMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getPath();
+		
+            
+        
+        String modelName =options.valueOf(generate);
+        String aLang=options.valueOf(lang);
+        String replacementType = "";
+        String muOperator = "";
+        
+        //replacementType = (options.valueOf(mutationType)).toString();
+        //muOperator = (options.valueOf(mutationOperator)).toString();
+        
+        //System.out.println("Replacement type used: "+replacementType);
+        
+        
+        /*if(languagePath.equals("JUnit")) {
+        	//
+        }*/
+        
+        //util.createUmpleTestSystem(path, modelName,languagePath);
+        try {
+        
+        	util.createUmpleTestSystem(path, modelName,languagePath);
+        	System.out.println("Unit system: "+languagePath);
+        	System.out.println("Unit tests generated successfully !");        
+        
+                       
+        }
+        catch(Exception e) {
+        	System.out.println("Failed to generate unit tests: ");
+        	
+        }
+        /*****
+        // Run Diff on original model against the mutated one to find changes.
+        try {
+         
+			//Runtime.getRuntime().exec("diff " + modelName +" "+ mutationType+File.separator+mutationType+"Mutation_"+modelName);
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		*/
+        }
+	}
+
+}

--- a/cruise.umple.test-parser/src/ump/Utility.ump
+++ b/cruise.umple.test-parser/src/ump/Utility.ump
@@ -4,6 +4,8 @@ class Util{
 
 depend java.util.Random;
 depend java.lang.reflect.Method;
+depend cruise.umple.testparser.TestParser;
+depend  java.io.File;
 
 		
 
@@ -49,6 +51,73 @@ public Boolean assertMethod (Class cls, String methodName)
     	}
     	return hasMethod;    	
     }
+
+ public TestModel createUmpleTestSystem(String path, String filename,String lang)
+   {
+	  
+	   
+	   
+
+	 String language =lang;
+     //File file = new File(pathToInput+"/" + path, filename);
+     File file = new File(path+filename);
+     String grName = "";
+     TestModel aTestModel = new TestModel(null, null, null, null, null,null, null, language);
+     TestParser parser = new TestParser(null, "", file, 0);
+     //ParseResult result = new ParseResult(false);
+     //InputStream is = this.getClass().getResourceAsStream("mbt_parsing.grammar");
+     //ClassLoader classLoader = getClass().getClassLoader();
+     //File grammarFile = new File(classLoader.getResource("mbt_parsing.grammar").getFile());
+     ////system.out.println(grammarFile.tos);
+     //parser.setGrammarFile(path+"src/ump/mbt_parsing.grammar");
+     //InputStream in = getClass().getResourceAsStream("/mbt_parsing.grammar"); 
+     //BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+     //File grFile = new File (getClass().getResource("mbt_parsing.grammar").getPath().replace("file:", ""));
+     //File grFile = new File ();
+     //grName = file.getName();
+     
+     //grName = getClass().getResource("mbt_parsing.grammar").getFile();
+     ////system.out.println(Util.class.getResource("mbt_parsing.grammar").getFile());
+     //parser.setGrammarFile(Util.class.getResource("mbt_parsing.grammar").getFile().toString());
+     ////system.out.println(parser.getGrammarFile());
+     parser.setTestModelFile(file);
+     //parser.setTestModelFile(file);
+     
+     
+     ////system.out.println(path);
+     parser.prepare();
+     aTestModel = parser.getATestModel();
+     //system.out.println(file.getAbsoluteFile());
+     aTestModel.setCodeLang(language);
+     //system.out.println(aTestModel.getCodeLang());
+     if(aTestModel.getCodeLang().equals("JUnit"))
+     {
+     
+     //language = lang;
+     TestCaseJUnitGenerator junitGenerator = new TestCaseJUnitGenerator(null, null, null, null, null);
+	     junitGenerator.setTestModel(aTestModel);
+	     junitGenerator.setPath(path);
+	     junitGenerator.writeFile();
+     }
+     if(aTestModel.getCodeLang().equals("PhpUnit"))
+     {
+     	TestCasePhpUnitGenerator phpGenerator = new TestCasePhpUnitGenerator(null, null, null, null, null); 
+         phpGenerator.setTestModel(aTestModel);
+         phpGenerator.setPath(path);
+         phpGenerator.writeFile();
+   }
+     if(aTestModel.getCodeLang().equals("RubyUnit"))
+     {
+     	TestCaseRubyUnitGenerator rubyGenerator = new TestCaseRubyUnitGenerator(null, null, null, null, null); 
+         rubyGenerator.setTestModel(aTestModel);
+         rubyGenerator.setPath(path);
+         rubyGenerator.writeFile();
+     }
+     
+     
+     
+     return aTestModel;
+   }
 
 
 

--- a/cruise.umple.test-parser/src/ump/mbt_parser_src.ump
+++ b/cruise.umple.test-parser/src/ump/mbt_parser_src.ump
@@ -94,14 +94,43 @@ public void analyzeAllTokens(Token rootToken){
    
 
   private void analyzeAssertEqual(Token t, int analysisStep, TestCase aTestCase, int aLocOrder) {
-	  //System.out.println("EqualAnalysis");
+	  ////system.out.println("EqualAnalysis");
 	  Token ts = t.getSubToken("assertEqualCode");
 	  String assertCode = analyzeAssertEqualCode(ts, analysisStep);
 	  //assertCode = ts.getValue("objectName1") +","+ts.getValue("objectName2");
 	  aTestCase.addAssertion(new Assertion("AssertEqual", null, null, "equal", assertCode,null, null, locOrder));
-	  System.out.println("\t\tEquLOC");
-		System.out.println(locOrder);
+	  //system.out.println("\t\tEquLOC");
+		//system.out.println(locOrder);
 	  locOrder++;
+}
+
+
+private void analyzeTestInitAttribute(Token token, int analysisStep, TestCase aTestCase, int locOrder2) {
+	// TODO analyze attribute initialization 
+	Action ta = new Action ("initAtt", "", locOrder);
+	String code = "";
+	  for (Token subToken : token.getSubTokens())
+	  {
+		  if (subToken.getName().equals("identifier"))
+		  { code += subToken.getValue("identifier"); }
+		  if (subToken.getName().equals("attributeName"))
+		  { code += " "+subToken.getValue("attributeName") + ""; }
+		  
+		  if (subToken.getName().equals("name"))
+		  { code += " "+subToken.getValue("name") + ""; }
+		  
+		  if (subToken.getName().equals("\""))
+		  { code += "\"" ; }
+		  
+		  if (subToken.getName().equals("="))
+		  { code += "=" ; }
+		  
+		  if (subToken.getName().equals(";"))
+		  { code += ";"; }
+	  }
+	  ta.setCode(code);
+	  aTestCase.addAction(ta);
+	
 }
   private String analyzeAssertEqualCode(Token t, int analysisStep)
   {
@@ -111,8 +140,8 @@ public void analyzeAllTokens(Token rootToken){
 	  boolean isFirstMethod = true;
 	  for (Token tss : t.getSubTokens())
 	  {
-		  //System.out.println("EqToken");
-		  //System.out.println(t.getName());		  
+		  ////system.out.println("EqToken");
+		  ////system.out.println(t.getName());		  
 			if (tss.getName().equals("objectName1")) {
 				if (aTestModel.getCodeLang().equals("PhpUnit")) {
 					assertCode += "$" + tss.getValue();
@@ -233,16 +262,16 @@ public void analyzeAllTokens(Token rootToken){
 private void analyzeAssertFalse(Token t, int analysisStep, TestCase aTestCase, int aLocOrder) {
 	String assertCode = analyzeAssertCode(t, analysisStep, null);
 	aTestCase.addAssertion(new Assertion("AssertFalse", null, null, "equal", assertCode,null, null, locOrder));
-	System.out.println("\t\tFalseLOC");
-	System.out.println(locOrder);
+	//system.out.println("\t\tFalseLOC");
+	//system.out.println(locOrder);
 	locOrder++;
 }
 
 private  void analyzeAssertTrue(Token t, int analysisStep, TestCase aTestCase, int aLocOrder) {
 	String assertCode = analyzeAssertCode(t, analysisStep, null);
 	aTestCase.addAssertion(new Assertion("AssertTrue", null, null, "equal", assertCode,null, null, locOrder));
-	System.out.println("\t\tTrueLOC");
-	System.out.println(locOrder);
+	//system.out.println("\t\tTrueLOC");
+	//system.out.println(locOrder);
 	locOrder++;
 }
 
@@ -250,22 +279,17 @@ private  void analyzeAssertTrue(Token t, int analysisStep, TestCase aTestCase, i
 private void analyzeGenerate ( Token t, int analysisStep)
 {
 	//setting the target platform
-	System.out.println(t.getValue("codeLang"));
+	//system.out.println(t.getValue("codeLang"));
 	aTestModel.setCodeLang(t.getValue("codeLang"));
 	
 }
 
-private String analyzeAssertCode (Token t, int analysisStep, Assertion as)
+private String analyzeAssertCode (Token st, int analysisStep, Assertion as)
 {
 	String assertCode="";
 	String methodCallCode="";
 	boolean isFirst = true;
-for ( Token st : t.getSubTokens())
-		
-	{
-	
-	if(st.getName().equals("assertCode"))
-	 {
+
 		for (Token sst: st.getSubTokens())
 		{
 			if (sst.getName().equals("methodCall"))
@@ -276,8 +300,8 @@ for ( Token st : t.getSubTokens())
 			
 			else if (sst.getName().equals("compValue"))
 			{
-				//System.out.println("compV");
-				//System.out.println(sst.getValue());
+				////system.out.println("compV");
+				////system.out.println(sst.getValue());
 				if (aTestModel.getCodeLang().equals("RubyUnit") )
 				 {
 					if (sst.getValue().contains("null"))
@@ -300,10 +324,10 @@ for ( Token st : t.getSubTokens())
 			assertCode += sst.getName();
 			}
 		}
-	 }
+	 
 	
 		
-	}
+	
 	
 return assertCode;
 }
@@ -314,15 +338,15 @@ private String analyzeMethodCall(Token t, int analysisStep, Assertion as) {
 	
 	for (Token st: t.getSubTokens())
 	{
-		//System.out.println(st.getName());
+		////system.out.println(st.getName());
 		
 		if (st.getName().equals("objectName"))
 		{
 
 			if (aTestModel.getCodeLang().equals("PhpUnit"))
 			{
-				//System.out.println("codeLangforPhp");
-				//System.out.println(aTestModel.getCodeLang());
+				////system.out.println("codeLangforPhp");
+				////system.out.println(aTestModel.getCodeLang());
 				// Injecting '$' sign for Php objectName tokens.
 				code += ("$" + st.getValue());
 			}
@@ -382,8 +406,8 @@ private String analyzeMethodCall(Token t, int analysisStep, Assertion as) {
 			for (Token sbt : sst.getSubTokens())
 			{
 			 parameterCode += sbt.getValue();
-			 //System.out.println("parCode");
-			 //System.out.println(parameterCode);
+			 ////system.out.println("parCode");
+			 ////system.out.println(parameterCode);
 			}
 			code+= parameterCode;
 			
@@ -409,39 +433,27 @@ private String analyzeMethodCall(Token t, int analysisStep, Assertion as) {
 		
 		
 	}
-	//System.out.println("MethodCode");
-	//System.out.println(code+";");
+	////system.out.println("MethodCode");
+	////system.out.println(code+";");
 	return code;
 }
 
 private  void analyzeAssertions(Token t, int analysisStep, TestCase aTestCase, int aLocOrder) {
 	
-for ( Token st : t.getSubTokens())
+Assertion as = new Assertion(t.getValue("assertType"),"", "", "", "", "", "", locOrder);
+	   String code="";
+	   String assertCode="";
+	  for ( Token st : t.getSubTokens())
 		
-	{
-	
-	if(st.getName().equals("assertionTrue"))
-	 {
-		 analyzeAssertTrue(st,analysisStep, aTestCase, locOrder);
-		 
-		 
-	 }
-	 
-	 if(st.getName().equals("assertionFalse"))
-	 {
-		 analyzeAssertFalse(st,analysisStep, aTestCase, locOrder);
-		 
-	 }
-	 
-	 if(st.getName().equals("assertionEqual"))
-	 {
-		 analyzeAssertEqual(st,analysisStep, aTestCase, locOrder);
-		 
-	 }
-		
+	{		  		  
+		  if (st.getName().equals("assertCode"))
+		  {
+			  assertCode = analyzeAssertCode(st, analysisStep, as);
+		  }		  		  	
 	}
-	
-	
+	  as.setAssertCode(assertCode);	  
+	  aTestCase.addAssertion(as);
+	  locOrder++;
 	
 	
 }
@@ -457,30 +469,55 @@ for ( Token st : t.getSubTokens())
 	
 	if(st.getName().equals("initialization"))
 	 {
-		System.out.println("\tInitlocOrder");
-		System.out.println(locOrder);
+		//system.out.println("\tInitlocOrder");
+		//system.out.println(locOrder);
 		analyzeInit(st,analysisStep, aTestCase, locOrder);
 		locOrder++;
 	 }
 	
 	 if(st.getName().equals("methodCall"))
   	 {
-		 System.out.println("\tMethlocOrder");
-		 System.out.println(locOrder);
+		 //system.out.println("\tMethlocOrder");
+		 //system.out.println(locOrder);
   		 analyzeMethodCall(st,analysisStep, aTestCase,locOrder);
   		 locOrder++;
   	 }
 	
-   	 if(st.getName().equals("assertions"))
+   	 if(st.getName().equals("assertion"))
    	 {
    		
    		analyzeAssertions(st,analysisStep, aTestCase, locOrder);
    	 }
+
+   	 if(st.getName().equals("testInitAttWithMethodCall"))
+  	 {
+  		
+  		analyzeTestInitAttributeMethodCall(st,analysisStep, aTestCase, locOrder);
+  	 }
+  	 
+  	 if(st.getName().equals("testInitAtt"))
+ 	 { 		
+ 		analyzeTestInitAttribute(st,analysisStep, aTestCase, locOrder);
+ 	 }
+  	 
+  	 if(st.getName().equals("inlineComment"))
+ 	 {
+   		Action ta = new Action ("inlinecomment", "//"+st.getValue("inlineComment"), locOrder);
+   		////system.out.println("comment");
+   		aTestCase.addAction(ta);
+   		locOrder++;
+ 	 }
+   	
+   	if(st.getName().equals("multilineComment"))
+	 {
+  		Action ta = new Action ("multilinecomment","/*" +st.getValue("multilineComment")+"*/", locOrder);
+  		////system.out.println("comment");
+  		aTestCase.addAction(ta);
+  		locOrder++;
+	 }
 		
 	}
-	System.out.println("TClocOrder");
-	System.out.println("testName "+aTestCase.getName());
-	System.out.println(locOrder);
+	
 	aTestCase.setLocOrder(locOrder);
 	aTestModel.getTestSuite(0).addTestcase(aTestCase);
 	
@@ -494,15 +531,15 @@ private void analyzeMethodCall(Token t, int analysisStep, TestCase aTestCase, in
 	
 	for (Token st: t.getSubTokens())
 	{
-		//System.out.println(st.getName());
+		////system.out.println(st.getName());
 		
 		if (st.getName().equals("objectName"))
 		{
 
 			if (aTestModel.getCodeLang().equals("PhpUnit"))
 			{
-				//System.out.println("codeLangforPhp");
-				//System.out.println(aTestModel.getCodeLang());
+				////system.out.println("codeLangforPhp");
+				////system.out.println(aTestModel.getCodeLang());
 				// Injecting '$' sign for Php objectName tokens.
 				code += ("$" + st.getValue());
 			}
@@ -555,8 +592,8 @@ private void analyzeMethodCall(Token t, int analysisStep, TestCase aTestCase, in
 			for (Token sbt : sst.getSubTokens())
 			{
 			 parameterCode += sbt.getValue();
-			 //System.out.println("parCode");
-			 //System.out.println(parameterCode);
+			 ////system.out.println("parCode");
+			 ////system.out.println(parameterCode);
 			}
 			code+= parameterCode;
 			
@@ -575,10 +612,10 @@ private void analyzeMethodCall(Token t, int analysisStep, TestCase aTestCase, in
 		
 		
 	}
-	//System.out.println("MethodCode");
-	//System.out.println(code+";");
-	//System.out.println("ActionCode");
-	//System.out.println(code);
+	////system.out.println("MethodCode");
+	////system.out.println(code+";");
+	////system.out.println("ActionCode");
+	////system.out.println(code);
 	aTestCase.addAction( new Action("",code,locOrder));
 	
 }
@@ -603,6 +640,131 @@ for ( Token sst : st.getSubTokens())
 		
 }
 
+
+private void analyzeTestInitAttributeMethodCall(Token token, int analysisStep, TestCase aTestCase, int locOrder) {
+	// TODO Auto-generated method stub
+	  Action ta = new Action("initAttMethodCall", "", locOrder);
+	  String code = "";
+	  
+	  for(Token subToken : token.getSubTokens())
+	  {
+		  if(subToken.getName().equals("identifier"))
+		  {
+			  code+=subToken.getValue("identifer");			  
+		  }
+		  
+		  if(subToken.getName().equals("attributeName"))
+		  {
+			  code+= " " +subToken.getValue("attributeName");			  
+		  }
+		  
+		  if(subToken.getName().equals("="))
+		  {
+			  code+= " " +"= ";			  
+		  }
+		  
+		  if(subToken.getName().equals("testMethodCall"))
+		  {
+			  code += analyzeInitMethodCall(subToken, aTestCase, locOrder);			  
+		  }
+		  ta.setCode(code);		  		  
+		  aTestCase.addAction(ta);		  
+		  
+	  }
+	  
+	
+}
+
+private String analyzeInitMethodCall(Token token, TestCase aTestCase, int locOrder) {
+	// TODO Auto-generated method stub
+	String code = "";
+	  	  	  
+	  for (Token subToken: token.getSubTokens())
+	  {
+		  if ( subToken.getName().equals("objectName"))
+		  {
+			  code += subToken.getValue("objectName");
+		  }
+		  
+		  if ( subToken.getName().equals("methodName"))
+		  {
+			  code += subToken.getValue("methodName");
+		  }
+		  
+		  
+		  
+		  
+		  if (subToken.getName().equals("testActionParameterList"))
+		  {
+			  ////system.out.println("before test Action: "+code);
+			  String paramCode = "";
+			  for(Token parToken : subToken.getSubTokens())
+			  {
+				  
+				  if(parToken.getName().equals("testParameter"))
+				  {
+				  paramCode = analyzeTestParameter(parToken,aTestCase,"");					  
+				  }
+				  
+				  
+			  }
+			  
+			  code += paramCode;
+			  paramCode="";
+			  
+		  }
+		  
+		  if ( subToken.getName().equals(","))
+		  {
+			  code += ", ";
+		  }
+		  if ( subToken.getName().equals("\""))
+		  {
+			  code += "\"";
+		  }
+		  
+		  if ( subToken.getName().equals("("))
+		  {
+			  code+="(";
+		  }
+		  
+		  if ( subToken.getName().equals(")"))
+		  {
+			  code+=")";
+		  }
+		  
+		  if ( subToken.getName().equals("."))
+		  {
+			  code+=".";
+		  }
+	  }
+	  
+	return code;
+	
+	
+	//return "";
+	
+	
+	
+}
+
+private String analyzeTestParameter(Token parToken, TestCase aTestCase, String string) {
+	// TODO Auto-generated method stub
+	String parCode = "";
+	for(Token spToken : parToken.getSubTokens())
+	  {
+		  if (spToken.getName().equals("testActionParameterList"))
+		  {
+			  //system.out.println("nested");
+		  }
+		  if (spToken.getName().equals("\"")) { parCode+="\""; }
+		  if (spToken.getName().equals(",")) { parCode+=","; }
+		  if (spToken.getName().equals("name")) { parCode += spToken.getValue("name"); }
+	  }
+	  
+	  return parCode;
+}
+
 private  void analyzeThen(Token t, int analysisStep) {
 	
 for ( Token st : t.getSubTokens())
@@ -620,7 +782,7 @@ for ( Token st : t.getSubTokens())
 }
 
 private  void analyzeParameter(Token t, int analysisStep) {
-	//System.out.println("analyzeParam"); analysis done within parent token
+	////system.out.println("analyzeParam"); analysis done within parent token
 }
 
 private  void analyzeWhen(Token t, int analysisStep) {

--- a/cruise.umple.test-parser/src/ump/mbt_parsing.grammar
+++ b/cruise.umple.test-parser/src/ump/mbt_parsing.grammar
@@ -5,42 +5,55 @@ entity- : [[modelDefinition]]
 
 // Classes are the most common elements in Umple.
 // See user manual page [*ClassDefinition*]
-modelDefinition- : test [modelName] { [[modelContent]] }
+modelDefinition- : [=isAbstract:abstract]? test [modelName] { [[modelContent]] }
 
 // The following items can be found inside the body of classes or association classes
-modelContent- : [[generate]]? [[depend]]* [[givenCont]] [[whenCont]] [[thenCont]] 
+modelContent- : [[generate]]? [[depend]]* [[givenCont]]? [[whenCont]]? [[thenCont]]? 
 
 generate: generate [=codeLang:JUnit|PhpUnit|RubyUnit] ( [=subOptionIndicator:-s|-suboption] " [**subOption] " )* ;
 
 depend: depend [pValue] (, [pValue])* ;
 
  
-givenCont: GIVEN: [[givenUmpleModel]]* 
-whenCont: WHEN: [[initialization]]*
-thenCont: THEN: [[testCase]]*
+givenCont: (GIVEN:)? [[givenUmpleModel]]*
+givenUmpleModel : [~modelName].ump;
+
+ 
+whenCont: (WHEN:)? [[initialization]]*
+thenCont: (THEN:)? [[testCase]]*
 
 
 
-testCase: test [~testCaseName] {( [[initialization]] | [[methodCall]] | [[assertions]] | [[comment]])* }
-givenUmpleModel: [~modelName].ump;
-initialization: [~identifier] [~name] [[parameter]]*;
-construct: OPEN_ROUND_BRACKET ([**value] | "[**value]") (,([**value] | "[**value]"))* CLOSE_ROUND_BRACKET
-parameter: OPEN_ROUND_BRACKET ([pValue] | "[pValue]") (,([pValue] | "[pValue]"))* CLOSE_ROUND_BRACKET
-pValue: [**name]
+//testCase : test [~testCaseName] {( [[initialization]] | [[methodCall]] | [[assertions]] | [[testInitAtt]] | [[comment]] )* }
+testCase : test [~testCaseName] {( [[initialization]] | [[assertion]] | [[testInitAtt]] | [[comment]] )* }
+initialization : [~identifier] [~name] OPEN_ROUND_BRACKET  [[parameter]]* CLOSE_ROUND_BRACKET  ;
+//testinitAtt 
+testInitAtt : [~identifier] [~attributeName] =  [[pValue]] ;
+//testInitAttWithMethodCall : [~identifier]? [~attributeName] =  [[testMethodCall]] ;
+//testMethodCall : [~objectName] ( (.)[~methodName] )? OPEN_ROUND_BRACKET  [[testActionParameterList]] CLOSE_ROUND_BRACKET
+parameter : ([pValue] | "[pValue]") (,([pValue] | "[pValue]"))*
+pValue- : ( [~name] | "[~name]" ) 
 
-
-assertions: ([[assertionTrue]]|[[assertionFalse]]|[[assertionEqual]])*
-
+//testActionParameterList :  [[testParameter]]?
+//testParameter :  [[pValue]] ( , [[pValue]] )*
 //Assertions Rules:
 
-assertionTrue: assertTrue OPEN_ROUND_BRACKET [[assertCode]] CLOSE_ROUND_BRACKET ;
-assertionFalse: assertFalse OPEN_ROUND_BRACKET [[assertCode]] CLOSE_ROUND_BRACKET ;
-assertionEqual: assertEqual OPEN_ROUND_BRACKET [[assertEqualCode]] CLOSE_ROUND_BRACKET ;
-assertEqualCode:[~objectName1](.)?[[assertEqualMethodCall]]? (,) [~objectName2](.)?[[assertEqualMethodCall]]?
-assertEqualMethodCall: [~methodName]  OPEN_ROUND_BRACKET CLOSE_ROUND_BRACKET 
+assertion : [=assertType:assertTrue|assertFalse|assertEqual|assertNull|assertMethod] OPEN_ROUND_BRACKET [[assertCode]] CLOSE_ROUND_BRACKET ;
+//assertCode : [[methodCall]]?
+chainedAction : [[methodCall]]
+assertEqualCode :  [~value1] , [~value2]
+
+
+//assertionTrue : assertTrue OPEN_ROUND_BRACKET [[assertCode]] CLOSE_ROUND_BRACKET ;
+//assertionFalse : assertFalse OPEN_ROUND_BRACKET [[assertCode]] CLOSE_ROUND_BRACKET ;
+//assertionEqual : assertEqual OPEN_ROUND_BRACKET [[assertEqualCode]] CLOSE_ROUND_BRACKET ;
+//assertEqualCode :[~objectName1](.)?[[assertEqualMethodCall]]? (,) [~objectName2](.)?[[assertEqualMethodCall]]?
+//assertEqualMethodCall : [~methodName]  OPEN_ROUND_BRACKET CLOSE_ROUND_BRACKET 
 assertCode : [[methodCall]] (== | != )? ( [**compValue] | ( "[**compValue]" )? | [[methodCall]] )?
-methodCall: [~objectName](.)[~methodName]  OPEN_ROUND_BRACKET [[assertParameter]]* CLOSE_ROUND_BRACKET(;)?
-assertParameter:  ([pValue] | "[pValue]") (,([pValue] | "[pValue]"))*
+methodCall : ([~objectName](.))?[~methodName]  OPEN_ROUND_BRACKET [[assertParameter]]* CLOSE_ROUND_BRACKET (;)?
+assertParameter :  ([pValue] | "[pValue]") (,([pValue] | "[pValue]"))*
+
+
 
 // Comments follow the same conventions as C-family languages. [*UmpleComments*]
 comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/UnitTemplateTest.java
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/UnitTemplateTest.java
@@ -103,7 +103,7 @@ public class UnitTemplateTest
    
 
     File expected = new File(pathToInput, codeFile);
-    System.out.println(actual);
+    //system.out.println(actual);
 
 
     if (isFullMatch)
@@ -132,13 +132,29 @@ public class UnitTemplateTest
     parser.setGrammarFile("src/ump/mbt_parsing.grammar");
     parser.setTestModelFile(file);
     parser.setTestModelFile(file);
-    //System.out.println(file.getAbsolutePath());
-    //System.out.println(path);
+    ////system.out.println(file.getAbsolutePath());
+    ////system.out.println(path);
     parser.prepare();
     aTestModel = parser.getATestModel();
-    //System.out.println(file.getPath());
+    ////system.out.println(aTestModel.toString());
+    String codeLang = "";
+    codeLang = aTestModel.getCodeLang();
+    /*try {
+    	
+    }
     
-    switch(aTestModel.getCodeLang())
+    catch (Exception e) {
+    	//system.out.println("Error parsing model: " + e.getMessage());    	
+    }*/
+    
+    if(codeLang == null)
+    {
+    	//system.out.println("Error parsing model: ");
+    }
+    
+    
+    
+    switch(codeLang)
     {
     case "JUnit" :
     TestCaseJUnitGenerator junitGenerator = new TestCaseJUnitGenerator(null, null, null, null, null);

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/JUnitTemplateTest.java
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/JUnitTemplateTest.java
@@ -52,9 +52,9 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 		//createUmpleSystem(languagePath, "/testGenerator_jUnit_testGenerate.ump");
 		
 		language = "JUnit";
-	    System.out.println(pathToInput);    	    
+	    //system.out.println(pathToInput);    	    
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_testGenerate.umpt");
-	    System.out.println(pathToInput);
+	    //system.out.println(pathToInput);
 	    assertGeneratedCodeEquals(pathToInput, "/junit/GenerateTest.java");
 	    Assert.assertEquals(true, (new File(pathToInput + "/junit/GenerateTest.java")).exists());
 	    
@@ -65,7 +65,7 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void depends()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_depend.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    assertGeneratedCodeEquals(pathToInput, "/junit/DependTest.java");
@@ -76,7 +76,7 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void subOption()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_subOption.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    assertGeneratedCodeEquals(pathToInput, "/junit/SubOptionTest.java");
@@ -87,7 +87,7 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void testCase()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_testcase.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    assertGeneratedCodeEquals(pathToInput, "/junit/TestcaseTest.java");
@@ -98,7 +98,7 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void testCase_assertion()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_testcase_assertion.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    assertGeneratedCodeEquals(pathToInput, "/junit/AssertionTest.java");
@@ -109,7 +109,7 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void testCase_assertionTrue()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_depend.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    Assert.assertEquals(true, (new File(pathToInput + "/junit/DependTest.java")).exists());
@@ -119,7 +119,7 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void testCase_assertionFalse()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_depend.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    Assert.assertEquals(true, (new File(pathToInput + "/junit/DependTest.java")).exists());
@@ -129,9 +129,19 @@ public class JUnitTemplateTest extends UnitTemplateTest{
 	  public void testCase_assertioneEqual()
 	  {
 	    language = "JUnit";
-	    //System.out.println(languagePath);
+	    ////system.out.println(languagePath);
 	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_depend.umpt");
 	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
 	    Assert.assertEquals(true, (new File(pathToInput + "/junit/DependTest.java")).exists());
+	  }
+	  
+	  @Test 
+	  public void testCase_NoGiven()
+	  {
+	    language = "JUnit";
+	    ////system.out.println(languagePath);
+	    createUmpleTestSystem(languagePath, "/testGenerator_jUnit_testGenerate.umpt");
+	    //assertUmpleTemplateFor("junit/testGenerate_model.umpt","junit/Testgenerate_model.java");
+	    Assert.assertEquals(true, (new File(pathToInput + "/junit/GenerateTest.java")).exists());
 	  }
 }

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/TestcaseTest.java.txt
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/TestcaseTest.java.txt
@@ -37,7 +37,11 @@ public class TestcaseTest {
             Person p1 = new Person ("John","123","someAddrss");     
             Assert.assertTrue (p1.getId()!=null);
     
-  }  
+ 
+            String id= id;
+             
+            //comment
+              }  
   
  
  

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/testGenerator_jUnit_NoGiven.umpt
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/testGenerator_jUnit_NoGiven.umpt
@@ -1,18 +1,18 @@
-test Testcase {
+test Generate {
 
-	generate PhpUnit;
+	generate JUnit;
 	
 	depend Person;
 	
-	GIVEN:
-	 testGenerator_junit_depend.ump;
 	WHEN:
 	 Person p1 ("John", 123) ;
 	THEN:
 	
 	test someTest {	
+	 /* comment */
+
 	 Person p1 ("John", "123","someAddrss" );
 	 assertTrue(p1.getId() != null);	 
-	 // comment test 
+	 
 	 }
 }

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/testGenerator_jUnit_testcase.umpt
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/testGenerator_jUnit_testcase.umpt
@@ -1,4 +1,4 @@
-test Testcase {
+ test Testcase {
 
 	generate JUnit;
 	
@@ -10,8 +10,11 @@ test Testcase {
 	 Person p1 ("John", 123) ;
 	THEN:
 	
-	test someTest {	
+	test someTest {		 	 
 	 Person p1 ("John", "123","someAddrss" );
-	 assertTrue(p1.getId() != null);	 
+	 assertTrue (p1.getId()!=null);	 
+	 String id = id;
+	 //comment 	 	 
 	 }
+	 	 
 }

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/testGenerator_jUnit_testcase_init.umpt
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/jUnit/testGenerator_jUnit_testcase_init.umpt
@@ -11,7 +11,6 @@ test Depend {
 	THEN:
 	
 	test someTest {	
-	 Person p1 ("John", "123","someAddrss" );
-	 assertTrue(p1.getId() != null);	 
+	 Person p1 ("John", "123","someAddrss" ); 
 	 }
 }

--- a/cruise.umple.test-parser/test/cruise/umple/testgenerator/phpUnit/TestcaseTest.php.txt
+++ b/cruise.umple.test-parser/test/cruise/umple/testgenerator/phpUnit/TestcaseTest.php.txt
@@ -36,11 +36,6 @@ class TestcaseTest extends UnitTestCase{
             $p1 = new Person ("John","123","someAddrss");     
             $this->assertTrue($p1->getId()!=null);
     
-
+      
+            //comment test
   }
-  
-  
- 
- 
-
-}

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -264,6 +264,8 @@ class UmpleTestCase {
 	int locOrder;
 	boolean isTimed = false;
 	boolean isOverride = false;
+	boolean isConcrete = false;
+	String concreteLang = "";
 	0..1 -- * UmpleAssertion;	
 	0..1 -- * TestAction;
 	0..1 -- * TestInit;	

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -390,6 +390,11 @@ class UmpleInternalParser
       postTokenAbstractTestAnalysis();
     }
     
+    if (getParseResult().getWasSuccess())
+    {
+      postTokenTestSequeceAnalysis();
+    }
+    
     
   }
   

--- a/cruise.umple/src/UmpleInternalParser_CodeTest.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTest.ump
@@ -209,6 +209,16 @@ private void analyzeTestCase(Token token, UmpleElement uElement, UmpleTestCase u
     for (Token subToken : token.getSubTokens())
 	    {
 	     
+	      if(subToken.getName().equals("isConcrete"))
+	      {	    	
+	         if( subToken.getValue("isConcrete")!= null)
+	         {
+	        	 uTestCase.setIsConcrete(true);
+	        	 uTestCase.setConcreteLang(subToken.getValue("isConcrete"));
+	         }
+	         
+	      }
+	      
 	      if(subToken.getName().equals("testAction"))
 	      {	    	
 	        analyzeTestAction(subToken,uElement,uTestCase);	      	    	

--- a/cruise.umple/src/UmpleInternalParser_CodeTest.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeTest.ump
@@ -20,6 +20,45 @@ private void analyzeTraitTestCaseToken(Token token, UmpleTrait aTrait){
 	  copyTestCasefromExtendedTrait(token, aTrait);
 	  
   }
+  
+  /////////////////
+  //post check for test sequence and test cases
+  // 
+  private void postTokenTestSequeceAnalysis() {
+	// TODO check for test cases not found in test sequence and raise a warning 
+	  
+	  for(UmpleClass uClass : model.getUmpleClasses())
+	  {
+		  if (uClass.hasTestSequences())
+		  {
+			  for (TestSequence ts : uClass.getTestSequences())
+			  {
+			  if(uClass.hasUmpleTestCases())
+			  {
+				  
+				  for (UmpleTestCase tc : uClass.getUmpleTestCases())
+				  {
+					  for (String tsTestCase : ts.getTests())
+					  {
+					if(!tsTestCase.equals(tc.getName()))
+					{
+						getParseResult().addErrorMessage(new ErrorMessage(6007,uClass.getPosition(0),uClass.getName(),ts.getName(),tc.getName()));
+					}
+						  
+				  }
+				  }
+			  }
+			  else {
+				  // test sequence found but class has no test cases
+				  getParseResult().addErrorMessage(new ErrorMessage(6006,uClass.getPosition(0),uClass.getName(),ts.getName()));
+				  
+			  }
+			  
+			  }
+		  }
+	  }
+	
+}
 
 /////////////////////////
 // This method copies testcases found in trait into the class 

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -270,4 +270,6 @@
 6003: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing assertion . {0} ;
 6004: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test inside method . {0} ;
 6005: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test case in interface . {0} ;
+6006: 4, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Class {0} has test sequence {1} but no tests were detected. ;
+6006: 4, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Class {0}:  test case {2} is not included in test sequence {1}. ;
 

--- a/cruise.umple/src/umple_classes.grammar
+++ b/cruise.umple/src/umple_classes.grammar
@@ -62,7 +62,7 @@ methodThrowsExceptions : throws [~exception] ( , [~exception] )*
 parameterList : OPEN_ROUND_BRACKET ([[parameter]] ( , [[parameter]] )* )? CLOSE_ROUND_BRACKET
 parameter : [[typedName]]
 
-testCase : [=isTimed:before|after]? [=isOverride:override]? test [~testCaseName] { ( [[assertion]] | [[testAction]] | [[testInit]] | [[testInitAtt]] | [[testInitAttWithMethodCall]] | [[comment]] )* }
+testCase : [=isTimed:before|after]? [=isConcrete:JUnit|PhpUnit|RubyUnit]? [=isOverride:override]? test [~testCaseName] { ( [[assertion]] | [[testAction]] | [[testInit]] | [[testInitAtt]] | [[testInitAttWithMethodCall]] | [[comment]] )* }
 assertion : [=isTimed:before|after]? [=assertType:assertTrue|assertFalse|assertEqual|assertNull|assertMethod] OPEN_ROUND_BRACKET [**code] CLOSE_ROUND_BRACKET ;
 testAction : [~objectName] ( (.)[~methodName] )? OPEN_ROUND_BRACKET  [[testActionParameterList]] CLOSE_ROUND_BRACKET ;
 testMethodCall : [~objectName] ( (.)[~methodName] )? OPEN_ROUND_BRACKET  [[testActionParameterList]] CLOSE_ROUND_BRACKET

--- a/cruise.umple/src/umple_classes.grammar
+++ b/cruise.umple/src/umple_classes.grammar
@@ -77,6 +77,9 @@ interfaceTest : test [~testName] ;
 testSequence : testSequence [~sequenceName] { [[testSequenceEntry]] }
 testSequenceEntry : [~name] ( -> [~name] )* ;
 
+
+
+
 // Details of associations: See manual page [*AssociationDefinition*]
 
 association : [=modifier:immutable]?  [[associationEnd]] [=arrow:--|->|<-|><|<@>-|-<@>] [[associationEnd]] ;

--- a/cruise.umple/test/cruise/umple/implementation/test/TestCaseAction.ump
+++ b/cruise.umple/test/cruise/umple/implementation/test/TestCaseAction.ump
@@ -26,7 +26,7 @@ class Person {
         }
         
         
-        test checkName {
+        JUnit test checkName {
         //test code 
         
         }

--- a/cruise.umple/test/cruise/umple/implementation/test/TestSequence_noTestCases.ump
+++ b/cruise.umple/test/cruise/umple/implementation/test/TestSequence_noTestCases.ump
@@ -1,0 +1,10 @@
+
+class Person {  
+  
+   testSequence ts { checkName -> checkStatus ; }
+      
+       
+  
+}  
+ 
+  

--- a/cruise.umple/test/cruise/umple/implementation/test/TestTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/test/TestTemplateTest.java
@@ -298,6 +298,18 @@ public class TestTemplateTest extends ClassTemplateTest{
 	    
 	  }
 	  
+	  @Test
+	  public void testSequence_noTestCasesTest()
+	  {
+	    language = "Test";
+	    assertUmpleTemplateFor("test/TestSequence_noTestCases.ump","test/testTestSequence_noTestCases.test.txt");
+	    //Assert.assertEquals(true, (new File(pathToInput  + "/test/test/NNToManyAssociation_ModelTest.umpt")).exists());
+	    createUmpleSystem(pathToInput, "test/TestSequence_noTestCases.ump");
+	    Assert.assertEquals(true, (new File(pathToInput  + "/test/test/TestSequence_noTestCases_ModelTest.umpt")).exists());
+	   
+	    
+	  }
+	  
 	  
 	 
 	  

--- a/cruise.umple/test/cruise/umple/implementation/test/testTestSequence_noTestCases.test.txt
+++ b/cruise.umple/test/cruise/umple/implementation/test/testTestSequence_noTestCases.test.txt
@@ -1,5 +1,5 @@
 /*PLEASE DO NOT EDIT THIS CODE*/
-/*This test code was generated using the UMPLE ${last.version} modeling language!*/
+/*This code was generated using the UMPLE ${last.version} modeling language!*/
 
 
 

--- a/cruise.umple/test/cruise/umple/implementation/test/testTestSequence_noTestCases.test.txt
+++ b/cruise.umple/test/cruise/umple/implementation/test/testTestSequence_noTestCases.test.txt
@@ -1,0 +1,14 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This test code was generated using the UMPLE ${last.version} modeling language!*/
+
+
+
+////---- Tests for  TestSequence_noTestCases ----/////
+Test Person {
+ 
+
+  
+ 
+   
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/test/testTestcaseAction.test.txt
+++ b/cruise.umple/test/cruise/umple/implementation/test/testTestcaseAction.test.txt
@@ -64,7 +64,7 @@ Test Person {
         
     
       
-      test checkName {
+      JUnit test checkName {
         //test code
         }
       


### PR DESCRIPTION
## Pull request description
Several updates to grammar rules for the test parser and also including the files for the mutation test suite. In addition to several features added/modified in the syntax.


## Pull request content
- Adding the Umple model mutation test
- Updating xUnit Parser rules to match changes on Umple model test syntax.
- added warnings for test cases not included in test sequences and also if the test sequence has test cases that don't exist. 
- included the command-line tool for xUnit test generation (the jar is still not compiled with the distribution but will be in future commit), This includes a console main class to prompt the user for xUnit test generation inputs.
- Added the feature to allow targeting test cases to be declared toward specific xUnit system. The syntax will allow these tests to be generated only if the xUnit system used matches the one in the test. If the model has tests tagged PhpUnit, when compiled using JUnitGenerator the PhpUnit tests will be ignored unless compiled with PhpUnit generator. This helps if a particular test is to be written differently for different unit systems.

