### PR TITLE
Fixing uppercase lowercase filename clash in mutant testing

### DIFF
--- a/cruise.umple.mutation/src/Master.ump
+++ b/cruise.umple.mutation/src/Master.ump
@@ -2,7 +2,7 @@ generate Java "../src-gen-umple";
 
 namespace cruise.umple.mutation;
 
-use Mutant.ump;
+use mutant.ump;
 use MutationMetamodel.ump;
 use MutationSuite_code.ump;
 use MutationConsoleMain.ump;


### PR DESCRIPTION
Build was failing on linux due to reference of a file that starts with a lowercase letter, but referred to with uppercase. 