### PR TITLE
Fix Uottawa URLs to point to Cruise.umple Plus Misc

### DIFF
--- a/build/_template.xml
+++ b/build/_template.xml
@@ -122,7 +122,7 @@
         <isreachable property="access.maven" 
                      host="https://repo1.maven.org" />
         <isreachable property="access.umple" 
-                     host="https://cruise.eecs.uottawa.ca/index.shtml" />
+                     host="https://cruise.umple.org/index.shtml" />
         <isreachable property="access.github" 
                      host="https://github.com" />
       </parallel>

--- a/build/build.deps.xml
+++ b/build/build.deps.xml
@@ -149,8 +149,6 @@
     <echo>Installing Ivy v${ivy.install.version}</echo>
     <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
          dest="${ivy.jar.file}" usetimestamp="true" />
-    <!-- COMMENTED OUT AS WAS GETTING 503 ERROR get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
-         dest="${ivy.jar.file}" usetimestamp="true" / -->
 
     <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpath="${ivy.jar.file}" />
 
@@ -180,9 +178,9 @@
       <else>
         <echo>Fetching umple-${umple.version}</echo>
 
-        <echo level="warning">WARNING: This is merely wget-ing http://cruise.eecs.uottawa.ca/umpleonline/scripts/umple.jar</echo>
+        <echo level="warning">WARNING: This is merely wget-ing https://cruise.umple.org/umpleonline/scripts/umple.jar</echo>
         <mkdir dir="${umple.deps.dir}" />
-        <get src="http://cruise.eecs.uottawa.ca/umpleonline/scripts/umple.jar"
+        <get src="https://cruise.umple.org/umpleonline/scripts/umple.jar"
              dest="${umple.stable.jar}"
              usetimestamp="true" />
         <copy file="${umple.stable.jar}" tofile="${umple.stable.jar}" />
@@ -216,8 +214,8 @@
 
         <echo>Fetching org.eclipse.cdt.core_5.5.0.jar</echo>
 
-        <echo level="warning">WARNING: This is merely wget-itng https://cruise.site.uottawa.ca/preserved-deps/org.eclipse.cdt.core_5.5.0.201309180223.jar</echo>
-        <get src="https://cruise.site.uottawa.ca/preserved-deps/org.eclipse.cdt.core_5.5.0.201309180223.jar"
+        <echo level="warning">WARNING: This is merely wget-itng https://cruise.umple.org/preserved-deps/org.eclipse.cdt.core_5.5.0.201309180223.jar</echo>
+        <get src="https://cruise.umple.org/preserved-deps/org.eclipse.cdt.core_5.5.0.201309180223.jar"
              dest="${umple.deps.manual.dir}/"
              usetimestamp="true" />
       </else>

--- a/build/build.websitetests.xml
+++ b/build/build.websitetests.xml
@@ -23,9 +23,8 @@
 
   <target name="help">
     <echo>Using this build script:
-  There are four entry targets for this build script:
-  testUmpleOnlineMain - runs the tests against the public umpleonline (http://cruise.eecs.uottawa.ca/umpleonline/)
-  testUmpleOnlineTest - runs the tests against the test umpleonline (http://cruise.eecs.uottawa.ca/umpleonline/test/)
+  There are several entry targets for this build script:
+  testUmpleOnlineMain - runs the tests against the public umpleonline (https://cruise.umple.org/umpleonline/)
   testUmpleOnlineLocal - runs against the local server (http://cruise.local/)
 
   You can specify a custom hostname with -Dhostname="yourserver" 
@@ -59,12 +58,7 @@
   </target>
 
   <target name="testUmpleOnlineMain">
-    <property name="hostName" value="http://cruise.eecs.uottawa.ca/umpleonline/" />
-    <antcall target="doWebsiteTests" />
-  </target>
-
-  <target name="testUmpleOnlineTest">
-    <property name="hostName" value="http://cruise.eecs.uottawa.ca/umpleonline/test/" />
+    <property name="hostName" value="https://cruise.umple.org/umpleonline/" />
     <antcall target="doWebsiteTests" />
   </target>
 

--- a/umpleonline/download_eclipse_umple_plugin.html
+++ b/umpleonline/download_eclipse_umple_plugin.html
@@ -66,14 +66,14 @@
 
 <h3>A. Downloading Umple for Command-Line use</h3>
 
-<p><b>Requirement:</b> An up-to-date Java 8 JVM. The compiler has been tested and is also known to work under the latest Java 9 JVM and generate code compatible with Java 9, but it may generate some deprecation warnings with Java 9.</p>
+<p><b>Requirement:</b> An up-to-date Java 8 JDK or higher. The compiler has been tested and is also known to work under Java versions up to Java 15.</p>
 
 <p>Options:</p>
 
  <ul>
 
-    <li><a class="button" href="http://try.umple.org/scripts/umple.jar">The latest build of the command-line
-     compiler at the University of Ottawa</a><br/> &nbsp;<br/>
+    <li><a class="button" href="https://try.umple.org/scripts/umple.jar">The latest build of the command-line
+     compiler from continuous integration.</a><br/> &nbsp;<br/>
      This is built after every merge to master from our continuous build process, which can occur as frequently as every few hours, or as infrequently as every few weeks, depending on season. This version is thoroughly tested and will always contain the latest enhancements and fixes.
     This is also the version of the compiler used by <a href="http://try.umple.org">UmpleOnline</a><br />&nbsp;<br />
 

--- a/umpleonline/umplibrary/OhHellWhist.ump
+++ b/umpleonline/umplibrary/OhHellWhist.ump
@@ -54,8 +54,8 @@ class ScoringTeam {
    Integer score;
 }
 
-class Match {
-  // A match is played in a number of games
+class CardsMatch {
+  // A cards match is played in a number of games
   Boolean isWhist; // True if whist; false if Oh Hell  
 
   // The following determines the players
@@ -115,11 +115,11 @@ class ScoringTeam
   position.association Player__ScoringTeam 0,31 192,55;
 }
 
-class Match
+class CardsMatch
 {
   position 532 48 159 82;
-  position.association Match__ScoringTeam 120,82 60,0;
-  position.association Game:games__Match 29,84 116,0;
+  position.association CardsMatch__ScoringTeam 120,82 60,0;
+  position.association Game:games__CardsMatch 29,84 116,0;
 }
 
 


### PR DESCRIPTION
This PR:

* Changes some build links so they grab umple from the cruise.umple.org machine instead of the cruise.eecs.uottawa.ca machine

* Changes an example class name to avoid a class called 'Match', since this is new a keyword in PhP 8.
