### PR TITLE
[ci skip] Adding standalone state machines to manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ nohup.out
 /ump
 
 # umple specific
+umpleonline/ump*
 umpleonline/ump/tmp*
 umpleonline/ump/2*
 umpleonline/ump/1*
@@ -15,6 +16,7 @@ umpleonline/ump/index.html
 umpleonline/ump/aalertMessage.txt
 build/UserManualAndExampleTests_output.txt
 umpleonline/manual
+umpleonline/qr*
 umpleonline/countlog.txt
 umpleonline/scripts/commandcount.txt
 umpleonline/scripts/specialPort.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ nohup.out
 /ump
 
 # umple specific
-umpleonline/ump*
+umpleonline/ump/
 umpleonline/ump/tmp*
 umpleonline/ump/2*
 umpleonline/ump/1*

--- a/build/reference/0607traits_state_machines.txt
+++ b/build/reference/0607traits_state_machines.txt
@@ -4,40 +4,49 @@ noreferences
 
 @@description
 <p align = "justify">
-A <a href="Traits.html">trait</a> can have zero or many <a href="BasicStateMachines.html">state machines</a>, each with a unique name. The definition of state machines in traits follows the same rules and constraints that exist for them in classes. The example 1 shows a trait called T1 (lines 4-13) with two state machines sm1 (lines 5-8) and sm2 (lines 9-12). Use of trait T1 in class C1 results in class C1 having those two state machines as native state machines. In general, if a class already has state machines with completely distinct names to those being introduced via traits, the introduced state machines are just ‘flattened’ into the class, i.e. they are treated as though they were coded directly in the class.
-</P>
+A <a href="Traits.html">trait</a> can have zero or many <a href="BasicStateMachines.html">state machines</a>, each with a unique name. The definition of state machines in traits follows the same rules and constraints that exist for them in classes.</p>
 
-<p align = "justify">
-Introduced machines that have names duplicating existing state machine names are composed (merged) with the existing machines, and the resulting composed machines are flattened into the class. The same concept is applied when traits are used by other traits. The example 2 expresses the same model designed in the example 1, in which class C1 has two state machines, but it uses trait T2 (line 18) to obtain the same state machine. Trait T2 provides state machine sm2 from its own definition (lines 12-15) and state machine sm1 from trait T1 (line 11). This use of traits by other traits allows building more complex traits (and hence more complex state machines) from simpler ones.
+<p align = "justify">The first example shows a trait called T1 (lines 4-13) with two state machines sm1 (lines 5-8) and sm2 (lines 9-12). Use of trait T1 in class C1 results in class C1 having those two state machines as native state machines. In general, if a class already has state machines with completely distinct names to those being introduced via traits, the introduced state machines are just ‘flattened’ into the class, i.e. they are treated as though they were coded directly in the class.
 </p>
 
 <p align = "justify">
-State machines in traits are considered as provided functionality. More concretely, any event in a state machine is considered as a provided method, and so can satisfy the required methods of used traits. State machines are supposed to encapsulate their own actions and guards so they can be reused as a piece of functionality. For example, a guard can be defined as a reference to an attribute in the trait or to a parameter of the event, so when the state machine is reused the attribute and parameter are reused as well. The same perspective is true for actions. In real world cases, state machines may need to obtain those conditions and actions from the context (e.g. <a href="ClientsofTraits.html">clients</a>) in which they are reused. State machines hence require those conditions and actions to behave correctly. This requirement is in alignment with the notion of required methods of traits. Therefore, required actions and guards of state machines can be expressed as required methods of traits. Indeed, if events of state machines are considered as provided methods and their guards and actions are considered as required methods, then state machines can define functional behavior and therefore the required behavior of them can again be satisfied by other state machines in the clients. It should be noted that if guards, actions, and activities of state machines are defined as methods (not inline code blocks directly in the state machine), they are not anymore required methods. They will be treated as provided methods, and traits’ rules related to provided methods will be applied to them
+Introduced machines that have names duplicating existing state machine names are composed (merged) with the existing machines, and the resulting composed machines are flattened into the class. The same concept is applied when traits are used by other traits. The second example below expresses the same model designed in  example 1, in which class C1 has two state machines, but it uses trait T2 (line 18) to obtain the same state machine. Trait T2 provides state machine sm2 from its own definition (lines 12-15) and state machine sm1 from trait T1 (line 11). This use of traits by other traits allows building more complex traits (and hence more complex state machines) from simpler ones.
 </p>
 
 <p align = "justify">
-The example 3 shows how required methods are satisfied by events of state machines. As seen, trait T1 has two required methods, m1(String) and m2(), called in actions of transitions e1(string) and e2 in states s1 and s2 of state machine sm1 respectively. Class C1 uses trait T1 and must satisfy those required methods. Class C1 does not have any concrete method to satisfy the required methods, but it has state machine sm2. State machine sm2 has two event m1(String) and m2 which satisfy the required methods of trait T1. If state machines are used to satisfy the required methods, there is a limitation in return types of required methods. All required methods must have Boolean as their return types, otherwise, events cannot satisfy them. The reason for this limitation is that all event automatically obtain Boolean as their return types by the Umple compiler.
+State machines in traits are considered as <em>provided</em> functionality. More concretely, any event in a state machine is considered as a <em>provided method</em>, and so can satisfy the required methods of used traits. State machines are supposed to encapsulate their own actions and guards so they can be reused as a piece of functionality. For example, a guard can be defined as a reference to an attribute in the trait or to a parameter of the event, so when the state machine is reused the attribute and parameter are reused as well. The same perspective is true for actions. In real world cases, state machines may need to obtain those conditions and actions from the context (e.g. <a href="ClientsofTraits.html">clients</a>) in which they are reused. State machines hence require those conditions and actions to behave correctly. This requirement is in alignment with the notion of required methods of traits. Therefore, required actions and guards of state machines can be expressed as required methods of traits. Indeed, if events of state machines are considered as provided methods and their guards and actions are considered as required methods, then state machines can define functional behavior and therefore the required behavior of them can again be satisfied by other state machines in the clients. It should be noted that if guards, actions, and activities of state machines are defined as methods (not inline code blocks directly in the state machine), they are not anymore required methods. They will be treated as provided methods, and traits’ rules related to provided methods will be applied to them
+</p>
+
+<p align = "justify">
+The third example below shows how required methods are satisfied by events of state machines. As seen, trait T1 has two required methods, m1(String) and m2(), called in actions of transitions e1(string) and e2 in states s1 and s2 of state machine sm1 respectively. Class C1 uses trait T1 and must satisfy those required methods. Class C1 does not have any concrete method to satisfy the required methods, but it has state machine sm2. State machine sm2 has two event m1(String) and m2 which satisfy the required methods of trait T1. If state machines are used to satisfy the required methods, there is a limitation in return types of required methods. All required methods must have Boolean as their return types, otherwise, events cannot satisfy them. The reason for this limitation is that all event automatically obtain Boolean as their return types by the Umple compiler.
 </p>
 
 <p align = "justify">
 Like the way <a href="TraitTemplateParameters.html">template parameters</a> defined in traits are used for required and provided methods, they can also be used in collaboration with state machines. Template parameters can be used to define the types of parameters for events. They can also be used in code blocks related to actions and activities. The example 4 illustrates how template parameters can be used with events of state machines. State machine sm in trait T1 has two events. Event e1 has a parameter of type TP (line 6) and event e2 has two parameters with types TP and String (line 7). Class C2 uses trait T1 (line 12) and binds class C1 to the template parameters TP.
 </p>
 
+<p align = "justify">
+The final example below shows how two classes can reuse the same state machine using a trait. This functionality is equivalent to that achieved using <a href="StandaloneStateMachines.html">standalone state machines</a>.
+</p>
 
 
-@@example
+@@example @@caption Example 1: Building a class with two state machines @@endcaption
 @@source manualexamples/traits_example_012.ump
 @@endexample
 
-@@example
+@@example @@caption Example 2: Events as provided methods @@endcaption
 @@source manualexamples/traits_example_013.ump
 @@endexample
 
-@@example
+@@example @@caption Example 3: Satisfying required methods@@endcaption
 @@source manualexamples/traits_example_014.ump
 @@endexample
-@@example
 
+@@example @@caption Example 4: Use of template parameters @@endcaption
 @@source manualexamples/traits_example_015.ump
+@@endexample
+
+@@example @@caption Example 5: Equivalence to standalone state machines@@endcaption
+@@source manualexamples/traits_example_standaloneStateMachine.ump &diagramtype=state
 @@endexample
 

--- a/build/reference/3014StandaloneStateMachines.txt
+++ b/build/reference/3014StandaloneStateMachines.txt
@@ -22,8 +22,12 @@ Standalone state machines can be used to make code appear simpler than it does w
 
 @@syntax
 
-[[stateMachineDefinition]]
+[[stateMachineDefinition]] [[referencedStateMachine]] [[extendedStateMachine]]
 
-@@example
+@@example @@caption Standalone state machine used in two classes @@endcaption
 @@source manualexamples/standaloneStatemachine1.ump &diagramtype=state
+@@endexample
+
+@@example @@caption Standalone state machine modified when reused @@endcaption
+@@source manualexamples/standaloneStatemachine2.ump &diagramtype=state
 @@endexample

--- a/build/reference/3014StandaloneStateMachines.txt
+++ b/build/reference/3014StandaloneStateMachines.txt
@@ -1,0 +1,29 @@
+Standalone State Machines
+State Machines
+noreferences
+
+@@description
+<p>      
+State machines can be defined at the top level of a model. This feature allows the definition of reusable state machines, to simplify code, or to facilitate separation of concerns.
+</p>
+
+<p>
+The example below shows that the <em>statemachine</em> keyword is used to specify a standalone state machine. Such a state machine, by itself, must be syntactically correct, and error messages will be generated, enabling debugging. However, the state machine is not displayed as a diagram and will not result in any code generation unless it is incorporated in one or more classes. The <em>as</em> keyword is used to do incorporate a standalone state machine in a class, as shown in the example.
+</p>
+
+<p>
+An alternative, and equivalent, way to define state machines outside of classes is to use traits. A model equivalent to the example below is shown in <a href="StateMachinesinTraits.html">Example 5 of the page on state machines in traits.</a>
+</p>
+
+<p>
+Standalone state machines can be used to make code appear simpler than it does when the state machine is directly incorporated in a class or trait, as there is less indentation, and the statemachine keyword makes it more explicit that what is being described is a state machine.
+</p>
+
+
+@@syntax
+
+[[stateMachineDefinition]]
+
+@@example
+@@source manualexamples/standaloneStatemachine1.ump &diagramtype=state
+@@endexample

--- a/umpleonline/umplibrary/manualexamples/standaloneStatemachine1.ump
+++ b/umpleonline/umplibrary/manualexamples/standaloneStatemachine1.ump
@@ -1,0 +1,35 @@
+// Class Diagram illustrating use of top-level state machine with
+// usage in separate classes.
+// Note that this could also be accomplished by putting the
+// state machine in a trait, and then having each class use the trait
+
+class MotorController {
+   motorStatus as deviceStatus;
+}
+
+class BrakeController {
+   brakeStatus as deviceStatus;
+}
+
+// By itself, the following will not generate any code
+// but it can be debugged by itself outside of any class
+// and can be incorporated in multiple classes, as above
+statemachine deviceStatus {
+  inactive {
+    activate -> booting;
+  }
+  booting {
+    completedStartupChecks -> active;
+    startupCriticalErrorDetected -> outOfOrder;
+  }
+  active {
+    runtimeCriticalErrorDetected -> outOfOrder;
+    deactivate -> shuttingDown;
+  }
+  shuttingDown {
+    shutdownComplete -> inactive;
+  }
+  outOfOrder {
+    repaired -> inactive;
+  }
+}

--- a/umpleonline/umplibrary/manualexamples/standaloneStatemachine2.ump
+++ b/umpleonline/umplibrary/manualexamples/standaloneStatemachine2.ump
@@ -1,0 +1,48 @@
+// Class Diagram illustrating standalone state machine being
+// modified when it is reused, to add additional events
+// states and entry/exit actions
+
+class MotorController {
+  Boolean warmup = false;
+  motorStatus as deviceStatus {
+    // Add a transition to the reused state machine
+    cancel booting-> inactive;
+    completedStartupWhilewarning  booting -> warm ;
+    
+    // Add transition with action
+    warmSoReady inactive -> / {warmup=true;} booting ;
+    
+    // Add an entirely new state
+    warm {
+      go -> active;
+    }
+    
+    // add an entry action to an existing state
+    inactive {
+      entry / {warmup=false;};
+    }
+  };
+}
+
+// Reusable standalone state machine
+statemachine deviceStatus {
+  inactive {
+    activate -> booting;
+  }
+  booting {
+    completedStartupChecks -> active;
+    startupCriticalErrorDetected -> outOfOrder;
+  }
+  active {
+    runtimeCriticalErrorDetected -> outOfOrder;
+    deactivate -> shuttingDown;
+  }
+  shuttingDown {
+    shutdownComplete -> inactive;
+  }
+  outOfOrder {
+    repaired -> inactive;
+  }
+}
+
+      

--- a/umpleonline/umplibrary/manualexamples/standaloneStatemachine2.ump
+++ b/umpleonline/umplibrary/manualexamples/standaloneStatemachine2.ump
@@ -44,5 +44,6 @@ statemachine deviceStatus {
     repaired -> inactive;
   }
 }
+// @@@skipphpcompile - contains java code
 
       

--- a/umpleonline/umplibrary/manualexamples/traits_example_standaloneStateMachine.ump
+++ b/umpleonline/umplibrary/manualexamples/traits_example_standaloneStateMachine.ump
@@ -1,0 +1,35 @@
+// Class Diagram illustrating use of a trait
+// to incorporate the same state machine in multiple
+// classes. This is an alternative to using 
+// standalone state machines (see an equivalent model
+// in the state machine section of the manual)
+
+class MotorController {
+  isA DeviceWithStatus;
+}
+
+class BrakeController {
+  isA DeviceWithStatus;
+}
+
+trait DeviceWithStatus {
+  deviceStatus {
+    inactive {
+      activate -> booting;
+    }
+    booting {
+      completedStartupChecks -> active;
+      startupCriticalErrorDetected -> outOfOrder;
+    }
+    active {
+      runtimeCriticalErrorDetected -> outOfOrder;
+      deactivate -> shuttingDown;
+    }
+    shuttingDown {
+      shutdownComplete -> inactive;
+    }
+    outOfOrder {
+      repaired -> inactive;
+    }
+  }
+}


### PR DESCRIPTION
This adds a page to the user manual to explain standalone state machines. It also adds an example.

It modifies the manual page on traits to refer to the new page, and adds an example showing the equivalence