### PR TITLE
Minor fixes. Contrb to #1634

### DIFF
--- a/build/reference/5140SettingUpTasks.txt
+++ b/build/reference/5140SettingUpTasks.txt
@@ -90,9 +90,9 @@ noreferences
 <br/>&nbsp;
 
 
-<h2>How do responders respond to a task</h2>
+<h2>How do responders respond to a task?</h2>
 
-<p>This information is <a href="RespondingToTasks.html">in a separate manual page intended for responders</a>. The tool is designed, however, such that responders should not need to access any help. They just read the instructions provided by the requestor, do the task, and submit.</p>
+<p>This information is <a href="RespondingtoTasks.html">in a separate manual page intended for responders</a>. The tool is designed, however, such that responders should not need to access any help. They just read the instructions provided by the requestor, do the task, and submit.</p>
 
 <p>There are a few points responders should be aware of in certain circumstances.
 

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -411,15 +411,25 @@ else if (isset($_REQUEST["umpleCode"]))
           $command = $command . " " . $afile;
        }                  
        
-       exec($command);
-       exec("cd $thedir; rm javadocFromUmple.zip; zip -r javadocFromUmple javadoc");
+       exec($command." 2>&1",$outputlines,$retcode);
+       if(!file_exists("$thedir/javadoc")) {
+         // Javadoc failed
+         $html="Javadoc was not able to produced any output, since there are errors in the embedded Java. Look for syntax errors the embedded code in methods, guards, conditions and aspects . ";
+         foreach($outputlines as $outputline){
+           $foundresult=strstr($outputline,"error:");
+           if($foundresult != FALSE) $html = $html . "<br/><b>".$foundresult."</b>\n";
+         }
+       }
+       else {
+         exec("cd $thedir; rm javadocFromUmple.zip; zip -r javadocFromUmple javadoc");
        
-       $javadocdir = $workDir->makePermalink('javadoc/');
-       $javadoczip = $workDir->makePermalink('javadocFromUmple.zip');
-       $html = "<a href=\"{$javadoczip}\">Download the following as a zip file</a>&nbsp;{$errhtml}
-      <iframe width=100% height=1000 src=\"" . $javadocdir . "\">This browser does not
-      support iframes, so the javadoc cannot be displayed</iframe> 
-     ";
+         $javadocdir = $workDir->makePermalink('javadoc/');
+         $javadoczip = $workDir->makePermalink('javadocFromUmple.zip');
+         $html = "<a href=\"{$javadoczip}\">Download the following as a zip file</a>&nbsp;{$errhtml}
+         <iframe width=100% height=1000 src=\"" . $javadocdir . "\">This browser does not
+         support iframes, so the javadoc cannot be displayed</iframe> 
+         ";
+       }
        echo $html;
     }  // end javadoc
     

--- a/umplewww/404.shtml
+++ b/umplewww/404.shtml
@@ -5,7 +5,7 @@
 <head>
   <!--#include virtual="files/inclcommonhead.html" -->
 
-  <title>CRuiSE Server - Page not Found - Error 404</title>
+  <title>Umple-Related Page not Found - Error 404</title>
 </head>
 
 <body>
@@ -32,13 +32,7 @@
 <h1>A page you requested was not found</h1>
 
 <p>A page you requested was not found. If you came to this page via clicking on a
-link or from a search engine, please report the information at the bottom to <a href="mailto:tcl@eecs.uottawa.c">tcl@eecs.uottawa.ca</a></p>
-
-<br/>&nbsp;<br/>
-
-<h2>Models 2015 Conference</h2>
-
-<p>If you are looking for a page related to the Models 2015 conference, please go to <a href="http://www.modelsconference.org">http://www.modelsconference.org</a>
+link or from a search engine, please report the information at the bottom to <a href="mailto:timothy.lethbridge@uottawa.ca">timothy.lethbridge@uottawa.ca</a></p>
 
 <br/>&nbsp;<br/>
 
@@ -46,16 +40,13 @@ link or from a search engine, please report the information at the bottom to <a 
 
 <p>If this was an UmpleOnline request to
 display a model, it might be that the page has expired; temporary models are
-kept for about a day unless they are saved as a bookmarkable URL.</p>
+kept for about a day unless they are saved as a bookmarkable URL. Permanent models are kept for about a year after they were last edited</p>
 
 <p>For more information about Umple <a href="/umple">see the Umple home
-page</a> or the <a href="/umple/GettingStarted.html">Umple user
+page</a> or the <a href="http://manual.umple.org">Umple user
 manual</a>.</p>
 
 <br/>&nbsp;<br/>
-
-<p>For other information about the CRuiSE group, see one of the links on
-the left.</p>
 
 <p>For debugging purposes, here is some data to report</p>
       
@@ -66,7 +57,6 @@ the left.</p>
   <li>Document URI =  <!--#echo var="document_uri" -->
   <li>Forwarded =  <!--#echo var="forwarded" -->
   <li>From =  <!--#echo var="from" -->
-  <li>Gateway_interface =  <!--#echo var="gateway_interface" -->
   <li>Document name =  <!--#echo var="document_name" -->
 </ul>
 


### PR DESCRIPTION
As per issue #1634 if there is an embedded method in Umple code that is uncompilable, Javadoc can not be generated and the UmpleOnline feature to generate javadoc would fail and display a 404 message.

This PR fixes that by displaying a sensible message. It also displays the actual syntax error. However, currently it does NOT display the Umple line where the syntax error occurred. That would require extra work (compiling with -c - will map the java error number to the umple line number, but javadoc doesn't do that). So there is more work to deal with #1634 properly, but this will at least avoid the confusion that currently results.

 The 404 message was also misleading, so it is fixed here too. It referred to Models 2015, and needed updating.

A glitch in a manual page from a recent PR is also fixed.