### PR TITLE
Adding -u option to command line to allow a program to be specified directly without a file

### DIFF
--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -611,7 +611,13 @@ class ParserDataPackage
     }
     catch(NullPointerException n)
     {
-      this.getParseResult().addErrorMessage(new ErrorMessage(1510,usePosition==null?new Position(filename,1,0,0):usePosition,filename));
+      // Special case when we don't want to read a file
+      if(filename.equals("dummy__.ump")) {
+        input="";
+      }
+      else {
+        this.getParseResult().addErrorMessage(new ErrorMessage(1510,usePosition==null?new Position(filename,1,0,0):usePosition,filename));
+      }
     }
     catch(IOException e)
     {
@@ -662,7 +668,13 @@ class ParserDataPackage
       {
         this.setParseResult(new ParseResult(false));
       }
-      this.getParseResult().addErrorMessage(new ErrorMessage(1510,usePosition==null?new Position(filename,1,0,0):usePosition,filename));
+      // Special case when we don't want to read a file
+      if(filename.equals("dummy__.ump")) {
+        input="";
+      }
+      else {
+        this.getParseResult().addErrorMessage(new ErrorMessage(1510,usePosition==null?new Position(filename,1,0,0):usePosition,filename));
+      }
     }
     couples = new HashMap<String,ParsingCouple>();    
     BalancedRule.initialize(input,this);

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -31,6 +31,7 @@ class UmpleConsoleConfig {
   defaulted boolean exitOnFirstFailure = false; // option e to exit on first failure with the -f option 
 
   internal Optional<String> generate   = Optional.empty(); // option g to specify what to generate
+  internal Optional<String> umpleDirect   = Optional.empty(); // option u to specify umple code directly
   defaulted boolean override           = false;
   defaulted boolean removePrevious     = false;  
   internal Optional<String> path       = Optional.empty(); // place to put output, otherwise in current directory
@@ -55,6 +56,7 @@ class UmpleConsoleConfig {
     this.beQuiet    = optSet.has("quiet");    
     this.importFile = Optional.ofNullable((String)optSet.valueOf("import"));
     this.generate   = Optional.ofNullable((String)optSet.valueOf("generate"));
+    this.umpleDirect   = Optional.ofNullable((String)optSet.valueOf("umple"));    
     this.override   = optSet.has("override");
     this.removePrevious = optSet.has("removeprevious");
     this.path       = Optional.ofNullable((String)optSet.valueOf("path"));
@@ -106,6 +108,10 @@ class UmpleConsoleConfig {
 
   public void setGenerate(String generate) {
     this.generate = Optional.of(generate);
+  }
+
+  public Optional<String> getUmpleDirect() {
+    return this.umpleDirect;
   }
 
   public Optional<String> getCompile() {
@@ -201,22 +207,25 @@ class UmpleConsoleMain
       return 0;
     }
 
+    String filename = "dummy__.ump"; // used when we may not want to read any file
     if (cfg.getUmpleFile() == null || "".equals(cfg.getUmpleFile()))
     {
-      if(!cfg.getTestUmpFilesFile().isPresent()) {
-        System.out.println("Please specify <umple_file> to process");
+      // We have no filename
+      if(!cfg.getTestUmpFilesFile().isPresent() && !cfg.getUmpleDirect().isPresent()) {
+        System.out.println("Please specify an umple_file to process or use the -f or -u options");
         printUsage();
         return 1;
       }
-      else {
+      else if (!cfg.getUmpleDirect().isPresent()) {
         // Will use -f option for files to process
         return 0;
       }
     }
-
-    final String filename = cfg.getUmpleFile();
-    if(!cfg.getBeQuiet()) {
-      System.out.println("Processing -> " + filename);
+    else {
+      filename = cfg.getUmpleFile();
+      if(!cfg.getBeQuiet()) {
+        System.out.println("Processing -> " + filename);
+      }
     }
 
     final UmpleFile umpleFile = new UmpleFile(filename);
@@ -228,6 +237,12 @@ class UmpleConsoleMain
     //this loop is used to add mixset names as liked umple files.
     cfg.getLinkedMixsetAsString().stream()
         .forEach(umpleFile::addLinkedFiles);
+    
+    // This adds any special extra statement as a linked file (not really a file but ...)
+    if (cfg.getUmpleDirect().isPresent()) {
+      umpleFile.addLinkedFiles("__UMPLE"+
+        Base64.getEncoder().encodeToString(cfg.getUmpleDirect().orElse(null).getBytes()));
+    }
        
     final UmpleModel model = new UmpleModel(umpleFile);
 
@@ -499,7 +514,10 @@ class UmpleConsoleMain
     optparser.acceptsAll(Arrays.asList("version", "v"), "Print out the current Umple version number");
     optparser.acceptsAll(Arrays.asList("performance", "p"), "Indicate time taken to parse and generate code");
     optparser.acceptsAll(Arrays.asList("help"), "Display the help message");
+
     optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: " + languages).withRequiredArg().ofType(String.class);
+    optparser.acceptsAll(Arrays.asList("u", "umple"), "Include umple code directly as a single string, instead of or addition to in files.").withRequiredArg().ofType(String.class);
+    
     optparser.acceptsAll(Arrays.asList("override"), "If a output language <lang> is specified using option -g, output will only generate language <lang>");
     optparser.acceptsAll(Arrays.asList("removeprevious", "r"), "used with -g; remove previously generated code before generating new. Can help prevent leftover code causing errors. Does not work with generators specified inside a file.");
     optparser.acceptsAll(Arrays.asList("path"), "If a output language is specified using option -g, output source code will be placed to path").withRequiredArg().ofType(String.class);

--- a/cruise.umple/src/UmpleInternalParser_CodeParserHandlers.ump
+++ b/cruise.umple/src/UmpleInternalParser_CodeParserHandlers.ump
@@ -79,13 +79,24 @@ class UseStatementParserAction{
  */
 class UmpleLinkedFileHandler{ 
   depend java.io.File;
+  depend java.util.Base64;
+  depend java.util.Base64.Decoder;
   depend cruise.umple.parser.analysis.LinkedFileHandler;
   
   isA LinkedFileHandler;
 
   public String onFileLink( String input, File[] linkedFiles ){
     for( File file : linkedFiles ){
-      input += "\nuse " + file.getPath() + ";";
+      String theFileName = file.getPath();
+      if(theFileName.startsWith("__UMPLE")) {
+        byte[] decodedBytes = Base64.getDecoder().decode(theFileName.substring(7));
+        // This is a direct Umple statement
+        input += "\n"+(new String(decodedBytes));
+      }
+      else {
+        // It is something that should be a use statement (file or mixset)
+        input += "\nuse " + file.getPath() + ";";
+      }
     }
     return input;
   }

--- a/dev-tools/umple
+++ b/dev-tools/umple
@@ -1,7 +1,9 @@
-#!/bin/csh -f
-if ! $?UMPLEROOT then
-  setenv UMPLEROOT ~/umple
-endif
-echo Compiling using $UMPLEROOT/dist/umple.jar
-java -jar $UMPLEROOT/dist/umple.jar $*
-exit $status
+#!/bin/bash
+if [ -z ${UMPLEROOT+x} ]
+then
+  export UMPLEROOT=~/umple
+fi
+JAR=$UMPLEROOT/dist/umple.jar
+echo Compiling using $JAR
+java -jar $JAR "$@"
+exit $?


### PR DESCRIPTION
This allows a complete (presumably small) umple program to be specified on the command line following the -u option.

Use cases:
  - Quick testing, as needed for the homebrew formula (so the -u option would be the only option)
  - Adding an extra statement or two to a program compiled from files, such as to suppress warnings. This use case will be further used later to suppress or expect warning messages in the user manual tests that are demonstrating warnings'