### PR TITLE
Template mixsets

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
+++ b/UmpleToJava/UmpleTLTemplates/JavaClassGenerator.ump
@@ -250,7 +250,7 @@ for (StateMachine smq : uClass.getStateMachines())
             handelMixsetInsideMethod(umodel, childMixsetInMethod, mBody);
           //Then ...
           String methodCode = mBody.getCodeblock().getCode();
-          Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{");
+          Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+"+"\\"+"\u007B"); //==> /u007B means an open curly bracket
           Matcher matcher = labelPatternToMatch.matcher(methodCode);
           // below code, to delete mixset def. and its closing bracket.
           if (matcher.find()) {

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -558,34 +558,48 @@ mixset Template {
 
   class TemplateDefinitionWalker {
     depend java.util.ArrayList;
-    private void processInlineMixset(Token aToken) 
-    {
-      Token templateTextContentToken = null ;
-      Token templateAttributeToken = aToken.getSubToken("templateAttribute");
-      for (Token templateAttributeSubToken : templateAttributeToken.getSubTokens())
+    
+    private void handleTemplateTokenContainMixset(Token codeToken) {
+      if (codeToken != null) 
       {
-        if (templateAttributeSubToken == null  || templateAttributeSubToken.getSubTokens().size() <1)
-          continue;
-        Token templateTextContent_parent =  templateAttributeSubToken.getSubToken("templateTextContent");
-        if( templateTextContent_parent != null )
-        {
-          templateTextContentToken = templateAttributeSubToken.getSubToken("templateTextContent");
-          if (templateTextContentToken == null )
-          continue;
-
-          String codeToLookAt= templateTextContentToken.getValue() ;
-          ArrayList<MixsetInMethod> mixsetWithinTemplate = MethodBody.getMixsetsFromCode(codeToLookAt);
-          if( mixsetWithinTemplate.size()  < 1 )
-            continue;
-          // else, when there is  one mixset or more ...
-          for (MixsetInMethod m : mixsetWithinTemplate) 
-          {
-            codeToLookAt = MethodBody.handelMixsetInsideMethod(this.getParser().getModel(), m, codeToLookAt);
-            templateTextContentToken.setValue(codeToLookAt);
+        String codeToLookAt = codeToken.getValue();
+        ArrayList<MixsetInMethod> mixsetWithinTemplate = MethodBody.getMixsetsFromCode(codeToLookAt);
+        if (mixsetWithinTemplate.size() > 0) {
+          for (MixsetInMethod inlineMixsetFragment : mixsetWithinTemplate) {
+            codeToLookAt = MethodBody.handelMixsetInsideMethod(this.getParser().getModel(), inlineMixsetFragment,codeToLookAt);
+            codeToken.setValue(codeToLookAt);
           }
         }
       }
     }
+    
+    private void processInlineMixset(Token aToken) {
+      Token templateTextContentToken = null;
+      Token templateAttributeToken = aToken.getSubToken("templateAttribute");
+      for (Token templateAttributeSubToken : templateAttributeToken.getSubTokens()) 
+      {
+        Token templateCodeBlock = templateAttributeSubToken.getSubToken("templateCodeBlock");
+        if (templateCodeBlock != null) 
+        {
+          // handle inline mixsets within Template CodeBlock
+          Token templateLanguageCodeToken = templateCodeBlock.getSubToken("templateLanguageCode");
+          handleTemplateTokenContainMixset(templateLanguageCodeToken);
+        }
+        // handle inline mixsets within Template templateTextContent
+        if (templateAttributeSubToken == null || templateAttributeSubToken.getSubTokens().size() < 1)
+        continue;
+        Token templateTextContent_sub = templateAttributeSubToken.getSubToken("templateTextContent");
+        if (templateTextContent_sub != null) 
+        {
+          templateTextContentToken = templateAttributeSubToken.getSubToken("templateTextContent");
+          if (templateTextContentToken == null)
+          continue;
+          //else
+          handleTemplateTokenContainMixset(templateTextContentToken);
+        }
+      }
+    }
+    
   }
   
   class MethodBody {

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -516,8 +516,10 @@ mixset AspectInjection {
     }
     return closeIndex;
   }
-    public ArrayList<MixsetInMethod> getMixsetsWithinMethod() { 
-    String codeToLockAt= this.getCodeblock().getCode(); // the code to look at. 
+  public  ArrayList<MixsetInMethod> getMixsetsWithinMethod(){
+    return getMixsetsFromCode(this.getCodeblock().getCode());
+  }
+  public static ArrayList<MixsetInMethod> getMixsetsFromCode(String codeToLockAt){
     ArrayList<MixsetInMethod> mixsetInsideMethodList = new ArrayList<MixsetInMethod>();
     Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{"); // to detect mixset def.
     Matcher matcher = labelPatternToMatch.matcher(codeToLockAt);
@@ -549,5 +551,85 @@ mixset AspectInjection {
     }
     return mixsetInsideMethodList;
   }
+  }
+}
+
+mixset Template {
+
+  class TemplateDefinitionWalker {
+    depend java.util.ArrayList;
+    private void processInlineMixset(Token aToken) 
+    {
+      Token templateTextContentToken = null ;
+      Token templateAttributeToken = aToken.getSubToken("templateAttribute");
+      for (Token templateAttributeSubToken : templateAttributeToken.getSubTokens())
+      {
+        if (templateAttributeSubToken == null  || templateAttributeSubToken.getSubTokens().size() <1)
+          continue;
+        Token templateTextContent_parent =  templateAttributeSubToken.getSubToken("templateTextContent");
+        if( templateTextContent_parent != null )
+        {
+          templateTextContentToken = templateAttributeSubToken.getSubToken("templateTextContent");
+          if (templateTextContentToken == null )
+          continue;
+
+          String codeToLookAt= templateTextContentToken.getValue() ;
+          ArrayList<MixsetInMethod> mixsetWithinTemplate = MethodBody.getMixsetsFromCode(codeToLookAt);
+          if( mixsetWithinTemplate.size()  < 1 )
+            continue;
+          // else, when there is  one mixset or more ...
+          for (MixsetInMethod m : mixsetWithinTemplate) 
+          {
+            codeToLookAt = MethodBody.handelMixsetInsideMethod(this.getParser().getModel(), m, codeToLookAt);
+            templateTextContentToken.setValue(codeToLookAt);
+          }
+        }
+      }
+    }
+  }
+  
+  class MethodBody {
+    public static String handelMixsetInsideMethod(UmpleModel umodel, MixsetInMethod mixsetInMethod, String  sourceCodeBody)
+    {
+      Mixset mixset = umodel.getMixset(mixsetInMethod.getMixsetName());
+      boolean mixsetIsUsed = false;
+      try {
+        if(mixset != null) // the mixset has been used. 
+        {
+         if(mixset.getUseUmpleFile() != null)
+         {
+           mixsetIsUsed = true;
+           //first process children
+           for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
+             handelMixsetInsideMethod(umodel, childMixsetInMethod, sourceCodeBody);
+           //Then ...
+           String methodCode = sourceCodeBody;
+           Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{");
+           Matcher matcher = labelPatternToMatch.matcher(methodCode);
+           // below code, to delete mixset def. and its closing bracket.
+           if (matcher.find()) {
+             String mixsetDefPlusAfterCode = methodCode.substring(matcher.start());
+             int indexOfMixsetClosingBracket = matcher.start() + MethodBody.indexOfMixsetClosingBracket(mixsetDefPlusAfterCode) - 1 ;
+             String methodCodeRemovedMixset = methodCode.substring(0,indexOfMixsetClosingBracket) + " " ; // remove closing bracket 
+             if(indexOfMixsetClosingBracket + 1 < methodCode.length())
+             methodCodeRemovedMixset = methodCodeRemovedMixset + methodCode.substring(indexOfMixsetClosingBracket +1); 
+             methodCodeRemovedMixset = methodCodeRemovedMixset.substring(0,matcher.start()) + methodCodeRemovedMixset.substring(matcher.end()+1); // remove mixset def.
+             sourceCodeBody = methodCodeRemovedMixset;
+           }
+         }
+       }
+     }
+     finally
+     {
+       if(!mixsetIsUsed)
+       {
+         // delete body of unused mixsets  
+         String mixsetInMethodCode = mixsetInMethod.getMixsetFragment();
+         String code = sourceCodeBody.replace(mixsetInMethodCode, "");
+         sourceCodeBody = code;
+       }
+     }
+     return sourceCodeBody; // after processing
+    }
   }
 }

--- a/cruise.umple/src/template/UmpleInternalParser_CodeTemplate.ump
+++ b/cruise.umple/src/template/UmpleInternalParser_CodeTemplate.ump
@@ -790,9 +790,9 @@ class TemplateDefinitionWalker {
 	      	return;
 	  	}
     	if (aToken.is("templateAttributeDefinition")) {
-			mixset Mixset {
-				processInlineMixset(aToken);
-			}
+        mixset Mixset {
+          processInlineMixset(aToken);
+        }
     		analyzer.analyzeEmission(aToken);
     	} else if (aToken.is("emitMethod")) {
         	analyzer.analyzeEmitMethodDeclarator(aToken);

--- a/cruise.umple/src/template/UmpleInternalParser_CodeTemplate.ump
+++ b/cruise.umple/src/template/UmpleInternalParser_CodeTemplate.ump
@@ -790,6 +790,9 @@ class TemplateDefinitionWalker {
 	      	return;
 	  	}
     	if (aToken.is("templateAttributeDefinition")) {
+			mixset Mixset {
+				processInlineMixset(aToken);
+			}
     		analyzer.analyzeEmission(aToken);
     	} else if (aToken.is("emitMethod")) {
         	analyzer.analyzeEmitMethodDeclarator(aToken);

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -890,8 +890,6 @@ public class UmpleMixsetTest {
     Assert.assertFalse(templateGeneratedCode.contains("I am inner , this line should NOT be included"));
     // no mixset definitions i
     Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
-    Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
-    Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
     Assert.assertFalse(templateGeneratedCode.contains("mixset M2"));
     Assert.assertFalse(templateGeneratedCode.contains("mixset M3"));
     Assert.assertFalse(templateGeneratedCode.contains("mixset Outer"));

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -870,5 +870,36 @@ public class UmpleMixsetTest {
     model.run();
     Assert.assertEquals(model.getUmpleClasses().size() , 3);
   }
+  @Test
+  public void inlineMixsetsInTemplate()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideTemplate.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(true);
+    model.run();
+    String generatedFile =  umpleParserTest.pathToInput+"/TemplateMixset.java";
+    SampleFileWriter.assertFileExists(generatedFile);
+    String templateGeneratedCode = SampleFileWriter.readContent(new File(generatedFile));
+    //  included mixsets
+    Assert.assertTrue(templateGeneratedCode.contains("Print out the following "));
+    Assert.assertTrue(templateGeneratedCode.contains("M1 is used, this line should be included"));
+    Assert.assertTrue(templateGeneratedCode.contains("M2 is used, this line should be included"));
+    // not included mixsets
+    Assert.assertFalse(templateGeneratedCode.contains("M3 is not used, this line NOT should be included"));
+    Assert.assertFalse(templateGeneratedCode.contains("I am outer , this line should NOT be included"));
+    Assert.assertFalse(templateGeneratedCode.contains("I am inner , this line should NOT be included"));
+    // no mixset definitions i
+    Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
+    Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
+    Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
+    Assert.assertFalse(templateGeneratedCode.contains("mixset M2"));
+    Assert.assertFalse(templateGeneratedCode.contains("mixset M3"));
+    Assert.assertFalse(templateGeneratedCode.contains("mixset Outer"));
+    Assert.assertFalse(templateGeneratedCode.contains("mixset Inner"));
+    //delete generated file
+    SampleFileWriter.destroy(generatedFile);
+
+    
+  }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideTemplate.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideTemplate.ump
@@ -1,0 +1,41 @@
+//namespace cruise.umple.compiler.mixset;
+
+use M1;
+use M2;
+
+use Inner; 
+
+class TemplateMixset {
+  text <<! Print out the following :  
+  mixset M1 {
+    // M1 is used, this line should be included.
+    
+  }
+  
+  mixset Outer {
+       mixset Inner {  
+      // I am inner , this line should NOT be included.
+    }
+    
+    
+    // I am outer , this line should NOT be included.
+  }
+  
+  int x ; 
+  x ++;
+  
+  mixset M2 {
+    // M2 is used, this line should be included..
+  }
+  
+  mixset M3 {
+    // M3 is not used, this line NOT should be included..
+  }
+  
+  !>>
+  // Specification for two methods to be generated
+  
+  emit text();
+  }
+}
+


### PR DESCRIPTION
Templates are heavily used to form Umple generators. Content of templates may contain code related to a particular feature. This PR allows inline mixsets within template code.