### PR TITLE
fixes Issue#1536 'Umple does not parse properly the guards'

### DIFF
--- a/cruise.umple/src/umple_constraints.grammar
+++ b/cruise.umple/src/umple_constraints.grammar
@@ -19,7 +19,7 @@ constraintToken : [[constraint]]
 
 // A constraint is an expression optionally be surrounded in round brackets or negated
 constraint- :  [[constraintBody]] [[linkingOp]]? |  [[constraintExpr]] [[linkingOp]]?
-//negativeConstraint : ( ! | not ) ( [[constraintName]] | [[constraint]] )
+//negativeConstraint : ( ! | not ) ( [[constraintName]] | [[constraint]] )   fixed issue1536 'Umple does not parse properly the guards'
 negativeConstraint : ( ! | [!constraintNegSymbol:not\s+] ) ( [[constraintName]] | [[constraint]] )
 
 // A constraint body is a constraint expression (possibly with a linking operator such as && or ||). 

--- a/cruise.umple/src/umple_constraints.grammar
+++ b/cruise.umple/src/umple_constraints.grammar
@@ -19,7 +19,8 @@ constraintToken : [[constraint]]
 
 // A constraint is an expression optionally be surrounded in round brackets or negated
 constraint- :  [[constraintBody]] [[linkingOp]]? |  [[constraintExpr]] [[linkingOp]]?
-negativeConstraint : ( ! | not ) ( [[constraintName]] | [[constraint]] )
+//negativeConstraint : ( ! | not ) ( [[constraintName]] | [[constraint]] )
+negativeConstraint : ( ! | [!constraintNegSymbol:not\s+] ) ( [[constraintName]] | [[constraint]] )
 
 // A constraint body is a constraint expression (possibly with a linking operator such as && or ||). 
 constraintBody : OPEN_ROUND_BRACKET [[constraint]] CLOSE_ROUND_BRACKET

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/guardNegSymbolSpacing.ump
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/guardNegSymbolSpacing.ump
@@ -1,0 +1,13 @@
+namespace example;
+
+class Agent{
+  status{
+    follow{change_lane -> changing_lane;}
+    changing_lane{
+      change_lane [not_achieved==False] ->changing_lane;
+      change_lane [not_achieved==True] -> final;
+    }
+    final{}
+  }
+}
+

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNegSymbolSpacing.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/guardNegSymbolSpacing.java.txt
@@ -1,0 +1,82 @@
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.29.1.4823.43e750332 modeling language!*/
+
+package example;
+
+// line 2 "model.ump"
+public class Agent
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Agent State Machines
+  public enum Status { follow, changing_lane, final }
+  private Status status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public Agent()
+  {
+    setStatus(Status.follow);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public String getStatusFullName()
+  {
+    String answer = status.toString();
+    return answer;
+  }
+
+  public Status getStatus()
+  {
+    return status;
+  }
+
+  public boolean change_lane()
+  {
+    boolean wasEventProcessed = false;
+    
+    Status aStatus = status;
+    switch (aStatus)
+    {
+      case follow:
+        setStatus(Status.changing_lane);
+        wasEventProcessed = true;
+        break;
+      case changing_lane:
+        if (not_achieved.equals(False))
+        {
+          setStatus(Status.changing_lane);
+          wasEventProcessed = true;
+          break;
+        }
+        if (not_achieved.equals(True))
+        {
+          setStatus(Status.final);
+          wasEventProcessed = true;
+          break;
+        }
+        break;
+      default:
+        // Other states do respond to this event
+    }
+
+    return wasEventProcessed;
+  }
+
+  private void setStatus(Status aStatus)
+  {
+    status = aStatus;
+  }
+
+  public void delete()
+  {}
+
+}

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/guardNegSymbolSpacing.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/guardNegSymbolSpacing.php.txt
@@ -1,0 +1,85 @@
+<?php
+/*PLEASE DO NOT EDIT THIS CODE*/
+/*This code was generated using the UMPLE 1.29.1.4823.43e750332 modeling language!*/
+
+class Agent
+{
+
+  //------------------------
+  // MEMBER VARIABLES
+  //------------------------
+
+  //Agent State Machines
+  private static $StatusFollow = 1;
+  private static $StatusChanging_lane = 2;
+  private static $StatusFinal = 3;
+  private $status;
+
+  //------------------------
+  // CONSTRUCTOR
+  //------------------------
+
+  public function __construct()
+  {
+    $this->setStatus(self::$StatusFollow);
+  }
+
+  //------------------------
+  // INTERFACE
+  //------------------------
+
+  public function getStatusFullName()
+  {
+    $answer = $this->getStatus();
+    return $answer;
+  }
+
+  public function getStatus()
+  {
+    if ($this->status == self::$StatusFollow) { return "StatusFollow"; }
+    elseif ($this->status == self::$StatusChanging_lane) { return "StatusChanging_lane"; }
+    elseif ($this->status == self::$StatusFinal) { return "StatusFinal"; }
+    return null;
+  }
+
+  public function change_lane()
+  {
+    $wasEventProcessed = false;
+    
+    $aStatus = $this->status;
+    if ($aStatus == self::$StatusFollow)
+    {
+      $this->setStatus(self::$StatusChanging_lane);
+      $wasEventProcessed = true;
+    }
+    elseif ($aStatus == self::$StatusChanging_lane)
+    {
+      if ($this->not_achieved==$this->False)
+      {
+        $this->setStatus(self::$StatusChanging_lane);
+        $wasEventProcessed = true;
+      }
+      if ($this->not_achieved==$this->True)
+      {
+        $this->setStatus(self::$StatusFinal);
+        $wasEventProcessed = true;
+      }
+    }
+    return $wasEventProcessed;
+  }
+
+  private function setStatus($aStatus)
+  {
+    $this->status = $aStatus;
+  }
+
+  public function equals($compareTo)
+  {
+    return $this == $compareTo;
+  }
+
+  public function delete()
+  {}
+
+}
+?>


### PR DESCRIPTION
Fixes Issue#1536 "Umple does not parse properly the guards starting with the word 'not' and no space after 'not'".

Change a line related to negative constraint in file umple_constrains.grammar. Replace the "not" with regex.
Add a state machine test case called "guardNegSymbolSpacing".
 

