### PR TITLE
Semicolons in strings 

### DIFF
--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -109,6 +109,22 @@ class RuleBasedParser
     return grootToken;
   }
 
+
+
+private void cleanSemicolon(Token token){
+
+  if(token.getValue() != null)
+  {
+    if(token.getValue().contains("\\u003B"))
+      token.setValue(token.getValue().replace("\\u003B",";")); 
+  } 
+  for(Token subToken : token.getSubTokens())
+  {
+    cleanSemicolon(subToken);
+  }
+
+}
+
   /*
     Takes a root rule and uses it to start parsing. The result will be put into the root token passed. The parsing will be performed
     on the file. data is a DataPackage which needs to be initialized(using the init(Position)) before passing to this function.
@@ -123,6 +139,7 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getInput().length(),data.getInput(),data);
     if(parseResult==data.getInput().length())
     {
+cleanSemicolon(token);
       setRootToken(token);
     }
     else
@@ -152,6 +169,7 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getLine(line).length(),data.getLine(line),data);
     if(parseResult==data.getInput().length())
     {
+cleanSemicolon(token);
       setRootToken(token);
     }
     else
@@ -327,6 +345,7 @@ class RuleBasedParser
     }
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
+cleanSemicolon(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
   }
@@ -357,6 +376,7 @@ class RuleBasedParser
     
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
+cleanSemicolon(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
   }

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -109,19 +109,21 @@ class RuleBasedParser
     return grootToken;
   }
 
+  /*
+    This method helps to clean the string value of a token by tranforming an unicode character into its value. Such as semicolon "\u003B" into ";".
+    It supports \u003B ---> semicolon. This method can extended to support other unicode characters.
+  */
+  private void cleanEscapeChars(Token token){
 
-
-private void cleanSemicolon(Token token){
-
-  if(token.getValue() != null)
-  {
-    if(token.getValue().contains("\\u003B"))
-      token.setValue(token.getValue().replace("\\u003B",";")); 
-  } 
-  for(Token subToken : token.getSubTokens())
-  {
-    cleanSemicolon(subToken);
-  }
+    if(token.getValue() != null)
+    {
+      if(token.getValue().contains("\\u003B"))
+        token.setValue(token.getValue().replace("\\u003B",";")); 
+    } 
+    for(Token subToken : token.getSubTokens())
+    {
+      cleanEscapeChars(subToken);
+    }
 
 }
 
@@ -139,7 +141,7 @@ private void cleanSemicolon(Token token){
     int parseResult = root.parse(token, 0,data.getInput().length(),data.getInput(),data);
     if(parseResult==data.getInput().length())
     {
-cleanSemicolon(token);
+      cleanEscapeChars(token);
       setRootToken(token);
     }
     else
@@ -169,7 +171,7 @@ cleanSemicolon(token);
     int parseResult = root.parse(token, 0,data.getLine(line).length(),data.getLine(line),data);
     if(parseResult==data.getInput().length())
     {
-cleanSemicolon(token);
+      cleanEscapeChars(token);
       setRootToken(token);
     }
     else
@@ -345,7 +347,7 @@ cleanSemicolon(token);
     }
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
-cleanSemicolon(analyzer.getRootToken());
+    cleanEscapeChars(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
   }
@@ -376,7 +378,7 @@ cleanSemicolon(analyzer.getRootToken());
     
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
-cleanSemicolon(analyzer.getRootToken());
+    cleanEscapeChars(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
   }

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -117,7 +117,7 @@ class RuleBasedParser
 
     if(token.getValue() != null)
     {
-      if(token.getValue().contains("\\u003B"))
+      if(token.is("value") && token.getValue().contains("\\u003B"))
         token.setValue(token.getValue().replace("\\u003B",";")); 
     } 
     for(Token subToken : token.getSubTokens())

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -141,7 +141,6 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getInput().length(),data.getInput(),data);
     if(parseResult==data.getInput().length())
     {
-      if(!filename.endsWith("GrammarParsing_Code.ump"))
       cleanEscapeChars(token);cleanEscapeChars(token);
       setRootToken(token);
     }
@@ -172,7 +171,6 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getLine(line).length(),data.getLine(line),data);
     if(parseResult==data.getInput().length())
     {
-      if(!filename.endsWith("GrammarParsing_Code.ump"))
       cleanEscapeChars(token);
       setRootToken(token);
     }
@@ -349,7 +347,6 @@ class RuleBasedParser
     }
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
-    if(!file.getName().endsWith("GrammarParsing_Code.ump"))
     cleanEscapeChars(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
@@ -381,7 +378,6 @@ class RuleBasedParser
     
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
-    if(!fileName.endsWith("GrammarParsing_Code.ump"))
     cleanEscapeChars(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -141,7 +141,8 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getInput().length(),data.getInput(),data);
     if(parseResult==data.getInput().length())
     {
-      cleanEscapeChars(token);
+      if(!filename.endsWith("GrammarParsing_Code.ump"))
+      cleanEscapeChars(token);cleanEscapeChars(token);
       setRootToken(token);
     }
     else
@@ -171,6 +172,7 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getLine(line).length(),data.getLine(line),data);
     if(parseResult==data.getInput().length())
     {
+      if(!filename.endsWith("GrammarParsing_Code.ump"))
       cleanEscapeChars(token);
       setRootToken(token);
     }
@@ -347,6 +349,7 @@ class RuleBasedParser
     }
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
+    if(!file.getName().endsWith("GrammarParsing_Code.ump"))
     cleanEscapeChars(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();
@@ -378,6 +381,7 @@ class RuleBasedParser
     
     analyzer.execute();
     setRootToken(analyzer.getRootToken());
+    if(!fileName.endsWith("GrammarParsing_Code.ump"))
     cleanEscapeChars(analyzer.getRootToken());
     setParseResult(analyzer.getParseResult());
     return getParseResult();

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3109,7 +3109,15 @@ public class UmpleParserTest
   public void validCodeInjection() {
     assertHasNoWarningsParse("702_validCodeInjection.ump");
   }
-
+  @Test
+  void testSemicolonUnicode()
+  {
+    UmpleFile uFile = new UmpleFile("classAttributeContainsSemicolons.ump");
+    UmpleModel umodel = new UmpleModel(uFile);
+    umodel.run();
+    String attributeValue = umodel.getUmpleClass(0).getAttribute(0).getValue().trim();
+    Assert.assertTrue(attributeValue.equals("\"int x =10 ; x++ ;\""));	
+  }
   public boolean parse(String filename)
   {
     //String input = SampleFileWriter.readContent(new File(pathToInput, filename));

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3110,7 +3110,7 @@ public class UmpleParserTest
     assertHasNoWarningsParse("702_validCodeInjection.ump");
   }
   @Test
-  void testSemicolonUnicode()
+  public void testSemicolonUnicode()
   {
     UmpleFile uFile = new UmpleFile("classAttributeContainsSemicolons.ump");
     UmpleModel umodel = new UmpleModel(uFile);

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3112,7 +3112,7 @@ public class UmpleParserTest
   @Test
   public void testSemicolonUnicode()
   {
-    UmpleFile uFile = new UmpleFile("classAttributeContainsSemicolons.ump");
+    UmpleFile uFile = new UmpleFile(pathToInput,"classAttributeContainsSemicolons.ump");
     UmpleModel umodel = new UmpleModel(uFile);
     umodel.run();
     String attributeValue = umodel.getUmpleClass(0).getAttribute(0).getValue().trim();

--- a/cruise.umple/test/cruise/umple/compiler/classAttributeContainsSemicolons.ump
+++ b/cruise.umple/test/cruise/umple/compiler/classAttributeContainsSemicolons.ump
@@ -1,0 +1,6 @@
+class AttriWithSemicolons
+{
+
+ String aJavaStatement = "int x =10 \u003B x++ \u003B" ;
+ 
+}


### PR DESCRIPTION
This PR allows encoding of semicolon inside umple strings. This is similar to C/Java in which "\u003B" represent semicolon. The java string: "Hello \u003B world!"  is equivalent to "Hello ; world!".

The code below is in Umple:
```
class AAA
{
 String aJavaStatement = "int x =10 \u003B x++ \u003B" ;
}
```
Will result in code having the following: 
```
//AAA Attributes
  private String aJavaStatement;

  //------------------------
  // CONSTRUCTOR
  //------------------------

  public AAA()
  {
    aJavaStatement = "int x =10 ; x++ ;";
  }`
```