### PR TITLE
Fixes #1519 "Use of a filter with a trait that has an attribute causes compiler crash"

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -987,6 +987,11 @@ class Attribute
   after constructor { codeblock.setCode(normalizeValue(aType,aValue)); }
   before setType { codeblock.setCode(normalizeValue(aType,getValue())); }
   after setType { setValue(getValue()); }
+  before delete { 
+    if (traceRecords == null) {
+      traceRecords = new ArrayList<TraceRecord>();
+    }
+  }
 
   // Specifies whether or not the method parameter is lazy.
   Boolean isLazy = false;

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -2310,7 +2310,7 @@ class Attribute
 	codeblock = another.getCodeblock();
 	isLazy = another.getIsLazy();
 	//Attribute Associations
-	comments = new ArrayList<Comment>(); // Create a shallow copy of comments.
+	comments = new ArrayList<Comment>(); // Create a deep copy of comments.
   for (Comment comment : another.getComments())
   {
     comments.add(new Comment(comment));

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -2310,7 +2310,11 @@ class Attribute
 	codeblock = another.getCodeblock();
 	isLazy = another.getIsLazy();
 	//Attribute Associations
-	comments = another.getComments();
+	comments = new ArrayList<Comment>(); // Create a shallow copy of comments.
+  for (Comment comment : another.getComments())
+  {
+    comments.add(new Comment(comment));
+  }
 	position = another.getPosition();
 	endPosition = another.getEndPosition();
 	umpleClass = another.getUmpleClass();
@@ -4060,6 +4064,13 @@ class Comment
 {
   Boolean isInline = true;
 
+  // deep copy constructor
+  public Comment(Comment aComment)
+  {
+    text = aComment.getText();
+    annotation = aComment.getAnnotation();
+    isInline = aComment.getIsInline();
+  }
   /**
    * Used to take a comment and process it into a format appropriate for displaying in generated code.
    *

--- a/cruise.umple/test/cruise/umple/compiler/1519_filterWithAttributeInTrait.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1519_filterWithAttributeInTrait.ump
@@ -1,0 +1,9 @@
+filter {include X;}
+
+trait Device {
+  serialNumber;   // attribute; String by default
+}
+
+class SmartLightConsole {
+  isA Device;
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2467,6 +2467,14 @@ public class UmpleParserTest
   {
     assertHasWarningsParse("1488_multipleMethodBodyWarning.ump", 49);
   }
+  
+  // Issue 1519
+  @Test
+  public void filterWithAttributeInTrait() 
+  {
+    assertHasNoWarningsParse("1519_filterWithAttributeInTrait.ump");
+    Assert.assertEquals(1, model.numberOfUmpleClasses());
+  }
 
   @Test
   public void multiInject()


### PR DESCRIPTION
This pull request fixes null pointer exceptions that cause the compiler to crash when encountering a filter with a trait that has an attribute.
Also add a test case '1519_filterWithAttributeInTait'.