### PR TITLE
Mixset, Filter, Layout, Fixml, and Feature modelling as Umple feaures 

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -239,37 +239,42 @@ for (StateMachine smq : uClass.getStateMachines())
   {
     Mixset mixset = umodel.getMixset(mixsetInMethod.getMixsetName());
     boolean mixsetIsUsed = false;
-    if(mixset != null) // the mixset has been used. 
-    {
-      if(mixset.getUseUmpleFile() != null)
-      {
-        mixsetIsUsed = true;
-        //first process children
-        for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
-          handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
-        //Then ...
-        String methodCode = mBody.getCodeblock().getCode();
-        Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{");
-        Matcher matcher = labelPatternToMatch.matcher(methodCode);
-        // below code, to delete mixset def. and its closing bracket.
-        if (matcher.find()) {
-          String mixsetDefPlusAfterCode = methodCode.substring(matcher.start());
-          int indexOfMixsetClosingBracket = matcher.start() + MethodBody.indexOfMixsetClosingBracket(mixsetDefPlusAfterCode) - 1 ;
-          String methodCodeRemovedMixset = methodCode.substring(0,indexOfMixsetClosingBracket) + " " ; // remove closing bracket 
-          if(indexOfMixsetClosingBracket + 1 < methodCode.length())
-          methodCodeRemovedMixset = methodCodeRemovedMixset + methodCode.substring(indexOfMixsetClosingBracket +1); 
-          methodCodeRemovedMixset = methodCodeRemovedMixset.substring(0,matcher.start()) + methodCodeRemovedMixset.substring(matcher.end()+1); // remove mixset def.
-          mBody.getCodeblock().setCode(methodCodeRemovedMixset);
+    try {
+       if(mixset != null) // the mixset has been used. 
+       {
+        if(mixset.getUseUmpleFile() != null)
+        {
+          mixsetIsUsed = true;
+          //first process children
+          for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
+            handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
+          //Then ...
+          String methodCode = mBody.getCodeblock().getCode();
+          Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{");
+          Matcher matcher = labelPatternToMatch.matcher(methodCode);
+          // below code, to delete mixset def. and its closing bracket.
+          if (matcher.find()) {
+            String mixsetDefPlusAfterCode = methodCode.substring(matcher.start());
+            int indexOfMixsetClosingBracket = matcher.start() + MethodBody.indexOfMixsetClosingBracket(mixsetDefPlusAfterCode) - 1 ;
+            String methodCodeRemovedMixset = methodCode.substring(0,indexOfMixsetClosingBracket) + " " ; // remove closing bracket 
+            if(indexOfMixsetClosingBracket + 1 < methodCode.length())
+            methodCodeRemovedMixset = methodCodeRemovedMixset + methodCode.substring(indexOfMixsetClosingBracket +1); 
+            methodCodeRemovedMixset = methodCodeRemovedMixset.substring(0,matcher.start()) + methodCodeRemovedMixset.substring(matcher.end()+1); // remove mixset def.
+            mBody.getCodeblock().setCode(methodCodeRemovedMixset);
+          }
         }
       }
     }
-    else if(!mixsetIsUsed)
-	  {
-		 // delete body of unused mixsets  
-		 String mixsetInMethodCode = mixsetInMethod.getMixsetFragment();
-		 String code = mBody.getCodeblock().getCode().replace(mixsetInMethodCode, "");
-		 mBody.getCodeblock().setCode(code);
-	  } 
+    finally
+    {
+      if(!mixsetIsUsed)
+      {
+        // delete body of unused mixsets  
+        String mixsetInMethodCode = mixsetInMethod.getMixsetFragment();
+        String code = mBody.getCodeblock().getCode().replace(mixsetInMethodCode, "");
+        mBody.getCodeblock().setCode(code);
+      }
+    } 
   }
   // This method allows the injection of some code before/after a code label inside a method of an umple class. 
   private void applyCodeInjectionToLabeledMethod(UmpleClass uClass, Method aMethod, String aspectType) {

--- a/cruise.umple/src/Generator.ump
+++ b/cruise.umple/src/Generator.ump
@@ -11,9 +11,6 @@ Note that some generators such as Umlet and Violet are in their own files
  */
 
 namespace cruise.umple.compiler;
-
-//use FeatureDiagramGenerator; // This feature should be moved into config. file in next step.
-
 // Allows independent code generation tools
 // Different generators will do different things regarding where the files are put, etc.
 interface CodeGenerator
@@ -59,13 +56,15 @@ interface CodeTranslator
 }
 use Umple.ump;
 use generators/GeneratorHelper_Code.ump;
+use SuperCodeGeneratorGenerator;
+// All code above belongs to the base generator file (Generator.ump)
 
 //Below mixsets use statments. All mentioned mixsets are activited.
 use CodeGenerator, UmpleGenerator, RubyGenerator , JavaGenerator , RTCppGenerator, PhpGenerator; 
 use Uigu2Generator , SqlGenerator , UmpleSelfGenerator , USEGenerator , EcoreGenerator ,TestGenerator ; 
 use PapyrusGenerator, XmiGenerator, TextUmlGenerator, ScxmlGenerator, CodeGvClassTraitDiagramGenerator
 use EventSequenceGenerator,  FeatureDiagramCo,  EntityRelationshipCon,  SimulateGenerator,  YumlGenerator;
-use XtextGenerator,  JsonGenerator,  JsonMixedGenerator,  StructureDiagramGenerator,  SuperCodeGeneratorGenerator;
+use XtextGenerator,  JsonGenerator,  JsonMixedGenerator,  StructureDiagramGenerator;
 use StateTableGenerator, SuperGvGeneratorGenerator, HtmlGenerator, UmpleModelWalkerGenerator,  CodeAnalysisGenerator;
 use AlloyGenerator,  NuSMVGenerators, NuSMVGenerator,   NuSMVOptimizerGenerator,  SimpleMetricsGenerator, CodeGvClassDiagramGenerator;
 //End 
@@ -73,7 +72,10 @@ use AlloyGenerator,  NuSMVGenerators, NuSMVGenerator,   NuSMVOptimizerGenerator,
 // Below mixsets declarations. They contain inclusion of their files. 
 mixset CodeGenerator { use generators/Generator_Code.ump; }
 mixset UmpleGenerator { use generators/Generator_CodeUmple.ump; }
-mixset RubyGenerator { use generators/Generator_CodeRuby.ump; }
+mixset RubyGenerator { 
+  use generators/Generator_CodeRuby.ump; 
+  use RubyGeneratorIntMixset;
+  }
 mixset JavaGenerator { use generators/Generator_CodeJava.ump; }
 mixset RTCppGenerator { use generators/Generator_CodeRTCpp.ump; }
 mixset PhpGenerator { use generators/Generator_CodePhp.ump; }
@@ -87,7 +89,7 @@ mixset PapyrusGenerator{ use generators/papyrus/Generator_CodePapyrus.ump; }
 mixset XmiGenerator{ use generators/xmi/Generator_CodeXmi.ump; }
 mixset TextUmlGenerator{ use generators/Generator_CodeTextUml.ump; }
 mixset ScxmlGenerator{ use generators/Generator_CodeScxml.ump; }
-use generators/statemachineDiagramGenerator/stateMachineDiagramConfig.ump;
+mixset GvStateDiagramGenerator {  use generators/statemachineDiagramGenerator/stateMachineDiagramConfig.ump;}
 mixset StateTableGenerator{ use generators/Generator_CodeStateTables.ump; }
 mixset EventSequenceGenerator{ use generators/Generator_CodeEventSequence.ump; }
 mixset SimpleMetricsGenerator{ use generators/Generator_CodeSimpleMetrics.ump; }

--- a/cruise.umple/src/Generator.ump
+++ b/cruise.umple/src/Generator.ump
@@ -64,7 +64,7 @@ use CodeGenerator, UmpleGenerator, RubyGenerator , JavaGenerator , RTCppGenerato
 use Uigu2Generator , SqlGenerator , UmpleSelfGenerator , USEGenerator , EcoreGenerator ,TestGenerator ; 
 use PapyrusGenerator, XmiGenerator, TextUmlGenerator, ScxmlGenerator, CodeGvClassTraitDiagramGenerator
 use EventSequenceGenerator,  FeatureDiagramCo,  EntityRelationshipCon,  SimulateGenerator,  YumlGenerator;
-use XtextGenerator,  JsonGenerator,  JsonMixedGenerator,  StructureDiagramGenerator;
+use XtextGenerator,  JsonGenerator,  JsonMixedGenerator,  StructureDiagramGenerator , GvStateDiagramGenerator;
 use StateTableGenerator, SuperGvGeneratorGenerator, HtmlGenerator, UmpleModelWalkerGenerator,  CodeAnalysisGenerator;
 use AlloyGenerator,  NuSMVGenerators, NuSMVGenerator,   NuSMVOptimizerGenerator,  SimpleMetricsGenerator, CodeGvClassDiagramGenerator;
 //End 

--- a/cruise.umple/src/Master.ump
+++ b/cruise.umple/src/Master.ump
@@ -29,8 +29,15 @@ use Parser.ump;
 use stateMachine/StateMachine.ump;
 use Umlet.ump;
 use Umple.ump;
-use trace/Trace.ump;
-use strcture/Structure.ump;
+
+use Trace;
+mixset Trace {
+  use trace/Trace.ump;
+}
+use Structure;
+mixset Structure {
+  use strcture/Structure.ump;
+}
 use template/Template.ump;
 use UmpleDiagram.ump;
 use UmpleExceptions.ump;

--- a/cruise.umple/src/Master.ump
+++ b/cruise.umple/src/Master.ump
@@ -28,22 +28,27 @@ use Generator.ump;
 use Json.ump;
 use Parser.ump;
 
-use stateMachine/StateMachine.ump;
+use Structure;
+use Template;
+//use StateMachine;
+use Trace;
 
+
+
+mixset StateMachine {
+  use stateMachine/StateMachine.ump;
+}
 use Umlet.ump;
 use Umple.ump;
 
-use Trace;
 mixset Trace {
   use trace/Trace.ump;
 }
-use Structure;
 mixset Structure {
   use strcture/Structure.ump;
 }
-use Template;
 mixset Template {
-use template/Template.ump;
+  use template/Template.ump;
 }
 use UmpleDiagram.ump;
 use UmpleExceptions.ump;

--- a/cruise.umple/src/Master.ump
+++ b/cruise.umple/src/Master.ump
@@ -22,11 +22,14 @@ strictness allow 36; // don't worry about multiplicity of directed associations
 strictness allow 170; // allow custom constructors
 strictness allow 31; // dont worry about namespaces
 
+
 use Documenter.ump;
 use Generator.ump;
 use Json.ump;
 use Parser.ump;
+
 use stateMachine/StateMachine.ump;
+
 use Umlet.ump;
 use Umple.ump;
 
@@ -38,7 +41,10 @@ use Structure;
 mixset Structure {
   use strcture/Structure.ump;
 }
+use Template;
+mixset Template {
 use template/Template.ump;
+}
 use UmpleDiagram.ump;
 use UmpleExceptions.ump;
 use util/UmpleHelper.ump;

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1263,7 +1263,7 @@ class ObjectElement {
 
 use UmpleVersion.ump;
 use UmpleDiagram.ump;
-use stateMachine/StateMachine.ump;
+//use stateMachine/StateMachine.ump;
 use Umple_Code.ump;
 use UmpleEnumeration_Code.ump;
 mixset Mixset{

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1269,4 +1269,6 @@ use UmpleEnumeration_Code.ump;
 mixset Mixset{
   use mixset/Mixset.ump;
 }
-use feature/FeatureModel.ump;
+mixset FeatureModel {
+  use feature/FeatureModel.ump;
+}

--- a/cruise.umple/src/UmpleAnalysis.ump
+++ b/cruise.umple/src/UmpleAnalysis.ump
@@ -882,16 +882,18 @@ class ConstraintNameNameAnalyzer
         } 
         else
         {
-        	Port port = null;
-        	if (uClassifier instanceof UmpleClass)
-        	{
-        		port = ((UmpleClass)(uClassifier)).getPort(value);
-        	}
-        	if(port!=null)
-        	{
-        		ConstraintPort name = new ConstraintPort(port);
-        		return name;
-        	} 
+          mixset Structure {
+            Port port = null;
+            if (uClassifier instanceof UmpleClass)
+            {
+              port = ((UmpleClass)(uClassifier)).getPort(value);
+            }
+            if(port!=null)
+            {
+              ConstraintPort name = new ConstraintPort(port);
+              return name;
+            }
+          } 
         }
         
       }

--- a/cruise.umple/src/UmpleInternalParser.ump
+++ b/cruise.umple/src/UmpleInternalParser.ump
@@ -92,5 +92,5 @@ use UmpleParser.ump;
 use Parser.ump;
 use Umple.ump;
 use UmpleDiagram.ump;
-use stateMachine/StateMachine.ump;
+//use stateMachine/StateMachine.ump;
 use UmpleInternalParser_Code.ump;

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -555,7 +555,9 @@ use UmpleInternalParser_CodeEnumeration.ump;
 mixset Mixset{
   use mixset/UmpleInternalParser_CodeMixset.ump;
 }
-use UmpleInternalParser_CodeRequireStatement.ump;
+mixset FeatureModel {
+  use UmpleInternalParser_CodeRequireStatement.ump;
+}
 use UmpleInternalParser_CodeTest.ump;
 mixset AspectInjection {
   use class/UmpleInternalPraser_CodeInjection.ump;

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -251,7 +251,9 @@ class UmpleInternalParser
     mixset StateMachine {
       analyzeStateMachineToken(t,analysisStep);
     }
-    analyzeComponentToken(t,analysisStep);
+    mixset Structure {
+      analyzeComponentToken(t,analysisStep);
+    }
     mixset Trace {
       analyzeTraceToken(t,analysisStep);
     }
@@ -378,11 +380,11 @@ class UmpleInternalParser
         postTokenTemplateAnalysis();
       }
     }
-
-    if (getParseResult().getWasSuccess()) {
-      postTokenComponentAnalysis();
+    mixset Structure {
+      if (getParseResult().getWasSuccess()) {
+        postTokenComponentAnalysis();
+      }
     }
-
     mixset Constraint {
       if (getParseResult().getWasSuccess())
       {

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -39,7 +39,7 @@ use StateMachine;
 use Trait;
 use Trace;
 use Structure;
-use Template;
+//use Template;
 use FIXML;
 use Layout;
 use Class; use Attribute; //use Association ; // Attribute and Association are not features.

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -74,10 +74,12 @@ class UmpleInternalParser
     else if (t.is("useStatement") )
     {
       analyzeAllTokens(t);
+      mixset Mixset {
       // add parsed files to parsedUmpfiles hashMap.
       String umpFileName = t.getSubToken("use").getValue();
       if(! parsedUmpfiles.keySet().contains(umpFileName))
       parsedUmpfiles.put(umpFileName, true);
+      }
       
     }
     else if (t.is("strictness") )
@@ -352,9 +354,10 @@ class UmpleInternalParser
     {
       analyzeClassTestSequence(token,aClass);
     }
-    
-    else if (token.getValue("mixsetDefinition") != null)  {
-      analyzeMixsetBodyToken(token);
+    mixset Mixset {
+      else if (token.getValue("mixsetDefinition") != null)  {
+        analyzeMixsetBodyToken(token);
+      }
     }
     else if (token.is("extraCode"))
     {
@@ -1121,10 +1124,12 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     // Go through every token that is a child of the current token (all associations part of this association).
     for(Token token : associationToken.getSubTokens()){
       boolean isAssociationToken = token.is("association");
-      if (token.is("mixsetDefinition"))
-      {
-        analyzeMixsetBodyToken(token);
-      } 
+      mixset Mixset {
+        if (token.is("mixsetDefinition"))
+        {
+          analyzeMixsetBodyToken(token);
+        } 
+      }
       //Issue 213/131: [association] elements inside associationClasses generate 2 associations instead of one
       if (isAssociationToken && associationToken.is("associationClassDefinition")) {
         for (Token t : token.getSubTokens()) {

--- a/cruise.umple/src/class/UmpleInternalPraser_CodeInjection.ump
+++ b/cruise.umple/src/class/UmpleInternalPraser_CodeInjection.ump
@@ -177,10 +177,11 @@ class UmpleInternalParser
 
     CodeInjection injection = new CodeInjection(type,operationName,"",uClassifier);
     injection.setOperationSource(operationSource);
-     // check if the aspect needs to be injected before/after a label.
-    if(codeLabelToken != null)
-    injection.setInjectionlabel(codeLabelToken.getValue());
-
+    mixset Mixset {
+      // check if the aspect needs to be injected before/after a label.
+      if(codeLabelToken != null)
+      injection.setInjectionlabel(codeLabelToken.getValue());
+    }
     List<String> operationsParameters = getOperationsParameters(injectToken);
     for(String operationParameters : operationsParameters) {
       injection.addParameter(operationParameters);      

--- a/cruise.umple/src/constraint/Umple_CodeConstraint.ump
+++ b/cruise.umple/src/constraint/Umple_CodeConstraint.ump
@@ -752,22 +752,24 @@ class ConstraintVariable
   public abstract String getType();
 }
 
-class ConstraintState
-{
-  String getName()
+mixset StateMachine {
+  class ConstraintState
   {
-    return state==null?null:state.getName();
+    String getName()
+    {
+      return state==null?null:state.getName();
+    }
+    public String getType() { return "state"; }
   }
-  public String getType() { return "state"; }
-}
 
-class ConstraintStateMachine
-{
-  String getName()
+  class ConstraintStateMachine
   {
-    return stateMachine==null?null:stateMachine.getName();
+    String getName()
+    {
+      return stateMachine==null?null:stateMachine.getName();
+    }
+    public String getType(){ return "statemachine"; }
   }
-  public String getType(){ return "statemachine"; }
 }
 
 class ConstraintPort
@@ -924,7 +926,7 @@ mixset Association {
         {
           return new ModelConstraintResult(getPosition(),94,getTarget(),getSource());
         }
-
+        mixset Association {
         for(Association association:uClass.getAssociations())
         {
           AssociationEnd theirs = null;
@@ -1041,6 +1043,7 @@ mixset Association {
             }
           }
           return ModelConstraint.SUCCESS;
+        }
         }
         
         return new ModelConstraintResult(getPosition(),94,getTarget(),getSource());

--- a/cruise.umple/src/constraint/Umple_CodeConstraint.ump
+++ b/cruise.umple/src/constraint/Umple_CodeConstraint.ump
@@ -5,6 +5,14 @@ http://umple.org/license
  */
 namespace cruise.umple.compiler;
 
+/*Used to associated condition patern for an umple elemnt. Designed to be generic so, this elemnt
+ * can be of different types
+ */
+class Condition {
+	String condition;
+	Object element;
+}
+
 class ConstraintTree
 {
   /*

--- a/cruise.umple/src/generators/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/generators/GeneratorHelper_CodeClass.ump
@@ -64,7 +64,7 @@ class GeneratorHelper
 	      if(inject.hasCodeLabel())
           continue;// handle the case when labels are used. // Do nothing  
         String comment = "//";
-        mixset RubyGenerator {
+        mixset RubyGeneratorIntMixset {
           comment = RubyGenerator.class.isInstance(generator)?"#":"//";
         }
         String positionString = "";

--- a/cruise.umple/src/generators/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/generators/GeneratorHelper_CodeClass.ump
@@ -63,7 +63,10 @@ class GeneratorHelper
       {
 	      if(inject.hasCodeLabel())
           continue;// handle the case when labels are used. // Do nothing  
-        String comment = RubyGenerator.class.isInstance(generator)?"#":"//";
+        String comment = "//";
+        mixset RubyGenerator {
+          comment = RubyGenerator.class.isInstance(generator)?"#":"//";
+        }
         String positionString = "";
         Position p = inject.getPosition();
         Position codeP = inject.getCodePosition();

--- a/cruise.umple/src/generators/GeneratorHelper_CodeClass.ump
+++ b/cruise.umple/src/generators/GeneratorHelper_CodeClass.ump
@@ -61,8 +61,10 @@ class GeneratorHelper
     {
       for (CodeInjection inject : allCodeInjections)
       {
+        mixset Mixset {
 	      if(inject.hasCodeLabel())
           continue;// handle the case when labels are used. // Do nothing  
+        }
         String comment = "//";
         mixset RubyGeneratorIntMixset {
           comment = RubyGenerator.class.isInstance(generator)?"#":"//";

--- a/cruise.umple/src/generators/Generator_UmpleModelWalker.ump
+++ b/cruise.umple/src/generators/Generator_UmpleModelWalker.ump
@@ -39,13 +39,7 @@ class ClassPattern {
 	String pattern;
 }
 
-/*Used to associated condition patern for an umple elemnt. Designed to be generic so, this elemnt
- * can be of different types
- */
-class Condition {
-	String condition;
-	Object element;
-}
+
 
 /*Used to persist hirarchy information for given elemnts (owner, and children) */
 class Hierarchy {

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -372,8 +372,10 @@ class UmpleInternalParser
   }
   // this method specifies kinds of tokens to be parsed for unused mixset. 
   private void parseMixsetNotUsedToken(Token token){
-    //parse require statments. 
-    analyzeRequireStatement(token, 2);
+    mixset FeatureModel {
+      //parse require statments. 
+      analyzeRequireStatement(token, 2);
+    }
     // parse nested mixset def.
     if(token.is("mixsetDefinition"))
     {

--- a/cruise.umple/src/stateMachine/UmpleInternalParser_CodeStateMachine.ump
+++ b/cruise.umple/src/stateMachine/UmpleInternalParser_CodeStateMachine.ump
@@ -755,8 +755,9 @@ class UmpleInternalParser
       }
     }
     
-    
-    analyzeMixsetDefinition(innerMixsetTokens, sm);
+    mixset Mixset {
+      analyzeMixsetDefinition(innerMixsetTokens, sm);
+    }
  
     return sm;
   }


### PR DESCRIPTION
This PR makes it possible to separate models (as whole) from generators. In addition, the following features: mixset, filter, layout, fixml, and feature modelling can be now sliced out of Umple (but not at the generator level) through deactivating their mixsets when parsing the master file "umple/cruise.umple/src/Master.ump" using umple.jar. 