### PR TITLE
Temporarily disable PhP tests

### DIFF
--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -154,7 +154,7 @@
 
   <target name="test">
     <antcall target="testJava" />
-    <antcall target="testPhp" />
+    <!--COMMENTED OUT SINCE NOTLOADING DOMDOCUMENT  antcall target="testPhp" /> -->
     <antcall target="testRuby" />
     <!--
     <antcall target="allUserManualAndExampleTests" />


### PR DESCRIPTION
The Php target testPhp was failing on some platforms because of a failure to instantiate class DOMDocument, which requires installation of php-xml, but that was not always straightforward. Additionally the testPhp code us using the deprecated __autoload API in allTestHelper.php, so needs refactoring to load classes to test.

This PR will be referenced in a new issue which will call for reactivation of the testPhp.

This does not negate all PHP testing, since all examples are still compiled and verified that they conform to correct php syntax.