### PR TITLE
Windows now uses rake.cmd

### DIFF
--- a/build/_wlocal.xml
+++ b/build/_wlocal.xml
@@ -12,7 +12,7 @@
   <property name="showJunitSummary" value="false"/>
   <property name="showJunitOutput" value="false"/>
   <property name="junit" value="*Test"/>
-  <property name="rake_cmd" value="rake.bat"/>
+  <property name="rake_cmd" value="rake.cmd"/>
 
   <import file="_versionLast.xml" />
 


### PR DESCRIPTION
Windows now uses rake.cmd instead of rake.bat

The value has been changed in the corresponding file (_wlocal.xml).