### PR TITLE
Quell build warnings

### DIFF
--- a/cruise.umple/src/Compiler.ump
+++ b/cruise.umple/src/Compiler.ump
@@ -22,8 +22,9 @@ class CodeCompiler {
   depend javax.tools.JavaCompiler;
 
   public static String console;
+  public static boolean subsequentCompilation = false; // true if compile used more than once to quell messages
 
-  public static boolean compile(UmpleModel model, String generator, boolean useExec, String entryClass, String... extraArgs) {
+  public static boolean compile(UmpleModel model, String generator, boolean useExec, boolean beQuiet, String entryClass, String... extraArgs) {
     boolean wasSuccessful = true;
     String extra = "";
     for(String arg:extraArgs)
@@ -38,7 +39,7 @@ class CodeCompiler {
       }
       if (entryClass.equals("-") || entryClass.equals(currentElement.getName())) {
         if(generator.equals("Java")) {
-          wasSuccessful = wasSuccessful & compileJava(currentElement, model, useExec, extra);
+          wasSuccessful = wasSuccessful & compileJava(currentElement, model, useExec, beQuiet, extra);
         }
         else if (generator.equals("Php")) {
           wasSuccessful = wasSuccessful & compilePhp(currentElement, model,extra);
@@ -48,6 +49,7 @@ class CodeCompiler {
         }
       }
     }
+    subsequentCompilation = true;
     return wasSuccessful;
   }
 
@@ -108,7 +110,7 @@ class CodeCompiler {
     return (retval == 0);
   }
   
-  private static boolean compileJava(UmpleElement aClass, UmpleModel model, boolean useExec, String args) {
+  private static boolean compileJava(UmpleElement aClass, UmpleModel model, boolean useExec, boolean beQuiet, String args) {
     String path="";
     String base="";
     for (GenerateTarget gt : model.getGenerates()) {
@@ -123,7 +125,7 @@ class CodeCompiler {
     PipedOutputStream out = null;
 
     try {
-      if(base.contains(" ")) {
+      if(base.contains(" ") && !(beQuiet && subsequentCompilation)) {
         System.err.println("Warning: Compiling generated Java from a directory or path containing a space character may produce an error message from the Java compiler.");
       }
       

--- a/cruise.umple/src/Compiler.ump
+++ b/cruise.umple/src/Compiler.ump
@@ -40,20 +40,21 @@ class CodeCompiler {
       if (entryClass.equals("-") || entryClass.equals(currentElement.getName())) {
         if(generator.equals("Java")) {
           wasSuccessful = wasSuccessful & compileJava(currentElement, model, useExec, beQuiet, extra);
+          subsequentCompilation = true;
         }
         else if (generator.equals("Php")) {
-          wasSuccessful = wasSuccessful & compilePhp(currentElement, model,extra);
+          wasSuccessful = wasSuccessful & compilePhp(currentElement, model, beQuiet, extra);
+          subsequentCompilation = true;
         }
         else {
           System.out.println("Compilation of generated code not supported yet for generator "+generator);
         }
       }
     }
-    subsequentCompilation = true;
     return wasSuccessful;
   }
 
-  private static boolean compilePhp(UmpleElement aClass, UmpleModel model, String args) {
+  private static boolean compilePhp(UmpleElement aClass, UmpleModel model, boolean beQuiet, String args) {
     String path="";
     String base="";
     for (GenerateTarget gt : model.getGenerates()) {
@@ -67,8 +68,8 @@ class CodeCompiler {
     int retval=0;
 
     try {
-      if(base.contains(" ")) {
-        System.err.println("Warning: Compiling generated Php from a directory or path containing a space character may produce an error message from the Java compiler.");
+      if(base.contains(" ") && !(beQuiet && subsequentCompilation)) {
+        System.err.println("Warning: Compiling generated Php from a directory or path containing a space character may produce an error message from the PhP compiler.");
       }
       
       BufferedReader reader;

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -282,7 +282,7 @@ class UmpleConsoleMain
             }
           
             if (generatorCodeToCompile.equals("Java") || generatorCodeToCompile.equals("Php")) {
-              compileSuccess = CodeCompiler.compile(model, generatorCodeToCompile,cfg.getUseExec(), cfg.getCompile().get());
+              compileSuccess = CodeCompiler.compile(model, generatorCodeToCompile,cfg.getUseExec(), cfg.getBeQuiet(), cfg.getCompile().get());
             }
           }
         }

--- a/cruise.umple/src/generators/Generator_CodeJava.ump
+++ b/cruise.umple/src/generators/Generator_CodeJava.ump
@@ -130,7 +130,7 @@ class JavaGenerator
     
     if (lastElement == null)
     {
-      System.err.println("No classes were compiled. It is likely there was no compilable code in the source .ump file(s) including "+getModel().getUmpleFile());
+      System.err.println("No classes were compiled. It is likely there was no compilable code in the source .ump file(s) including "+getModel().getUmpleFile().getFileName());
     }
     
     if(mainClasses.size()>0)

--- a/cruise.umple/src/generators/Generator_CodeJava.ump
+++ b/cruise.umple/src/generators/Generator_CodeJava.ump
@@ -130,7 +130,7 @@ class JavaGenerator
     
     if (lastElement == null)
     {
-      System.err.println("No classes were compiled. It is likely the source .ump file(s) contained no compilable code.");
+      System.err.println("No classes were compiled. It is likely there was no compilable code in the source .ump file(s) including "+getModel().getUmpleFile());
     }
     
     if(mainClasses.size()>0)

--- a/umpleonline/umplibrary/Messenger.ump
+++ b/umpleonline/umplibrary/Messenger.ump
@@ -22,9 +22,11 @@ class Messenger {
     }
     
     Delivered {
-      read -> read;
+      read -> Read;
     }
     Deleted { } 
+    Read { } 
+    Discarded { } 
   }
   Boolean internalContact = false;
   Boolean externalContact = false;

--- a/umpleonline/umplibrary/manualexamples/SimpleConstraints1.ump
+++ b/umpleonline/umplibrary/manualexamples/SimpleConstraints1.ump
@@ -3,9 +3,9 @@
 // The test code demonstrates that this works
 // as expected.
 class Client {
-  const Integer minAge =18;
+  const Integer MinAge =18;
   Integer age;
-  [age >= minAge]
+  [age >= MinAge]
   [age <= 120]
   
   public static void main(String [ ] args) {

--- a/umpleonline/umplibrary/manualexamples/W046AttributeHasTemplateType1.ump
+++ b/umpleonline/umplibrary/manualexamples/W046AttributeHasTemplateType1.ump
@@ -2,6 +2,6 @@
 
 class A {
   depend java.util.List;
-  List<OtherClass> otherClassGroup;
+  List<OtherClassA> otherClassGroup;
 }
-class OtherClass {}
+class OtherClassA {}

--- a/umpleonline/umplibrary/manualexamples/W046AttributeHasTemplateType2.ump
+++ b/umpleonline/umplibrary/manualexamples/W046AttributeHasTemplateType2.ump
@@ -1,8 +1,8 @@
 // The following shows how to avoid
 // the message using a multivalued attribute
-class A {
-  OtherClass[] otherClassGroup;
+class B {
+  OtherClassB[] otherClassGroup;
 }
-class OtherClass {}
+class OtherClassB {}
 //$?[End_of_model]$?
 // @@@skipphpcompile - Skipped due to issue 700

--- a/umpleonline/umplibrary/manualexamples/W046AttributeHasTemplateType3.ump
+++ b/umpleonline/umplibrary/manualexamples/W046AttributeHasTemplateType3.ump
@@ -1,6 +1,6 @@
 // The following shows how to avoid
 // the message using an association
-class A {
-  0..1 -- * OtherClass;
+class C {
+  0..1 -- * OtherClassC;
 }
-class OtherClass {}
+class OtherClassC {}


### PR DESCRIPTION
Progress towards quelling some of the excess warnings that can appear in certain builds. In particular, before this, if there was a space in the pathname, there were a lot of repetitive messages mentioning this.

Also fixed warnings from a few examples. More warnings still need to be quelled in a later PR.