### PR TITLE
Fixes #1615 "Error on Generating Class diagram using Yuml"

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -487,7 +487,7 @@ else if (isset($_REQUEST["umpleCode"]))
         // could not generate either because of Python problem
         // or the yuml server not delivering because it doesn't like automated systems
         $yumltxt = file_get_contents($thedir."/yuml.txt");        
-        $dltext = "&nbsp;<a target=\"yumlimg\" href=\"http://yuml.me/diagram/plain/class/".urlencode($yumltxt).".php\"> Click on this link to display the png in a different Tab (yuml.me doesn't like automated systems generating their images)</a>&nbsp;";
+        $dltext = "&nbsp;<a target=\"yumlimg\" href=\"http://yuml.me/diagram/plain/class/".$yumltxt.".php\"> Click on this link to display the png in a different Tab (yuml.me doesn't like automated systems generating their images)</a>&nbsp;";
       }  
 
       $html = "<a href=\"$yumllink\">Download the Yuml text for the yuml image</a>. You can then use this text to generate various image formats at <a target=\"yumlimg\" href=\"https://yuml.me/diagram/plain/class/draw\">yuml.me</a>&nbsp;<br/>$dltext";


### PR DESCRIPTION
Although on my local server with python version 2.7.17 file "yuml.png" can be successfully generated with python script so umpleonline will directly show the yuml image (not a URL), on the main server the file "yuml.png" could not be generated so the PHP script will show a URL directs to the yuml official webserver to generated the image, which will fail if the yuml text in the requested link is URL encoded.
This PR fixes the issue by avoiding urlEncoding $yumltxt in requested URL.