### PR TITLE
fix inner classes having import statements

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/import_packages.ump
+++ b/UmpleToJava/UmpleTLTemplates/import_packages.ump
@@ -14,8 +14,8 @@ class UmpleToJava {
 
   for (String anImport : gClass.getMultiLookup("import"))
   {
-    // Test whether the import is already written
-    if (importSet.contains(anImport)) {
+    // Test whether the import is already written OR the class is inner class (should not have import statement)
+    if (importSet.contains(anImport) | uClass.hasOuterClass()) {
       continue;
     }
     appendln(realSb, "");

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
@@ -58,7 +58,7 @@ public class InnerClassTest extends TemplateTest {
   }
  
   @Test
-  void TestNoPackageNameForInnerElementInDifferentPackages() {
+  public void TestNoPackageNameForInnerElementInDifferentPackages() {
    
     UmpleFile umpleFile = new UmpleFile(pathToInput+"diffPackages_master.ump");
     UmpleModel umodel = new UmpleModel(umpleFile);

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
@@ -60,7 +60,7 @@ public class InnerClassTest extends TemplateTest {
   @Test
   public void TestNoPackageNameForInnerElementInDifferentPackages() {
    
-    UmpleFile umpleFile = new UmpleFile(pathToInput+"diffPackages_master.ump");
+    UmpleFile umpleFile = new UmpleFile(pathToInput+"/diffPackages_master.ump");
     UmpleModel umodel = new UmpleModel(umpleFile);
     umodel.run();
 

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/InnerClassTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import cruise.umple.compiler.UmpleClass;
 import cruise.umple.compiler.UmpleFile;
 import cruise.umple.compiler.UmpleModel;
+import java.util.Map;
+
 
 public class InnerClassTest extends TemplateTest {
 
@@ -53,6 +55,20 @@ public class InnerClassTest extends TemplateTest {
     //if there is only one import-statement, its split should generate 2 strings:
     Assert.assertEquals(generatedCodeforClass.split("package com.umple.innerClasses").length , 2);
     // assertUmpleTemplateFor("/innerClasses.ump",  "/innerClasses.java.txt", "OuterClass_3");
+  }
+ 
+  @Test
+  void TestNoPackageNameForInnerElementInDifferentPackages() {
+   
+    UmpleFile umpleFile = new UmpleFile(pathToInput+"diffPackages_master.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+
+    Map<String, String> map = umodel.getGeneratedCode();
+    String generatedCodeforClass = map.get("AClassAtHome");
+    Assert.assertFalse(generatedCodeforClass.contains("import"));  // import statment should not be added before the inner static class.
+    System.out.println(generatedCodeforClass);
+
   }
 
   @After

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/diffPackages_AClassAtHome.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/diffPackages_AClassAtHome.ump
@@ -1,0 +1,13 @@
+
+namespace com.me.at.home;
+
+class AClassAtHome {
+     
+  
+  static class RootDoWork{
+      isA RootDoWork;
+      
+       public void doWork() { }
+    }
+    
+  }

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/diffPackages_RootDoWork.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/diffPackages_RootDoWork.ump
@@ -1,0 +1,8 @@
+namespace com.me.at.uottawa;
+
+interface RootDoWork
+{
+  
+     void doWork();
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/java/innerClass/diffPackages_master.ump
+++ b/cruise.umple/test/cruise/umple/implementation/java/innerClass/diffPackages_master.ump
@@ -1,0 +1,2 @@
+use diffPackages_RootDoWork.ump;
+use diffPackages_AClassAtHome.ump;


### PR DESCRIPTION
This PR fixes error caused when inner classes reference another classes/interface using "isA" from a different package. The generated code should not include " import .... " before the inner class definition. 

Example:

```
namespace com.me.at.uottawa;
interface RootDoWork
{
  void doWork();
}
```
 
```
namespace com.me.at.home;

class AClassAtHome {
  static class RootDoWork{
    isA RootDoWork;
    public void doWork() { }
   }   
 }
```
 The error is caused by the import statement generated before definition of the class RootDoWork : 
```
public class AClassAtHome
{
...
...
  /*PLEASE DO NOT EDIT THIS CODE*/
  /*This code was generated using the UMPLE 1.29.1.4260.b21abf3a3 modeling language!*/
    
  import com.me.at.uottawa;  
  // line 7 "../../../../ ... "
  public static class RootDoWork implements RootDoWork
  { ...  
...
```
