### PR TITLE
Fixes #1522, and add a test case

### DIFF
--- a/cruise.umple/src/umple_classes.grammar
+++ b/cruise.umple/src/umple_classes.grammar
@@ -30,7 +30,7 @@ enumerationDefinition : enum [name] { [enumValue](, [enumValue])* }
 
 // The following items can be found inside the body of classes or association classes
 classContent- : [[comment]] | [[innerClass]] | [[mixsetDefinition]] | [[distributable]] | [[proxyPattern]] | [[strictness]] | [[classDefinition]] | [[trace]] | [[emitMethod]] | [[templateAttributeDefinition]] | [[primitiveDefinition]] | [[portDefinition]] | [[portBindingDefinition]] | [[position]] | [[displayColor]] | [[abstract]] | [[keyDefinition]] | [[softwarePattern]] | [[depend]] | [[symmetricReflexiveAssociation]] | [[attribute]] | [[testCase]] | [[genericTestCase]] | [[testSequence]] | [[testClassInit]] | [[stateMachine]] | [[activeMethodDefinition]] | [[inlineAssociation]] | [[concreteMethodDeclaration]] | [[constantDeclaration]] | [[modelConstraint]] | [[invariant]] | ; | [[enumerationDefinition]] | [[exception]] | [[extraCode]] 
-associationClassContent- :  [[comment]] | [[classDefinition]] | [[position]] | [[displayColor]] | [[invariant]] | [[softwarePattern]] | [[depend]] | [[association]] | [[inlineAssociation]] | [[singleAssociationEnd]] | [[attribute]] | [[stateMachine]] | ; | [[extraCode]]
+associationClassContent- :  [[comment]] | [[classDefinition]] | [[position]] | [[displayColor]] | [[invariant]] | [[softwarePattern]] | [[depend]] | [[association]] | [[inlineAssociation]] | [[singleAssociationEnd]] | [[attribute]] | [[stateMachine]] | [[enumerationDefinition]] | ; | [[extraCode]]
 innerClass : [[innerStaticClass]] | [[innerNonStaticClass]]
 innerStaticClass : static [[classDefinition]]
 innerNonStaticClass : inner [[classDefinition]]

--- a/cruise.umple/test/cruise/umple/compiler/050_enumerationDefinedInAssociationClass.ump
+++ b/cruise.umple/test/cruise/umple/compiler/050_enumerationDefinedInAssociationClass.ump
@@ -1,0 +1,10 @@
+class A {}  
+  
+class B {}  
+  
+associationClass C {  
+  * A;  
+  * B; 
+  enum AttributeName {something};
+  AttributeName attribute;
+}  

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2986,6 +2986,17 @@ public class UmpleParserTest
   assertFailedParse("050_duplicateEnumsInClass.ump", 95);
  }
 
+ //Issue 1522
+ @Test
+ public void parseUmpleEnumerationDefinedInAssociationClass () {
+    assertSimpleParse("050_enumerationDefinedInAssociationClass.ump");
+    UmpleClass uClass = model.getUmpleClass("C");
+    Assert.assertEquals(1, uClass.getEnums().size());
+
+    Assert.assertEquals("AttributeName", uClass.getEnum(0).getName());
+    Assert.assertEquals("something", uClass.getEnum(0).getEnumValue(0));
+ }
+
  // Issue 1008
  @Test
  public void namingConflictBetweenEnumerationAndClass() {


### PR DESCRIPTION
Fixes the issue#1522 "enum declaration in associationClass causes error".

1. Add "[[enumerationDefinition]]" in "associationClassContent" grammar, which fixes the issue.
2. Add a test case called "parseUmpleEnumerationDefinedInAssociationClass" in Class cruise.umple.compiler.UmpleParserTest.
