### PR TITLE
adding mixsets video to user manual

### DIFF
--- a/build/reference/4101BasicMixsets.txt
+++ b/build/reference/4101BasicMixsets.txt
@@ -19,12 +19,13 @@ included in the system. A mixset is included using a <i>use</i> statement or a c
   <li>Within a class, trait or other top-level entity. In this case the contents of the block are included in that entity (if a matching use statement is encountered).
 </ul>
 
+@@videoURL https://www.youtube.com/embed/fHec6Z8_udI 
+
+
 @@syntax
 [[mixsetDefinition]] [[mixsetInnerContent]] [[mixsetInlineDefinition]] [[extraCode]]
 
 @@example
 @@source manualexamples/SimpleMixsets1.ump
 @@endexample
-
-
 


### PR DESCRIPTION
This PR adds the LampSPL example to the user manual.  The example shows how mixsets can add variation to state machines.