### PR TITLE
Progress on parsing mixsets not used 

### DIFF
--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -65,7 +65,7 @@ digraph FeatureModel {
       else 
       {// link source to leaf node 
         code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getName()+" ");
-        code.append(getGvTargetShape(featureLink.getFeatureConnectingOpType()));
+        code.append(getGvTargetShape(featureLink.getFeatureConnectingOpType(), featureLink.getIsSub() ));
         code.append(" ;"+"\n");    
         fillColorOfFeatureNode(code,featureNode,indentLevel);
       }
@@ -111,20 +111,28 @@ digraph FeatureModel {
     terminateCode(code);
   }
 
-  public static String getGvTargetShape(FeatureConnectingOpType featureConnectingOpType)
+  public static String getGvTargetShape(FeatureConnectingOpType featureConnectingOpType , boolean isSub)
   { 
+		String shapeProp = " ";
+	  if(! isSub)
+    shapeProp = " constraint=false ";
+
     switch(featureConnectingOpType)
     {
       case Exclude:
-      return "["+"arrowhead=normal color=red constraint=false label=exclude "+"]";
+      return "["+ shapeProp +" arrowhead=normal color=red label=exclude " +" ]";
       case Include:
-      return "["+ "arrowhead=normal color=blue constraint=false label=include "+"]";
+			if(isSub)
+      shapeProp += " arrowhead=dot ";
+      else 
+      shapeProp += " arrowhead=normal label=include color=blue ";
+      return "["+ shapeProp +" ]";
       case Optional:
-      return "[arrowhead=odot]";
+      return "[arrowhead=odot "+shapeProp+" ]";
       case Conjunctive:
-      return "[arrowhead=dot]";
+      return "[arrowhead=dot "+shapeProp+" ]";
       default:
-      return "";
+      return "[ "+shapeProp+" ]";
     }
   }
 

--- a/cruise.umple/src/Mixset.ump
+++ b/cruise.umple/src/Mixset.ump
@@ -38,9 +38,9 @@ class UmpleFile {
 // It consists of one or more fragments that are encountered anywhere in the Umple source
 // including in other mixsets
 class Mixset {
-  mixsetName; // THe name of the mixset
+  mixsetName; // name of the mixset
   isA MixsetOrFile;
-  
+  boolean isFeature = false;  // Specify a mixset to be a feature. Default value is false.. 
 
   after constructor {  
     setIsMixset(true);

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -273,9 +273,20 @@ class UmpleInternalParser
   }
 
   private Mixset analyzeMixset(Token token){
+    String mixsetName = token.getValue("mixsetName");
+    // check if the mixset is was not added before
+    Mixset mixset = model.getMixset(mixsetName);
+    
+    if(mixset  == null)
+    {
+       mixset  = new Mixset(mixsetName);
+       model.addMixsetOrFile(mixset);
+    }
     //inline mixset def.
-    MixsetFragment mixsetFragment = createMixsetFragment(token);      
-    Mixset mixset = mixsetFragment.getMixset();
+    MixsetFragment mixsetFragment = createMixsetFragment(token, mixset);
+    if(mixsetFragment == null)
+    return mixset;
+    //else      
     // Here the mixset fragment is considered as waitingFragment (mixsetFragment.isParsed==false). 
     mixset.addMixsetFragment(mixsetFragment);
     mixsetFragment.setMixset(mixset);
@@ -286,24 +297,17 @@ class UmpleInternalParser
       return mixset;
   }
   
-  private MixsetFragment createMixsetFragment(Token token) {  
-    String mixsetName = token.getValue("mixsetName");
-    // check if the mixset is was not added before
-    Mixset mixset = model.getMixset(mixsetName);
-    
-    if(mixset  == null)
-    {
-       mixset  = new Mixset(mixsetName);
-       model.addMixsetOrFile(mixset);
-    }
+  private MixsetFragment createMixsetFragment(Token token,  Mixset mixset) {  
+  
     
     Position mixsetFragmentPosition = null;
+    int mixsetFragmentLineNumber = 0;
+
     String mixsetBody = token.getValue("extraCode");
     if(mixsetBody != null)
     {
       mixsetFragmentPosition = token.getSubToken("extraCode").getPosition();
     }       
-    int mixsetFragmentLineNumber;
     String entityType = token.getValue("entityType");
     String entityName = token.getValue("entityName");
     
@@ -327,7 +331,7 @@ class UmpleInternalParser
       }
       
       if(mixsetBody == null)
-      mixsetBody = ""; // because there is no fragment to add. 
+      return null; // because there is no fragment to add. 
       
       mixsetFragmentLineNumber = mixsetFragmentPosition.getLineNumber();
       UmpleFile mixsetFragmentUmpleFile = model.getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -271,69 +271,72 @@ class UmpleInternalParser
     }
     
   }
+
+  private Mixset analyzeMixset(Token token){
+    //inline mixset def.
+    MixsetFragment mixsetFragment = createMixsetFragment(token);      
+    Mixset mixset = mixsetFragment.getMixset();
+    // Here the mixset fragment is considered as waitingFragment (mixsetFragment.isParsed==false). 
+    mixset.addMixsetFragment(mixsetFragment);
+    mixsetFragment.setMixset(mixset);
+    // parse mixset fragments right away if there is a use-statement. 
+    if(mixset.getUseUmpleFile() != null)
+      parseMixsetWaitingFragment(mixsetFragment);
+      
+      return mixset;
+  }
   
-  private Mixset analyzeMixset(Token token)
-  {
+  private MixsetFragment createMixsetFragment(Token token) {  
     String mixsetName = token.getValue("mixsetName");
     // check if the mixset is was not added before
-    Mixset mixset = model.getMixset(mixsetName);
+    Mixset mixset = getModel().getMixset(mixsetName);
+    
     if(mixset  == null)
     {
        mixset  = new Mixset(mixsetName);
-       model.addMixsetOrFile(mixset);
+       getModel().addMixsetOrFile(mixset);
     }
-	
-	
+    
     Position mixsetFragmentPosition = null;
-    int mixsetFragmentLineNumber = 0;
-	
     String mixsetBody = token.getValue("extraCode");
     if(mixsetBody != null)
     {
       mixsetFragmentPosition = token.getSubToken("extraCode").getPosition();
-    }		
-	
-    //inline mixset def.
+    }       
+    int mixsetFragmentLineNumber;
     String entityType = token.getValue("entityType");
     String entityName = token.getValue("entityName");
-	
+    
     // mixset with one element
     String oneElementMixset = token.getValue("oneElement");
-	
+    
     if(entityType != null) {
         if (oneElementMixset != null)
-	  {
-	    mixsetBody = entityType + " "+entityName + " { "+ oneElementMixset + " }";
-	    mixsetFragmentPosition = token.getSubToken("oneElementMixset").getPosition();	    
-	  }
-	  else
-	    mixsetBody = entityType + " "+entityName + " { "+ mixsetBody + " }";
-	    mixsetFragmentPosition = token.getSubToken("extraCode").getPosition();	
-	  }
-	  else if (oneElementMixset != null) 
-	  {
-	    mixsetBody = oneElementMixset;
-	    mixsetFragmentPosition = token.getSubToken("oneElementMixset").getPosition();	  
-	  }
-	  
-	  if(mixsetBody == null)
-	  return mixset; // becuase there is no fragment to add. 
-	  
-	  mixsetFragmentLineNumber = mixsetFragmentPosition.getLineNumber();
-	  UmpleFile mixsetFragmentUmpleFile = model.getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
-	  MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, mixsetFragmentLineNumber, mixsetBody);
-	  
-	  // Here the mixset fragmet is considered as waitingFragment (mixsetFragment.isParsed==flase). 
-	  mixset.addMixsetFragment(mixsetFragment);
-	  mixsetFragment.setMixset(mixset);
-	  // parse mixset fragments right away if there is a use statment.
-	  // 
-	  if(mixset.getUseUmpleFile() != null)
-	  parseMixsetWaitingFragment(mixsetFragment);
-	  
-	  
-	return  mixset ;
+      {
+        mixsetBody = entityType + " "+entityName + " { "+ oneElementMixset + " }";
+        mixsetFragmentPosition = token.getSubToken("oneElementMixset").getPosition();       
+      }
+      else
+        mixsetBody = entityType + " "+entityName + " { "+ mixsetBody + " }";
+        mixsetFragmentPosition = token.getSubToken("extraCode").getPosition();  
+      }
+      else if (oneElementMixset != null) 
+      {
+        mixsetBody = oneElementMixset;
+        mixsetFragmentPosition = token.getSubToken("oneElementMixset").getPosition();     
+      }
+      
+      if(mixsetBody == null)
+      mixsetBody = ""; // because there is no fragment to add. 
+      
+      mixsetFragmentLineNumber = mixsetFragmentPosition.getLineNumber();
+      UmpleFile mixsetFragmentUmpleFile = getModel().getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
+      MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, mixsetFragmentLineNumber, mixsetBody);
+      mixsetFragment.setMixset(mixset);
+    return mixsetFragment;
   }
+
+
   
   private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment){
     if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
@@ -348,7 +351,8 @@ class UmpleInternalParser
       //    model.setLastResult(result);
       answer.setName("mixsetDefinition"); //attach the mixset name for the fragment instead of ROOT
       answer.setValue(mixsetFragment.getMixset().getMixsetName());
-      //isFeature + umpFiles + require-st
+      //  getIsFeature()
+      //isFeature + umpFiles(use-st) + require-st
 
       //    analyzeAllTokens(answer);
       //  mixsetFragment.setIsParsed(true);

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -334,6 +334,48 @@ class UmpleInternalParser
 	  
 	return  mixset ;
   }
+  
+  private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment){
+    if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
+    {
+      String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getFileName();
+      int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine() - 1;
+      String mixsetFragmentBodyExtraLine = mixsetFragment.getBody()+"\n;";
+      ParseResult result= parse("MixsetFragmentParsing",  mixsetFragmentBodyExtraLine, mixsetFragmentFile, null, mixsetFragmentLine,0); 
+      setParseResult(result);
+      Token answer = getParser().getRootToken(); // result of parsing the body of a mixset waitingFragments
+      //    setRootToken(answer);
+      //    model.setLastResult(result);
+      answer.setName("mixsetDefinition"); //attach the mixset name for the fragment instead of ROOT
+      answer.setValue(mixsetFragment.getMixset().getMixsetName());
+      //isFeature + umpFiles + require-st
+
+      //    analyzeAllTokens(answer);
+      //  mixsetFragment.setIsParsed(true);
+    }
+  }
+  /*
+   * This method does partial parsing for mixsets that have no use-statements.
+   */
+    private void parseMixsetsNotUsed() {
+      
+    List<Mixset> mixsetList = model.getMixsetOrFiles().stream().filter(mixset -> mixset.getIsMixset()).map(obj -> (Mixset)obj).collect(Collectors.toList());
+    for (Mixset aMixset: mixsetList)
+    {
+      List<MixsetFragment>mixsetFragmentList= aMixset.getMixsetFragments();
+      for(MixsetFragment aMixsetFragment :  mixsetFragmentList)
+      {
+        if(aMixsetFragment.getIsParsed()) // the fragment is already parsed 
+          continue;
+        else
+        {
+          parseMixsetFragmentNotUsed(aMixsetFragment);
+          
+        }
+      }
+      
+    }
+  }
     
   
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -338,6 +338,9 @@ class UmpleInternalParser
   }
   
   private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment){
+    if(mixsetFragment == null)
+    return;
+    //else
     if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
     {
       String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getFileName();
@@ -366,7 +369,7 @@ class UmpleInternalParser
             model.addMixsetOrFile(mixset);
           }
           
-           createMixsetFragment(token,  mixset) ;
+           parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
         }
       }
 

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -289,12 +289,12 @@ class UmpleInternalParser
   private MixsetFragment createMixsetFragment(Token token) {  
     String mixsetName = token.getValue("mixsetName");
     // check if the mixset is was not added before
-    Mixset mixset = getModel().getMixset(mixsetName);
+    Mixset mixset = model.getMixset(mixsetName);
     
     if(mixset  == null)
     {
        mixset  = new Mixset(mixsetName);
-       getModel().addMixsetOrFile(mixset);
+       model.addMixsetOrFile(mixset);
     }
     
     Position mixsetFragmentPosition = null;
@@ -330,7 +330,7 @@ class UmpleInternalParser
       mixsetBody = ""; // because there is no fragment to add. 
       
       mixsetFragmentLineNumber = mixsetFragmentPosition.getLineNumber();
-      UmpleFile mixsetFragmentUmpleFile = getModel().getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
+      UmpleFile mixsetFragmentUmpleFile = model.getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
       MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, mixsetFragmentLineNumber, mixsetBody);
       mixsetFragment.setMixset(mixset);
     return mixsetFragment;

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -341,14 +341,14 @@ class UmpleInternalParser
     if(mixsetFragment == null)
     return;
     //else
-    if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
+    if(! mixsetFragment.getIsParsed()) // process a fragment that has not been parsed. 
     {
       String mixsetFragmentFile = mixsetFragment.getOriginalUmpFile().getPath()+"/"+mixsetFragment.getOriginalUmpFile().getFileName();
       int mixsetFragmentLine = mixsetFragment.getOriginalUmpLine() - 1;
       String mixsetFragmentBodyExtraLine = mixsetFragment.getBody()+"\n;";
       ParseResult result= parse("MixsetFragmentParsing",  mixsetFragmentBodyExtraLine, mixsetFragmentFile, null, mixsetFragmentLine,0); 
       setParseResult(result);
-      Token answer = getParser().getRootToken(); // result of parsing the body of a mixset waitingFragments
+      Token answer = getParser().getRootToken(); // result of parsing the body of a MixsetFragment
       //    setRootToken(answer);
       //    model.setLastResult(result);
       answer.setName("mixsetDefinition"); //attach the mixset name for the fragment instead of ROOT
@@ -367,14 +367,10 @@ class UmpleInternalParser
           {
             mixset  = new Mixset(mixsetName);
             model.addMixsetOrFile(mixset);
-          }
-          
+          }   
            parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
         }
       }
-
-      //    analyzeAllTokens(answer);
-      //  mixsetFragment.setIsParsed(true);
     }
   }
   /*

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -298,11 +298,8 @@ class UmpleInternalParser
   }
   
   private MixsetFragment createMixsetFragment(Token token,  Mixset mixset) {  
-  
-    
     Position mixsetFragmentPosition = null;
     int mixsetFragmentLineNumber = 0;
-
     String mixsetBody = token.getValue("extraCode");
     if(mixsetBody != null)
     {
@@ -339,8 +336,6 @@ class UmpleInternalParser
       mixsetFragment.setMixset(mixset);
     return mixsetFragment;
   }
-
-
   
   private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment){
     if(! mixsetFragment.getIsParsed()) // a fragment that is not parsed before. 
@@ -357,6 +352,23 @@ class UmpleInternalParser
       answer.setValue(mixsetFragment.getMixset().getMixsetName());
       //  getIsFeature()
       //isFeature + umpFiles(use-st) + require-st
+      for(Token token : answer.getSubTokens())
+      {
+        analyzeRequireStatement(token, 2);
+        if(token.is("mixsetDefinition"))
+        {
+          String mixsetName = token.getValue("mixsetName");
+          // check if the mixset is was not added before
+          Mixset mixset = model.getMixset(mixsetName);
+          if(mixset  == null)
+          {
+            mixset  = new Mixset(mixsetName);
+            model.addMixsetOrFile(mixset);
+          }
+          
+           createMixsetFragment(token,  mixset) ;
+        }
+      }
 
       //    analyzeAllTokens(answer);
       //  mixsetFragment.setIsParsed(true);

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -21,6 +21,7 @@ class UmpleInternalParser
       shouldProcessAgain = shouldProcessAgain || (analysisStep == 1);
       return;
     }
+    /*
     if (t.is("mixsetIsFeature"))
     {
       FeatureModel featureModel = model.getFeatureModel();
@@ -36,7 +37,7 @@ class UmpleInternalParser
         sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset); 
       }
 
-    }    
+    }   */ 
     if (t.is("requireStatement"))
     {
       FeatureModel featureModel = model.getFeatureModel();
@@ -402,7 +403,7 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(List<Toke
   }
   public void analyzeFeatureModel()
   {
-    parseMixsetsNotUsed();
+   // parseMixsetsNotUsed();
     
     if(model.getFeatureModel() != null)
     model.getFeatureModel().satisfyFeatureModel();

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -402,6 +402,8 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(List<Toke
   }
   public void analyzeFeatureModel()
   {
+    parseMixsetsNotUsed();
+    
     if(model.getFeatureModel() != null)
     model.getFeatureModel().satisfyFeatureModel();
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -403,7 +403,7 @@ private ArrayList<TokenTree> generateFeatureTreeTokenFromRequireStList(List<Toke
   }
   public void analyzeFeatureModel()
   {
-   // parseMixsetsNotUsed();
+    parseMixsetsNotUsed();
     
     if(model.getFeatureModel() != null)
     model.getFeatureModel().satisfyFeatureModel();

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -20,6 +20,22 @@ class UmpleInternalParser
     {
       shouldProcessAgain = shouldProcessAgain || (analysisStep == 1);
       return;
+    }
+    if (t.is("mixsetIsFeature"))
+    {
+      FeatureModel featureModel = model.getFeatureModel();
+      if(featureModel == null)
+        featureModel = new FeatureModel("featureModel");
+      featureModel.setUmpleModel(model);
+
+      FeatureLeaf sourceFeatureLeaf;
+      Mixset sourceMixset = getMixsetFromToken(t); // the mixset containing the isFeature;
+      if(sourceMixset != null)
+      {
+        sourceFeatureLeaf = featureModel.getOrCreateFeatureLeafNode(sourceMixset.getName());
+        sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset); 
+      }
+
     }    
     if (t.is("requireStatement"))
     {

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -21,7 +21,7 @@ class UmpleInternalParser
       shouldProcessAgain = shouldProcessAgain || (analysisStep == 1);
       return;
     }
-    /*
+    
     if (t.is("mixsetIsFeature"))
     {
       FeatureModel featureModel = model.getFeatureModel();
@@ -37,7 +37,7 @@ class UmpleInternalParser
         sourceFeatureLeaf.setMixsetOrFileNode(sourceMixset); 
       }
 
-    }   */ 
+    }   
     if (t.is("requireStatement"))
     {
       FeatureModel featureModel = model.getFeatureModel();

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -46,7 +46,7 @@ namespace- : namespace [namespace] [[namespaceoption]]? ;
 namespaceoption : [=option:--redefine]
 
 // The main top level elements to be found in an Umple file
-entity- : [[requireStatement]] | [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
+entity- : [[mixsetIsFeature]] | [[requireStatement]] | [[mixsetDefinition]] | [[classDefinition]] | [[traitDefinition]] | [[fixml]] | [[interfaceDefinition]] | [[externalDefinition]] | [[associationDefinition]] | [[associationClassDefinition]] | [[stateMachineDefinition]] | [[templateDefinition]] | [[enumerationDefinition]]
 
 // Comments follow the same conventions as C-family languages. [*UmpleComments*]
 comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -18,7 +18,7 @@ mixsetIsFeature : isFeature
 
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require ( subfeature )? [[requireBody]] 
+requireStatement : require ( [=subfeature] )? [[requireBody]] 
 
 requireBody- : [(([[requireLinkingOptNot]])? (OPEN_ROUND_BRACKET)* [[requireTerminal]] [[requireList]])] 
 

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -5,7 +5,7 @@
 // This file is made available subject to the open source license found at:
 // [*http://umple.org/license*]
 
-//mixsets allow creation of mixins composed from multiple locations plus some constraints regarding usage of these mixins.
+//Mixsets allow creation of mixins composed from multiple locations plus some constraints regarding usage of these mixins.
 // See user manual page [*BasicMixsets*]
 
 mixsetDefinition : mixset [mixsetName] ( [[mixsetInnerContent]] | [[mixsetInlineDefinition]] )
@@ -13,6 +13,8 @@ mixsetInnerContent- : { [[extraCode]] }
  
 mixsetInlineDefinition- : ( [entityType] [entityName] ( [[mixsetInnerContent]] | [entityOneElement] ) | [oneElement] )
 
+// Specialize a mixset to be a feature. 
+mixsetIsFeature : isFeature 
 
 // require statement allows adding dependencies between mixsets.
 

--- a/cruise.umple/src/umple_mixsets.grammar
+++ b/cruise.umple/src/umple_mixsets.grammar
@@ -18,7 +18,7 @@ mixsetIsFeature : isFeature
 
 // require statement allows adding dependencies between mixsets.
 
-requireStatement : require ( [=subfeature:sub] )? [[requireBody]] 
+requireStatement : require ( subfeature )? [[requireBody]] 
 
 requireBody- : [(([[requireLinkingOptNot]])? (OPEN_ROUND_BRACKET)* [[requireTerminal]] [[requireList]])] 
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -818,4 +818,18 @@ public class UmpleMixsetTest {
    }
   }
 
+
+ @Test
+  public void reqStatmentForMixsetNotusedIsParsed()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseReqStInsideMixsetNotUsed.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    Assert.assertEquals(model.getMixsetOrFiles().size() , 9);
+
+
+
+  }
+
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireSubStatementNoWarnings.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetRequireSubStatementNoWarnings.ump
@@ -1,15 +1,15 @@
 
-require sub [Mixset1]; use Mixset1; mixset Mixset1{}
+require subfeature [Mixset1]; use Mixset1; mixset Mixset1{}
 
-require sub [GSMProtocol opt Mp3Recording and Playback and AudioFormat opt Camera ];
+require subfeature [GSMProtocol opt Mp3Recording and Playback and AudioFormat opt Camera ];
 
-require sub [ 1..3 of {M1,M2,M3 } ];
+require subfeature [ 1..3 of {M1,M2,M3 } ];
 
-require sub [M1 opt M3];
+require subfeature [M1 opt M3];
 
-require sub [M3 or M2];
+require subfeature [M3 or M2];
 
-require sub [0..1 of {M1}]; 
+require subfeature [0..1 of {M1}]; 
 
 
 /*

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseReqStInsideMixsetNotUsed.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseReqStInsideMixsetNotUsed.ump
@@ -1,0 +1,46 @@
+mixset Phone {
+  require subfeature [ GSM_Protocols];
+  require subfeature [ opt  MP3_Recording ];
+  require subfeature [ Audio_Formats  ];
+  require subfeature [ Playback ];
+  require subfeature [ opt Camera ];
+}
+    
+mixset GSM_Protocols 
+{
+  require subfeature [GSM1800];
+  require subfeature [opt GSM1900];
+}
+
+mixset MP3_Recording 
+{
+  require [  MP3  ];
+}
+
+mixset Audio_Formats 
+{
+  require subfeature [  MP3 xor WAV  ];
+}
+
+
+mixset GSM1800
+{
+  
+}
+mixset Playback 
+{
+  
+}
+mixset Audio 
+{
+
+}
+mixset  Camera 
+{    
+  require subfeature [  Resolution ];
+}
+
+mixset Resolution 
+{
+  require subfeature [  _2MP or _3MP or _5MP  ];
+}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotValidXorFeatureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_NotValidXorFeatureModel.ump
@@ -1,7 +1,7 @@
-require sub [A and B];
-require sub [opt C];
+require subfeature [A and B];
+require subfeature [opt C];
 require [not D];
-require sub [E xor F];
+require subfeature [E xor F];
 
 
 mixset A {} mixset B {} mixset C{}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_featureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_featureModel.ump
@@ -1,10 +1,10 @@
 /*
 map the require-statement to feature model. 
 */
-require sub [A and B];
-require sub [opt C];
+require subfeature [A and B];
+require subfeature [opt C];
 require [not D];
-require sub [E xor F];
+require subfeature [E xor F];
 
 
 mixset A {} mixset B {} mixset C{}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_validFeatureModel.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_validFeatureModel.ump
@@ -1,8 +1,8 @@
 
-require sub [A and B];
-require sub [opt C];
+require subfeature [A and B];
+require subfeature [opt C];
 require [not D];
-require sub [E xor F];
+require subfeature [E xor F];
 
 
 mixset A {} mixset B {} mixset C{}


### PR DESCRIPTION
Currently require-statemets inside mixsets, which are not used, are not parsed. In this PR, Umple parser will parse only require-statements inside an unused mixset. 

Feature diagram rendered by graphiz engine is improved in this PR. Example: 
   
```
mixset Phone {
  require subfeature [ GSM_Protocols];
  require subfeature [ opt  MP3_Recording ];
  require subfeature [ Audio_Formats  ];
  require subfeature [ Playback ];
  require subfeature [ opt Camera ];
}
    
mixset GSM_Protocols 
{
  require subfeature [GSM1800];
  require subfeature [opt GSM1900];
}

mixset MP3_Recording 
{
  require [  MP3  ];
}

mixset Audio_Formats 
{
  require subfeature [  MP3 xor WAV  ];
}


mixset GSM1800
{
  
}
mixset Playback 
{
  
}
mixset Audio 
{

}
mixset  Camera 
{    
  require subfeature [  Resolution ];
}

mixset Resolution 
{
  require subfeature [  _2MP or _3MP or _5MP  ];
}
```
The code above has no use-statements. It will generated the following feature diagram: 
![phoneGraphviz](https://user-images.githubusercontent.com/11878501/83050420-8d64aa80-a01a-11ea-8c37-21ed5aecb755.Jpg)
