### PR TITLE
Fixes #1586 "Crash in compiling state machine that has an after and an event with guards"

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -1432,8 +1432,11 @@ class UmpleInternalParser
           for(Token guardedTransition : guardedTransitions){
             Boolean subTokenIsAutoTransition = subToken.is("autoTransition");
             Boolean guardTransitionIsAutoTransition = guardedTransition.is("autoTransition");
-            if ((guardTransitionIsAutoTransition && subTokenIsAutoTransition) || (!guardTransitionIsAutoTransition && guardedTransition.getValue("event") == subToken.getValue("event"))
-             || (!guardTransitionIsAutoTransition && guardedTransition.getValue("event").equals(subToken.getValue("event"))))
+            if ((guardTransitionIsAutoTransition && subTokenIsAutoTransition) 
+              || (!guardTransitionIsAutoTransition && guardedTransition.getValue("event") != null && guardedTransition.getValue("event") == subToken.getValue("event"))
+              || (!guardTransitionIsAutoTransition && guardedTransition.getValue("event") != null && guardedTransition.getValue("event").equals(subToken.getValue("event"))) 
+              || (!guardTransitionIsAutoTransition && guardedTransition.getValue("timer") != null && guardedTransition.getValue("timer") == subToken.getValue("timer"))
+              || (!guardTransitionIsAutoTransition && guardedTransition.getValue("timer") != null && guardedTransition.getValue("timer").equals(subToken.getValue("timer"))))
             {
               Position subTokenPosition = subToken.getPosition();
               String subTokenValue = subToken.getValue("event");

--- a/cruise.umple/test/cruise/umple/compiler/1586_AfterWithGuard.ump
+++ b/cruise.umple/test/cruise/umple/compiler/1586_AfterWithGuard.ump
@@ -1,0 +1,31 @@
+class MicrowaveOven { 
+  queued timeProcesser { 
+    time0 { 
+      startTime [isTimerMode0]->time1; 
+    } 
+
+    time1 { 
+      entry / {display("Timer: " + time);} 
+      after(1)  [time>=1]/ {time--;} -> time1; 
+      //after(1)  [time>=1]/ {time--;} -> timeOn; 
+      openedDoor [isTimerMode] -> time2; 
+      after(2)  [time>=1]/ {time--;} -> time3;
+      after(1)  [time>=2]/ {time--;} -> time4;
+      after(3)  [time>=3]/ {time--;} -> time5;
+      openedDoor [isTimerMode2] -> time6;
+    } 
+
+    time2 { 
+    } 
+    time3 { 
+    } 
+    time4 { 
+    } 
+    time5 { 
+    } 
+    time6 { 
+    } 
+    
+    
+  } 
+} 

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserStateMachineTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserStateMachineTest.java
@@ -2662,6 +2662,60 @@ public class UmpleParserStateMachineTest
     assertFailedParse("488_stateNameIsFinal_2.ump", new Position("488_stateNameIsFinal_2.ump", 4, 6, 32), 74);
   }
 
+  // Issue 1586
+  @Test
+  public void smAfterWithGuard()
+  {
+    assertNoWarnings("1586_AfterWithGuard.ump");
+    UmpleClass c = model.getUmpleClass("MicrowaveOven");
+    StateMachine sm = c.getStateMachine(0);
+    Assert.assertEquals("timeProcesser", sm.getName());
+
+    State time0 = sm.getState(0);
+    Assert.assertEquals("time0", time0.getName());
+    Transition t01 = time0.getTransition(0);
+    Assert.assertEquals("startTime", t01.getEvent().getName());
+
+    
+    State time1 = sm.getState(1);
+    Assert.assertEquals("time1", time1.getName());
+
+    Transition t10 = time1.getTransition(0);
+    Assert.assertTrue(t10.hasGuard());
+    Action a10 = t10.getAction();
+    Assert.assertNotNull(a10);
+    Assert.assertEquals("time--;", a10.getActionCode()); 
+
+    Transition t11 = time1.getTransition(1);
+    Assert.assertTrue(t11.hasGuard());
+    Assert.assertEquals("openedDoor", t11.getEvent().getName());
+    Action a11 = t11.getAction();
+    Assert.assertNull(a11);
+
+    Transition t12 = time1.getTransition(2);
+    Assert.assertTrue(t12.hasGuard());
+    Action a12 = t12.getAction();
+    Assert.assertNotNull(a12);
+    Assert.assertEquals("time--;", a12.getActionCode()); 
+
+    Transition t13 = time1.getTransition(3);
+    Assert.assertTrue(t13.hasGuard());
+    Action a13 = t13.getAction();
+    Assert.assertNotNull(a13);
+    Assert.assertEquals("time--;", a13.getActionCode()); 
+    
+    Transition t14 = time1.getTransition(4);
+    Assert.assertTrue(t14.hasGuard());
+    Action a14 = t14.getAction();
+    Assert.assertNotNull(a14);
+    Assert.assertEquals("time--;", a14.getActionCode()); 
+    
+    Transition t15 = time1.getTransition(5);
+    Assert.assertTrue(t15.hasGuard());
+    Action a15 = t15.getAction();
+    Assert.assertNull(a15);
+  }
+
   public void walkGraphTwiceNested_StateMachineGraph_ClearNodes()
   {
     assertParse("101_Nested_realExample2.ump","[classDefinition][name:StrobeLight][stateMachine][inlineStateMachine][name:dvdPlayer][state][stateName:Off][transition][event:turnOn][stateName:On][state][stateName:Sleep][transition][event:wake][stateName:Pause][state][stateName:On][transition][event:turnOff][stateName:Off][state][stateName:Play][transition][event:push][stateName:Pause][state][stateName:Pause][transition][event:push][stateName:Play][transition][event:standby][stateName:Sleep]");


### PR DESCRIPTION
An After in state machine is not considered an event thus will cause null pointer exceptions when invoking getValue("event").equals(). 
This PR fixes this issue in the checkStateForDuplicateEvents method, and also adds a test case in UmpleParserStateMachineTest.