### PR TITLE
Fixes #1587 "Incorrect class diagram drawn by GraphViz when there is an ampersand in a variable comment"

### DIFF
--- a/cruise.umple/src/Generator_SuperGvGenerator.ump
+++ b/cruise.umple/src/Generator_SuperGvGenerator.ump
@@ -129,8 +129,7 @@ digraph "<<=filename>>" {
       } else {
         text = uComment.getText().replace("\"","'");
       }
-      text = text.replace("<", "&lt;"); // Issue1584 "Certain kinds of comments (with less than or greater than) result in failure to generate graphviz"
-      text = text.replace(">", "&gt;"); // Issue1584 "Certain kinds of comments (with less than or greater than) result in failure to generate graphviz"
+      text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"); // Issue1584 and 1587 "Certain kinds of comments (<,>,&) result in failure to generate graphviz"
       if(text.startsWith(" *")) {
         tooltip.append(text.substring(2)+"&#13;");
       }


### PR DESCRIPTION
This PR fixes the issue1587 by replacing all ampersands in comment with HTML entity.