### PR TITLE
More language support for inline mixsets  

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -3271,12 +3271,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
             String methodCode = token.getValue();
             // process mixsets inside code 
             mixset Mixset {
-              ArrayList<MixsetInMethod> mixsetInCodeList = MethodBody.getMixsetsFromCode(methodCode) ;
-              for (MixsetInMethod aMixsetInMethod : mixsetInCodeList) 
-              {
-                // update the code according to  use statements (of mixsets)
-                methodCode = MethodBody.handelMixsetInsideMethod(this.getModel(), aMixsetInMethod, methodCode);	        		
-              }
+              methodCode = processInlineMixset(token.getValue());
             } // end of MIXSET 
             cb.setCode(methodCode);
             aMethod.setCodePosition(token.getPosition());
@@ -4093,17 +4088,21 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         langs.add(sub.getValue());
       }
       if(sub.is("code"))
-      {          
+      {
+        String aspectCode = sub.getValue();
+        mixset Mixset {
+        aspectCode = processInlineMixset(sub.getValue());
+        }
         if(langs.size()==0)
         {
-          cb.setCode(sub.getValue());
+          cb.setCode(aspectCode);
           injection.setCodePosition(sub.getPosition());
         }
         else
         {
           for(String lang:langs)
             {
-                cb.setCode(lang,sub.getValue());
+                cb.setCode(lang,aspectCode);
                 if("Java".equals(lang))
                 {
                   injection.setCodePosition(sub.getPosition());

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -3268,7 +3268,17 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
                 token.getPosition().getLineNumber()+"", token.getPosition().getFilename(), ""));
           else
           {
-            cb.setCode(token.getValue());
+            String methodCode = token.getValue();
+            // process mixsets inside code 
+            mixset Mixset {
+              ArrayList<MixsetInMethod> mixsetInCodeList = MethodBody.getMixsetsFromCode(methodCode) ;
+              for (MixsetInMethod aMixsetInMethod : mixsetInCodeList) 
+              {
+                // update the code according to  use statements (of mixsets)
+                methodCode = MethodBody.handelMixsetInsideMethod(this.getModel(), aMixsetInMethod, methodCode);	        		
+              }
+            } // end of MIXSET 
+            cb.setCode(methodCode);
             aMethod.setCodePosition(token.getPosition());
             
             //559b

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -451,9 +451,19 @@ class UmpleInternalParser
       
     }
   }
-    
-  
+  // a helper method that process pure code to either remove it or to let mixset content stay.
+  private String processInlineMixset(String methodCode) {
+	// process mixsets inside code 
+	   ArrayList<MixsetInMethod> mixsetInCodeList = MethodBody.getMixsetsFromCode(methodCode) ;
+	  for (MixsetInMethod aMixsetInMethod : mixsetInCodeList) 
+	  {
+	    // update the code according to  use statements (of mixsets)
+	    methodCode = MethodBody.handelMixsetInsideMethod(this.getModel(), aMixsetInMethod, methodCode);	        		
+	  }
+    return methodCode;
+  }  
 }
+
 mixset AspectInjection {
   class CodeInjection{
     String injectionlabel = "";

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -616,7 +616,7 @@ mixset Template {
            mixsetIsUsed = true;
            //first process children
            for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
-             handelMixsetInsideMethod(umodel, childMixsetInMethod, sourceCodeBody);
+             sourceCodeBody = handelMixsetInsideMethod(umodel, childMixsetInMethod, sourceCodeBody);
            //Then ...
            String methodCode = sourceCodeBody;
            Pattern labelPatternToMatch = Pattern.compile("mixset\\s+\\S+\\s+\\{");

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -676,5 +676,26 @@ public class UmpleMixsetTest {
     //delete generated file
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/AphpClass.java");
   }
+  @Test
+  public void inlineMixsetsInsideAspectCode()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideAspect.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(true);
+    model.run();
+    String code = model.getGeneratedCode().get("AspectClass");
+    Assert.assertTrue(code.contains("public void doMethodOne()"));
+    Assert.assertTrue(code.contains("public void doMethodTwo"));
+    Assert.assertTrue(code.contains("M2 code to stay"));
+    Assert.assertTrue(code.contains("int y"));
+    // not included mixsets
+    Assert.assertFalse(code.contains("M1 code to be removed"));
+    Assert.assertFalse(code.contains("int x"));
+    // no mixset definitions 
+    Assert.assertFalse(code.contains("mixset M1 {"));
+    Assert.assertFalse(code.contains("mixset M2 {"));
+    //delete generated file
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/AspectClass.java");
+  }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import cruise.umple.compiler.Method;
 import cruise.umple.compiler.MethodBody;
 import cruise.umple.compiler.exceptions.*;
+import cruise.umple.compiler.php.PhpClassGenerator;
 import java.io.File;
 
 public class UmpleMixsetTest {
@@ -656,6 +657,18 @@ public class UmpleMixsetTest {
     SampleFileWriter.destroy(generatedFile);
 
     
+  }
+  @Test
+  public void inlineMixsetsInsideMethodPhpCode()
+  {
+    UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideMethod_generic.ump");
+    UmpleModel model = new UmpleModel(umpleFile);
+    model.setShouldGenerate(true);
+    model.run();
+    PhpClassGenerator phpGenerator = new PhpClassGenerator();		
+    String code = phpGenerator.getCode(model, model.getUmpleClass(0));
+    //delete generated file
+    SampleFileWriter.destroy(umpleParserTest.pathToInput+"/AphpClass.java");
   }
 
 }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -667,6 +667,12 @@ public class UmpleMixsetTest {
     model.run();
     PhpClassGenerator phpGenerator = new PhpClassGenerator();		
     String code = phpGenerator.getCode(model, model.getUmpleClass(0));
+    Assert.assertTrue(code.contains("M2 is used mixset."));
+    // not included mixsets
+    Assert.assertFalse(code.contains("M1 is not used mixset"));
+    // no mixset definitions 
+    Assert.assertFalse(code.contains("mixset M1 {"));
+    Assert.assertFalse(code.contains("mixset M2 {"));
     //delete generated file
     SampleFileWriter.destroy(umpleParserTest.pathToInput+"/AphpClass.java");
   }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideAspect.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideAspect.ump
@@ -1,0 +1,27 @@
+
+use M2;
+
+class AspectClass {
+  
+  void doMethodOne(){  }
+  
+  void doMethodTwo(){ }
+  
+  after doMethodOne{  
+    mixset M1 {
+      // M1 code to be removed.
+      int x = 1;
+    }
+    
+  }
+  
+  after doMethodTwo{
+    mixset M2 {
+      // M2 code to stay.
+      int y =0;
+    }
+    
+  }
+  
+  
+}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_M2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_M1_M2.ump
@@ -11,8 +11,7 @@ class MixsetWithinMethodClass
       x++;    
       int i = 0;
       System.out.println("mixset M1 ... ");
-      mixset InnerMixset 
-      {
+      mixset InnerMixset {
         //code for InnerMixset
       }
     //extra code for the mixset M1 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_generic.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/parseMixsetsInsideMethod_generic.ump
@@ -1,0 +1,18 @@
+use  M2;
+
+class AphpClass{
+  
+  name;
+  
+  void set_name_(name) {
+    $this->name = $name;
+    mixset M1 {
+      $this->name = "M1 is not used mixset." ;
+    }
+    
+    mixset M2 {  
+      $this->name = "M2 is used mixset.";
+    }
+  }
+
+}


### PR DESCRIPTION
In this PR, processing inline mixsets moved to the parser level. Therefore, inline mixsets can be applied to any programming language supported by Umple (not only Java). In addition, aspect injection can now inject a conditional code that will be included only when there is a use statement . 