### PR TITLE
Remove package names from Inner classes

### DIFF
--- a/cruise.umple/src/Generator_CodeJava.ump
+++ b/cruise.umple/src/Generator_CodeJava.ump
@@ -590,6 +590,9 @@ class JavaGenerator
     }
     else if ("packageDefinition".equals(keyName))
     {
+      if(aClass.hasOuterClass())
+      return "";
+      else
       return aClass.getPackageName().length() == 0 ? "" : "package " + aClass.getPackageName() + ";"; 
     }
     else if ("type".equals(keyName))

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
@@ -45,14 +45,14 @@ public class InnerClassTest extends TemplateTest {
   public void TestNoPackageNameForInnerElement()
   {
     UmpleFile uFile = new UmpleFile(pathToInput+"/OuterClassWithNameSpace.ump");
-		UmpleModel umpleModel = new UmpleModel(uFile);
-		umpleModel.run();
-		umpleModel.generate();
-		Map<String, String> map= umpleModel.getGeneratedCode();
-		String generatedCodeforClass = map.get("OuterClassWithNameSpace");
-		//if there is only one import-statement, its split should generate 2 strings:
-		Assert.assertEquals(generatedCodeforClass.split("package com.umple.innerClasses").length , 2);
-   // assertUmpleTemplateFor("/innerClasses.ump",  "/innerClasses.java.txt", "OuterClass_3");
+    UmpleModel umpleModel = new UmpleModel(uFile);
+    umpleModel.run();
+    umpleModel.generate();
+    Map<String, String> map= umpleModel.getGeneratedCode();
+    String generatedCodeforClass = map.get("OuterClassWithNameSpace");
+    //if there is only one import-statement, its split should generate 2 strings:
+    Assert.assertEquals(generatedCodeforClass.split("package com.umple.innerClasses").length , 2);
+    // assertUmpleTemplateFor("/innerClasses.ump",  "/innerClasses.java.txt", "OuterClass_3");
   }
 
   @After

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
@@ -4,6 +4,11 @@ import org.junit.*;
 import cruise.umple.implementation.TemplateTest;
 import cruise.umple.util.SampleFileWriter;
 
+import java.util.Map;
+import cruise.umple.compiler.UmpleClass;
+import cruise.umple.compiler.UmpleFile;
+import cruise.umple.compiler.UmpleModel;
+
 public class InnerClassTest extends TemplateTest {
 
   @Before
@@ -36,12 +41,27 @@ public class InnerClassTest extends TemplateTest {
     assertUmpleTemplateFor("/innerClasses.ump",  "/innerClasses.java.txt", "OuterClass_3");
   }
 
+  @Test
+  public void TestNoPackageNameForInnerElement()
+  {
+    UmpleFile uFile = new UmpleFile(pathToInput+"/OuterClassWithNameSpace.ump");
+		UmpleModel umpleModel = new UmpleModel(uFile);
+		umpleModel.run();
+		umpleModel.generate();
+		Map<String, String> map= umpleModel.getGeneratedCode();
+		String generatedCodeforClass = map.get("OuterClassWithNameSpace");
+		//if there is only one import-statement, its split should generate 2 strings:
+		Assert.assertEquals(generatedCodeforClass.split("package com.umple.innerClasses").length , 2);
+   // assertUmpleTemplateFor("/innerClasses.ump",  "/innerClasses.java.txt", "OuterClass_3");
+  }
+
   @After
   public void tearDown()
   {
     SampleFileWriter.destroy(pathToInput + "/OuterClass_1.java");
     SampleFileWriter.destroy(pathToInput + "/OuterClass_2.java");
     SampleFileWriter.destroy(pathToInput + "/OuterClass_3.java");
+    SampleFileWriter.destroy(pathToInput + "/com");
   }
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/OuterClassWithNameSpace.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/OuterClassWithNameSpace.ump
@@ -1,0 +1,11 @@
+namespace com.umple.innerClasses;
+
+class OuterClassWithNameSpace
+{
+
+  static class InnerStatic
+  {
+  
+  }
+
+}


### PR DESCRIPTION
Currently, the generated code for inner/static classes enclosed in outer classes having namespaces produced a syntax error caused by including the package name before each inner classes. This PR strips out package names from inner classes.