### PR TITLE
Fixes makePermalink glitch on some server

### DIFF
--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -174,10 +174,12 @@ class WorkDir{
         if ($choppoint == 0)
         {
             $serverroot = "";
+            $serverpath = $serverroot.$umpsubdir."/".$path;
+            return $serverpath;
         } else {
             $serverroot = substr($theURI, 1, $choppoint-1);
         }
-        $serverpath =$serverroot.$umpsubdir."/".$path;
+        $serverpath ="/".$serverroot.$umpsubdir."/".$path;
         return $serverpath;
     }
 }

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -171,8 +171,13 @@ class WorkDir{
         $umpsubdir=substr($this->root,$umpsubdirStart);
         $theURI = $_SERVER['REQUEST_URI'];
         $choppoint= strlen($theURI)-strlen("/scripts/compiler.php");
-        $serverroot = substr($theURI, 1, $choppoint-1);
-        $serverpath ="/".$serverroot.$umpsubdir."/".$path;
+        if ($choppoint == 0)
+        {
+            $serverroot = "";
+        } else {
+            $serverroot = substr($theURI, 1, $choppoint-1);
+        }
+        $serverpath =$serverroot.$umpsubdir."/".$path;
         return $serverpath;
     }
 }


### PR DESCRIPTION
On some server, the $choppoint is 0 which will cause the $serverroot to be invalid. This pull request fixes this problem.