### PR TITLE
Fixes #1584 "Certain kinds of comments (with less than or greater than) result in failure to generate graphviz"

### DIFF
--- a/cruise.umple/src/Generator_SuperGvGenerator.ump
+++ b/cruise.umple/src/Generator_SuperGvGenerator.ump
@@ -129,6 +129,8 @@ digraph "<<=filename>>" {
       } else {
         text = uComment.getText().replace("\"","'");
       }
+      text = text.replace("<", "&lt;"); // Issue1584 "Certain kinds of comments (with less than or greater than) result in failure to generate graphviz"
+      text = text.replace(">", "&gt;"); // Issue1584 "Certain kinds of comments (with less than or greater than) result in failure to generate graphviz"
       if(text.startsWith(" *")) {
         tooltip.append(text.substring(2)+"&#13;");
       }


### PR DESCRIPTION
This PR fixes the issue by replacing all greater than and less than sign within comment with HTML entities.