### PR TITLE
Progress on #1525 'Refactor PhP testing', php-xml package is still required in both PHP5.6 and PHP7.2.

### DIFF
--- a/UmpleToPhp/UmpleTLTemplates/state_machine_Set.ump
+++ b/UmpleToPhp/UmpleTLTemplates/state_machine_Set.ump
@@ -89,8 +89,6 @@ class UmpleToPhp {
           {
             exitActions.append("\n    ");
             exitActions.append(StringFormatter.format("elseif ($this->{0} == self::${1})\n    {",gen.translate("stateMachineOne",sm),gen.translate("stateOne",state)));
-            //System.out.println("DDDDDD");
-              //System.out.println("stateOne: " + gen.translate("stateOne",state) + "  stateMachineOne: " + gen.translate("stateMachineOne",sm));
           }
           isFirstExit = false;
         }
@@ -100,14 +98,10 @@ class UmpleToPhp {
         if(action.getActionCode() == null) //verify why it returns null
         {
           exitActions.append("\n      " + StringFormatter.format("$this->{0}(self::${1});", gen.translate("setMethod",sm), gen.translate("stateNull",sm)));
-          //System.out.println("BBBBBBBBBBBBB");
-          //System.out.println("null: " + gen.translate("setMethod",sm) + ", " + gen.translate("stateNull",sm));
         }
         else
         {
           exitActions.append("\n      " + action.getActionCode());
-          //System.out.println("action.getActionCode(): " + action.getActionCode());
-          //System.out.println("StringBuilder: " + exitActions);
         }
       }
     }

--- a/UmpleToPhp/UmpleTLTemplates/state_machine_Set.ump
+++ b/UmpleToPhp/UmpleTLTemplates/state_machine_Set.ump
@@ -66,29 +66,31 @@ class UmpleToPhp {
           {
             exitActions.append(StringFormatter.format("if ($this->{0} == self::${1})\n    {",gen.translate("stateMachineOne",sm),gen.translate("stateOne",state)));
             for( TraceDirective tc : uClass.getTraceDirectives() )
-        	{
+          	{
               for( int i = 0 ; i < tc.numberOfStateMachineTraceItems() ; ++ i )
               {
             	  StateMachineTraceItem tracedState = tc.getStateMachineTraceItem(i);
-        		  StateMachine stm = tracedState.getStateMachine();
-        		  for( int j = 0 ; j < stm.numberOfStates() ; ++j )
-        		  {
-        		  	State stat = stm.getState(j);
-        		  	String statName =  stm.getName() + stat.getName();
-        		  	if( tracedState.getExit() )
-        			  if( statName.equalsIgnoreCase(gen.translate("stateOne",state)))
-            			if( model.getTraceType().equals("Console"))
-            				exitActions.append(StringFormatter.format( "\n      " + "print(\"Tracing state {0} exit action(s)\");",gen.translate("stateOne",state)));
-         				else if( model.getTraceType().equals("File"))
-         					exitActions.append(StringFormatter.format( "\n      " + "fileTracer(\"Tracing state {0} exit action(s)\");",gen.translate("stateOne",state))); 
-         		  }
-        	  }
-        	}
+          		  StateMachine stm = tracedState.getStateMachine();
+          		  for( int j = 0 ; j < stm.numberOfStates() ; ++j )
+          		  {
+          		  	State stat = stm.getState(j);
+          		  	String statName =  stm.getName() + stat.getName();
+          		  	if( tracedState.getExit() )
+          			  if( statName.equalsIgnoreCase(gen.translate("stateOne",state)))
+              			if( model.getTraceType().equals("Console"))
+              				exitActions.append(StringFormatter.format( "\n      " + "print(\"Tracing state {0} exit action(s)\");",gen.translate("stateOne",state)));
+           				  else if( model.getTraceType().equals("File"))
+           					exitActions.append(StringFormatter.format( "\n      " + "fileTracer(\"Tracing state {0} exit action(s)\");",gen.translate("stateOne",state))); 
+           		  }
+          	  }
+          	}
           }
           else
           {
             exitActions.append("\n    ");
             exitActions.append(StringFormatter.format("elseif ($this->{0} == self::${1})\n    {",gen.translate("stateMachineOne",sm),gen.translate("stateOne",state)));
+            //System.out.println("DDDDDD");
+              //System.out.println("stateOne: " + gen.translate("stateOne",state) + "  stateMachineOne: " + gen.translate("stateMachineOne",sm));
           }
           isFirstExit = false;
         }
@@ -97,11 +99,15 @@ class UmpleToPhp {
         isFirstExit = false;
         if(action.getActionCode() == null) //verify why it returns null
         {
-          exitActions.append("\n      " + StringFormatter.format("$this->{0}(self::{1});", gen.translate("setMethod",sm), gen.translate("stateNull",sm)));
+          exitActions.append("\n      " + StringFormatter.format("$this->{0}(self::${1});", gen.translate("setMethod",sm), gen.translate("stateNull",sm)));
+          //System.out.println("BBBBBBBBBBBBB");
+          //System.out.println("null: " + gen.translate("setMethod",sm) + ", " + gen.translate("stateNull",sm));
         }
         else
         {
           exitActions.append("\n      " + action.getActionCode());
+          //System.out.println("action.getActionCode(): " + action.getActionCode());
+          //System.out.println("StringBuilder: " + exitActions);
         }
       }
     }

--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -154,7 +154,7 @@
 
   <target name="test">
     <antcall target="testJava" />
-    <!--COMMENTED OUT SINCE NOTLOADING DOMDOCUMENT  antcall target="testPhp" /> -->
+    <antcall target="testPhp" />
     <antcall target="testRuby" />
     <!--
     <antcall target="allUserManualAndExampleTests" />

--- a/cruise.umple/src/Generator_CodePhp.ump
+++ b/cruise.umple/src/Generator_CodePhp.ump
@@ -794,7 +794,7 @@ class PhpGenerator
           ,translate("setMethod",sm)
           ,translate("stateOne",sm.getStartState()))
       );
-      lookups.put("parentExitActionCode",StringFormatter.format("$this->{0}();",translate("exitMethod",parentState)));
+      lookups.put("parentExitActionCode",StringFormatter.format("$this->{0}();",translate("exitMethod",sm)));
       GeneratorHelper.prepareNestedStateMachine(sm,concurrentIndex,lookups);  
     }
 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/nestedStates_StateMachine_timedEvent.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/nestedStates_StateMachine_timedEvent.php.txt
@@ -107,7 +107,7 @@ class Window
   {
     if ($this->WindowControllerStationary == self::$WindowControllerStationaryNormalStationary)
     {
-      $this->setWindowControllerStationary(self::WindowControllerStationaryNull);
+      $this->setWindowControllerStationary(self::$WindowControllerStationaryNull);
     }
   }
 

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/php/nestedStates_StateMachine_timedEvent.php.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/php/nestedStates_StateMachine_timedEvent.php.txt
@@ -83,7 +83,7 @@ class Window
   {
     if ($this->WindowController == self::$WindowControllerStationary)
     {
-      $this->exitStationary();
+      $this->exitWindowControllerStationary();
     }
   }
 

--- a/testbed_php/src/LocalHarness.ump
+++ b/testbed_php/src/LocalHarness.ump
@@ -5,14 +5,14 @@ class DoorA
 {
   immutable DoorB doorId = new DoorB(5);
   immutable Date dateId = date(1234);
-  immutable Time timeId = time(1235);
+  immutable Time timeId = time();
 }
 
 class DoorD
 {
   defaulted DoorB doorId = new DoorB(5);
   defaulted Date dateId = date(1234);
-  defaulted Time timeId = time(1235);
+  defaulted Time timeId = time();
 }
 
 

--- a/testbed_php/test/AllTestHelper.php
+++ b/testbed_php/test/AllTestHelper.php
@@ -1,9 +1,4 @@
 <?php
-set_error_handler(function($severity, $message, $file, $line) {
-    if (error_reporting() & $severity) {
-        throw new ErrorException($message, 0, $severity, $file, $line);
-    }
-});
 spl_autoload_register(function ($class_name) 
 {
   if ($class_name == "Date")

--- a/testbed_php/test/AllTestHelper.php
+++ b/testbed_php/test/AllTestHelper.php
@@ -1,13 +1,17 @@
 <?php
-
-function __autoload($class_name) 
+set_error_handler(function($severity, $message, $file, $line) {
+    if (error_reporting() & $severity) {
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    }
+});
+spl_autoload_register(function ($class_name) 
 {
   if ($class_name == "Date")
   {
     return;
   }
   require_once "../src-gen-umple/" . $class_name . '.php';
-}
+});
 
 function endsWith($str, $sub ) 
 {

--- a/testbed_php/test/AllTests.php
+++ b/testbed_php/test/AllTests.php
@@ -7,11 +7,11 @@ require_once('AllTestHelper.php');
 
 $test = new TestSuite('All Tests');
 loadTestsIn($test,'associations');
-// Issue 935 -> Ignore PHP test, PHP generation to be updated in the future
-// loadTestsIn($test,'statemachine');
+loadTestsIn($test,'statemachine');
 loadTestsIn($test,'attributes');
 loadTestsIn($test,'patterns');
-loadTestsIn($test,'tracer');
+// issue#1525  I commented out this beacuse no tracer folder found in the /umple/testbed_php/test/.
+//loadTestsIn($test,'tracer');
 
 $reporter = new HtmlReporter();
 $test->run($reporter);

--- a/testbed_php/test/AllXmlTests.php
+++ b/testbed_php/test/AllXmlTests.php
@@ -9,7 +9,8 @@ $test = new TestSuite('All Tests');
 loadTestsIn($test,'associations');
 loadTestsIn($test,'statemachine');
 loadTestsIn($test,'attributes');
-loadTestsIn($test,'tracer');
+// issue#1525  I commented out this beacuse no tracer folder found in the /umple/testbed_php/test/.
+// loadTestsIn($test,'tracer');
 
 $reporter = new XmlReporter();
 $test->run($reporter);

--- a/testbed_php/test/associations/MNToMNTest.php
+++ b/testbed_php/test/associations/MNToMNTest.php
@@ -259,8 +259,8 @@ class MNToMNTest extends UnitTestCase
     $s4 = new StudentS(96);
     $s5 = new StudentS(95);
     
-    $m->setStudents($s,$s2,$s3,$s4,$s5);
-    $m2->setStudents($s,$s2,$s3);
+    $m->setStudents(array($s,$s2,$s3,$s4,$s5));
+    $m2->setStudents(array($s,$s2,$s3));
     
     $p = new ProgramS();
     $s->setProgram($p);

--- a/testbed_php/test/associations/ManyToMNTest.php
+++ b/testbed_php/test/associations/ManyToMNTest.php
@@ -113,7 +113,7 @@ class ManyToMNTest extends UnitTestCase
     $this->assertEqual(0,$s4->numberOfMentors());
     $this->assertEqual(0,$s5->numberOfMentors());
 
-    $this->assertEqual(false,$m->setStudents($s5));
+    $this->assertEqual(false,$m->setStudents(array($s5)));
     $this->assertEqual(2,$m->numberOfStudents());
     $this->assertEqual($m,$s->getMentor_index(0));
     $this->assertEqual($m,$s2->getMentor_index(0));

--- a/testbed_php/test/associations/ManyToMStarTest.php
+++ b/testbed_php/test/associations/ManyToMStarTest.php
@@ -132,7 +132,7 @@ class ManyToMStarTest extends UnitTestCase
     $s3 = new StudentR(97);
     
     $m = new MentorR("blah",array($s,$s2,$s3));
-    $this->assertEqual(false, $m->setStudents($s2,$s2,$s3));
+    $this->assertEqual(false, $m->setStudents(array($s2,$s2,$s3)));
   }
 
 

--- a/testbed_php/test/associations/ManyToNTest.php
+++ b/testbed_php/test/associations/ManyToNTest.php
@@ -84,7 +84,7 @@ class ManyToNTest extends UnitTestCase
 
     $m = new MentorQ("blah",array($s,$s2));
     
-    $this->assertEqual(false,$m->setStudents($s2,$s3,$s4));
+    $this->assertEqual(false,$m->setStudents(array($s2,$s3,$s4)));
     $this->assertEqual(2,$m->numberOfStudents());
     $this->assertEqual($m,$s->getMentor_index(0));
     $this->assertEqual($m,$s2->getMentor_index(0));
@@ -92,7 +92,7 @@ class ManyToNTest extends UnitTestCase
     $this->assertEqual(0,$s4->numberOfMentors());
     $this->assertEqual(0,$s5->numberOfMentors());
 
-    $this->assertEqual(false,$m->setStudents($s5));
+    $this->assertEqual(false,$m->setStudents(array($s5)));
     $this->assertEqual(2,$m->numberOfStudents());
     $this->assertEqual($m,$s->getMentor_index(0));
     $this->assertEqual($m,$s2->getMentor_index(0));
@@ -111,7 +111,7 @@ class ManyToNTest extends UnitTestCase
     $s3 = new StudentQ(97);
 
     $m = new MentorQ("blah",array($s,$s2));
-    $this->assertEqual(false,$m->setStudents($s2,$s2,$s3));
+    $this->assertEqual(false,$m->setStudents(array($s2,$s2,$s3)));
   }
 
 

--- a/testbed_php/test/associations/ManyToOptionalNTest.php
+++ b/testbed_php/test/associations/ManyToOptionalNTest.php
@@ -94,7 +94,7 @@ class ManyToOptionalNTest extends UnitTestCase
     $m = new MentorAA("blah");
     
     $this->assertEqual(true,$m->setStudents(array($s,$s2)));
-    $this->assertEqual(false, $m->setStudents($s2,$s3,$s4,$s5,$s));
+    $this->assertEqual(false, $m->setStudents(array($s2,$s3,$s4,$s5,$s)));
     $this->assertEqual(2,$m->numberOfStudents());
     $this->assertEqual($m,$s->getMentor_index(0));
     $this->assertEqual($m,$s2->getMentor_index(0));

--- a/testbed_php/test/attributes/DefaultedTest.php
+++ b/testbed_php/test/attributes/DefaultedTest.php
@@ -31,11 +31,11 @@ class DefaultedTest extends UnitTestCase
     $this->assertEqual(true, $door->resetDateId());
     $this->assertEqual(date(1234),$door->getDateId());
 
-    $this->assertEqual(time(1234),$door->getTimeId());
-    $this->assertEqual(true, $door->setTimeId(time(5321)));
-    $this->assertEqual(time(5321),$door->getTimeId());
+    $this->assertEqual(time(),$door->getTimeId());
+    $this->assertEqual(true, $door->setTimeId(time()));
+    $this->assertEqual(time(),$door->getTimeId());
     $this->assertEqual(true, $door->resetTimeId());
-    $this->assertEqual(time(1234),$door->getTimeId());
+    $this->assertEqual(time(),$door->getTimeId());
 
     $this->assertEqual(false,$door->getBooleanId());
     $this->assertEqual(true, $door->setBooleanId(true));

--- a/testbed_php/test/attributes/ImmutableTest.php
+++ b/testbed_php/test/attributes/ImmutableTest.php
@@ -6,7 +6,7 @@ class ImmutableTest extends UnitTestCase
   // TODO: Look at writing a helper test to use reflection to make sure the "setX" method is not available   
   public function test_Immutable()
   {
-    $door = new DoorC("1",2,3.4,date(1234),time(1235),false,new DoorB(5));
+    $door = new DoorC("1",2,3.4,date(1234),time(),false,new DoorB(5));
 
     $this->assertEqual("1",$door->getId());
     // $this->assertEqual(false,$door->setId("2"));
@@ -24,7 +24,7 @@ class ImmutableTest extends UnitTestCase
     // $this->assertEqual(false,$door->setDateId(date(4321)));
     // $this->assertEqual(date(1234),$door->getDateId());
 
-    $this->assertEqual(time(1235),$door->getTimeId());
+    $this->assertEqual(time(),$door->getTimeId());
     // $this->assertEqual(false,$door->setTimeId(date(5321)));
     // $this->assertEqual(time(1235),$door->getTimeId());
 
@@ -57,7 +57,7 @@ class ImmutableTest extends UnitTestCase
     // $this->assertEqual(false,$door->setDateId(date(4321)));
     // $this->assertEqual(date(1234),$door->getDateId());
 
-    $this->assertEqual(time(1235),$door->getTimeId());
+    $this->assertEqual(time(),$door->getTimeId());
     // $this->assertEqual(false,$door->setTimeId(date(5321)));
     // $this->assertEqual(time(1235),$door->getTimeId());
 

--- a/testbed_php/test/statemachine/DoActivityTest.php
+++ b/testbed_php/test/statemachine/DoActivityTest.php
@@ -12,7 +12,7 @@ class DoActivityTest extends UnitTestCase
     $course->flip();
     
     sleep(3);
-    $this->assertEqual("Excepted 5 or more, but only produced " + $course->numberOfLogs(), true,$course->numberOfLogs() >= 5);
+    $this->assertEqual(true, $course->numberOfLogs() >= 5);
     $this->assertEqual("Open Entry", $course->getLog(0));
     $this->assertEqual("Do Activity On Open",$course->getLog(1));
     $this->assertEqual("Closed Entry",$course->getLog(2));

--- a/testbed_php/test/statemachine/FinalStateTest.php
+++ b/testbed_php/test/statemachine/FinalStateTest.php
@@ -23,8 +23,8 @@ class FinalStateTest extends UnitTestCase
     $this->assertEqual(1,$c->numberOfLogs());
     $this->assertEqual("deleted",$c->getLog(0));
 
-    $this->assertEqual("StatusOn",$c->getStatus());
-    $this->assertEqual("StatusOnMotorIdleFinal",$c->getStatusOnMotorIdle());
+    $this->assertEqual("StatusFinal",$c->getStatus());
+    $this->assertEqual("StatusOnMotorIdleNull",$c->getStatusOnMotorIdle());
     $this->assertEqual("StatusOnFanIdleFanIdle",$c->getStatusOnFanIdle());
   }
   

--- a/testbed_php/test/statemachine/NestedStateMachineTest.php
+++ b/testbed_php/test/statemachine/NestedStateMachineTest.php
@@ -49,16 +49,16 @@ class NestedStateMachineTest extends UnitTestCase
   
     // TODO: Missing Exit Event
     // Assert.assertEquals(9,course.numberOfLogs());
-    $this->assertEqual(8,$course->numberOfLogs());
+    $this->assertEqual(9,$course->numberOfLogs());
     $this->assertEqual("Enter Off", $course->getLog(0));
     $this->assertEqual("Exit Off", $course->getLog(1));
     $this->assertEqual("Enter On", $course->getLog(2));
     $this->assertEqual("Enter Play", $course->getLog(3));
     $this->assertEqual("Exit Play", $course->getLog(4));
     $this->assertEqual("Enter Pause", $course->getLog(5));
-    // $this->assertEqual("Exit Pause", $course->getLog(6));
-    $this->assertEqual("Exit On", $course->getLog(6));
-    $this->assertEqual("Enter Off", $course->getLog(7));
+    $this->assertEqual("Exit Pause", $course->getLog(6));
+    $this->assertEqual("Exit On", $course->getLog(7));
+    $this->assertEqual("Enter Off", $course->getLog(8));
     
     $this->assertEqual("StatusOff", $course->getStatus());
     $this->assertEqual("StatusOnNull", $course->getStatusOn());    


### PR DESCRIPTION
Re-enabled PHP testbed testing. 
Resolved all exceptions in PHP version 5.6 and 7.2.
Php-xml package is still required in both PHP5.6 and PHP7.2.