### PR TITLE
Example updates Fixes #1605 Fixes #1604

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -52,7 +52,7 @@ class UmpleToJava {
 		
 			append(realSb,"\n  {");
 		
-			append(realSb,"\n    Vector v = new Vector({0});", aMethod.numberOfMethodParameters());
+			append(realSb,"\n    Vector<Object> v = new Vector<Object>({0});", aMethod.numberOfMethodParameters());
 			for ( int i=0; i < aMethod.numberOfMethodParameters(); i++)
 			{
 			  append(realSb,"\n    v.add({0}, {1});",i, aMethod.getMethodParameter(i).getName());

--- a/UmpleToJava/UmpleTLTemplates/queued_state_machine_queuedEvent.ump
+++ b/UmpleToJava/UmpleTLTemplates/queued_state_machine_queuedEvent.ump
@@ -66,7 +66,7 @@ class UmpleToJava {
           
                 if (!event.getArgs().equals(""))
                 {
-                  append(realSb,"\n    Vector v = new Vector({0});", event.getParams().size());
+                  append(realSb,"\n    Vector<Object> v = new Vector<Object>({0});", event.getParams().size());
                   for ( int i=0; i < event.getParams().size(); i++)
                   {
                     append(realSb,"\n    v.add({0}, {1});",i, event.getParam(i).getName());
@@ -160,7 +160,7 @@ class UmpleToJava {
                      if (!e.getArgs().equals(""))
                      {
                        evList.add(e.getName());
-                       append(realSb,"\n    Vector v = new Vector({0});", e.getParams().size());
+                       append(realSb,"\n    Vector<Object> v = new Vector<Object>({0});", e.getParams().size());
                        for ( int i=0; i < e.getParams().size(); i++)
                        {
                          append(realSb,"\n    v.add({0}, {1});",i, e.getParam(i).getName());

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -222,6 +222,13 @@ class UmpleConsoleMain
          }
 
       String successWord = compileSuccess ? "Success! " : "";
+      
+      if(compileSuccess) {
+        for (UmpleClass mainClass: CodeCompiler.getMainClasses(model)) {
+          System.out.println("  Main method found. Run java "+mainClass.getName());
+        }
+      }  
+      
       System.out.println(successWord + "Processed "+ cfg.getUmpleFile() + ".");
       cfg.getLinkedFilesAsFile().stream()
         .filter(File::exists)

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/pooledStateMachine_withParameters.java.txt
@@ -235,7 +235,7 @@ public class LightFixture implements Runnable
 
   public void turnDimmer (Integer lightval)
   {
-    Vector v = new Vector(1);
+    Vector<Object> v = new Vector<Object>(1);
     v.add(0, lightval);
     pool.put(new Message(MessageType.turnDimmer_M, v));
   }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters.java.txt
@@ -207,7 +207,7 @@ public class LightFixture implements Runnable
 
   public void turnDimmer (Integer lightval)
   {
-    Vector v = new Vector(1);
+    Vector<Object> v = new Vector<Object>(1);
     v.add(0, lightval);
     queue.put(new Message(MessageType.turnDimmer_M, v));
   }

--- a/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
+++ b/cruise.umple/test/cruise/umple/statemachine/implementation/java/queuedStateMachine_withParameters_1.java.txt
@@ -207,7 +207,7 @@ public class LightFixture implements Runnable
 
   public void turnDimmer (Integer lightval,Double grade)
   {
-    Vector v = new Vector(2);
+    Vector<Object> v = new Vector<Object>(2);
     v.add(0, lightval);
     v.add(1, grade);
     queue.put(new Message(MessageType.turnDimmer_M, v));

--- a/umpleonline/download_eclipse_umple_plugin.html
+++ b/umpleonline/download_eclipse_umple_plugin.html
@@ -136,10 +136,10 @@
   docker pull umple/umpleonline
 </pre>
 
-<li>In a terminal (console), invoke the image (you can change the 8000 to be another port both here and in the next instruction if you prefer):
+<li>In a terminal (console), invoke the image (you can change the first 8000 to be another port both here and in the next instruction if you prefer):
 
 <pre>
-  docker run --rm -ti -p 8000:80 umple/umpleonline >/dev/null
+  docker run --rm -ti -p 8000:8000 umple/umpleonline >/dev/null
 </pre>
 
 <li>In a web browser, go to the following link: <a href="http://localhost:8000/umple.php">http://localhost:8000/umple.php</a><br/>&nbsp;<br/>
@@ -155,9 +155,9 @@
 <ul>
 
   <li> Run docker as:
-  docker run --rm -ti -p 8000:80 umple/umpleonline >/dev/null
+  docker run --rm -ti -p 8000:8000 umple/umpleonline >/dev/null
   <pre>
-    docker run --rm -ti -p 8000:80 -v {dir}:{dir:t} umple/umpleonline >/dev/null
+    docker run --rm -ti -p 8000:8000 -v {dir}:{dir:t} umple/umpleonline >/dev/null
   </pre>
   
   <li> and open your browser to href="http://localhost:8000/umple.php">http://localhost:8000/umple.php?model={dir:t}
@@ -187,7 +187,7 @@
 
 </ul>
 
-<p>The Docker UmpleOnline option is not designed for large-scale projects; for those use the command-line (A) or Eclipse (B) downloads above. However, the Docker option can 
+<p>More information about Umple in Docker can be found at <a href="http://docker.umple.org">http://docker.umple.org</a></p>
 
 
 

--- a/umpleonline/ump/Dishwasher.ump
+++ b/umpleonline/ump/Dishwasher.ump
@@ -1,0 +1,182 @@
+// This example illustrates a simple simulation of a Dishwasher 
+// Author: Timothy Lethbridge
+// The simulation accepts input of a cycle to run,
+//    and also c to cancel and q to quit (see the main program)
+// The commands do and dc can also be used to simulate
+//    door opening and closing
+// These inputs are converted into methods that trigger events
+//    on state machines
+//
+// There are three state machines:
+//  core operates the cycles
+//    states: active (has substates), draining, idle and suspended
+//  timingSm runs a timer that updates the display
+//  doorSm tracks the door state and helps ensure pausing when open
+// Note that the main program and the two state machines operate
+// in separate threads.
+
+class Dishwasher {
+  // This will be used to display the time remaining and
+  // track that time
+  // In a real system, this would be in minutes,
+  // but it will be seconds in this simulation
+  Integer minutesRemaining = 0;
+  
+  // Time in cycle segments we are not timing yet
+  Integer subsequentTime = 0;
+  
+  // Fixed times for various tasks
+  const Integer PrewashTime=5;
+  const Integer WashTime=10;
+  const Integer RinseTime=5;
+  
+  // This will be set if a timed operation needs to not count down,
+  // e.g. when the door is open
+  Boolean paused = false;
+  
+  queued doorSm {
+    closed {
+      openDoor / {paused = true;} -> open;
+    }
+    open {
+      closeDoor / {paused = false;}-> closed;
+    }
+  }
+
+  // Central state machine for system state
+  queued core {
+    idle {
+      // in this state the dishwasher can accept a cycle command
+      entry / {display("Enter cycle to run (n,f,r,c,q)");}
+      normal [!paused] / {minutesRemaining = PrewashTime;} -> active;
+      fast [!paused]
+        / {minutesRemaining = WashTime;} -> mainWash;  // skips prewash
+      rinse [!paused]
+        / {minutesRemaining = RinseTime;}-> rinsing;  // skips wash
+    }
+    active {
+      cancel
+        / {display("CANCELLING");startTimer(1,0);} -> draining;
+      openDoor -> suspended;      
+      preWash {
+        // The normal cycle starts with the use of pure water
+        // to get most of the dirt off
+        entry / {display("PREWASH");}
+        entry
+          / {startTimer(minutesRemaining,WashTime+RinseTime);}
+        timerEnded [minutesRemaining == 0]
+          / {minutesRemaining=WashTime;} -> mainWash;
+      }
+      mainWash {
+        entry / {display("MAIN WASH");}
+        entry / {startTimer(minutesRemaining,RinseTime);}              
+        timerEnded [minutesRemaining == 0]
+          / {minutesRemaining=RinseTime;} -> rinsing;
+      }
+      rinsing {
+        entry / {display("RINSING");}
+        entry / {startTimer(minutesRemaining,0);}          
+        timerEnded [minutesRemaining == 0] -> draining;
+      }
+    }
+    
+    draining {
+       entry / {display("DRAINING");}
+       after(1) -> idle;
+    }
+    suspended {
+      entry / {display("SUSPENDED - door open "
+        +(minutesRemaining+subsequentTime)+" left");}    
+      closeDoor -> active.H;
+      exit / {display("RESUMING");}       
+    }
+  }
+  
+ 
+  
+  queued timingSm {
+    idle {
+      startTimer(int numMins, int subsequentMins) -> countingDown;
+    }
+    countingDown {
+      startTimer(int numMins, int subsequentMins) -> countingDown;
+      
+      after(1.0) [minutesRemaining >= 1 && ! paused]  / {
+        displayTime();
+        minutesRemaining--;
+      } -> countingDown;
+      
+      after(1.0) [minutesRemaining <= 0] -> idle;
+      
+      openDoor -> idle;
+      
+      exit / {timerEnded();}
+    }
+  }
+  
+  before startTimer {
+    minutesRemaining = numMins;
+    subsequentTime = subsequentMins;
+  }
+  
+  void display(String s) {
+    System.out.println(s);
+  }
+  
+  void displayTime() {
+    System.out.println("DISPLAY: "+(minutesRemaining+subsequentTime));
+  } 
+  
+  // This main program allows the user to enter commands to change state
+  // The user can therefore operate the dishwasher in simulation
+  // with real timing
+  public static void main(String[] argv) {
+    Dishwasher dw = new Dishwasher();
+    System.out.println("c/q/do can interrupt to cancel/quit/door open");
+    System.out.println("dc to close door");
+    Scanner s = new Scanner(System.in);
+    String command ="";
+    while(true) {
+      while(!s.hasNextLine()) {
+        try { Thread.sleep(1000); }
+        catch (InterruptedException e) {
+          dw.display("Quitting due to end of input");
+          System.exit(0);          
+        }
+      }
+      command = s.nextLine();
+
+      switch(command) {
+        case "q":
+          dw.display("Quitting due to q command");
+          System.exit(0);
+        case "n":
+          dw.normal();
+          break;
+        case "f":
+          dw.fast();
+          break;          
+        case "r":
+          dw.rinse();
+          break;          
+        case "c":
+          dw.cancel();
+          break;          
+        case "dc":
+          dw.closeDoor();
+          break;    
+        case "do":
+          dw.openDoor();
+          break;            
+        
+        default:
+          break;
+      }
+    }
+  }
+}
+//$?[End_of_model]$?
+// @@@skipcppcompile - Contains Java Code
+// @@@skipphpcompile - Contains Java Code
+// @@@skiprubycompile - Contains Java Code
+    

--- a/umpleonline/ump/Phone.ump
+++ b/umpleonline/ump/Phone.ump
@@ -8,11 +8,11 @@ class PhoneSystemSimulation {
   // lazy PhoneLine[] lines;
   1 -- * PhoneLine lines;
   after constructor {
-    addLine(new PhoneLine("line1","Bruce",this));
-    addLine(new PhoneLine("line2","Ralph",this));
+    addLine(new PhoneLine("line1","Alex",this));
+    addLine(new PhoneLine("line2","Thomas",this));
     addLine(new PhoneLine("line3","Victoria",this));
-    addLine(new PhoneLine("line4","Vicki",this));
-    addLine(new PhoneLine("line5","Agnes",this));
+    addLine(new PhoneLine("line4","Samantha ",this));
+    addLine(new PhoneLine("line5","Karen",this));
   }
 
   static PhoneSystemSimulation s;

--- a/umpleonline/ump/TimedCommands.ump
+++ b/umpleonline/ump/TimedCommands.ump
@@ -1,0 +1,99 @@
+// This program will accept a series of command line
+// arguments and will issue them on standard output.
+// You can specify the amount of time to elapse before
+// each command by preceding it with a number of seconds
+// followed by a colon
+//
+// Example arguments:
+//   m 6:c 5:r 8:q would would output
+//      m
+//      and 6 seconds later s
+//      5 seconds later r and so on.
+// This is intended to be used to test time-sensitive
+// systems. Pipe standard output of this program to
+// standard input of the system under test.
+//
+// to compile this:
+//  java -jar umple.jar timedcommands.ump
+//  jar cfe CommandIssuer.jar CommandIssuer *.class
+//
+// to run it
+//  java -jar CommandIssuer.jar arg1 arg2 4:arg3
+//
+// Example of running with Dishwasher example
+//  java -jar CommandIssuer.jar n 25:r 2:do 2:dc 15:n 20:q | java Dishwasher
+
+
+
+class CommandIssuer {
+  Command nextCommand = null;
+  int nextDelay = 0;
+  
+  queued sm {
+    initializing {
+      processCommands -> processing;
+    }
+ 
+    processing {
+      [!hasCommands()] -> done;
+
+      [hasCommands()] -> doingACommand;
+    }
+    
+    doingACommand {
+      entry / {
+        nextCommand = getCommand(0);
+        nextDelay = nextCommand.getDelay();
+      }
+      
+      after(nextDelay) -> processing;
+
+      exit / {
+        System.out.println(nextCommand.getName());      
+        removeCommand(nextCommand);
+      }
+    }
+    
+    done {
+      entry / {System.exit(0);}
+    }
+  }
+
+  public static void main(String[] argv) {
+    CommandIssuer tt = new CommandIssuer();
+
+    for (String anArg: argv) {
+      String[] parts = anArg.split(":");
+
+      if(parts.length == 0) {
+        // Just a colon. Ignore.
+      }
+      else if(parts.length == 1 && !anArg.endsWith(":")) {
+        // no colon
+        tt.addCommand(new Command(0,parts[0]));
+      }
+      else if(parts.length >= 1) {
+        // colon present
+        int theDelay = 0;
+        String theCommand = "";
+        if(parts.length > 1) theCommand = parts[1];
+        
+        try  {
+          theDelay = Integer.parseInt(parts[0]);
+        }
+        catch (Exception e) {
+          // ignore badly formed numbers and assume zero
+        }
+        tt.addCommand(new Command(theDelay, theCommand));
+      }
+    }
+    tt.processCommands();
+  }
+  
+  0..1 -- * Command;
+}
+
+class Command {
+  int delay;
+  name;
+}

--- a/umpleonline/ump/TimedCommands.ump
+++ b/umpleonline/ump/TimedCommands.ump
@@ -97,3 +97,7 @@ class Command {
   int delay;
   name;
 }
+//$?[End_of_model]$?
+// @@@skipcppcompile - Contains Java Code
+// @@@skipphpcompile - Contains Java Code
+// @@@skiprubycompile - Contains Java Code

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -412,18 +412,19 @@ $output = $dataHandle->readData('model.ump');
                 <option name = "optionExample" value="Booking.ump">Booking (Airline)</option>
                 <option name = "optionExample" value="CanalLockStateMachine.ump">Canal Lock</option>
                 <option name = "optionExample" value="CarTransmission.ump">Car Transmission</option>
-		<option name = "optionExample" value="CollisionAvoidance.ump">Collision Avoidance With And-Cross Transition</option>
-		<option name = "optionExample" value="CollisionAvoidanceA1.ump">Collision Avoidance - Alternative 1</option>
-		<option name = "optionExample" value="CollisionAvoidanceA2.ump">Collision Avoidance - Alternative 2</option>
-		<option name = "optionExample" value="CollisionAvoidanceA3.ump">Collision Avoidance - Alternative 3</option>
+                <option name = "optionExample" value="CollisionAvoidance.ump">Collision Avoidance With And-Cross Transition</option>
+                <option name = "optionExample" value="CollisionAvoidanceA1.ump">Collision Avoidance - Alternative 1</option>
+                <option name = "optionExample" value="CollisionAvoidanceA2.ump">Collision Avoidance - Alternative 2</option>
+                <option name = "optionExample" value="CollisionAvoidanceA3.ump">Collision Avoidance - Alternative 3</option>
                 <option name = "optionExample" value="ComplexStateMachine.ump">Complex Symbolic</option>
                 <option name = "optionExample" value="CourseSectionFlat.ump">Course Section</option>
                 <option name = "optionExample" value="CourseSectionNested.ump">Course Section (Nested)</option>
                 <option name = "optionExample" value="DigitalWatchNested.ump">Digital Watch Nested</option>
                 <option name = "optionExample" value="DigitalWatchFlat.ump">Digital Watch (Flat)</option>
+                <option name = "optionExample" value="Dishwasher.ump">Dishwasher</option>                
                 <option name = "optionExample" value="Elevator_State_Machine.ump">Elevator</option>
                 <option name = "optionExample" value="GarageDoor.ump">Garage Door</option>
-		<option name = "optionExample" value="HomeHeater.ump">Home Heating System</option>
+                <option name = "optionExample" value="HomeHeater.ump">Home Heating System</option>
                 <option name = "optionExample" value="LibraryLoanStateMachine.ump">Library Loan</option>
                 <option name = "optionExample" value="Lights.ump">Light (3 alternatives)</option>
                 <option name = "optionExample" value="MicrowaveOven2.ump">Microwave Oven</option>
@@ -437,6 +438,7 @@ $output = $dataHandle->readData('model.ump');
                 <option name = "optionExample" value="TcpIpSimulation.ump">TCP/IP Simulation</option>
                 <option name = "optionExample" value="TelephoneSystem2.ump">Telephone Set Modes</option>
                 <option name = "optionExample" value="TicTacToe.ump">Tic Tac Toe or Noughts and Crosses</option>
+                <option name = "optionExample" value="TimedCommands.ump">Timed Commands</option>                     
                 <option name = "optionExample" value="TollBooth.ump">Toll Booth</option>
                 <option name = "optionExample" value="TrafficLightsA.ump">Traffic Lights A</option>
                 <option name = "optionExample" value="TrafficLightsB.ump">Traffic Lights B</option>


### PR DESCRIPTION
This PR adds two new state machine examples. A dishwasher simulation with a main program, and a Timed Commands example ( Fixes #1605 )

It also tells the command line user the Java classes that have main methods Fixes #1604

And it makes a few other minor improvements such as getting rid of an unchecked warning related to #1617