### PR TITLE
Fixes Issue#1488

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3393,24 +3393,39 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
             }
             else
             {
-            
-            if (isGetterSetter(actualMethod)) {
-              String methodName = aMethod.getName();
-              String attributeName = methodName.substring(3,methodName.length()).toLowerCase();
-              getParseResult().addErrorMessage(new ErrorMessage(1009, aMethod.getPosition(), methodName, attributeName, uClass.getName()));
-            }
-            //Issue 771
-            else if(uClass.hasSameType(aMethod)) 
-            {
-              getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
-                      aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
-                      aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
+              if (isGetterSetter(actualMethod)) {
+                String methodName = aMethod.getName();
+                String attributeName = methodName.substring(3,methodName.length()).toLowerCase();
+                getParseResult().addErrorMessage(new ErrorMessage(1009, aMethod.getPosition(), methodName, attributeName, uClass.getName()));
+              }
+              //Issue 771
+              else if(uClass.hasSameType(aMethod)) 
+              {
+                //Issue 1488
+                boolean raiseWarning49 = !method.getSubToken("code").getValue().equals("");
+                System.out.println("issue1488!!"); //DEBUG
+                System.out.println("code token Value: " + method.getSubToken("code").getValue().equals(""));
+                for (Token token : method.getSubTokens())
+                {
+                  if (token.is("codeLang"))
+                  {
+                    System.out.println("TOKEN: codeLang " + token);
+                    raiseWarning49 = true;
+                  }
+                }
+                if (raiseWarning49) // if no executable code, don't raise warning 49.
+                {
+                  getParseResult().addErrorMessage(new ErrorMessage(49,aMethod.getPosition(),
+                        aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
+                        aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
+                }
+                
               }
               else
               {
-              getParseResult().addErrorMessage(new ErrorMessage(71,aMethod.getPosition(),
-                      aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
-                      aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
+                getParseResult().addErrorMessage(new ErrorMessage(71,aMethod.getPosition(),
+                        aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
+                        aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
               }
             }
             

--- a/cruise.umple/src/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeClass.ump
@@ -3403,13 +3403,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
               {
                 //Issue 1488
                 boolean raiseWarning49 = !method.getSubToken("code").getValue().equals("");
-                System.out.println("issue1488!!"); //DEBUG
-                System.out.println("code token Value: " + method.getSubToken("code").getValue().equals(""));
                 for (Token token : method.getSubTokens())
                 {
                   if (token.is("codeLang"))
                   {
-                    System.out.println("TOKEN: codeLang " + token);
                     raiseWarning49 = true;
                   }
                 }
@@ -3419,7 +3416,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
                         aMethod.getName(),uClass.getName(), actualMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", actualMethod.getMethodBody().getImplementationPositions().get(l).getFilename(),
                         aMethod.getMethodBody().getImplementationPositions().get(l).getLineNumber()+"", aMethod.getPosition().getFilename(), l));
                 }
-                
               }
               else
               {

--- a/cruise.umple/test/cruise/umple/compiler/1488_multipleConstraintMethodBody.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1488_multipleConstraintMethodBody.ump
@@ -1,0 +1,14 @@
+class X {
+  Integer age;
+  m1 () {
+    // test1
+  }
+
+  m1 () {
+    [pre: age >= 18]  
+  }
+  m1 () {
+    [pre: age <= 99]  
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/compiler/1488_multipleMethodBodyWarning.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1488_multipleMethodBodyWarning.ump
@@ -6,9 +6,10 @@ class X {
 
   m1 () {
     [pre: age >= 18] 
-    System.out.println("Should have warning 49"); 
+    return "Should have warning 49"; 
   }
   m1 () {
+    // testing comment
     [pre: age <= 99]  
   }
 

--- a/cruise.umple/test/cruise/umple/compiler/1488_multipleMethodBodyWarning.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1488_multipleMethodBodyWarning.ump
@@ -1,0 +1,15 @@
+class X {
+  Integer age;
+  m1 () {
+    // test1
+  }
+
+  m1 () {
+    [pre: age >= 18] 
+    System.out.println("Should have warning 49"); 
+  }
+  m1 () {
+    [pre: age <= 99]  
+  }
+
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -128,6 +128,7 @@ public class UmpleParserTest
   @Test
   public void multLanguageImplementation()
   {
+    System.out.println("multLanguageImplementation Tested!!!");
 	  assertNoWarningsParse("015_multLanguageImplementation.ump");
 	  assertNoWarningsParse("015_multLanguageImplementation2.ump");
 	  assertHasWarningsParse("015_multLanguageImplementation3.ump", 49);
@@ -2336,7 +2337,6 @@ public class UmpleParserTest
     assertSimpleParse("1521_toplevelAfterOnTrait.ump");
 
     UmpleClass a = model.getUmpleClass("toplevelAfterOnTraitClass");
-    //System.out.println("numberOfExtendsTraits: " + a.numberOfExtendsTraits());
     Assert.assertEquals(1,a.numberOfCodeInjections());
 
     CodeInjection aInject = a.getCodeInjection(0);
@@ -2349,6 +2349,8 @@ public class UmpleParserTest
   @Test
   public void toplevelAfterGlobClassName()
   {
+    System.out.println("toplevelAfterGlobClassName Tested!!!"); //DEBUG
+    assertHasWarningsParse("1521_toplevelAfterGlobClassName.ump", 1012);
     assertSimpleParse("1521_toplevelAfterGlobClassName.ump");
     UmpleClass student1 = model.getUmpleClass("Student1");
     UmpleClass student2 = model.getUmpleClass("Student2");
@@ -2454,6 +2456,26 @@ public class UmpleParserTest
       Assert.assertEquals(true, afterLabelCode.contains("Label2:"));
       SampleFileWriter.destroy(pathToInput+"/"+"AroundClass.java");
     }
+  }
+
+  // Issue 1488
+  @Test
+  public void multipleConstraintMethodBody() 
+  {
+    System.out.println("1488_multipleConstraintMethodBody Tested!!!"); //DEBUG
+    //assertHasWarningsParse("1488_multipleConstraintMethodBody.ump", 49);
+    assertNoWarningsParse("1488_multipleConstraintMethodBody.ump");
+    assertSimpleParse("1488_multipleConstraintMethodBody.ump");
+  }
+
+  // Issue 1488
+  @Test
+  public void multipleMethodBodyWarning() 
+  {
+    System.out.println("1488_multipleMethodBodyWarning Tested!!!"); //DEBUG
+    assertHasWarningsParse("1488_multipleMethodBodyWarning.ump", 49);
+    //assertNoWarningsParse("1488_multipleMethodBodyWarning.ump");
+    assertSimpleParse("1488_multipleMethodBodyWarning.ump");
   }
 
   @Test

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2462,20 +2462,14 @@ public class UmpleParserTest
   @Test
   public void multipleConstraintMethodBody() 
   {
-    System.out.println("1488_multipleConstraintMethodBody Tested!!!"); //DEBUG
-    //assertHasWarningsParse("1488_multipleConstraintMethodBody.ump", 49);
     assertNoWarningsParse("1488_multipleConstraintMethodBody.ump");
-    assertSimpleParse("1488_multipleConstraintMethodBody.ump");
   }
 
   // Issue 1488
   @Test
   public void multipleMethodBodyWarning() 
   {
-    System.out.println("1488_multipleMethodBodyWarning Tested!!!"); //DEBUG
     assertHasWarningsParse("1488_multipleMethodBodyWarning.ump", 49);
-    //assertNoWarningsParse("1488_multipleMethodBodyWarning.ump");
-    assertSimpleParse("1488_multipleMethodBodyWarning.ump");
   }
 
   @Test

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -128,7 +128,6 @@ public class UmpleParserTest
   @Test
   public void multLanguageImplementation()
   {
-    System.out.println("multLanguageImplementation Tested!!!");
 	  assertNoWarningsParse("015_multLanguageImplementation.ump");
 	  assertNoWarningsParse("015_multLanguageImplementation2.ump");
 	  assertHasWarningsParse("015_multLanguageImplementation3.ump", 49);
@@ -2170,9 +2169,7 @@ public class UmpleParserTest
   @Test
   public void beforeKeyword()
   {
-    System.out.println("Testing in class beforeKeyword HERE"); //DEBUG
     assertParse("019_before.ump");
-        System.out.println(model.getUmpleClasses().size());
 
     UmpleClass student = model.getUmpleClass("Student");
     Assert.assertEquals(1,student.numberOfCodeInjections());
@@ -2349,7 +2346,6 @@ public class UmpleParserTest
   @Test
   public void toplevelAfterGlobClassName()
   {
-    System.out.println("toplevelAfterGlobClassName Tested!!!"); //DEBUG
     assertHasWarningsParse("1521_toplevelAfterGlobClassName.ump", 1012);
     assertSimpleParse("1521_toplevelAfterGlobClassName.ump");
     UmpleClass student1 = model.getUmpleClass("Student1");


### PR DESCRIPTION
Now if a method block only adds constraints, testcases, or assertion (but not codelangs) i.e. no new executable code, then warning 49 would be suppressed. 