### PR TITLE
Updating Docker-base to new Nginx

### DIFF
--- a/umpleonline/404.shtml
+++ b/umpleonline/404.shtml
@@ -5,7 +5,7 @@
 <head>
   <!--#include virtual="files/inclcommonhead.html" -->
 
-  <title>CRuiSE Server - Page not Found - Error 404</title>
+  <title>Umple-Related Page not Found - Error 404</title>
 </head>
 
 <body>
@@ -32,13 +32,7 @@
 <h1>A page you requested was not found</h1>
 
 <p>A page you requested was not found. If you came to this page via clicking on a
-link or from a search engine, please report the information at the bottom to <a href="mailto:tcl@eecs.uottawa.c">tcl@eecs.uottawa.ca</a></p>
-
-<br/>&nbsp;<br/>
-
-<h2>Models 2015 Conference</h2>
-
-<p>If you are looking for a page related to the Models 2015 conference, please go to <a href="http://www.modelsconference.org">http://www.modelsconference.org</a>
+link or from a search engine, please report the information at the bottom to <a href="mailto:timothy.lethbridge@uottawa.ca">timothy.lethbridge@uottawa.ca</a></p>
 
 <br/>&nbsp;<br/>
 
@@ -46,16 +40,13 @@ link or from a search engine, please report the information at the bottom to <a 
 
 <p>If this was an UmpleOnline request to
 display a model, it might be that the page has expired; temporary models are
-kept for about a day unless they are saved as a bookmarkable URL.</p>
+kept for about a day unless they are saved as a bookmarkable URL. Permanent models are kept for about a year after they were last edited</p>
 
 <p>For more information about Umple <a href="/umple">see the Umple home
-page</a> or the <a href="/umple/GettingStarted.html">Umple user
+page</a> or the <a href="http://manual.umple.org">Umple user
 manual</a>.</p>
 
 <br/>&nbsp;<br/>
-
-<p>For other information about the CRuiSE group, see one of the links on
-the left.</p>
 
 <p>For debugging purposes, here is some data to report</p>
       
@@ -66,7 +57,6 @@ the left.</p>
   <li>Document URI =  <!--#echo var="document_uri" -->
   <li>Forwarded =  <!--#echo var="forwarded" -->
   <li>From =  <!--#echo var="from" -->
-  <li>Gateway_interface =  <!--#echo var="gateway_interface" -->
   <li>Document name =  <!--#echo var="document_name" -->
 </ul>
 

--- a/umpleonline/Dockerfile
+++ b/umpleonline/Dockerfile
@@ -22,7 +22,8 @@ COPY . /var/www
 
 # make sure the php files are readable and log files are writable
 # for extra security, only /ump is writable since it is the only place
-# session data should be written
+# session data should be written. Windows EXE files are being removed
+# as they were triggering certain security warnings
 RUN chown -R :nginx /var/www && \
     chmod -R g+r /var/www && \
     chmod -R g+w /var/www/ump && \
@@ -33,7 +34,9 @@ RUN chown -R :nginx /var/www && \
     chown -R :nginx /var/log && \
     chmod -R g+rw /var/log && \
     chown -R :nginx /var/cache && \
-    chmod -R g+rw /var/cache
+    chmod -R g+rw /var/cache && \
+    rm /usr/lib/python*/site-packages/setuptools/*.exe && \
+    rm /usr/lib/python*/site-packages/pip/_vendor/distlib/*.exe
 
 # this is what runs on container startup
 CMD supervisord --nodaemon --configuration=/etc/supervisord.conf --logfile=/var/log/supervisord.log --pidfile=/var/log/supervisord.pid

--- a/umpleonline/Dockerfile-base
+++ b/umpleonline/Dockerfile-base
@@ -4,7 +4,7 @@ MAINTAINER Umple umple-help@googlegroups.com
 
 # give php its own user and install UmpleOnline's dependencies
 RUN adduser -D -H -h /var/cache/php -s /sbin/nologin -G nginx php && \
-    apk add --no-cache openjdk11 python supervisor graphviz zip \
+    apk add --no-cache openjdk11 python3 supervisor graphviz zip \
 		       php7 php7-fpm php7-sockets php7-zip php7-json
 
 

--- a/umpleonline/Dockerfile-base
+++ b/umpleonline/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM nginx:1.19.1-alpine
+FROM nginx:1.19.2-alpine
 
 MAINTAINER Umple umple-help@googlegroups.com
 

--- a/umpleonline/ReadMe.txt
+++ b/umpleonline/ReadMe.txt
@@ -2,16 +2,41 @@ Directory for the UmpleOnline web tool
 
 The public deployment of this can be found at http://try.umple.org
 
-Key files and directories *** means created at runtime
+This can also be used via Docker. Go to http://docker.umple.org
+
+Key files and directories means contents created at runtime
 
   umple.php - main program of UmpleOnline
-  vml.php - main program of VML, an alternative tool for variability
+
+  vml.php - main program of VML, an alternative tool for variability. This is obsolete and no longer works. Use Umple mixsets instead. This will be deleted shortly.
+
   simulate.php - code for the simulator (not recently maintained)
-  ump ***
-     *.ump and *.vml example files displayed by UmpleOnline
-     *** tmp* directories for each user session
-     *** numbered directories are created here for each saved user model
+
+  umplibrary
+     *.ump example files displayed by UmpleOnline
+     imagecache* - svg files that are displayed if Javascript is off
+     manualexamples/*.ump - examples loaded in the user manual
+
+
+  ump *** runtime directory for data storage in umpleonline
+     tmp* directories for each user session. These have randomly generated base-36 characters, meaning that guessing a directory would require trillions of tries. These are deleted after a month if not used
+     
+     yymmdd* directories. Longer-term storage for end users. These are deleted a year after last edit. Filenames also require guessing. The date the directory was originally created is embedded in the filename
+     
+     tasks Base directory for tasks set up by experimenters or professors
+     
+     taskroot* Storage of responses to tasks by end users
+     
         the date of the model is embeeded in the filename
-  scripts - PhP scripts for Umpleonline
+
+  scripts - PhP and JavaScript scripts for Umpleonline
+
   download_eclipse_umple_plugin.html - main page of http://dl.umple.org
+
   UmpleUpdateSite - website for automatic updating of Eclipse plugin
+  
+  docker_config - Directories used for setting up the Docker image, including setting up nginx, php and supervisord.
+  
+  Dockerfile - Instructions for the main Docker image built every brach push, pr and merge
+
+  Dockerfile-base - Instructions for the Docker base image built only when a tag is added to the repository. Make before every major release that you go here https://hub.docker.com/_/nginx and update this file with the latest nginx-alpine image. Consider also checking whether a higher version of openjdk is available out of testing (i.e. edge) than the version listed.


### PR DESCRIPTION
This updates Nginx to 1.19.2 next time the base Docker image is built.

It also updates the Readme.txt in Umpleonline to make up to date and to document Docker building a little.

Finally it deletes unneeded Windows files from the python installation in Docker. This may help avoid the image flagging CVE-2015-5652  (which is only relevant to Windows, and this is image is not a Windows image)