### PR TITLE
Improve Umple Feature Model

### DIFF
--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -31,6 +31,10 @@ class FeatureNode{
   int id = nextId.incrementAndGet();
   lazy name;
   boolean isLeaf =false; 
+  
+  0..1 targetFeatureNode -- * FeatureLink incomingFeatureLinks;
+  0..1 sourceFeatureNode -- * FeatureLink outgoingFeatureLinks;
+  
 
   public String getUniqueFeatureNodeName()
   {
@@ -43,6 +47,7 @@ class FeatureLeaf
 {
   isA FeatureNode;
   0..1 -- 0..1 MixsetOrFile mixsetOrFileNode;
+  
   after constructor { setIsLeaf(true);}
   //a leaf node returns its actual name as a unique name.
   public String getUniqueFeatureNodeName()
@@ -62,10 +67,8 @@ class FragmentFeatureLeaf
 // A FeatureLink connects a source feature to target feature(s) in the feature diagram.
 class FeatureLink
 {
-  * sourceFeatureLink -- 0..1 FeatureNode sourceFeature; // the sourceFeature can be FeatureLeaf or FeatureNode
-  0..* -- * FeatureNode targetFeature;
   boolean isSub =false; // isSub to differentiate between sub-features and include/exclude relationship
-  enum FeatureConnectingOpType{ Required, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
+  enum FeatureConnectingOpType{ Mandatory, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
   FeatureConnectingOpType featureConnectingOpType = null;
 
 }

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -31,7 +31,7 @@ class FeatureNode{
   int id = nextId.incrementAndGet();
   lazy name;
   boolean isLeaf =false; 
-  boolean isCompundFeature = false;  
+  boolean isCompoundFeature = false;  
   0..1 targetFeatureNode -- * FeatureLink incomingFeatureLinks;
   0..1 sourceFeatureNode -- * FeatureLink outgoingFeatureLinks;
   
@@ -46,7 +46,7 @@ class CompoundFeatureNode
 {
   isA FeatureNode;
   1--* FeatureNode targetFeatures;
-  after constructor { setIsCompundFeature(true);}
+  after constructor { setIsCompoundFeature(true);}
 }
 
 // A FeatureLeaf contains a full mixset or a full file. 

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -76,9 +76,9 @@ class FragmentFeatureLeaf
 class FeatureLink
 {
   boolean isSub =false; // isSub to differentiate between sub-features and include/exclude relationship
-  enum FeatureConnectingOpType{ Mandatory, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR};  
-  FeatureConnectingOpType featureConnectingOpType = null;
-
+  enum FeatureConnectingOpType{ Mandatory, Optional, Conjunctive, Disjunctive, Multiplicity, Include, Exclude, XOR}; 
+  //Set a default value for featureLinks. 
+  FeatureConnectingOpType featureConnectingOpType = FeatureConnectingOpType.Include;
 }
 // MultiplicityFeatureConnectingOpType is a special type of FeatureLink in which there are min and max multiplicity. 
 

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -32,6 +32,7 @@ class FeatureNode{
   lazy name;
   boolean isLeaf =false; 
   boolean isCompoundFeature = false;  
+  // A feature node in the feature diagram may have 0 or more incoming/outgoing links.
   0..1 targetFeatureNode -- * FeatureLink incomingFeatureLinks;
   0..1 sourceFeatureNode -- * FeatureLink outgoingFeatureLinks;
   
@@ -41,11 +42,11 @@ class FeatureNode{
   }
 }
 
-// Compund features cotains multiple of features (for example, xor , or and other what have multiplicity.)
+// A compund feature has multiple of features (like xor , or and other that have multiplicity.)
 class CompoundFeatureNode
 {
   isA FeatureNode;
-  1--* FeatureNode targetFeatures;
+  0..1--* FeatureNode childFeatures;
   after constructor { setIsCompoundFeature(true);}
 }
 

--- a/cruise.umple/src/FeatureModel.ump
+++ b/cruise.umple/src/FeatureModel.ump
@@ -31,15 +31,22 @@ class FeatureNode{
   int id = nextId.incrementAndGet();
   lazy name;
   boolean isLeaf =false; 
-  
+  boolean isCompundFeature = false;  
   0..1 targetFeatureNode -- * FeatureLink incomingFeatureLinks;
   0..1 sourceFeatureNode -- * FeatureLink outgoingFeatureLinks;
   
-
   public String getUniqueFeatureNodeName()
   {
     return name+"_"+id;
   }
+}
+
+// Compund features cotains multiple of features (for example, xor , or and other what have multiplicity.)
+class CompoundFeatureNode
+{
+  isA FeatureNode;
+  1--* FeatureNode targetFeatures;
+  after constructor { setIsCompundFeature(true);}
 }
 
 // A FeatureLeaf contains a full mixset or a full file. 
@@ -93,8 +100,3 @@ class XORFeatureConnectingOpType
     setMultiplicity(xorMultiplicity);
   }
 }
-
-/*
-class MixsetOrFile{}
-class MixsetFragment{}
-*/

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -39,13 +39,13 @@ digraph FeatureModel {
 
   public void generateFeatureNodeShape(FeatureLink featureLink , StringBuilder code)
   {
-    FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
-    FeatureNode sourceFeatureNode = featureLink.getSourceFeature();
+    FeatureNode featureNode = featureLink.getTargetFeatureNode();
+    FeatureNode sourceFeatureNode = featureLink.getSourceFeatureNode();
     int indentLevel = 2;
     appendSpaces(code,indentLevel);
     if(featureNode.getIsLeaf())
     {
-      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Multiplicity))
+      if(featureNode.getIsCompoundFeature())
       {
         MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
         int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
@@ -53,13 +53,12 @@ digraph FeatureModel {
         String minMax =""+lowerBound+".."+upperBound;
         code.append(sourceFeatureNode.getUniqueFeatureNodeName() + getGvMultiplicityShape(minMax));
         indentLevel+=2;
-        List<FeatureNode> featureNodes = featureLink.getTargetFeature();
+        List<FeatureNode> featureNodes = ((CompoundFeatureNode) featureNode).getChildFeatures();
         for(int i=0 ; i < featureNodes.size(); i++){
           FeatureLeaf fLeaf = ((FeatureLeaf)featureNodes.get(i));
           appendSpaces(code,indentLevel);
           code.append(sourceFeatureNode.getUniqueFeatureNodeName() +" -> "+ fLeaf.getName()+" ;"+"\n");
           fillColorOfFeatureNode(code,fLeaf,indentLevel);
-          
         }
       }
       else 
@@ -75,7 +74,7 @@ digraph FeatureModel {
       code.append(getGvNodeShape(featureLink.getFeatureConnectingOpType(),featureNode.getUniqueFeatureNodeName()));
       appendSpaces(code,indentLevel);
       code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getUniqueFeatureNodeName()+" ;"+"\n");
-      List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+      List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
       for(int i=0 ; i<outgoingLinks.size(); i++){
         generateFeatureNodeShape(outgoingLinks.get(i),code);
       }
@@ -100,7 +99,7 @@ digraph FeatureModel {
     // Iterate through each root feature. 
     for (FeatureNode featureNode : featureModel.getRootFeatures())
     {
-      List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
+      List <FeatureLink> featureNodeOutLinks = featureNode.getOutgoingFeatureLinks();
       for(FeatureLink flink : featureNodeOutLinks)
       {
         code.append("  "+featureNode.getUniqueFeatureNodeName()+" [label=\""+featureNode.getName()+" \" ]; \n");

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -73,11 +73,12 @@ digraph FeatureModel {
       code.append(getGvNodeShape(featureLink.getFeatureConnectingOpType(),featureNode.getUniqueFeatureNodeName()));
       appendSpaces(code,indentLevel);
       code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getUniqueFeatureNodeName()+" ;"+"\n");
-      List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
-      for(int i=0 ; i<outgoingLinks.size(); i++){
-        generateFeatureNodeShape(outgoingLinks.get(i),code);
       }
-      }
+    }
+    
+    List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
+    for(int i=0 ; i<outgoingLinks.size(); i++){
+      generateFeatureNodeShape(outgoingLinks.get(i),code);
     }
   }
 
@@ -89,7 +90,7 @@ digraph FeatureModel {
     _graphStart(0,code);
     if(featureModel == null)
     {
-      code.append("// Umple code does not have feature diagram. // \n");
+      code.append("// Umple code does not have a feature diagram. // \n");
       _nofeatureDiagram(0,code);
     }
     else
@@ -120,10 +121,10 @@ digraph FeatureModel {
     {
       case Exclude:
       return "["+ shapeProp +" arrowhead=normal color=red label=exclude " +" ]";
-      case Include:
-			if(isSub)
+      case Mandatory:
       shapeProp += " arrowhead=dot ";
-      else 
+      return "["+ shapeProp +" ]";
+      case Include:
       shapeProp += " arrowhead=normal label=include color=blue ";
       return "["+ shapeProp +" ]";
       case Optional:

--- a/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
+++ b/cruise.umple/src/Generator_CodeGvFeatureDiagram.ump
@@ -44,6 +44,14 @@ digraph FeatureModel {
     int indentLevel = 2;
     appendSpaces(code,indentLevel);
     if(featureNode.getIsLeaf())
+    { 
+      // link source to leaf node 
+        code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getName()+" ");
+        code.append(getGvTargetShape(featureLink.getFeatureConnectingOpType(), featureLink.getIsSub() ));
+        code.append(" ;"+"\n");    
+        fillColorOfFeatureNode(code,featureNode,indentLevel);
+    }
+    else //if the node is not leaf node 
     {
       if(featureNode.getIsCompoundFeature())
       {
@@ -61,22 +69,14 @@ digraph FeatureModel {
           fillColorOfFeatureNode(code,fLeaf,indentLevel);
         }
       }
-      else 
-      {// link source to leaf node 
-        code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getName()+" ");
-        code.append(getGvTargetShape(featureLink.getFeatureConnectingOpType(), featureLink.getIsSub() ));
-        code.append(" ;"+"\n");    
-        fillColorOfFeatureNode(code,featureNode,indentLevel);
-      }
-    }
-    else //if the node is not leaf node 
-    {
+      else{
       code.append(getGvNodeShape(featureLink.getFeatureConnectingOpType(),featureNode.getUniqueFeatureNodeName()));
       appendSpaces(code,indentLevel);
       code.append(""+sourceFeatureNode.getUniqueFeatureNodeName()+" -> "+featureNode.getUniqueFeatureNodeName()+" ;"+"\n");
       List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
       for(int i=0 ; i<outgoingLinks.size(); i++){
         generateFeatureNodeShape(outgoingLinks.get(i),code);
+      }
       }
     }
   }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -95,9 +95,9 @@ class UmpleInternalParser
     newFeatureNode.setName(treeNode.getNodeToken().getName());
     FeatureLink edge = new FeatureLink();
     edge.setFeatureConnectingOpType(treeNode.getFeatureConnectionOpType());
-    edge.setSourceFeature(sourceFeature);
+    edge.setSourceFeatureNode(sourceFeature);
     edge.setIsSub(isSubFeature);
-    edge.addTargetFeature(newFeatureNode); 
+    edge.setTargetFeatureNode(newFeatureNode); 
     edge.setFeatureModel(model.getFeatureModel());
     model.getFeatureModel().addFeaturelink(edge);
     return newFeatureNode;
@@ -122,8 +122,8 @@ class UmpleInternalParser
           targetFeature.setMixsetOrFileNode(targetMixset);
           edge = new FeatureLink();
           edge.setFeatureConnectingOpType(tokenTree.getFeatureConnectionOpType());
-          edge.setSourceFeature(sourceFeature);
-          edge.addTargetFeature(targetFeature);
+          edge.setSourceFeatureNode(sourceFeature);
+          edge.setTargetFeatureNode(targetFeature);
           edge.setIsSub(isSubFeature);
           model.getFeatureModel().addFeaturelink(edge);          
         }
@@ -144,8 +144,8 @@ class UmpleInternalParser
         else // this is for leaf node as the parent is not null 
         edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType());
         
-        edge.setSourceFeature(sourceFeature);       
-        edge.addTargetFeature(targetFeature);
+        edge.setSourceFeatureNode(sourceFeature);       
+        edge.setTargetFeatureNode(targetFeature);
         edge.setIsSub(isSubFeature);
         model.getFeatureModel().addFeaturelink(edge);
       }
@@ -157,11 +157,11 @@ class UmpleInternalParser
         
         FeatureNode newFeatureNode = new FeatureNode(model.getFeatureModel());
         newFeatureNode.setName("multiplicityTerminal");
-        edge.addTargetFeature(newFeatureNode); 
+        edge.setTargetFeatureNode(newFeatureNode); 
         edge.setFeatureModel(model.getFeatureModel());
         
         MultiplicityFeatureConnectingOpType intermediateFeatureNodeToTargetEdge = new MultiplicityFeatureConnectingOpType();
-        intermediateFeatureNodeToTargetEdge.setSourceFeature(newFeatureNode);
+        intermediateFeatureNodeToTargetEdge.setSourceFeatureNode(newFeatureNode);
         intermediateFeatureNodeToTargetEdge.setMultiplicity(featureLinkMultiplicity);
   
         for(Token subToken : node.getSubTokens())
@@ -171,10 +171,10 @@ class UmpleInternalParser
             Mixset targetMixset = new Mixset(subToken.getValue()); //To Do: check if its a mixset.
             FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
             targetFeature.setMixsetOrFileNode(targetMixset);
-            intermediateFeatureNodeToTargetEdge.addTargetFeature(targetFeature);
+            intermediateFeatureNodeToTargetEdge.setTargetFeatureNode(targetFeature);
           }
         }
-        edge.setSourceFeature(sourceFeature);       
+        edge.setSourceFeatureNode(sourceFeature);       
         edge.setIsSub(isSubFeature);
         model.getFeatureModel().addFeaturelink(edge);
       } 

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -164,8 +164,7 @@ class UmpleInternalParser
         edge.setFeatureModel(model.getFeatureModel());
         edge.setIsSub(isSubFeature);
         model.getFeatureModel().addFeaturelink(edge);
-        
-  
+        // add child elements to newCompoundFeatureNode.
         for(Token subToken : node.getSubTokens())
         {
           if(subToken.is("targetMixsetName"))
@@ -468,8 +467,7 @@ class FeatureModel{
   If the link is not satisfied, it return false.
   Ex: the link "source--> and" for M1 and M2 is true if there are use-statements for both M1 and M2.   
   */
-  public boolean evaluateFeatureLink(FeatureLink featureLink){ return true;}
-  public boolean evaluateFeatureLink2(FeatureLink featureLink)
+  public boolean evaluateFeatureLink(FeatureLink featureLink)
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeatureNode());
     if(featureNode.getIsLeaf())

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -158,7 +158,7 @@ class UmpleInternalParser
 
         CompoundFeatureNode newCompoundFeatureNode = new CompoundFeatureNode(model.getFeatureModel());
         newCompoundFeatureNode.setName("multiplicityTerminal");
-        newCompoundFeatureNode.setIsLeaf(true);
+        //newCompoundFeatureNode.setIsLeaf(true);
         edge.setTargetFeatureNode(newCompoundFeatureNode); 
         edge.setSourceFeatureNode(sourceFeature); 
         edge.setFeatureModel(model.getFeatureModel());
@@ -468,11 +468,16 @@ class FeatureModel{
   If the link is not satisfied, it return false.
   Ex: the link "source--> and" for M1 and M2 is true if there are use-statements for both M1 and M2.   
   */
-  public boolean evaluateFeatureLink(FeatureLink featureLink)
+  public boolean evaluateFeatureLink(FeatureLink featureLink){ return true;}
+  public boolean evaluateFeatureLink2(FeatureLink featureLink)
   {
     FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeatureNode());
     if(featureNode.getIsLeaf())
     {
+      if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Mandatory))
+      {
+        return isUsedFeatureLeaf((FeatureLeaf)featureNode);
+      } 
       if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
       {
         return isUsedFeatureLeaf((FeatureLeaf)featureNode);

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -143,26 +143,28 @@ class UmpleInternalParser
         edge.setFeatureConnectingOpType(FeatureConnectingOpType.Mandatory);
         else // this is for leaf node as the parent is not null 
         edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType());
-        
         edge.setSourceFeatureNode(sourceFeature);       
         edge.setTargetFeatureNode(targetFeature);
         edge.setIsSub(isSubFeature);
         model.getFeatureModel().addFeaturelink(edge);
       }
       else if(node.is("requireTerminal") && node.getSubToken("lowerBound") != null) //  [lowerBound]..[upperBound] of [A, B, ... ]
-      {
-        edge = new MultiplicityFeatureConnectingOpType();
-		    Multiplicity featureLinkMultiplicity = ((MultiplicityFeatureConnectingOpType) edge).getMultiplicity();
+      {        
+        MultiplicityFeatureConnectingOpType multiplicityFeatureConnectingOpTypeEdge = new MultiplicityFeatureConnectingOpType();
+        Multiplicity featureLinkMultiplicity = multiplicityFeatureConnectingOpTypeEdge.getMultiplicity();
         featureLinkMultiplicity.setRange(node.getSubToken("lowerBound").getValue(), node.getSubToken("upperBound").getValue());
-        
-        FeatureNode newFeatureNode = new FeatureNode(model.getFeatureModel());
-        newFeatureNode.setName("multiplicityTerminal");
-        edge.setTargetFeatureNode(newFeatureNode); 
+        multiplicityFeatureConnectingOpTypeEdge.setMultiplicity(featureLinkMultiplicity);
+        edge = (FeatureLink) multiplicityFeatureConnectingOpTypeEdge;
+
+        CompoundFeatureNode newCompoundFeatureNode = new CompoundFeatureNode(model.getFeatureModel());
+        newCompoundFeatureNode.setName("multiplicityTerminal");
+        newCompoundFeatureNode.setIsLeaf(true);
+        edge.setTargetFeatureNode(newCompoundFeatureNode); 
+        edge.setSourceFeatureNode(sourceFeature); 
         edge.setFeatureModel(model.getFeatureModel());
+        edge.setIsSub(isSubFeature);
+        model.getFeatureModel().addFeaturelink(edge);
         
-        MultiplicityFeatureConnectingOpType intermediateFeatureNodeToTargetEdge = new MultiplicityFeatureConnectingOpType();
-        intermediateFeatureNodeToTargetEdge.setSourceFeatureNode(newFeatureNode);
-        intermediateFeatureNodeToTargetEdge.setMultiplicity(featureLinkMultiplicity);
   
         for(Token subToken : node.getSubTokens())
         {
@@ -171,12 +173,9 @@ class UmpleInternalParser
             Mixset targetMixset = new Mixset(subToken.getValue()); //To Do: check if its a mixset.
             FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
             targetFeature.setMixsetOrFileNode(targetMixset);
-            intermediateFeatureNodeToTargetEdge.setTargetFeatureNode(targetFeature);
+            newCompoundFeatureNode.addChildFeature(targetFeature);
           }
         }
-        edge.setSourceFeatureNode(sourceFeature);       
-        edge.setIsSub(isSubFeature);
-        model.getFeatureModel().addFeaturelink(edge);
       } 
  
     }
@@ -471,7 +470,7 @@ class FeatureModel{
   */
   public boolean evaluateFeatureLink(FeatureLink featureLink)
   {
-    FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeature(0));
+    FeatureNode featureNode = ((FeatureNode) featureLink.getTargetFeatureNode());
     if(featureNode.getIsLeaf())
     {
       if(featureLink.getFeatureConnectingOpType().equals(FeatureConnectingOpType.Include))
@@ -493,7 +492,7 @@ class FeatureModel{
     { 
       if(!featureNode.getIsLeaf())
       {
-        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+        List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
         boolean result = true;
         for(int i=0 ; i<outgoingLinks.size(); i++){
           result = result && evaluateFeatureLink(outgoingLinks.get(i));
@@ -506,7 +505,7 @@ class FeatureModel{
       if(!featureNode.getIsLeaf())
       {
         boolean result = false;
-        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+        List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
         for(int i=0 ; i<outgoingLinks.size(); i++){
           result = result || evaluateFeatureLink(outgoingLinks.get(i));
         }
@@ -517,7 +516,7 @@ class FeatureModel{
     { 
       if(!featureNode.getIsLeaf())
           {
-            List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
+            List<FeatureLink> outgoingLinks = featureNode.getOutgoingFeatureLinks();
             int countOfUsedTarget = 0;
             for(int i=0 ; i < outgoingLinks.size(); i++){
               if(evaluateFeatureLink(outgoingLinks.get(i)))  // bitwise xor (^) can not be used here because it does not mean always only one. Example: (true ^ true ^ true == true) 
@@ -531,19 +530,14 @@ class FeatureModel{
         MultiplicityFeatureConnectingOpType multiplicityFeatureLink = (MultiplicityFeatureConnectingOpType) featureLink;
         int upperBound = multiplicityFeatureLink.getMultiplicity().getUpperBound();
         int lowerBound = multiplicityFeatureLink.getMultiplicity().getLowerBound();
-       // List<FeatureNode> featureNodes = featureLink.getTargetFeature(); //featureNode.
         
-        List<FeatureLink> outgoingLinks = featureNode.getSourceFeatureLink();
         int countOfUsedTarget = 0;
-        for(int i=0 ; i<outgoingLinks.size(); i++){
-          FeatureLink link = outgoingLinks.get(i);
-          List<FeatureNode> featureNodes = link.getTargetFeature();  
+          List<FeatureNode> featureNodes = ((CompoundFeatureNode)featureNode).getChildFeatures();
           for(int k=0 ; k < featureNodes.size(); k++){
             if(isUsedFeatureLeaf((FeatureLeaf)featureNodes.get(k)))
             countOfUsedTarget++;
           }
 
-        }
         return (countOfUsedTarget <= upperBound && countOfUsedTarget >= lowerBound) ? true: false;    
       }
     //otherwise
@@ -562,10 +556,10 @@ class FeatureModel{
     //getNode().stream().filter(n -> (n.hasSourceFeatureLink() && n.getIsLeaf())).collect(Collectors.toList());
     for(FeatureNode featureNode: rootFeatures)
     {
-      List <FeatureLink> featureNodeOutLinks = featureNode.getSourceFeatureLink();
-      for(FeatureLink flink : featureNodeOutLinks)
+      List <FeatureLink> featureNodeOutgoingLinks = featureNode.getOutgoingFeatureLinks();
+      for(FeatureLink featureLink : featureNodeOutgoingLinks)
       {
-        isSatisfied = isSatisfied && evaluateFeatureLink(flink);
+        isSatisfied = isSatisfied && evaluateFeatureLink(featureLink);
       }
     }
     return isSatisfied;
@@ -573,8 +567,8 @@ class FeatureModel{
 
   public List <FeatureNode> getRootFeatures()
   {
-        // get root features : has outgoing links but no incoming links
-    List <FeatureNode> rootFeatures = getNode().stream().filter(n -> (n.hasSourceFeatureLink() && n.getIsLeaf())).collect(Collectors.toList());
+    // A root feature : has outgoing links but no incoming links.
+    List <FeatureNode> rootFeatures = getNode().stream().filter(n -> (n.hasOutgoingFeatureLinks() && (! n.hasIncomingFeatureLinks()))).collect(Collectors.toList());
     return rootFeatures;
   }
 }

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -94,7 +94,7 @@ class UmpleInternalParser
     FeatureNode newFeatureNode = new FeatureNode(model.getFeatureModel());
     newFeatureNode.setName(treeNode.getNodeToken().getName());
     FeatureLink edge = new FeatureLink();
-    edge.setFeatureConnectingOpType(treeNode.getFeatureConnectionOpType());
+    edge.setFeatureConnectingOpType(treeNode.getFeatureConnectionOpType(isSubFeature));
     edge.setSourceFeatureNode(sourceFeature);
     edge.setIsSub(isSubFeature);
     edge.setTargetFeatureNode(newFeatureNode); 
@@ -121,7 +121,7 @@ class UmpleInternalParser
           FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
           targetFeature.setMixsetOrFileNode(targetMixset);
           edge = new FeatureLink();
-          edge.setFeatureConnectingOpType(tokenTree.getFeatureConnectionOpType());
+          edge.setFeatureConnectingOpType(tokenTree.getFeatureConnectionOpType(isSubFeature));
           edge.setSourceFeatureNode(sourceFeature);
           edge.setTargetFeatureNode(targetFeature);
           edge.setIsSub(isSubFeature);
@@ -136,13 +136,8 @@ class UmpleInternalParser
         Mixset targetMixset = new Mixset(node.getSubToken("targetMixsetName").getValue());
         FeatureLeaf targetFeature = featureModel.getOrCreateFeatureLeafNode(targetMixset.getName()); 
         targetFeature.setMixsetOrFileNode(targetMixset);
-        //targetFeature.setName(targetMixset.getName());
         edge = new FeatureLink();
-        
-        if(linkingParent.getNodeToken().is("ROOT"))
-        edge.setFeatureConnectingOpType(FeatureConnectingOpType.Mandatory);
-        else // this is for leaf node as the parent is not null 
-        edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType());
+        edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType(isSubFeature));
         edge.setSourceFeatureNode(sourceFeature);       
         edge.setTargetFeatureNode(targetFeature);
         edge.setIsSub(isSubFeature);
@@ -611,7 +606,7 @@ This method selects the the connection operator type based on the type of the (l
 If the type is not specified for the linking node, The default is Required.
 It returns null if the node is termainl node.
 */
-public FeatureConnectingOpType getFeatureConnectionOpType()
+public FeatureConnectingOpType getFeatureConnectionOpType(boolean isSubFeature)
 {
   if(nodeToken != null )
   {
@@ -630,7 +625,12 @@ public FeatureConnectingOpType getFeatureConnectionOpType()
       case "not":
         return FeatureConnectingOpType.Exclude;
       default:
+      {
+        if(isSubFeature)
         return FeatureConnectingOpType.Mandatory;
+        else
+        return FeatureConnectingOpType.Include;
+      }
      }
   }
 

--- a/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeRequireStatement.ump
@@ -140,7 +140,7 @@ class UmpleInternalParser
         edge = new FeatureLink();
         
         if(linkingParent.getNodeToken().is("ROOT"))
-        edge.setFeatureConnectingOpType(FeatureConnectingOpType.Include);
+        edge.setFeatureConnectingOpType(FeatureConnectingOpType.Mandatory);
         else // this is for leaf node as the parent is not null 
         edge.setFeatureConnectingOpType(linkingParent.getFeatureConnectionOpType());
         
@@ -633,7 +633,7 @@ public FeatureConnectingOpType getFeatureConnectionOpType()
       case "not":
         return FeatureConnectingOpType.Exclude;
       default:
-        return FeatureConnectingOpType.Required;
+        return FeatureConnectingOpType.Mandatory;
      }
   }
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -313,8 +313,8 @@ public class UmpleMixsetTest {
     model.run();
     FeatureModel featureModel= model.getFeatureModel();
     FeatureLink featureLink = featureModel.getFeaturelink().get(0);
-    FeatureLeaf source = ((FeatureLeaf) featureLink.getSourceFeature());
-    FeatureNode target = featureLink.getTargetFeature().get(0);
+    FeatureLeaf source = ((FeatureLeaf) featureLink.getSourceFeatureNode());
+    FeatureNode target = featureLink.getTargetFeatureNode();
     Assert.assertEquals(featureModel.getFeaturelink().size(),1); // test 
     Assert.assertEquals(false,source.getMixsetOrFileNode().getIsMixset());  // false
     Assert.assertEquals("reqStArgumentParse_oneArgument",source.getMixsetOrFileNode().getName());// == filename 
@@ -391,13 +391,13 @@ public class UmpleMixsetTest {
     FeatureModel featureModel= model.getFeatureModel();
     //source --> opt B
     Assert.assertEquals(featureModel.getFeaturelink(0).getFeatureConnectingOpType().name(), "Optional");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false); // false: its the source file
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getSourceFeatureNode()).getMixsetOrFileNode().isIsMixset(), false); // false: its the source file
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(0).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"B");
     //source --> and A C
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
-    Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(1).getTargetFeature(0)).getName() ,"and");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getSourceFeatureNode()).getMixsetOrFileNode().isIsMixset(), false);
+    Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(1).getTargetFeatureNode()).getName() ,"and");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"C");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"A");
   }
   @Test
   public void parseReqStArgumetToFeaureModel()
@@ -408,20 +408,20 @@ public class UmpleMixsetTest {
     model.run();
     FeatureModel featureModel= model.getFeatureModel();
     //source --> (and A B)
-    Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(0).getTargetFeature(0)).getName() ,"and");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"B");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"A");
+    Assert.assertEquals(((FeatureNode) featureModel.getFeaturelink(0).getTargetFeatureNode()).getName() ,"and");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(1).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"B");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(2).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"A");
     //source --> opt C
     Assert.assertEquals(featureModel.getFeaturelink(3).getFeatureConnectingOpType().name(), "Optional");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"C");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(3).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"C");
     //source --> not D
     Assert.assertEquals(featureModel.getFeaturelink(4).getFeatureConnectingOpType().name(), "Exclude");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(4).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"D");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(4).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"D");
     //source --> (xor F E)
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(5).getSourceFeature()).getMixsetOrFileNode().isIsMixset(), false);
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(5).getSourceFeatureNode()).getMixsetOrFileNode().isIsMixset(), false);
     Assert.assertEquals(featureModel.getFeaturelink(5).getFeatureConnectingOpType().name(), "XOR");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(6).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"F");
-    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(7).getTargetFeature(0)).getMixsetOrFileNode().getName() ,"E"); 
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(6).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"F");
+    Assert.assertEquals(((FeatureLeaf) featureModel.getFeaturelink(7).getTargetFeatureNode()).getMixsetOrFileNode().getName() ,"E"); 
   }
   @Test
   public void parseReqStArgumetToSatisfyFeatureModel_1()


### PR DESCRIPTION
This PR improves current feature modeling in Umple with no addition of new functionality. A FeatureNode in this PR may have multiple of outgoing links and incoming links. In addition, a FeatureLink will always have one source (sourceFeatureNode) and one target (targetFeatureNode).  In this way, the feature model can be constructed easily. The current way uses the following associations (in FeatureLink class): 
```
* sourceFeatureLink -- 0..1 FeatureNode sourceFeature; // the sourceFeature can be FeatureLeaf or FeatureNode
  0..* -- * FeatureNode targetFeature;
```
This relationship (sourceFeature and targetFeature) leads to confusion for complex feature models in the case of source features that are become target features of other features. This is not the case for outgoing and incoming links associations in the FeatureNode in this PR. 

I will follow this PR with checking of loop in the feature model and other checks. 