### PR TITLE
Ignoring some files in umpleonline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,15 @@ nohup.out
 
 # umple specific
 umpleonline/ump/tmp*
+umpleonline/ump/20*
+umpleonline/ump/ATempCrash*
 build/UserManualAndExampleTests_output.txt
 umpleonline/manual
 umpleonline/countlog.txt
 umpleonline/scripts/commandcount.txt
 umpleonline/scripts/specialPort.txt
 umpleonline/scripts/versionRunning.txt
+umpleonline/ump/aalertMessage.txt
 
 # generated Umple code that is not saved
 src-gen-umple/


### PR DESCRIPTION
Certain files are left in the ump directory and should be ignored by git; these include the directories created by users who store a semi-permanent URL. Also crash files for debugging starting with ATempCrash need ignoring, as does the alert message in aalertMessage.txt