### PR TITLE
Fixes #831 "cruise.statemachine.test.DoActivityTest sometimes fails due to race condition"

### DIFF
--- a/testbed/src/TestHarnessStateMachineJava.ump
+++ b/testbed/src/TestHarnessStateMachineJava.ump
@@ -298,6 +298,7 @@ class CourseWMultiDo {
           addLog("DoActivity in nested state Thread1");
         }
         do {
+          Thread.sleep(500);
           addLog("DoActivity in nested state Thread2");
         }
       }  

--- a/testbed/test/cruise/statemachine/test/DoActivityTest.java
+++ b/testbed/test/cruise/statemachine/test/DoActivityTest.java
@@ -19,9 +19,7 @@ public class DoActivityTest
     Assert.assertEquals("Do Activity On Closed",course.getLog(2));
   }
   
-  @Test
-  @Ignore
-  // Ignored because was nondeterministic and breaking build when build was running under heavily loaded machine FIX FIX TO DO    
+  @Test   
   public void stopProcessingIfYouLeaveTheState() throws InterruptedException
   {
     CourseC course = new CourseC();


### PR DESCRIPTION
In cruise.statemachine.test.DoActivityTest, sometime addLog() will be invoked by two different threads at the same time. This pull request adds a Thread.sleep(500) statement before one of the doActivity to avoid this situation.