### PR TITLE
[SKIP CI] updating home page

### DIFF
--- a/dev-tools/bumple
+++ b/dev-tools/bumple
@@ -36,6 +36,9 @@ if ($status == 0 || $failedstatus == 0) then
   echo The word FAILED or ERROR was found in the above. Build was NOT SUCCESSFUL.
   echo Build log is at $logfile
   echo Test log can be opened in a web browser at $UMPLEROOT/dist/qa/index.php
+  echo The following is a snippet of the log with the problem
+  grep -C3 -i -n -m 1  'Error ' $logfile 
+  grep -C3 -i -n -m 1  'failed' $logfile
 else
   rm $logfile
   echo Script bumple ended normally at $UMPLEROOT

--- a/umplewww/index.html
+++ b/umplewww/index.html
@@ -175,11 +175,16 @@ href="https://groups.google.com/forum/#!forum/umple-dev">Dev list
 
         <div class="level1">Development status</div>
  
-        <div class="level2"><a href="http://cc.umple.org">Continuous 
-integration
+        <div class="level2"><a href="http://travis.umple.org">CI: Travis
+         </a></div>
+
+        <div class="level2"><a href="http://appveyor.umple.org">CI: Appveyor
          </a></div>
 
         <div class="level2"><a href="http://qa.umple.org">Test report
+         </a></div>
+
+        <div class="level2"><a href="http://uptime.umple.org">Uptime
          </a></div>
 
         <div class="level2"><a href="http://grammar.umple.org">Grammar


### PR DESCRIPTION
This adds the Uptime link to Canarie and changes the CI links on the Umple home page.

Also the bumple script now gives contextual information about the location of the failure or error