### PR TITLE
Aspect around

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -306,10 +306,13 @@ for (StateMachine smq : uClass.getStateMachines())
         else
           methodCodeWithLabels.add("\n"+codeToAdd + "\n");
       }
-    	else if (codeInjectionItem.getType().equals("around"))
+
+    	 if (codeInjectionItem.getType().equals("around"))
       {
-        String[] BoundLabels = codeInjectionItem.getInjectionlabel().split("-");
-        String firstLabel = BoundLabels[0];
+				
+//			if(methodLabelToLookat.contains("-"))
+        String[] BoundLabels = methodLabelToLookat.split("-");
+        String firstLabel = BoundLabels[0]+":";
         String SecondLabel = BoundLabels[1]; 
         String[] codeToInjectArray = codeToAdd.split("around_proceed:");
         String afterCodeSegment = codeToInjectArray[0];
@@ -318,7 +321,7 @@ for (StateMachine smq : uClass.getStateMachines())
         int afterIndex = methodCodeWithLabels.indexOf(firstLabel);
         int beforeIndex = methodCodeWithLabels.indexOf(SecondLabel);
         methodCodeWithLabels.add(afterIndex+1, "\n"+afterCodeSegment + "\n");
-        methodCodeWithLabels.add(beforeIndex, "\n"+beforeCodeSegment + "\n");
+        methodCodeWithLabels.add(beforeIndex+1, "\n"+beforeCodeSegment + "\n");
 
       }
       // at the end, remove the codeInjection belongs to labeled aspect

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -306,6 +306,13 @@ for (StateMachine smq : uClass.getStateMachines())
         else
           methodCodeWithLabels.add("\n"+codeToAdd + "\n");
       }
+    	else if (codeInjectionItem.getType().equals("around"))
+      {
+        if(indexOfLabel < methodCodeWithLabels.size())
+          methodCodeWithLabels.add(indexOfLabel+1, "\n"+codeToAdd + "\n");
+        else
+          methodCodeWithLabels.add("\n"+codeToAdd + "\n");
+      }
       // at the end, remove the codeInjection belongs to labeled aspect
       // otherwise it will be added to the code when handling aspects 
       //uClassCodeInectionList.remove(codeInjectionItem); // causes error:ConcurrentModificationException

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -309,8 +309,6 @@ for (StateMachine smq : uClass.getStateMachines())
 
     	 if (codeInjectionItem.getType().equals("around"))
       {
-				
-//			if(methodLabelToLookat.contains("-"))
         String[] BoundLabels = methodLabelToLookat.split("-");
         String firstLabel = BoundLabels[0]+":";
         String SecondLabel = BoundLabels[1]; 

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -308,10 +308,18 @@ for (StateMachine smq : uClass.getStateMachines())
       }
     	else if (codeInjectionItem.getType().equals("around"))
       {
-        if(indexOfLabel < methodCodeWithLabels.size())
-          methodCodeWithLabels.add(indexOfLabel+1, "\n"+codeToAdd + "\n");
-        else
-          methodCodeWithLabels.add("\n"+codeToAdd + "\n");
+        String[] BoundLabels = codeInjectionItem.getInjectionlabel().split("-");
+        String firstLabel = BoundLabels[0];
+        String SecondLabel = BoundLabels[1]; 
+        String[] codeToInjectArray = codeToAdd.split("around_proceed:");
+        String afterCodeSegment = codeToInjectArray[0];
+        String beforeCodeSegment = codeToInjectArray[1];
+
+        int afterIndex = methodCodeWithLabels.indexOf(firstLabel);
+        int beforeIndex = methodCodeWithLabels.indexOf(SecondLabel);
+        methodCodeWithLabels.add(afterIndex+1, "\n"+afterCodeSegment + "\n");
+        methodCodeWithLabels.add(beforeIndex, "\n"+beforeCodeSegment + "\n");
+
       }
       // at the end, remove the codeInjection belongs to labeled aspect
       // otherwise it will be added to the code when handling aspects 

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -84,6 +84,7 @@ class UmpleToJava {
     
     applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
     applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
+    applyCodeInjectionToLabeledMethod(uClass, aMethod, "around");
    
    // handle mixsets inside methods(uClass, aMethod);
     ArrayList<MixsetInMethod> mixsetsWithinMethodList = aMethod.getMethodBody().getMixsetsWithinMethod();

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3808,7 +3808,9 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     String type = injectToken.is("beforeCode") ? "before" : "after";
     // arround 
     //
-    //
+    if(injectToken.getSubToken("around") != null) {
+      type="around";
+    }
     Token codeLabelToken = injectToken.getSubToken("codeLabel");
     CodeBlock cb = new CodeBlock();
     String operationName = getOperationName(injectToken);

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3806,8 +3806,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   private void analyzeInjectionCode(Token injectToken, UmpleClassifier uClassifier)
   {
     String type = injectToken.is("beforeCode") ? "before" : "after";
-    // arround 
-    //
+    // around as aspect type
     if(injectToken.getSubToken("around") != null) {
       type="around";
     }

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3806,6 +3806,9 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   private void analyzeInjectionCode(Token injectToken, UmpleClassifier uClassifier)
   {
     String type = injectToken.is("beforeCode") ? "before" : "after";
+    // arround 
+    //
+    //
     Token codeLabelToken = injectToken.getSubToken("codeLabel");
     CodeBlock cb = new CodeBlock();
     String operationName = getOperationName(injectToken);

--- a/cruise.umple/src/umple_patterns.grammar
+++ b/cruise.umple/src/umple_patterns.grammar
@@ -32,5 +32,5 @@ parameterListing : OPEN_ROUND_BRACKET ([[parameterTypes]])? CLOSE_ROUND_BRACKET
 
 injectionOperation : [operationName] ([[parameterListing]])?
 
-beforeCode : before ([=operationSource:custom|generated|all])? ([!codeLabel:\S+:])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
+beforeCode : ( before | [=around] ) ([=operationSource:custom|generated|all])? ([!codeLabel:\S+:])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*
 afterCode : after ([=operationSource:custom|generated|all])? ([!codeLabel:\S+:])? [[injectionOperation]] ( , [[injectionOperation]] )* ([[codeLang]] [[codeLangs]])? { [**code] } ( [[moreCode]] )*

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -697,7 +697,7 @@ public class UmpleMixsetTest {
     Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
   }
-@Test
+  @Test
   public void mixsetInsideMethods_useM1andInnerMixsetandM2Statement() {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_M1_InnerMixset_M2.ump");
     UmpleModel umodel = new UmpleModel(umpleFile);
@@ -719,6 +719,32 @@ public class UmpleMixsetTest {
     //after checks:
     Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+
+  @Test
+  public void testAround_twoLabels() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"aroundInjectionTwoLabels.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord = "int x=0;";
+    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+    //before checks: 
+    Assert.assertEquals(true, beforeLabelCode.contains("if (true) {"));
+    Assert.assertEquals(true, beforeLabelCode.contains("int x=0;"));
+
+    //after checks:
+    Assert.assertEquals(true, afterLabelCode.contains("}"));
+    Assert.assertEquals(true, afterLabelCode.contains("code after around."));
+    Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
+
+
   }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -734,7 +734,10 @@ public class UmpleMixsetTest {
     }
     catch (UmpleCompilerException e)
     {
-    // this is aspect injection warning.
+      if(!e.getMessage().contains("1013")) // ignore warning caused by aspect injection.
+    	{
+    	  throw e;
+    	}
     }
     finally 
     {  

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -14,6 +14,8 @@ import cruise.umple.compiler.FeatureLink;
 import cruise.umple.compiler.FeatureNode;
 import cruise.umple.compiler.FeatureLeaf;
 import cruise.umple.compiler.Method;
+import cruise.umple.compiler.exceptions.*;
+
 
 public class UmpleMixsetTest {
   
@@ -729,15 +731,15 @@ public class UmpleMixsetTest {
     try{
       umodel.run();
       umodel.generate();
-      UmpleClass uClass = umodel.getUmpleClass(0);
-      aMethod = uClass.getMethod(0);
     }
     catch (UmpleCompilerException e)
     {
-    // this is warning 
+    // this is aspect injection warning.
     }
     finally 
-    {
+    {  
+      UmpleClass uClass = umodel.getUmpleClass(0);
+      aMethod = uClass.getMethod(0);
       String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
       String keyWord = "int x=0;";
       String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -725,26 +725,34 @@ public class UmpleMixsetTest {
   public void testAround_twoLabels() {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"aroundInjectionTwoLabels.ump");
     UmpleModel umodel = new UmpleModel(umpleFile);
-    umodel.run();
-    umodel.generate();
-    UmpleClass uClass = umodel.getUmpleClass(0);
-    Method aMethod = uClass.getMethod(0);
-    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
-    String keyWord = "int x=0;";
-    String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
-    String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
-    Assert.assertEquals(true, methodBodyCode.contains(keyWord));
-    //before checks: 
-    Assert.assertEquals(true, beforeLabelCode.contains("if (true) {"));
-    Assert.assertEquals(true, beforeLabelCode.contains("int x=0;"));
-
-    //after checks:
-    Assert.assertEquals(true, afterLabelCode.contains("}"));
-    Assert.assertEquals(true, afterLabelCode.contains("code after around."));
-    Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
-    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
-
-
-  }
+    Method aMethod = null;
+    try{
+      umodel.run();
+      umodel.generate();
+      UmpleClass uClass = umodel.getUmpleClass(0);
+      aMethod = uClass.getMethod(0);
+    }
+    catch (UmpleCompilerException e)
+    {
+    // this is warning 
+    }
+    finally 
+    {
+      String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+      String keyWord = "int x=0;";
+      String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+      String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+      Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+      //before checks: 
+      Assert.assertEquals(true, beforeLabelCode.contains("if (true) {"));
+      Assert.assertEquals(true, beforeLabelCode.contains("int x=0;"));
+      //after checks:
+      Assert.assertEquals(true, afterLabelCode.contains("}"));
+      Assert.assertEquals(true, afterLabelCode.contains("code after around."));
+      Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
+      SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
+   }
+  
+}
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -741,7 +741,7 @@ public class UmpleMixsetTest {
       UmpleClass uClass = umodel.getUmpleClass(0);
       aMethod = uClass.getMethod(0);
       String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
-      String keyWord = "int x=0;";
+      String keyWord = "int x";
       String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
       String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
       Assert.assertEquals(true, methodBodyCode.contains(keyWord));

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -727,7 +727,7 @@ public class UmpleMixsetTest {
   public void testAround_twoLabels() {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"aroundInjectionTwoLabels.ump");
     UmpleModel umodel = new UmpleModel(umpleFile);
-    Method aMethod = null;
+    Method aMethod ;
     try{
       umodel.run();
       umodel.generate();
@@ -747,7 +747,6 @@ public class UmpleMixsetTest {
       Assert.assertEquals(true, methodBodyCode.contains(keyWord));
       //before checks: 
       Assert.assertEquals(true, beforeLabelCode.contains("if (true) {"));
-      Assert.assertEquals(true, beforeLabelCode.contains("int x=0;"));
       //after checks:
       Assert.assertEquals(true, afterLabelCode.contains("}"));
       Assert.assertEquals(true, afterLabelCode.contains("code after around."));

--- a/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionTwoLabels.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionTwoLabels.ump
@@ -1,0 +1,27 @@
+class AroundClass{
+    static void doSomeThing()
+    {
+      boolean flag= false;
+      Label1: int x=0;
+      Label2: int a= 0;
+      flag =true;
+    }
+}
+
+class AroundClass
+{
+   around Label1-Label2:doSomeThing()
+   {
+     // code before around.
+     if (true) {
+       around_proceed:
+     } else 
+     // code after around.
+ }
+   
+  
+  
+  
+  
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionTwoLabels.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionTwoLabels.ump
@@ -1,10 +1,10 @@
 class AroundClass{
     static void doSomeThing()
     {
-      boolean flag= false;
-      Label1: int x=0;
-      Label2: int a= 0;
-      flag =true;
+      boolean flag = false;
+      Label1: int x = 0;
+      Label2: int a = 0;
+      flag = true;
     }
 }
 
@@ -15,7 +15,7 @@ class AroundClass
      // code before around.
      if (true) {
        around_proceed:
-     } else 
+     }  
      // code after around.
  }
    


### PR DESCRIPTION
Around keyword is added to the aspect grammar. To make few changes, "around" grammar reuse the grammar of "before" aspect injection.
In this PR, "around" with two labels is implemented. As "around" has two fragment of code. The first fragment is added after the start label. The second fragment is added before the end label.  
```
around StartLabel-EndLabel:aMethod()
   {
     // code before around.
     if(TRUE) {
       around_proceed:
     }
     // code after around.
 }       

void aMethod()
    {
      boolean flag= false;
      StartLabel: int x=0;
      EndLabel: int a= 0;
      flag =true;
    }
```

The result will be : 
```
void aMethod()
    {
      boolean flag= false;
      StartLabel:    if(TRUE) {
      int x=0;
      }
      EndLabel: int a= 0;
      flag =true;
    }