### PR TITLE
Progress on parsing Umple files inside not-used mixsets

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -67,6 +67,11 @@ class UmpleInternalParser
     else if (t.is("useStatement") )
     {
       analyzeAllTokens(t);
+      // add parsed files to parsedUmpfiles hashMap.
+      String umpFileName = t.getSubToken("use").getValue();
+      if(! parsedUmpfiles.keySet().contains(umpFileName))
+      parsedUmpfiles.put(umpFileName, true);
+      
     }
     else if (t.is("strictness") )
     {

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -300,7 +300,12 @@ class UmpleInternalParser
   }
   
   private MixsetFragment createMixsetFragment(Token token,  Mixset mixset) {  
-    return createMixsetFragment(token).setMixset(mixset);
+    MixsetFragment mixsetFragment = createMixsetFragment(token);
+    if(mixsetFragment == null || mixset == null)
+    return null;
+    else
+    mixsetFragment.setMixset(mixset);
+    return mixsetFragment;
   }
 
   private MixsetFragment createMixsetFragment(Token token) {  
@@ -342,6 +347,24 @@ class UmpleInternalParser
     return mixsetFragment;
   }
   
+  private void parseMixsetNotUsedToken(Token token){
+    //parse require statments 
+    analyzeRequireStatement(token, 2);
+    // parse nested mixset def.
+    if(token.is("mixsetDefinition"))
+    {
+      String mixsetName = token.getValue("mixsetName");
+      // check if the mixset is was not added before
+      Mixset mixset = model.getMixset(mixsetName);
+      if(mixset  == null)
+      {
+        mixset  = new Mixset(mixsetName);
+        model.addMixsetOrFile(mixset);
+      }   
+      parseMixsetFragmentNotUsed(createMixsetFragment(token) );
+    }
+  }
+
   private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment){
     if(mixsetFragment == null)
     return;
@@ -362,46 +385,19 @@ class UmpleInternalParser
       //isFeature + umpFiles(use-st) + require-st
       for(Token token : answer.getSubTokens())
       {
-        analyzeRequireStatement(token, 2);
-        if(token.is("mixsetDefinition"))
-        {
-          String mixsetName = token.getValue("mixsetName");
-          // check if the mixset is was not added before
-          Mixset mixset = model.getMixset(mixsetName);
-          if(mixset  == null)
-          {
-            mixset  = new Mixset(mixsetName);
-            model.addMixsetOrFile(mixset);
-          }   
-          parseMixsetFragmentNotUsed(createMixsetFragment(token) );
-        }
-        else if (token.is("useStatement"))
-        {
+        parseMixsetNotUsedToken(token);
+        if (token.is("useStatement")) // an ump file 
+        {          
           String umpFileName = token.getSubToken("use").getValue();
-          if(! parsedUmpfiles.keySet().contains(umpFileName)) // accept a file that has not been parsed before.
+          if(parsedUmpfiles.keySet().contains(umpFileName)) // accept a file that has not been parsed before.
+          return;
+          //else
+          for (Token subToken : token.getSubTokens())
           {
-            /* here the goal is to create a fragment that contains the content of a refereced file.
-             * Then it will be parsed in similar way to a mixset fragment. 
-             */
-            // read ump files via ParserDataPackage (in which Umple parser read umple files ).
-            ParserDataPackage fileData = new ParserDataPackage(umpFileName, null);
-            fileData.init(null);
-            String fileContent = fileData.getInput(); // get the content of umpleFile as a String. 
-            UmpleFile aOriginalUmpFile = new UmpleFile(umpFileName); 
-            int aOriginalUmpLine = 1;
-            MixsetFragment mixsetFragmentOutOffUmpFile = new MixsetFragment(aOriginalUmpFile, aOriginalUmpLine, fileContent);
-            //mixsetFragmentOutOffUmpFile.setMixset(mixsetFragment.getMixset());
-
-            parseMixsetFragmentNotUsed(mixsetFragmentOutOffUmpFile);
-            parsedUmpfiles.put(umpFileName, false); // add current file to partially parsed files. 
-
+            parseMixsetNotUsedToken(subToken);
           }
-          else 
-          {
-            // The file is already parsed. 
-          }
+          parsedUmpfiles.put(umpFileName, false); // add current file to partially parsed files. 
         }
-
       }
     }
   }
@@ -420,8 +416,7 @@ class UmpleInternalParser
           continue;
         else
         {
-          parseMixsetFragmentNotUsed(aMixsetFragment);
-          
+          parseMixsetFragmentNotUsed(aMixsetFragment);   
         }
       }
       

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -54,7 +54,9 @@ class UmpleInternalParser
 {
 	depend cruise.umple.compiler.UmpleFile;
 	depend  java.util.stream.*;
-	
+  
+  Map<String, Boolean> parsedUmpfiles = new HashMap<>(); // The key is to store names of parsed umple files. The value is to specify if fully parsed file (true) or partially (false). 
+
 	// prepare mixsets that are inside a state machine. 
   private void analyzeMixsetDefinition(List<Token> tokenList , StateMachine stateMachine)
   {  
@@ -368,8 +370,47 @@ class UmpleInternalParser
             mixset  = new Mixset(mixsetName);
             model.addMixsetOrFile(mixset);
           }   
-           parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
+          parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
         }
+        else if (token.is("useStatement"))
+        {
+          String umpFileName = token.getSubToken("use").getValue();
+          if(! parsedUmpfiles.keySet().contains(umpFileName)) // accept a file that has not been parsed before.
+          {
+            /* here the goal is to create a fragment that contains the content of a refereced file.
+             * Then it will be parsed in similar way to a mixset fragment. 
+             */
+            // read ump files via ParserDataPackage (in which Umple parser read umple files ).
+            ParserDataPackage fileData = new ParserDataPackage(umpFileName, null);
+            fileData.init(null);
+            String fileContent = fileData.getInput(); // get the content of umpleFile as a String. 
+            UmpleFile aOriginalUmpFile = new UmpleFile(umpFileName); 
+            int aOriginalUmpLine = 1;
+            MixsetFragment mixsetFragmentOutOffUmpFile = new MixsetFragment(aOriginalUmpFile, aOriginalUmpLine, fileContent);
+            mixsetFragmentOutOffUmpFile.setMixset(mixsetFragment.getMixset().getMixsetName());
+
+            parseMixsetFragmentNotUsed(mixsetFragmentOutOffUmpFile);
+            parsedUmpfiles.put(umpFileName, false); // add current file to partially parsed files. 
+
+          }
+          else 
+          {
+            // The file is already parsed. 
+          }
+    
+ 
+ 
+          String mixsetName = token.getValue("mixsetName");
+          // check if the mixset is was not added before
+          Mixset mixset = model.getMixset(mixsetName);
+          if(mixset  == null)
+          {
+            mixset  = new Mixset(mixsetName);
+            model.addMixsetOrFile(mixset);
+          }   
+          parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
+        }
+
       }
     }
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -346,9 +346,9 @@ class UmpleInternalParser
       MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, mixsetFragmentLineNumber, mixsetBody);
     return mixsetFragment;
   }
-  
+  // this method specifies kinds of tokens to be parsed for unused mixset. 
   private void parseMixsetNotUsedToken(Token token){
-    //parse require statments 
+    //parse require statments. 
     analyzeRequireStatement(token, 2);
     // parse nested mixset def.
     if(token.is("mixsetDefinition"))
@@ -361,11 +361,11 @@ class UmpleInternalParser
         mixset  = new Mixset(mixsetName);
         model.addMixsetOrFile(mixset);
       }   
-      parseMixsetFragmentNotUsed(createMixsetFragment(token) );
+      parseMixsetFragmentNotUsed(createMixsetFragment(token), mixset.getName());
     }
   }
 
-  private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment){
+  private void parseMixsetFragmentNotUsed(MixsetFragment mixsetFragment, String parentMixset){
     if(mixsetFragment == null)
     return;
     //else
@@ -380,13 +380,15 @@ class UmpleInternalParser
       //    setRootToken(answer);
       //    model.setLastResult(result);
       answer.setName("mixsetDefinition"); //attach the mixset name for the fragment instead of ROOT
-      answer.setValue("TEMP_MIXSET");
+      answer.setValue(parentMixset);
       //  getIsFeature()
       //isFeature + umpFiles(use-st) + require-st
       for(Token token : answer.getSubTokens())
       {
         parseMixsetNotUsedToken(token);
-        if (token.is("useStatement")) // an ump file 
+        // an ump file included in an unused mixset: it should be partially parsed to know mixsets' dependencies.
+        // 
+        if (token.is("useStatement")) 
         {          
           String umpFileName = token.getSubToken("use").getValue();
           if(parsedUmpfiles.keySet().contains(umpFileName)) // accept a file that has not been parsed before.
@@ -416,7 +418,7 @@ class UmpleInternalParser
           continue;
         else
         {
-          parseMixsetFragmentNotUsed(aMixsetFragment);   
+          parseMixsetFragmentNotUsed(aMixsetFragment, aMixsetFragment.getMixset().getName());   
         }
       }
       

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -300,6 +300,10 @@ class UmpleInternalParser
   }
   
   private MixsetFragment createMixsetFragment(Token token,  Mixset mixset) {  
+    return createMixsetFragment(token).setMixset(mixset);
+  }
+
+  private MixsetFragment createMixsetFragment(Token token) {  
     Position mixsetFragmentPosition = null;
     int mixsetFragmentLineNumber = 0;
     String mixsetBody = token.getValue("extraCode");
@@ -331,11 +335,10 @@ class UmpleInternalParser
       
       if(mixsetBody == null)
       return null; // because there is no fragment to add. 
-      
+    
       mixsetFragmentLineNumber = mixsetFragmentPosition.getLineNumber();
       UmpleFile mixsetFragmentUmpleFile = model.getUmpleFile(); // where the mixset keyword is encountered. Not the use statement 
       MixsetFragment mixsetFragment = new MixsetFragment(mixsetFragmentUmpleFile, mixsetFragmentLineNumber, mixsetBody);
-      mixsetFragment.setMixset(mixset);
     return mixsetFragment;
   }
   
@@ -354,7 +357,7 @@ class UmpleInternalParser
       //    setRootToken(answer);
       //    model.setLastResult(result);
       answer.setName("mixsetDefinition"); //attach the mixset name for the fragment instead of ROOT
-      answer.setValue(mixsetFragment.getMixset().getMixsetName());
+      answer.setValue("TEMP_MIXSET");
       //  getIsFeature()
       //isFeature + umpFiles(use-st) + require-st
       for(Token token : answer.getSubTokens())
@@ -370,7 +373,7 @@ class UmpleInternalParser
             mixset  = new Mixset(mixsetName);
             model.addMixsetOrFile(mixset);
           }   
-          parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
+          parseMixsetFragmentNotUsed(createMixsetFragment(token) );
         }
         else if (token.is("useStatement"))
         {
@@ -387,7 +390,7 @@ class UmpleInternalParser
             UmpleFile aOriginalUmpFile = new UmpleFile(umpFileName); 
             int aOriginalUmpLine = 1;
             MixsetFragment mixsetFragmentOutOffUmpFile = new MixsetFragment(aOriginalUmpFile, aOriginalUmpLine, fileContent);
-            mixsetFragmentOutOffUmpFile.setMixset(mixsetFragment.getMixset().getMixsetName());
+            //mixsetFragmentOutOffUmpFile.setMixset(mixsetFragment.getMixset());
 
             parseMixsetFragmentNotUsed(mixsetFragmentOutOffUmpFile);
             parsedUmpfiles.put(umpFileName, false); // add current file to partially parsed files. 
@@ -397,18 +400,6 @@ class UmpleInternalParser
           {
             // The file is already parsed. 
           }
-    
- 
- 
-          String mixsetName = token.getValue("mixsetName");
-          // check if the mixset is was not added before
-          Mixset mixset = model.getMixset(mixsetName);
-          if(mixset  == null)
-          {
-            mixset  = new Mixset(mixsetName);
-            model.addMixsetOrFile(mixset);
-          }   
-          parseMixsetFragmentNotUsed(createMixsetFragment(token,  mixset) );
         }
 
       }
@@ -422,7 +413,7 @@ class UmpleInternalParser
     List<Mixset> mixsetList = model.getMixsetOrFiles().stream().filter(mixset -> mixset.getIsMixset()).map(obj -> (Mixset)obj).collect(Collectors.toList());
     for (Mixset aMixset: mixsetList)
     {
-      List<MixsetFragment>mixsetFragmentList= aMixset.getMixsetFragments();
+      List<MixsetFragment>mixsetFragmentList = aMixset.getMixsetFragments();
       for(MixsetFragment aMixsetFragment :  mixsetFragmentList)
       {
         if(aMixsetFragment.getIsParsed()) // the fragment is already parsed 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -827,9 +827,17 @@ public class UmpleMixsetTest {
     model.setShouldGenerate(false);
     model.run();
     Assert.assertEquals(model.getMixsetOrFiles().size() , 9);
-
-
-
   }
+
+ @Test
+  public void umpFileInsideMixsetNotusedIsParsed()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseUmpFileInsideMixsetNotUsed.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    Assert.assertEquals(model.getMixsetOrFiles().size() , 10);
+  }
+
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseUmpFileInsideMixsetNotUsed.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseUmpFileInsideMixsetNotUsed.ump
@@ -1,0 +1,9 @@
+
+mixset NotUsedMixset {
+  use parseReqStInsideMixsetNotUsed.ump; // this umple file is inside mixset not used.    
+}
+
+mixset GSM1800
+{
+  require subfeature [opt DummyFeature]; 
+}


### PR DESCRIPTION
Use-statement referencing Umple files inside mixsets that are not used are partialy parsed in this PR. Example: 
![image](https://user-images.githubusercontent.com/11878501/83535210-bcb66400-a4bf-11ea-825c-696699c5705a.png)

"second" tab contains most of the feature model. Also, it has a use-statement "use third.ump" :
```
mixset Phone {
  require subfeature [ GSM_Protocols];
  require subfeature [ opt  MP3_Recording ];
  require subfeature [ Audio_Formats  ];
  require subfeature [ Playback ];
  require subfeature [ opt Camera ]; 
  use third.ump;
}
...
```

 While "third" tab contains: 
```
mixset GSM1800
{ 
  require subfeature [opt DummyFeature]; 
}
```