### PR TITLE
[skip ci] Fixes issue#1546 "not turn off the scrollbars when 'photoReady' option is enabled."

### DIFF
--- a/umpleonline/scripts/styles.css
+++ b/umpleonline/scripts/styles.css
@@ -48,7 +48,7 @@ div.surface {
 }
 div.surface:focus { outline:none; }
 div.surface img { border:0; }
-div.photoReady { border:0; overflow:visible; }
+div.photoReady { border:0; overflow:scroll; }
 div.syncNeededMessage{ color: Gray; margin-left: 5px;}
 .structureInCanvas { 
   width: 100%; height: 100%; border: 1px solid gray; -moz-border-radius: 4px; 


### PR DESCRIPTION
This pull request fixes the issue#1546 by not turning off the scrollbars when 'photoReady' option is enabled.
