### PR TITLE
Fixes #1613 Ensures that docker supervisord no longer running as root for security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,8 @@ script:
         $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline &&
         docker build -t "umple/umpleonline-base:local"
                      -f ../umpleonline/Dockerfile-base ../umpleonline &&
-        docker build -t "umple/umpleonline:recentbuild" ../umpleonline;
+        docker build -t "umple/umpleonline:recentbuild" 
+                     --build-arg gitbranch=$TRAVIS_BRANCH ../umpleonline;
     fi
 
 after_success:

--- a/dev-tools/udock
+++ b/dev-tools/udock
@@ -64,6 +64,6 @@ echo "For log: open http://localhost:$port/scripts/log.php"
 if (`uname` == "Darwin") then
   ( sleep 2 ; open "http://localhost:$port/umple.php$modelarg" ) &
 endif
-echo running docker run --rm -ti -p "$port":80 $volcommand umple/umpleonline$image
-docker run --rm -ti -p "$port":80 $volcommand umple/umpleonline$image >/dev/null
+echo running docker run --rm -ti -p "$port":8000 $volcommand umple/umpleonline$image
+docker run --rm -ti -p "$port":8000 $volcommand umple/umpleonline$image >/dev/null
 echo Docker image quit

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -19,13 +19,17 @@ RUN echo $gitbranch > /etc/umplegitbranch.txt
 # copy over the website data
 COPY . /var/www
 
-# make sure the php files are readable
+# make sure the php files are readable and log files are writable
 # for extra security, only /ump is writable since it is the only place
 # session data should be written
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
-    chmod -R g+w /var/www/ump
+    chmod -R g+w /var/www/ump \
+    chown -R :nginx /var/run && \
+    chmod -R g+rw /var/run  && \
+    chown -R :nginx /var/log && \
+    chmod -R g+rw /var/log
 
 # this is what runs on container startup
-CMD supervisord --nodaemon --configuration=/etc/supervisord.conf --logfile=/tmp/supervisord.log --pidfile=/tmp/supervisord.pid
+CMD supervisord --nodaemon --configuration=/etc/supervisord.conf --logfile=/var/log/supervisord.log --pidfile=/var/log/supervisord.pid
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -24,7 +24,8 @@ COPY . /var/www
 # session data should be written
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
-    chmod -R g+w /var/www/ump
+    chmod -R g+w /var/www/ump && \
+    chmod a+rw /supervisord.log
 
 # this is what runs on container startup
 CMD supervisord --nodaemon --configuration=/etc/supervisord.conf

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -27,5 +27,5 @@ RUN chown -R :nginx /var/www && \
     chmod -R g+w /var/www/ump
 
 # this is what runs on container startup
-CMD supervisord --nodaemon --configuration=/etc/supervisord.conf
+CMD supervisord --nodaemon --configuration=/etc/supervisord.conf --logfile=/tmp/supervisord.log
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -12,11 +12,9 @@ COPY docker_config/php-fpm.conf /etc/php7/php-fpm.d/php-fpm.conf
 # javadoc by linking it into /usr/bin so UmpleOnline can use it.
 RUN ln -s /usr/lib/jvm/default-jvm/bin/javadoc /usr/bin/javadoc
 
+# Save the branch so it can be accessed internally
 ARG gitbranch
 RUN echo $gitbranch > /etc/umplegitbranch.txt
-
-# Save the branch of git so this can be displayed if needed
-RUN git symbolic-ref --short HEAD > /etc/umplegitbranch.txt
 
 # copy over the website data
 COPY . /var/www

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -12,6 +12,9 @@ COPY docker_config/php-fpm.conf /etc/php7/php-fpm.d/php-fpm.conf
 # javadoc by linking it into /usr/bin so UmpleOnline can use it.
 RUN ln -s /usr/lib/jvm/default-jvm/bin/javadoc /usr/bin/javadoc
 
+ARG gitbranch
+RUN echo $gitbranch > /etc/umplegitbranch.txt
+
 # Save the branch of git so this can be displayed if needed
 RUN git symbolic-ref --short HEAD > /etc/umplegitbranch.txt
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -14,7 +14,7 @@ RUN ln -s /usr/lib/jvm/default-jvm/bin/javadoc /usr/bin/javadoc
 
 # Save the branch so it can be accessed internally
 ARG gitbranch
-RUN echo $gitbranch > /etc/umplegitbranch.txt
+RUN echo $gitbranch > /tmp/umplegitbranch.txt
 
 # copy over the website data
 COPY . /var/www

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -27,5 +27,5 @@ RUN chown -R :nginx /var/www && \
     chmod -R g+w /var/www/ump
 
 # this is what runs on container startup
-CMD supervisord --nodaemon --configuration=/etc/supervisord.conf --logfile=/tmp/supervisord.log
+CMD supervisord --nodaemon --configuration=/etc/supervisord.conf --logfile=/tmp/supervisord.log --pidfile=/tmp/supervisord.pid
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -12,6 +12,9 @@ COPY docker_config/php-fpm.conf /etc/php7/php-fpm.d/php-fpm.conf
 # javadoc by linking it into /usr/bin so UmpleOnline can use it.
 RUN ln -s /usr/lib/jvm/default-jvm/bin/javadoc /usr/bin/javadoc
 
+# Save the branch of git so this can be displayed if needed
+RUN git symbolic-ref --short HEAD > /etc/umplegitbranch.txt
+
 # copy over the website data
 COPY . /var/www
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -25,6 +25,7 @@ COPY . /var/www
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
     chmod -R g+w /var/www/ump \
+    mkdir /var/run && \
     chown -R :nginx /var/run && \
     chmod -R g+rw /var/run  && \
     chown -R :nginx /var/log && \

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -24,9 +24,7 @@ COPY . /var/www
 # session data should be written
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
-    chmod -R g+w /var/www/ump && \
-    touch /supervisord.log && \
-    chmod a+rw /supervisord.log
+    chmod -R g+w /var/www/ump
 
 # this is what runs on container startup
 CMD supervisord --nodaemon --configuration=/etc/supervisord.conf

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -24,7 +24,7 @@ COPY . /var/www
 # session data should be written
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
-    chmod -R g+w /var/www/ump \
+    chmod -R g+w /var/www/ump && \
     mkdir /var/run && \
     chown -R :nginx /var/run && \
     chmod -R g+rw /var/run  && \

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -25,6 +25,7 @@ COPY . /var/www
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
     chmod -R g+w /var/www/ump && \
+    touch /supervisord.log && \
     chmod a+rw /supervisord.log
 
 # this is what runs on container startup

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -25,7 +25,6 @@ COPY . /var/www
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
     chmod -R g+w /var/www/ump && \
-    mkdir /var/run && \
     chown -R :nginx /var/run && \
     chmod -R g+rw /var/run  && \
     chown -R :nginx /var/log && \

--- a/umpleonline/counter.php
+++ b/umpleonline/counter.php
@@ -13,6 +13,7 @@ $versionpath = $dir."/scripts/versionRunning.txt";
 $commandlogpath = $dir."/scripts/commandcount.txt";
 $visitsString = "visits since October 2018";
 $commandsRunString = "commands run since July 2019";
+$branchpath = "/tmp/umplegitbranch.txt";
 if(file_exists($logpath)){
 	if(!is_writable($logpath)||!is_readable($logpath)) {
 		chmod($logpath, 0755);
@@ -71,5 +72,17 @@ if(file_exists($versionpath)){
 	fclose($vfile);
 	echo " | v$currentversion" ;
 }
+
+
+if(file_exists($branchpath)){
+	if(!is_readable($branchpath)) {
+		chmod($branchpath, 0755);
+	}
+	$bfile = fopen($branchpath, "r");
+	$currentbranch = fgets($bfile,1000);
+	fclose($bfile);
+	echo " | $currentbranch" ;
+}
+
 
 ?>

--- a/umpleonline/docker_config/nginx.conf
+++ b/umpleonline/docker_config/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen  80;
+    listen  8000;
 
     charset utf-8;
 

--- a/umpleonline/docker_config/supervisord.conf
+++ b/umpleonline/docker_config/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-user=root
+user=www:www
 loglevel=debug
 
 [program:nginx]

--- a/umpleonline/docker_config/supervisord.conf
+++ b/umpleonline/docker_config/supervisord.conf
@@ -1,4 +1,5 @@
 [supervisord]
+logfile=/tmp/supervisord.log
 user=nginx
 loglevel=debug
 

--- a/umpleonline/docker_config/supervisord.conf
+++ b/umpleonline/docker_config/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-user=www:www
+user=www
 loglevel=debug
 
 [program:nginx]

--- a/umpleonline/docker_config/supervisord.conf
+++ b/umpleonline/docker_config/supervisord.conf
@@ -1,5 +1,4 @@
 [supervisord]
-logfile=/tmp/supervisord.log
 user=nginx
 loglevel=debug
 

--- a/umpleonline/docker_config/supervisord.conf
+++ b/umpleonline/docker_config/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-user=www
+user=nginx
 loglevel=debug
 
 [program:nginx]


### PR DESCRIPTION
Prior to this PR, the Docker image caused supevisord,  the web server and php to run as root. This caused some security issues with Kubernetes. 

This PR arranges for the userid nginx to be used to run everything (user 100).

Internally port 8000 will be used to serve the website (nginx cannot serve on port 80 if it is not running as root). Logs have also moved from the root directory of the image to the logs directory.

The branch being tested will also be displayed when UmpleOnline is started, not just the version. This will allow better debugging when users report problems from the Docker image.