### PR TITLE
Casecade extended aspect

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -289,25 +289,7 @@ for (StateMachine smq : uClass.getStateMachines())
       String methodLabelToLookat = codeInjectionItem.getInjectionlabel();
       String codeToAdd = codeInjectionItem.getCode(codesKey_lang);
 
-      int indexOfLabel = methodCodeWithLabels.indexOf(methodLabelToLookat);
-      if (indexOfLabel == -1) // the method does not contain the required label
-      {
-        // raise error 
-        // raise warning 
-      }
-      else if (codeInjectionItem.getType().equals("before"))
-      {
-        methodCodeWithLabels.add(indexOfLabel, "\n"+codeToAdd + "\n");
-      }
-      else if (codeInjectionItem.getType().equals("after"))
-      {
-        if(indexOfLabel < methodCodeWithLabels.size())
-          methodCodeWithLabels.add(indexOfLabel+1, "\n"+codeToAdd + "\n");
-        else
-          methodCodeWithLabels.add("\n"+codeToAdd + "\n");
-      }
-
-    	 if (codeInjectionItem.getType().equals("around"))
+    	if (codeInjectionItem.getType().equals("around"))
       {
         String[] BoundLabels = methodLabelToLookat.split("-");
         String firstLabel = BoundLabels[0]+":";
@@ -320,8 +302,27 @@ for (StateMachine smq : uClass.getStateMachines())
         int beforeIndex = methodCodeWithLabels.indexOf(SecondLabel);
         methodCodeWithLabels.add(afterIndex+1, "\n"+afterCodeSegment + "\n");
         methodCodeWithLabels.add(beforeIndex+1, "\n"+beforeCodeSegment + "\n");
-
       }
+      else {
+        int indexOfLabel = methodCodeWithLabels.indexOf(methodLabelToLookat);
+        if (indexOfLabel == -1) // the method does not contain the required label
+        {
+          return;// raise error 
+          // raise warning 
+        }
+        else if (codeInjectionItem.getType().equals("before"))
+        {
+          methodCodeWithLabels.add(indexOfLabel, "\n"+codeToAdd + "\n");
+        }
+        else if (codeInjectionItem.getType().equals("after"))
+        {
+          if(indexOfLabel < methodCodeWithLabels.size())
+            methodCodeWithLabels.add(indexOfLabel+1, "\n"+codeToAdd + "\n");
+          else
+            methodCodeWithLabels.add("\n"+codeToAdd + "\n");
+        }
+      }
+
       // at the end, remove the codeInjection belongs to labeled aspect
       // otherwise it will be added to the code when handling aspects 
       //uClassCodeInectionList.remove(codeInjectionItem); // causes error:ConcurrentModificationException

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -87,8 +87,7 @@ class UmpleToJava {
     {
       handelMixsetInsideMethod(model, mixsetsWithinMethodItem, aMethod.getMethodBody());
     }
-    // End
-    //This code adds aspect with labels; the loop aims to make sure that casecaded additon are properly added in each method.
+    // End 
     for(int i =uClass.getCodeInjections().size() ; i > 0 ; i--)
     {
       applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
@@ -410,6 +409,8 @@ class UmpleToJava {
           appendln(realSb, "  }");
           addUncaughtExceptionVariables(methodName,p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/",""),p.getLineNumber(),javaline,methodBody.split("\\n").length);
         }
+
+      }
     }
 #>>!>>
 }

--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -81,18 +81,20 @@ class UmpleToJava {
       // If this is not a constructor, this method should return "void"
       methodType = methodType.equals("") ? "void" : methodType;
     }
-    
-    applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
-    applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
-    applyCodeInjectionToLabeledMethod(uClass, aMethod, "around");
-   
    // handle mixsets inside methods(uClass, aMethod);
     ArrayList<MixsetInMethod> mixsetsWithinMethodList = aMethod.getMethodBody().getMixsetsWithinMethod();
     for(MixsetInMethod mixsetsWithinMethodItem : mixsetsWithinMethodList)
     {
       handelMixsetInsideMethod(model, mixsetsWithinMethodItem, aMethod.getMethodBody());
     }
-    // End 
+    // End
+    //This code adds aspect with labels; the loop aims to make sure that casecaded additon are properly added in each method.
+    for(int i =uClass.getCodeInjections().size() ; i > 0 ; i--)
+    {
+      applyCodeInjectionToLabeledMethod(uClass, aMethod, "before");
+      applyCodeInjectionToLabeledMethod(uClass, aMethod, "after");
+      applyCodeInjectionToLabeledMethod(uClass, aMethod, "around");
+    } 
         String customBeforeInjectionCode = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("before", aMethod.getName(), aMethod.getMethodParameters()));
         String customAfterInjectionCode  = GeneratorHelper.toCode(uClass.getApplicableCodeInjectionsCustomMethod("after", aMethod.getName(), aMethod.getMethodParameters()));
         if( (customBeforeInjectionCode != null) && (customAfterInjectionCode == null) )
@@ -261,6 +263,7 @@ class UmpleToJava {
           if (customBeforeInjectionCode != null) {
             addUncaughtExceptionVariables(realSb.toString().split("\\n").length,customBeforeInjectionCode,methodName);
             append(realSb, "{0}\n",GeneratorHelper.doIndent(customBeforeInjectionCode, "    "));
+            aMethod.getMethodBody().getCodeblock().setCode("", GeneratorHelper.doIndent(customBeforeInjectionCode, "    ") + aMethod.getMethodBody().getCodeblock());
         }
           
           String traceCode = "";
@@ -407,7 +410,6 @@ class UmpleToJava {
           appendln(realSb, "  }");
           addUncaughtExceptionVariables(methodName,p.getFilename().replaceAll("\\\\","/").replaceAll("(.*)/",""),p.getLineNumber(),javaline,methodBody.split("\\n").length);
         }
-      }
     }
 #>>!>>
 }

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -25,6 +25,7 @@ import java.io.*;
 
 import cruise.umple.parser.Token;
 import cruise.umple.parser.Position;
+import cruise.umple.util.SampleFileWriter;
 
 public class UmpleParserTest
 {
@@ -3117,6 +3118,7 @@ public class UmpleParserTest
     umodel.run();
     String attributeValue = umodel.getUmpleClass(0).getAttribute(0).getValue().trim();
     Assert.assertTrue(attributeValue.equals("\"int x =10 ; x++ ;\""));	
+    SampleFileWriter.destroy(pathToInput+"/"+"AttriWithSemicolons.java");
   }
   public boolean parse(String filename)
   {

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -14,6 +14,7 @@ import cruise.umple.compiler.FeatureLink;
 import cruise.umple.compiler.FeatureNode;
 import cruise.umple.compiler.FeatureLeaf;
 import cruise.umple.compiler.Method;
+import cruise.umple.compiler.MethodBody;
 import cruise.umple.compiler.exceptions.*;
 import java.io.File;
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -804,11 +804,11 @@ public class UmpleMixsetTest {
     finally 
     { 
       MethodBody mBody = umodel.getUmpleClass(0).getMethod(0).getMethodBody();
-		  String code = mBody.getCodeblock().getCode();
+      String code = mBody.getCodeblock().getCode();
       int label0Index =  code.indexOf("Label_0");
-		  int label3Index =  code.indexOf("Label3");
-		  int label2Index =  code.indexOf("Label2");
-		  int label1Index =  code.indexOf("Label1");
+      int label3Index =  code.indexOf("Label3");
+      int label2Index =  code.indexOf("Label2");
+      int label1Index =  code.indexOf("Label1:");
       Assert.assertTrue(label0Index < label3Index);
       Assert.assertTrue(label3Index < label2Index);
       Assert.assertTrue(label2Index < label1Index);
@@ -817,6 +817,5 @@ public class UmpleMixsetTest {
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"Aclass.java");
    }
   }
-
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -756,7 +756,7 @@ public class UmpleMixsetTest {
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
    }
   }
-@Test
+  @Test
   public void testAround_noLabels() {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"aroundInjectionNoLabels.ump");
     UmpleModel umodel = new UmpleModel(umpleFile);
@@ -780,25 +780,42 @@ public class UmpleMixsetTest {
       String actual = umodel.getGeneratedCode().get("AroundClass");
       File expected = new File(pathToInput + "AroundClass.java.txt");
       SampleFileWriter.assertFileContent(expected, actual,true);
-      /*
-      UmpleClass uClass = umodel.getUmpleClass(0);
-      aMethod = uClass.getMethod(0);
-      String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
-      String keyWord = "int x";
-      String beforeLabelCode = methodBodyCode.substring(0,methodBodyCode.indexOf(keyWord));
-      String afterLabelCode = methodBodyCode.substring(methodBodyCode.indexOf(keyWord));
-      Assert.assertEquals(true, methodBodyCode.contains(keyWord));
-      //before checks: 
-      Assert.assertEquals(true, beforeLabelCode.contains("if (true)"));
-      Assert.assertEquals(true, beforeLabelCode.contains("boolean flag"));
-      Assert.assertEquals(true, beforeLabelCode.indexOf("boolean flag") > beforeLabelCode.indexOf("code before around"));
-      //after checks:
-      Assert.assertEquals(true, afterLabelCode.contains("}"));
-      Assert.assertEquals(true, afterLabelCode.contains("code after around."));
-      Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
-      */
       SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"AroundClass.java");
    }
   }
+
+  @Test
+  public void testCasecadeExtentionOfLabeledAspect() {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"casecadExtentionForLabeledAspect.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    Method aMethod ;
+    try{
+      umodel.run();
+      umodel.generate();
+    }
+    catch (UmpleCompilerException e)
+    {
+      if(!e.getMessage().contains("1013")) // ignore warning caused by aspect injection.
+    	{
+    	  throw e;
+    	}
+    }
+    finally 
+    { 
+      MethodBody mBody = umodel.getUmpleClass(0).getMethod(0).getMethodBody();
+		  String code = mBody.getCodeblock().getCode();
+      int label0Index =  code.indexOf("Label_0");
+		  int label3Index =  code.indexOf("Label3");
+		  int label2Index =  code.indexOf("Label2");
+		  int label1Index =  code.indexOf("Label1");
+      Assert.assertTrue(label0Index < label3Index);
+      Assert.assertTrue(label3Index < label2Index);
+      Assert.assertTrue(label2Index < label1Index);
+      String pathToInput = SampleFileWriter.rationalize("test/cruise/umple/compiler/mixset/");
+      SampleFileWriter.assertFileExists(pathToInput+"Aclass.java");
+      SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"Aclass.java");
+   }
+  }
+
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/casecadExtentionForLabeledAspect.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/casecadExtentionForLabeledAspect.ump
@@ -1,0 +1,41 @@
+
+class Aclass{  
+  void doA()
+  {
+   Label_0: int mainDoA = 0;// method original implementation. 
+  } 
+  
+}
+
+class Aclass{
+  after Label_0: doA()
+  {
+    ; // comment  
+    Label1_X: int x=0;//added by first code injection 
+    Label1: x++; //added by first code injection 
+  
+  }
+}
+
+class Aclass{  
+  before Label1:doA()
+  {
+     Label2: int y=0; // added by second code injection
+  }
+ }
+
+class Aclass{
+  before Label2:doA()
+  {
+     Label3: int y=0; // added by third code injection
+  }  
+  
+}
+
+class Aclass{  
+  after Label3:doA()
+  {
+     int finalAfterAddition=0;// added by fourth code injection
+  }
+    
+}


### PR DESCRIPTION
This PR handles the case when code injected by an aspect has some labels in which the new injected labels (as code) can be used in other aspect. This is not the case for the current aspect in Umple.

The result of the test case (for the file: casecadExtentionForLabeledAspect.ump) will be:
```
  public void doA(){
    Label_0:
    ; // comment  
    Label1_X: int x=0;//added by first code injection 
    
    Label3:
    int finalAfterAddition=0;// added by fourth code injection
    int y=0; // added by third code injection
    Label2: int y=0; // added by second code injection
    Label1: x++; //added by first code injection
    int mainDoA = 0;// method original implementation.
  }
```