### PR TITLE
Proper delete of close bracket for mixset inside method 

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -243,20 +243,22 @@ for (StateMachine smq : uClass.getStateMachines())
       {
         mixsetIsUsed = true;
         //first process children
-		    for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
+        for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
           handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
-		    //Then ... 
-        String searchFor = "mixset\\s+"+mixsetInMethod.getMixsetName()+"\\s+\\{"; 
-        String code = mBody.getCodeblock().getCode();
-        code = code.replaceFirst(searchFor, ""); // remove def. of mixset + open curly bracket 
-
-        int indexOfMixsetClosingBracket= MethodBody.indexOfMixsetClosingBracket(" { "+code) - 3; // 3 is the added Chars at beginning 
-        String resCode = code.substring(0,indexOfMixsetClosingBracket-1) + " ";
-        if(indexOfMixsetClosingBracket < code.length()) 
-          resCode = resCode + code.substring(indexOfMixsetClosingBracket+1); 
-        mBody.getCodeblock().setCode(resCode);
-
-
+        //Then ...
+        String methodCode = mBody.getCodeblock().getCode();
+        Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{");
+        Matcher matcher = labelPatternToMatch.matcher(methodCode);
+        // below code, to delete mixset def. and its closing bracket.
+        if (matcher.find()) {
+          String mixsetDefPlusAfterCode = methodCode.substring(matcher.start());
+          int indexOfMixsetClosingBracket = matcher.start() + MethodBody.indexOfMixsetClosingBracket(mixsetDefPlusAfterCode) - 1 ;
+          String methodCodeRemovedMixset = methodCode.substring(0,indexOfMixsetClosingBracket) + " " ; // remove closing bracket 
+          if(indexOfMixsetClosingBracket + 1 < methodCode.length())
+          methodCodeRemovedMixset = methodCodeRemovedMixset + methodCode.substring(indexOfMixsetClosingBracket +1); 
+          methodCodeRemovedMixset = methodCodeRemovedMixset.substring(0,matcher.start()) + methodCodeRemovedMixset.substring(matcher.end()+1); // remove mixset def.
+          mBody.getCodeblock().setCode(methodCodeRemovedMixset);
+        }
       }
     }
     else if(!mixsetIsUsed)

--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -41,6 +41,8 @@ class JavaClassGenerator {
     depend cruise.umple.util.*;
     depend java.util.*;
     depend cruise.umple.parser.Position;
+    depend java.util.regex.Matcher;
+    depend java.util.regex.Pattern;
 
     isA ILang;
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -4,7 +4,6 @@ import org.junit.*;
 import cruise.umple.UmpleConsoleMain;
 import cruise.umple.compiler.UmpleParserTest;
 import cruise.umple.util.SampleFileWriter;
-import jdk.jfr.Timestamp;
 import cruise.umple.parser.Position;
 import cruise.umple.compiler.UmpleFile;
 import cruise.umple.compiler.UmpleModel;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -4,6 +4,7 @@ import org.junit.*;
 import cruise.umple.UmpleConsoleMain;
 import cruise.umple.compiler.UmpleParserTest;
 import cruise.umple.util.SampleFileWriter;
+import jdk.jfr.Timestamp;
 import cruise.umple.parser.Position;
 import cruise.umple.compiler.UmpleFile;
 import cruise.umple.compiler.UmpleModel;
@@ -721,6 +722,29 @@ public class UmpleMixsetTest {
     //after checks:
     Assert.assertEquals(true, afterLabelCode.contains("code for mixset M2."));
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass.java");
+  }
+
+  @Test 
+  public void mixsetInsideMethods_deleteProperCloseBracket()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_properDeleteOfClosingBracket.ump");
+    UmpleModel umodel = new UmpleModel(umpleFile);
+    umodel.run();
+    umodel.generate();
+    UmpleClass uClass = umodel.getUmpleClass(0);
+    Method aMethod = uClass.getMethod(0);
+    String methodBodyCode= aMethod.getMethodBody().getCodeblock().getCode();
+    String keyWord1 = "//TAG_MIXSET_BEFORE_CLOSE";
+    String keyWord2 = "//TAG_MIXSET_CLOSE";
+  
+    int indexOfKeyWord1= methodBodyCode.indexOf(keyWord1);
+    int indexOfKeyWord2= methodBodyCode.indexOf(keyWord2);
+
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord1));
+    Assert.assertEquals(true, methodBodyCode.contains(keyWord2));
+    Assert.assertEquals(false, methodBodyCode.substring(indexOfKeyWord1, indexOfKeyWord2).contains("}"));
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/"+"MixsetWithinMethodClass_CloseBracket.java");
+
   }
 
   @Test

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_properDeleteOfClosingBracket.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_properDeleteOfClosingBracket.ump
@@ -1,0 +1,209 @@
+
+use StateMachine;
+
+class MixsetWithinMethodClass_CloseBracket
+{
+  public void aMethod( )
+  {
+    List<UmpleElement> umpleElements = model.getUmpleElements();
+		
+		for(UmpleElement element: umpleElements){
+			visitor.visit(element);			
+			String extraCode = element.getExtraCode();
+			if(extraCode!= null&& !extraCode.isEmpty()){
+				visitor.visit(new UserCode(extraCode)); 
+			}
+			
+			if(element instanceof UmpleClassifier){
+				UmpleClassifier classifier= (UmpleClassifier) element;
+				visitor.visit(classifier);
+				
+				if(element.getPackageName() != null){
+					visitor.visit(new Package(element.getPackageName()));
+				}
+				for(Depend dep : classifier.getDepends()) {
+					visitor.visit(dep);
+				}
+				for(Method mth : classifier.getMethods()) {
+					visitor.visit(mth); // isImplemented
+					for(MethodParameter param : mth.getMethodParameters()) {
+						visitor.visit(param);
+					}
+					MethodBody mthBody = mth.getMethodBody();
+					visitor.visit(mthBody);					
+					visitor.visit(new UserCode(mthBody.getExtraCode()));
+					
+					for(Comment cmt : mth.getComments()) {
+						visitor.visit(cmt);
+					}
+				}
+				for(Constant cnst : classifier.getConstants()) {
+					visitor.visit(cnst);
+				}
+				
+				if(element instanceof UmpleInterface){
+					UmpleInterface uInterface= (UmpleInterface) element;
+					visitor.visit(uInterface);
+					
+					if(uInterface.getExtendsInterface().size() > 0) {
+						Hierarchy hier = new Hierarchy(uInterface);
+						hier.setParentClass(null);
+						for(UmpleInterface uin : uInterface.getExtendsInterface()) {
+							hier.addParentInterface(uin);							
+						}	
+						visitor.visit(hier);					
+					}
+				}
+				if(element instanceof UmpleClass){
+					UmpleClass clazz= (UmpleClass) element;
+					if(element instanceof AssociationClass){
+						visitor.visit((AssociationClass)element);
+					} else {
+						visitor.visit(clazz);
+					}
+					
+					for(Comment cmt : clazz.getComments()) {
+						visitor.visit(cmt);
+					}
+					
+					if(clazz.getParentInterface().size() > 0 || clazz.getExtendsClass() != null) {
+						Hierarchy hier = new Hierarchy(clazz);
+						hier.setParentClass(clazz.getExtendsClass());
+						for(UmpleInterface uin : clazz.getParentInterface()) {
+							hier.addParentInterface(uin);							
+						}	
+						visitor.visit(hier);					
+					}
+					
+					if(clazz.isImmutable() ) {
+						visitor.visit(new ClassPattern(clazz,"Immutable"));
+					}
+					if(clazz.isIsAbstract() ) {
+						visitor.visit(new ClassPattern(clazz,"Abstract"));
+					}
+					if(clazz.isIsInternal() ) {
+						visitor.visit(new ClassPattern(clazz,"Internal"));
+					}
+					if(clazz.isIsSingleton() ) {
+						visitor.visit(new ClassPattern(clazz,"Singleton"));
+					}
+					
+					Key key = clazz.getKey();
+					if(key!= null&& key.getMembers().length>0){
+						visitor.visit(key);
+					}
+					
+					for(Association assoc : clazz.getAssociations()) {
+						if(assoc.getEnds().size() == 0 || clazz.getName().equals(assoc.getEnd(0).getReferenceToClassName())) {
+							visitor.visit(assoc);
+							for(AssociationEnd assocEnd : assoc.getEnds()) {
+								visitor.visit(assocEnd);
+							}
+						}
+					}
+					
+					for(Precondition pr : clazz.getPreConds()) {
+						visitor.visit(pr);
+					}
+					
+					if(clazz.getUniqueIdentifier() != null ) {
+						visitor.visit(clazz.getUniqueIdentifier());
+					}
+					
+					for(ConstraintTree cnst : clazz.getConstraintTrees()){
+                                          for(ConstraintVariable var:cnst)
+                                          {
+                                            visitor.visit(var);       
+                                          }
+                                        }
+					
+					for(AssociationVariable aVar : clazz.getAssociationVariables()) {
+						visitor.visit((UmpleVariable)aVar);
+						visitor.visit(aVar);
+						for(Comment cmt : aVar.getComments()) {
+							visitor.visit(cmt);
+						}
+					}
+					
+					for(Attribute attribute: clazz.getAttributes()) {
+						visitor.visit((UmpleVariable)attribute);
+						visitor.visit(attribute); // isIsDerived
+						if(attribute.getCodeblock() != null) {
+							visitor.visit(attribute.getCodeblock());
+						}
+						for(Comment cmt : attribute.getComments()) {
+							visitor.visit(cmt);
+						}					
+					}
+					for(StateMachine sm: clazz.getAllStateMachines()){
+						visitor.visit(sm);
+						for(State state: sm.getStates()){
+							visitor.visit(state);
+							for (Activity activity : state.getActivities()){
+								visitor.visit(activity);
+								visitor.visit(new UserCode(activity.getActivityCode()));
+							}
+							for(Transition transition: state.getTransitions()){
+								visitor.visit(transition);
+								visitor.visit(transition.getGuard());
+								if(transition.getGuard() != null) {
+									Guard gElm = (Guard)transition.getGuard();
+									String condition = gElm.getCondition(new cruise.umple.compiler.JavaGenerator());
+									visitor.visit(gElm);
+								}	
+								visitor.visit(transition.getEvent());
+							}
+							for(Action action: state.getActions()){
+								visitor.visit(action);
+								visitor.visit(new UserCode(action.getActionCode()));
+							}					
+						}
+					}
+					
+					for(CodeInjection ci: clazz.getCodeInjections()){
+						if(ci.getConstraintTree() != null) {
+							visitor.visit(ci.getConstraintTree());
+						}
+						visitor.visit(ci);
+						if(ci.getCode() != null) {
+							visitor.visit(new UserCode(ci.getCode()));
+						}
+					}
+					
+					for(TraceDirective td: clazz.getTraceDirectives()){
+						visitor.visit(td);
+						visitor.visit(td.getTracerDirective());
+						
+						for(AttributeTraceItem ati : td.getAttributeTraceItems()) {
+							visitor.visit(ati);
+						}
+						
+						for(TraceCondition tc : td.getCondition()) {
+							visitor.visit(tc);
+						}
+						
+						for(MethodTraceItem mte : td.getMethodTraceItems()) {
+							visitor.visit(mte);
+						}
+						
+						mixset StateMachine {
+                          
+						for(StateMachineTraceItem smte : td.getStateMachineTraceItems()) {
+						    visitor.visit(smte);
+					      }
+                        //TAG_MIXSET_BEFORE_CLOSE
+						}  // The above closing bracket should be removed as StateMachine is used.
+                        //TAG_MIXSET_CLOSE 
+                      
+					}
+					
+					for(TraceCase tc: clazz.getTraceCases()){
+						visitor.visit(tc);
+					}
+				}
+			}
+		}
+		visitor.done();
+  }
+		
+}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_properDeleteOfClosingBracket.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_properDeleteOfClosingBracket.ump
@@ -192,7 +192,8 @@ class MixsetWithinMethodClass_CloseBracket
 						    visitor.visit(smte);
 					      }
                         //TAG_MIXSET_BEFORE_CLOSE
-						}  // The above closing bracket should be removed as StateMachine is used.
+						}  
+                        // The above closing bracket should be removed as StateMachine is used.
                         //TAG_MIXSET_CLOSE 
                       
 					}


### PR DESCRIPTION
The current implementaion to handle mixsets inside methods does not remove the proper closing bracket of a mixset when it is nested in a complicated method structure. The generated code from the provided test case (in current Umple version) will generate code containing:  
```
//TAG_MIXSET_BEFORE_CLOSE
}  
// The above closing bracket should be removed as StateMachine is used.
//TAG_MIXSET_CLOSE
```
This PR improves handling mixsets inside method bodies by removing the proper close brackets.