### PR TITLE
Multiple mixsets in one use statement

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -166,9 +166,13 @@ class UmpleInternalParser
       //UmpleFile mixsetUseFile = model.getUmpleFile(); 
       String fileName = t.getPosition().getFilename();
       UmpleFile mixsetUseFile = new UmpleFile(fileName);
-
-      //if(value.contains(",")) // like: use M1,M2, ... 
-      String[] mixsetNames = value.split(","); // it includes the case if no comma.
+      ArrayList<String> mixsetNames = new ArrayList<String>();
+      mixsetNames.put(value); // add first use. 
+      for(Token subToken : t.getSubTokens()) // add the rest of use-statment that are in : use M1,M2, ... 
+      {
+        if(subToken.is("extraUse"))
+        mixsetNames.put(t.getValue("extraUse"));
+      }
 
       for (String mixsetName : mixsetNames)
       {
@@ -192,6 +196,8 @@ class UmpleInternalParser
       }
     }
   }
+
+
   
 /*
  * This method parses all waiting fragments of a mixset, if there is a mixset-use-statment specified in some of the files.  

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -171,7 +171,7 @@ class UmpleInternalParser
       for(Token subToken : t.getSubTokens()) // add the rest of use-statment that are in : use M1,M2, ... 
       {
         if(subToken.is("extraUse"))
-        mixsetNames.add(t.getValue("extraUse"));
+        mixsetNames.add(subToken.getValue("extraUse"));
       }
 
       for (String mixsetName : mixsetNames)

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -162,28 +162,34 @@ class UmpleInternalParser
       } 
        //Otherwise
        
-      String mixsetName = value;
       int useLineNumber = t.getPosition().getLineNumber();
       //UmpleFile mixsetUseFile = model.getUmpleFile(); 
       String fileName = t.getPosition().getFilename();
       UmpleFile mixsetUseFile = new UmpleFile(fileName);
-      // check if the mixset was added before 
-      Mixset mixset = model.getMixset(mixsetName);
-      if(mixset == null)
+
+      //if(value.contains(",")) // like: use M1,M2, ... 
+      String[] mixsetNames = value.split(","); // it includes the case if no comma.
+
+      for (String mixsetName : mixsetNames)
       {
-        mixset = new Mixset(mixsetName);
-        mixset.setUseUmpleFile(mixsetUseFile);
-        mixset.setUseUmpleLine(useLineNumber);
-        model.addMixsetOrFile(mixset);
-      }
-      else if (mixset.getUseUmpleFile() == null)
-      {
-        mixset.setUseUmpleFile(mixsetUseFile);
-        mixset.setUseUmpleLine(useLineNumber);
-      }
+        // check if the mixset was added before 
+        Mixset mixset = model.getMixset(mixsetName.trim());
+        if(mixset == null)
+        {
+          mixset = new Mixset(mixsetName);
+          mixset.setUseUmpleFile(mixsetUseFile);
+          mixset.setUseUmpleLine(useLineNumber);
+          model.addMixsetOrFile(mixset);
+        }
+        else if (mixset.getUseUmpleFile() == null)
+        {
+          mixset.setUseUmpleFile(mixsetUseFile);
+          mixset.setUseUmpleLine(useLineNumber);
+        }
 	   
 	    // this handles the case when a mixset definition is in a file and the mixset use exists in a subsequent file.
 	    parseMixset(mixset); 
+      }
     }
   }
   

--- a/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeMixset.ump
@@ -167,11 +167,11 @@ class UmpleInternalParser
       String fileName = t.getPosition().getFilename();
       UmpleFile mixsetUseFile = new UmpleFile(fileName);
       ArrayList<String> mixsetNames = new ArrayList<String>();
-      mixsetNames.put(value); // add first use. 
+      mixsetNames.add(value); // add first use. 
       for(Token subToken : t.getSubTokens()) // add the rest of use-statment that are in : use M1,M2, ... 
       {
         if(subToken.is("extraUse"))
-        mixsetNames.put(t.getValue("extraUse"));
+        mixsetNames.add(t.getValue("extraUse"));
       }
 
       for (String mixsetName : mixsetNames)

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -37,7 +37,7 @@ generate : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureD
 generate_path : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvClassTraitDiagram|GvFeatureDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|UmpleSelf|USE|test] " [**output] " [=override:--override|--override-all]? ( [=suboptionIndicator:-s|--suboption]  " [**suboption] " )* ;
 
 // Use statements allow incorporation of other Umple files. See [*UseStatements*]
-useStatement : use [!use=\S.*.;]
+useStatement : use [use] ( , [extraUse] )*
 
 toplevelExtracode : top [top] [[moreCode]]
 

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -37,7 +37,7 @@ generate : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureD
 generate_path : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvClassTraitDiagram|GvFeatureDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|UmpleSelf|USE|test] " [**output] " [=override:--override|--override-all]? ( [=suboptionIndicator:-s|--suboption]  " [**suboption] " )* ;
 
 // Use statements allow incorporation of other Umple files. See [*UseStatements*]
-useStatement : use [use] ( , [[use]] )*
+useStatement : use [!use=\S.*.;]
 
 toplevelExtracode : top [top] [[moreCode]]
 

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -37,7 +37,7 @@ generate : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureD
 generate_path : generate [=language:Java|Php|RTCpp|SimpleCpp|Ruby|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvClassTraitDiagram|GvFeatureDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|UmpleSelf|USE|test] " [**output] " [=override:--override|--override-all]? ( [=suboptionIndicator:-s|--suboption]  " [**suboption] " )* ;
 
 // Use statements allow incorporation of other Umple files. See [*UseStatements*]
-useStatement : use [use] ;
+useStatement : use [use] ( , [[use]] )*
 
 toplevelExtracode : top [top] [[moreCode]]
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -838,6 +838,14 @@ public class UmpleMixsetTest {
     model.run();
     Assert.assertEquals(model.getMixsetOrFiles().size() , 10);
   }
-
+  @Test
+  public void multipleMixsetsInOneUseStatment()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetUseInOneUseStatement.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(false);
+    model.run();
+    Assert.assertEquals(model.getUmpleClasses().size() , 3);
+  }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetUseInOneUseStatement.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetUseInOneUseStatement.ump
@@ -1,0 +1,19 @@
+// This file has a use-statement activating multiple mixsets at the same time.
+mixset M1
+{
+  class ClassA{ }
+}
+    
+use M1, M2, M3; 
+
+
+mixset M2
+{
+  class ClassB{ }
+
+}
+
+mixset M3
+{
+  class ClassC { }
+}


### PR DESCRIPTION
This PR enhances the use statement. It allows use statement to handle multiple mixsets in one use statement. such as: 
`use M1, M2, M3; `    instead of `use M1; use M2; use M3; `