### PR TITLE
Update Docker and fix serverrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ matrix:
       services:
         - docker
     - os: osx
+      osx_image: xcode12.2
 
     # test gradle builds - commented out for now
 #    - os: linux

--- a/umpleonline/Dockerfile-base
+++ b/umpleonline/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM nginx:1.19.2-alpine
+FROM nginx:1.19-alpine
 
 MAINTAINER Umple umple-help@googlegroups.com
 

--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -787,7 +787,7 @@ function executeCommand($command, $rawcommand = null)
   $useServerIfPossble=true;  // Set to false to deactivate the server feature
   
   ob_start();
-  if(substr($command,0,23) == "java -jar umplesync.jar" && $useServerIfPossble && !strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+  if(substr($command,0,23) == "java -jar umplesync.jar" && $useServerIfPossble && !(strtoupper(substr(PHP_OS, 0, 3)) == 'WIN')) {
     serverRun(substr($command,24),$rawcommand);
   }
   else {


### PR DESCRIPTION
Updates docker to ensure the latest version of Nginix would be used in next base build

Fixes glitch in recent compiler_config.php that was meaning server was not being used by UmpleOnline due to bracket issue