### PR TITLE
Fixes #1606 "State machine called timer will generate bad Java if there is an after statement somewhere"

### DIFF
--- a/build/reference/9075UserDefinedStateMachineCannotBeNamedTimer.txt
+++ b/build/reference/9075UserDefinedStateMachineCannotBeNamedTimer.txt
@@ -4,10 +4,10 @@ noreferences
 
 @@description
 
-<h2>Umple semantic error reported when a user-defined state machine is named 'timer' keyword</h2>
+<h2>Umple error reported when a user-defined state machine is named 'timer'</h2>
 
 <p>
-In Umple, 'timer' is a reserved keyword. It is used to define the Timer in TimedEvent.
+In Umple, 'timer' cannot be used as a state machine name. This is because generated code for 'after' statements  creates timers and there would be a naming conflict in the generated code. To fix the problem, give the state machine a slightly different name,
 </p>
 
 

--- a/build/reference/9075UserDefinedStateMachineCannotBeNamedTimer.txt
+++ b/build/reference/9075UserDefinedStateMachineCannotBeNamedTimer.txt
@@ -1,0 +1,20 @@
+E075 UserDefinedStateMachineCannotBeNamedTimer
+Errors and Warnings 51-99
+noreferences
+
+@@description
+
+<h2>Umple semantic error reported when a user-defined state machine is named 'timer' keyword</h2>
+
+<p>
+In Umple, 'timer' is a reserved keyword. It is used to define the Timer in TimedEvent.
+</p>
+
+
+@@example
+@@source manualexamples/E075UserDefinedStateMachineCannotBeNamedTimer1.ump
+@@endexample
+
+@@example @@caption Solution to The Above So the Message No Longer Appears @@endcaption
+@@source manualexamples/E075UserDefinedStateMachineCannotBeNamedTimer2.ump
+@@endexample

--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -507,6 +507,11 @@ class UmpleInternalParser
     placeholderStateMachine = new StateMachine("PLACE_HOLDER");
     String name = stateMachineToken.getValue("name");
 
+    if (name.equals("timer"))
+    {
+      getParseResult().addErrorMessage(new ErrorMessage(75, stateMachineToken.getSubToken("name").getPosition(), "" + stateMachineToken.getSubToken("name").getPosition().getLineNumber()));
+    }
+
     if(!Token.isValidIdentifier(stateMachineToken.getValue("name"))){
     	setFailedPosition(stateMachineToken.getPosition(), 150, stateMachineToken.getValue("name"));
     }
@@ -1078,11 +1083,16 @@ class UmpleInternalParser
       	fromState.addAction(analyzeAction(subToken, fromState));
       }
       else if (subToken.is("||"))
-      {
+      {//System.out.println("stateToken: " + stateToken);
         if (fromState.numberOfNestedStateMachines() == 0) { continue; }
         int previousSmIndex = fromState.numberOfNestedStateMachines() - 1;
               StateMachine nestedSm = fromState.getNestedStateMachine(previousSmIndex);
               if (nestedSm.numberOfStates() == 0) { continue; }
+              //System.out.println("fromState.getName(): " + fromState.getName());
+              //System.out.println(fromState.getNestedStateMachines());
+              //System.out.println(nestedSm.getStates());
+              //System.out.println(nestedSm.getState(0).getNestedStateMachines());
+              //System.out.println("nestedSm.getName(): " + nestedSm.getName());
               nestedSm.setName(nestedSm.getState(0).getName());
               addNewSm = true;
               isConcurrentState = true;

--- a/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeStateMachine.ump
@@ -1083,16 +1083,11 @@ class UmpleInternalParser
       	fromState.addAction(analyzeAction(subToken, fromState));
       }
       else if (subToken.is("||"))
-      {//System.out.println("stateToken: " + stateToken);
+      {
         if (fromState.numberOfNestedStateMachines() == 0) { continue; }
         int previousSmIndex = fromState.numberOfNestedStateMachines() - 1;
               StateMachine nestedSm = fromState.getNestedStateMachine(previousSmIndex);
               if (nestedSm.numberOfStates() == 0) { continue; }
-              //System.out.println("fromState.getName(): " + fromState.getName());
-              //System.out.println(fromState.getNestedStateMachines());
-              //System.out.println(nestedSm.getStates());
-              //System.out.println(nestedSm.getState(0).getNestedStateMachines());
-              //System.out.println("nestedSm.getName(): " + nestedSm.getName());
               nestedSm.setName(nestedSm.getState(0).getName());
               addNewSm = true;
               isConcurrentState = true;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -83,7 +83,7 @@
 72: 4, "http://manual.umple.org/?W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
 73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
 74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
-75: 2, "http://manual.umple.org/?E075UserDefinedStateMachineCannotBeNamedTimer.html", Cannot name user-defined state machine on line '{0}' as timer because it is a reserved keyword ;
+75: 2, "http://manual.umple.org/?E075UserDefinedStateMachineCannotBeNamedTimer.html", Cannot name state machine on line '{0}' as timer because this name is reserved for internal use. Please choose another name ;
 
 80: 2, "http://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The association between a class and an abstract class declared in '{0}' must be a directed association or have one end whose multiplicity lower bound is 0 ;
 81: 2, "http://manual.umple.org/?E081InvalidMultivaluedAttributeAssignment.html", Invalid multivalued attribute assignment of attribute '{1}' in class '{0}' ;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -83,6 +83,7 @@
 72: 4, "http://manual.umple.org/?W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
 73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
 74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
+75: 2, "http://manual.umple.org/?E075UserDefinedStateMachineCannotBeNamedTimer.html", Cannot name user-defined state machine on line '{0}' as timer because it is a reserved keyword ;
 
 80: 2, "http://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The association between a class and an abstract class declared in '{0}' must be a directed association or have one end whose multiplicity lower bound is 0 ;
 81: 2, "http://manual.umple.org/?E081InvalidMultivaluedAttributeAssignment.html", Invalid multivalued attribute assignment of attribute '{1}' in class '{0}' ;

--- a/umpleonline/ump/manualexamples/E075UserDefinedStateMachineCannotBeNamedTimer1.ump
+++ b/umpleonline/ump/manualexamples/E075UserDefinedStateMachineCannotBeNamedTimer1.ump
@@ -1,0 +1,9 @@
+class X {
+  timer {
+    s1 {
+      after(1) -> s2;
+    }
+    s2 {
+    }
+  }
+}

--- a/umpleonline/ump/manualexamples/E075UserDefinedStateMachineCannotBeNamedTimer2.ump
+++ b/umpleonline/ump/manualexamples/E075UserDefinedStateMachineCannotBeNamedTimer2.ump
@@ -1,0 +1,9 @@
+class X {
+  sm_timer {
+    s1 {
+      after(1) -> s2;
+    }
+    s2 {
+    }
+  }
+}


### PR DESCRIPTION
Generate an error message when a state machine is named as "timer". Update manual page.