### PR TITLE
Fixing document generator to properly position certain files and inde…

### DIFF
--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -362,6 +362,36 @@
     <copy todir="${dist.path}/reference/files">
       <fileset dir="build/reference/files"/>
     </copy>
+    <copy todir="${dist.path}/reference/">
+      <fileset file="umplewww/index.html"/>
+    </copy>
+    <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/umple_logo.jpg"/>
+    </copy>
+    <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/uottawa_ver_black.png"/>
+    </copy>
+    <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/Octocat.jpg"/>
+    </copy>
+    <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/umple_example_uml.jpg"/>
+    </copy>
+    <copy todir="${dist.path}/reference/syntaxhighlighter">
+      <fileset dir="umplewww/syntaxhighlighter"/>
+    </copy>
+    <copy todir="${dist.path}/reference/examples">
+      <fileset dir="umplewww/examples"/>
+    </copy>
+    <copy todir="${dist.path}/reference/">
+      <fileset file="umplewww/umple-core-classDiagram.shtml"/>
+    </copy>
+    <copy todir="${dist.path}/reference/">
+      <fileset file="umplewww/umple-compiler-classDiagram.shtml"/>
+    </copy>
+    <copy todir="${dist.path}/reference/">
+      <fileset file="umplewww/umple-state-classDiagram.shtml"/>
+    </copy>
   </target>
 
   <target name="travisCopyManual">
@@ -373,11 +403,10 @@
     </copy>
     <copy todir="umpleonline/manual/examples">
       <fileset dir="umplewww/examples"/>
-    </copy>     
+    </copy>
     <copy todir="umpleonline/manual/syntaxhighlighter">
       <fileset dir="umplewww/syntaxhighlighter"/>
-    </copy>     
-    
+    </copy>
   </target>
 
   <target name="packageUmpleonline" if="${shouldPackageUmpleOnline}">

--- a/dev-tools/mumple
+++ b/dev-tools/mumple
@@ -6,14 +6,10 @@ echo Building Umple User manual at $UMPLEROOT
 cd $UMPLEROOT/build
 ant -Dmyenv=local -f build.umple.xml packageDocs
 cd $UMPLEROOT/dist/cruise.umple/reference
-echo Ensuring syntaxhighlighter is present - it sometimes gets deleted
-ln -s ../../../umplewww/syntaxhighlighter .
-echo Ensuring example images are present - they sometimes get deleted
-ln -s ../../../umplewww/examples .
 if (! -e ~/umple/umplewww/examples/airline.png) then
- echo need to restore examples in cd ~/umple
- echo first yes pipe rm -r umplewww
- echo either svn update
- echo or unzip umplewww.zip
+ echo need to restore examples in $UMPLEROOT
+ echo They are sometimes deleted for an unknown reason
+ echo Do git checkout umplewww
+ echo Then rerun mumple
 endif
 echo To open user manual open $UMPLEROOT/dist/cruise.umple/reference/ClassDefinition.html


### PR DESCRIPTION
Updates the user manual generator ant target packageDocs in build.umple.org so that it properly copies certain files from umplewww. This ensures that the umple home page and other pages in the manual directory remain present