### PR TITLE
Update Grunt for security reasons

### DIFF
--- a/umpleonline/scripts/jquery/jquery-ui-1.12.1.custom/package.json
+++ b/umpleonline/scripts/jquery/jquery-ui-1.12.1.custom/package.json
@@ -53,9 +53,9 @@
 	"dependencies": {},
 	"devDependencies": {
 		"commitplease": "2.3.0",
-		"grunt": "0.4.5",
-		"grunt-bowercopy": "1.2.4",
-		"grunt-cli": "0.1.13",
+		"grunt": "1.3.0",
+		"grunt-bowercopy": "1.2.5",
+		"grunt-cli": "1.3.2",
 		"grunt-compare-size": "0.4.0",
 		"grunt-contrib-concat": "0.5.1",
 		"grunt-contrib-csslint": "0.5.0",


### PR DESCRIPTION
Following a dependabot alert this updates the grunt reference. However since we are not developing JQueryUI itself, this should have no effect on Umple. The purpose of this is to clear out the security alert