### PR TITLE
Aspect around for methods with no labels 

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -94,6 +94,7 @@ class UmpleToJava {
     }
     // End 
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
+        //if(customBeforeInjectionCode)
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        
         String customPostconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Postcondition"));

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -95,12 +95,15 @@ class UmpleToJava {
     // End 
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
-        if( customBeforeInjectionCode.contains("around_proceed:") && (customAfterInjectionCode == null) )
+        if( (customBeforeInjectionCode != null) && (customAfterInjectionCode == null) )
         {
-          String[] codeToInjectArray = customBeforeInjectionCode.split("around_proceed:");
-          customBeforeInjectionCode = codeToInjectArray[0];
-          customAfterInjectionCode = ""+codeToInjectArray[1];
-         // customAfterInjectionCode = customAfterInjectionCode.replace("END OF UMPLE BEFORE INJECTION","END OF UMPLE AROUND INJECTION");
+          if(customBeforeInjectionCode.contains("around_proceed:"))
+          {
+            String[] codeToInjectArray = customBeforeInjectionCode.split("around_proceed:");
+            customBeforeInjectionCode = codeToInjectArray[0];
+            customAfterInjectionCode = ""+codeToInjectArray[1];
+            customAfterInjectionCode = customAfterInjectionCode.replace("END OF UMPLE BEFORE INJECTION","END OF UMPLE AROUND INJECTION");
+          }
         }
         
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -94,8 +94,13 @@ class UmpleToJava {
     }
     // End 
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
-        //if(customBeforeInjectionCode)
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
+        if(customBeforeInjectionCode.contains("around_proceed:") && (customAfterInjectionCode == null) )
+        {
+          String[] codeToInjectArray = split("around_proceed:");
+          customBeforeInjectionCode = codeToInjectArray[0];
+          customAfterInjectionCode = codeToInjectArray[1];
+        }
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        
         String customPostconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Postcondition"));
         customPostconditionCode = customPostconditionCode==null?"":customPostconditionCode;

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -95,13 +95,14 @@ class UmpleToJava {
     // End 
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
-        if(customBeforeInjectionCode.contains("around_proceed:") && (customAfterInjectionCode == null) )
+        if( customBeforeInjectionCode.contains("around_proceed:") && (customAfterInjectionCode == null) )
         {
           String[] codeToInjectArray = customBeforeInjectionCode.split("around_proceed:");
           customBeforeInjectionCode = codeToInjectArray[0];
-          customAfterInjectionCode = codeToInjectArray[1];
+          customAfterInjectionCode = ""+codeToInjectArray[1];
           customAfterInjectionCode = customAfterInjectionCode.replace("END OF UMPLE BEFORE INJECTION","END OF UMPLE AROUND INJECTION");
         }
+        
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        
         String customPostconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Postcondition"));
         customPostconditionCode = customPostconditionCode==null?"":customPostconditionCode;

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -97,9 +97,10 @@ class UmpleToJava {
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         if(customBeforeInjectionCode.contains("around_proceed:") && (customAfterInjectionCode == null) )
         {
-          String[] codeToInjectArray = split("around_proceed:");
+          String[] codeToInjectArray = customBeforeInjectionCode.split("around_proceed:");
           customBeforeInjectionCode = codeToInjectArray[0];
           customAfterInjectionCode = codeToInjectArray[1];
+          customAfterInjectionCode = customAfterInjectionCode.replace("END OF UMPLE BEFORE INJECTION","END OF UMPLE AROUND INJECTION");
         }
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        
         String customPostconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Postcondition"));

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -100,7 +100,7 @@ class UmpleToJava {
           String[] codeToInjectArray = customBeforeInjectionCode.split("around_proceed:");
           customBeforeInjectionCode = codeToInjectArray[0];
           customAfterInjectionCode = ""+codeToInjectArray[1];
-          customAfterInjectionCode = customAfterInjectionCode.replace("END OF UMPLE BEFORE INJECTION","END OF UMPLE AROUND INJECTION");
+         // customAfterInjectionCode = customAfterInjectionCode.replace("END OF UMPLE BEFORE INJECTION","END OF UMPLE AROUND INJECTION");
         }
         
         String customPreconditionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjections("before", aMethod.getName()+"Precondition"));        

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3806,11 +3806,12 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   private void analyzeInjectionCode(Token injectToken, UmpleClassifier uClassifier)
   {
     String type = injectToken.is("beforeCode") ? "before" : "after";
+    Token codeLabelToken = injectToken.getSubToken("codeLabel");
+
     // around as aspect type
-    if(injectToken.getSubToken("around") != null) {
+    if( (injectToken.getSubToken("around") != null) && (codeLabelToken != null) ) {
       type="around";
     }
-    Token codeLabelToken = injectToken.getSubToken("codeLabel");
     CodeBlock cb = new CodeBlock();
     String operationName = getOperationName(injectToken);
     String operationSource = getOperationSource(injectToken).toLowerCase();

--- a/cruise.umple/test/cruise/umple/compiler/mixset/AroundClass.java.txt
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/AroundClass.java.txt
@@ -1,0 +1,46 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!*/
+
+
+
+// line 1 "InnerStatic.ump"
+// line 12 "InnerStatic.ump"
+public class AroundClass
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public AroundClass()
+  {}
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public void delete()
+  {}
+
+  // line 4 "InnerStatic.ump"
+   static  void doSomeThing(){
+    // line 16 "InnerStatic.ump"
+    // code before around.
+     if (true) { 
+           
+    int x; int a;
+      boolean flag = false;
+      Label1: x = 0;
+      Label2: a = 0;
+      flag = true;
+    
+     }  
+         // code after around.
+    // END OF UMPLE AROUND INJECTION
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -756,7 +756,42 @@ public class UmpleMixsetTest {
       Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
    }
-  
-}
+  }
+@Test
+  public void testAround_noLabels() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"aroundInjectionNoLabels.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    Method aMethod ;
+    try{
+      umodel.run();
+      umodel.generate();
+    }
+    catch (UmpleCompilerException e)
+    {
+      if(!e.getMessage().contains("1013")) // ignore warning caused by aspect injection.
+    	{
+    	  throw e;
+    	}
+    }
+    finally 
+    {  
+      UmpleClass uClass = umodel.getUmpleClass(0);
+      aMethod = uClass.getMethod(0);
+      String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+      String keyWord = "int x";
+      String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
+      String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
+      Assert.assertEquals(true, methodBodyCode.contains(keyWord));
+      //before checks: 
+      Assert.assertEquals(true, beforeLabelCode.contains("if (true) {"));
+      Assert.assertEquals(true, beforeLabelCode.contains("boolean flag"));
+      Assert.assertEquals(true, beforeLabelCode.indexOf("boolean flag") > beforeLabelCode.indexOf("code before around"));
+      //after checks:
+      Assert.assertEquals(true, afterLabelCode.contains("}"));
+      Assert.assertEquals(true, afterLabelCode.contains("code after around."));
+      Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
+      SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
+   }
+  }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -15,7 +15,7 @@ import cruise.umple.compiler.FeatureNode;
 import cruise.umple.compiler.FeatureLeaf;
 import cruise.umple.compiler.Method;
 import cruise.umple.compiler.exceptions.*;
-
+import java.io.File;
 
 public class UmpleMixsetTest {
   
@@ -26,7 +26,6 @@ public class UmpleMixsetTest {
   {
     umpleParserTest = new UmpleParserTest();
     umpleParserTest.pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset");
-
   }
 
   @Test
@@ -765,6 +764,7 @@ public class UmpleMixsetTest {
     try{
       umodel.run();
       umodel.generate();
+
     }
     catch (UmpleCompilerException e)
     {
@@ -775,6 +775,11 @@ public class UmpleMixsetTest {
     }
     finally 
     {  
+      SampleFileWriter.assertFileExists("/"+"AroundClass.java");
+      String actual = umodel.getGeneratedCode().get("AroundClass");
+      File expected = new File(umpleParserTest.pathToInput + "/AroundClass.java.txt");
+      SampleFileWriter.assertFileContent(expected, actual,true);
+      /*
       UmpleClass uClass = umodel.getUmpleClass(0);
       aMethod = uClass.getMethod(0);
       String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
@@ -783,13 +788,14 @@ public class UmpleMixsetTest {
       String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
       Assert.assertEquals(true, methodBodyCode.contains(keyWord));
       //before checks: 
-      Assert.assertEquals(true, beforeLabelCode.contains("if (true) {"));
+      Assert.assertEquals(true, beforeLabelCode.contains("if (true)"));
       Assert.assertEquals(true, beforeLabelCode.contains("boolean flag"));
       Assert.assertEquals(true, beforeLabelCode.indexOf("boolean flag") > beforeLabelCode.indexOf("code before around"));
       //after checks:
       Assert.assertEquals(true, afterLabelCode.contains("}"));
       Assert.assertEquals(true, afterLabelCode.contains("code after around."));
       Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
+      */
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
    }
   }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -775,9 +775,10 @@ public class UmpleMixsetTest {
     }
     finally 
     {  
-      SampleFileWriter.assertFileExists("/"+"AroundClass.java");
+      String pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset/");
+      SampleFileWriter.assertFileExists(pathToInput+"AroundClass.java");
       String actual = umodel.getGeneratedCode().get("AroundClass");
-      File expected = new File(umpleParserTest.pathToInput + "/AroundClass.java.txt");
+      File expected = new File(pathToInput + "AroundClass.java.txt");
       SampleFileWriter.assertFileContent(expected, actual,true);
       /*
       UmpleClass uClass = umodel.getUmpleClass(0);

--- a/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionNoLabels.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionNoLabels.ump
@@ -1,0 +1,27 @@
+class AroundClass{
+    static void doSomeThing()
+    {
+      boolean flag = false;
+      Label1: int x = 0;
+      Label2: int a = 0;
+      flag = true;
+    }
+}
+
+class AroundClass
+{
+   around doSomeThing()
+   {
+     // code before around.
+     if (true) {
+       around_proceed:
+     }  
+     // code after around.
+ }
+   
+  
+  
+  
+  
+}
+

--- a/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionNoLabels.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/aroundInjectionNoLabels.ump
@@ -1,9 +1,10 @@
 class AroundClass{
     static void doSomeThing()
-    {
+    { 
+      int x; int a;
       boolean flag = false;
-      Label1: int x = 0;
-      Label2: int a = 0;
+      Label1: x = 0;
+      Label2: a = 0;
       flag = true;
     }
 }
@@ -13,9 +14,9 @@ class AroundClass
    around doSomeThing()
    {
      // code before around.
-     if (true) {
+ if (true) { 
        around_proceed:
-     }  
+ }  
      // code after around.
  }
    


### PR DESCRIPTION
This PR allows "around" aspects for methods with no labels (around the entire method). "Around" is considered as a before aspect. In the code generation, the generator of before aspect is extended to handle the case of around by splitting around code into two aspects: before aspect and after aspect. 