### PR TITLE
Resolving dependency issues with SimpleTest and Umplificator

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.26.0-{build}-{branch}
+version: 1.29.1-{build}-{branch}
 
 skip_branch_with_pr: true
 

--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -29,9 +29,9 @@
   <property name="threadcount" value="4"/>
   <property name="cleanonfinish" value="true" />
 
-  <property name="php.simpletest.version" value="1.1" />
+  <property name="php.simpletest.version" value="1.2" />
   <property name="php.simpletest.url" 
-            value="https://github.com/git-mirror/simpletest/archive/${php.simpletest.version}.0.tar.gz" />
+            value="https://github.com/simpletest/simpletest/archive/v${php.simpletest.version}.0.tar.gz" />
   <property name="php.libs.dir" value="${dist.dir}/libs/php" />
 
   <path id="project.classpath">

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -63,14 +63,14 @@
         <arg value="cruise.umple/src/Master.ump"/>
         <jvmarg value="-Xmx500m"/>
       </java>
-      <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+      <!--java jar="${umple.stable.jar}" fork="true" failonerror="true">
         <arg value="cruise.umple.validator/src/Master.ump"/>
         <jvmarg value="-Xmx500m"/>
-      </java>
-       <java jar="${umple.stable.jar}" fork="true" failonerror="true">
+      </java-->
+       <!--java jar="${umple.stable.jar}" fork="true" failonerror="true">
         <arg value="cruise.umplificator/src/Master.ump"/>
         <jvmarg value="-Xmx500m"/>
-      </java>
+      </java-->
     </parallel>
   </target>
 
@@ -92,12 +92,12 @@
       <java jar="${umplejar.built.here}" fork="true" failonerror="true">
         <arg value="cruise.umple/src/Master.ump"/>
       </java>
-      <java jar="${umplejar.built.here}" fork="true" failonerror="true">
+      <!--java jar="${umplejar.built.here}" fork="true" failonerror="true">
         <arg value="cruise.umple.validator/src/Master.ump"/>
-      </java>
-      <java jar="${umplejar.built.here}" fork="true" failonerror="true">
+      </java-->
+      <!--java jar="${umplejar.built.here}" fork="true" failonerror="true">
         <arg value="cruise.umplificator/src/Master.ump"/>
-      </java>
+      </java-->
     </parallel>
   </target>
 
@@ -621,8 +621,8 @@
     <antcall target="template.setVersion" />
     <antcall target="resetUmpleSelf" />
     <antcall target="compile" />
-    <antcall target="compileValidator" />
-    <antcall target="compileUmplificator" />
+    <!--antcall target="compileValidator" -->
+    <!--antcall target="compileUmplificator" -->
     <antcall target="package" />
     <antcall target="template.resetVersion" />
   </target>
@@ -670,8 +670,8 @@
     <antcall target="template.setVersion" />
     <antcall target="umpleSelf" />
     <antcall target="compile" />
-    <antcall target="compileValidator" />
-    <antcall target="compileUmplificator" />
+    <!--antcall target="compileValidator" -->
+    <!--antcall target="compileUmplificator" -->
     <antcall target="package" />
     <antcall target="template.test" />
     <antcall target="deploy" />

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -221,8 +221,8 @@
     <deps-load-path conf="test"   pathid="test.ivy.classpath" />
 
     <javac debug="true" includeantruntime="false" debuglevel="source,lines,vars" destdir="${bin.path}" source="1.8" target="1.8">
-	    <src path="${xtext.project.path}/src"/>
-      <src path="${xtext.project.path}/src-gen"/>
+	    <!--src path="${xtext.project.path}/src"/ -->
+      <!-- src path="${xtext.project.path}/src-gen"/ -->
       <src path="${project.path}/src"/>
       <src path="${project.path}/src-gen-umpletl"/>
       <src path="${project.path}/src-gen-umple"/>

--- a/build/ivy.xml
+++ b/build/ivy.xml
@@ -35,8 +35,8 @@
         <!-- Validator -->
         <dependency org="org.eclipse.core" name="runtime" rev="3.9.0-v20130326-1255" conf="validator->default"/>
 
-
-        <!-- Umplificator -->
+<!-- Cmmmenting out as we are not building the Umplificator or Xtext any more due to lack of use
+        < Recomment this when activating Umplificator >
         <dependency org="commons-io"                name="commons-io"               rev="2.4"       conf="umplificator->default"/>
         <dependency org="org.apache.commons"        name="commons-collections4"     rev="4.0"       conf="umplificator->default"/>
         <dependency org="commons-configuration"     name="commons-configuration"    rev="1.10"      conf="umplificator->default"/>
@@ -52,10 +52,10 @@
         <dependency org="org.eclipse.core"          name="runtime"                  rev="3.10.0-v20140318-2214" conf="umplificator->default" />
         <dependency org="org.osgi"                  name="org.osgi.core"            rev="4.3.0"       conf="umplificator->default" />
 
-        <!-- XText/Xtend Plugin -->
+        < Recomment this when activating XText/Xtend Plugin >
         <dependency org="org.eclipse.xtext" name="org.eclipse.xtext.ui"     rev="2.9.0.beta3"   conf="xtext->default"/>
         <dependency org="org.eclipse.xtend" name="org.eclipse.xtend.core"   rev="2.9.0.beta3"   conf="xtext->default"/>
-
+-->
         <!-- Eclipse Plugin dependencies -->
         <dependency org="org.eclipse.jdt"   name="org.eclipse.jdt.core" rev="3.10.0" conf="eclipseplugin->default"/>
         


### PR DESCRIPTION
The old SimpleTest php tool was causing deprecation warnings; this updates to use a new version. This is one of the few dependencies the Umple build system has for the main umple compiler.

However, dependency problems are also occurring when trying to build the Umplificator and the Validator. Rather than build these in every full build, this PR elects to stop building them. This should speed up the build somewhat. It would still be possible to build them separately if the dependency issue is looked into.

