### PR TITLE
Cleaning warnings in examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1041,7 +1041,7 @@ def runUserManualAndExampleTests(language, languageOpt, excludes) {
       target.append(name+"\n")
     }
    
-    def cmd = "java -jar  ${rootProject.ext.umpleCurrentJar} -g ${languageOpt} --path src-gen-umple -q -c - -f  dist/gradle/test/workingDir/temp/${language}/allExamplesList.txt"
+    def cmd = "java -jar  ${rootProject.ext.umpleCurrentJar} -g ${languageOpt} --path src-gen-umple -w -q -c - -f  dist/gradle/test/workingDir/temp/${language}/allExamplesList.txt"
     def proc = cmd.execute();
     proc.waitForProcessOutput(System.out, System.err);
     if (proc.exitValue()!=0){

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -107,6 +107,7 @@
             <arg value="--path" />
             <arg value="src-gen-umple" />
             <!--arg value="-r" --> <!-- Uncomment to remove prev generated java+class files before each compile -->
+            <arg value="-w" /> <!-- Suppress expected warnings for files starting W -->
             <arg value="-q" /> <!-- Comment out for more verbose trace -->
             <arg value="-c" /> <!-- Do the Java compilation of whatever is produced by Umple -->
             <arg value="-" />
@@ -178,6 +179,7 @@
             <arg value="--path" />
             <arg value="src-gen-umple" />
             <!--arg value="-r" --> <!-- Uncomment to remove prev generated java+class files before each compile -->
+            <arg value="-w" /> <!-- Suppress expected warnings for files starting W -->
             <arg value="-q" /> <!-- Comment out for more verbose trace -->
             <arg value="-c" /> <!-- Do the Java compilation of whatever is produced by Umple -->
             <arg value="-" />

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -21,12 +21,14 @@ class UmpleConsoleConfig {
   depend java.io.*;
   depend java.nio.file.Files;
   depend java.nio.file.Paths;
+  depend java.util.regex.*;
 
   // See function initializeOptionParser() for the setup of the options
   defaulted boolean version = false; // option to print version only
   defaulted boolean help = false; // option to output help only
   defaulted boolean performance = false; // option to measure performance
   defaulted boolean beQuiet = false; // option q to be quiet
+  defaulted boolean warningIgnore = false; // option w to ignore a warning number in filename
   defaulted boolean useExec = false; // option x to use slower but more reliable exec java compiler
   defaulted boolean exitOnFirstFailure = false; // option e to exit on first failure with the -f option 
 
@@ -54,6 +56,7 @@ class UmpleConsoleConfig {
     this.useExec    = optSet.has("x");
     this.exitOnFirstFailure = optSet.has("e");
     this.beQuiet    = optSet.has("quiet");    
+    this.warningIgnore    = optSet.has("warningignore");    
     this.importFile = Optional.ofNullable((String)optSet.valueOf("import"));
     this.generate   = Optional.ofNullable((String)optSet.valueOf("generate"));
     this.umpleDirect   = Optional.ofNullable((String)optSet.valueOf("umple"));    
@@ -81,7 +84,34 @@ class UmpleConsoleConfig {
         List<String> allLines = Files.readAllLines(Paths.get(fileOfFiles));
         allLinesOfFilesToTest = new ArrayList<String[]>();
         for(String aLine: allLines) {
-          allLinesOfFilesToTest.add(aLine.split(" "));
+          // Split the line based on spaces, but converting those in quotes into code
+          List<String> listOfFilesThisLine = new ArrayList<String>();
+          Matcher m = Pattern.compile("([^\']\\S*|\'.+?\')\\s*").matcher(aLine);
+          while (m.find()) {
+            String foundString = m.group(1);
+            // foundString is either a file or (if second and subsequent) a single quoted string
+
+            if(foundString.startsWith("\'")) {
+              // We have a program -- convert
+              foundString="__UMPLE"+
+                Base64.getEncoder()
+                .encodeToString(foundString.substring(1,foundString.length()-1).getBytes());
+            }
+            else if(foundString.startsWith("W") && warningIgnore) {
+              // Potential to ignore the warning
+              Matcher m2 = Pattern.compile("\\d+").matcher(foundString);
+              if(m2.find()) {
+                String supressWarningCode="strictness ignore "+m2.group()+";";
+                listOfFilesThisLine.add(foundString);
+                foundString="__UMPLE"+
+                  Base64.getEncoder().encodeToString(supressWarningCode.getBytes());
+              }
+            }
+            listOfFilesThisLine.add(foundString);
+          }
+          //allLinesOfFilesToTest.add(aLine.split(" "));
+          allLinesOfFilesToTest
+            .add(listOfFilesThisLine.toArray(new String[listOfFilesThisLine.size()]));
         }
       }
       catch  (IOException e) {
@@ -525,6 +555,7 @@ class UmpleConsoleMain
     optparser.acceptsAll(Arrays.asList("f","file"), "Read in a file containing sets of umple-files to process, one set per line. Each is an independent compilation. Intended for testing.").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("e","exitonfirstfailure"), "Used with -f. Exit with nonzero on first failure of a compile specified in the file passed to -f. Otherwise exits after completing all compilations with nonzero if any failed.");    
     optparser.acceptsAll(Arrays.asList("q","quiet"), "Be quiet. Only output compilation information in case of failure");
+    optparser.acceptsAll(Arrays.asList("w","warningignore"), "Ignore a warning whose number is embedded in the file name if the file name starts with W. Used for testing.");
     optparser.acceptsAll(Arrays.asList("x","useexec"), "Use an external exec call to invoke the Java compiler when using the -c option. May be needed on some platforms or with certain examples.");    
     optparser.acceptsAll(Arrays.asList("import","i"), "Indicate to read in XMI model and generate ump files").withRequiredArg().ofType(String. class);
     optparser.acceptsAll(Arrays.asList("suboption","s"), "Indicate to generate files with suboptions "+suboptionsAvail).withRequiredArg().ofType(String.class);

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -394,8 +394,9 @@ class UmpleInternalParser
     {
       postTokenTestSequeceAnalysis();
     }
-    
-    
+    // We have to look at the error messages again to see if
+    // any need to be removed
+    analyzeParseResult();
   }
 
   // Locate all 'use *.ump' references and add those files if not already parsed

--- a/umpleonline/umplibrary/Ball_Game.ump
+++ b/umpleonline/umplibrary/Ball_Game.ump
@@ -29,10 +29,10 @@ class Ball_Game {
     
     Moving {
       do {moving();}
-      (ballPossition==wallPosition) -> HitsWall;
-      (ballPosition==paddlePosition) -> HitsPaddle;
-      (ballPosition==brickPosition) -> HitsBrick;
-      ballOut -> behindPaddle;
+      [ballPossition==wallPosition] -> HitsWall;
+      [ballPosition==paddlePosition] -> HitsPaddle;
+      [ballPosition==brickPosition] -> HitsBrick;
+      ballOut -> BehindPaddle;
     }
    
     HitsBrick  {
@@ -59,4 +59,4 @@ class Ball_Game {
   }
 }
 //$?[End_of_model]$?
-// @@@skipcompile - example needs polishing it has missing methods and unreachable states
+// @@@skipcompile - example has missing methods

--- a/umpleonline/umplibrary/BankSystem.ump
+++ b/umpleonline/umplibrary/BankSystem.ump
@@ -1,7 +1,5 @@
 // Sample UML class diagram for a banking system, written in Umple
 
-namespace BankingSystem;
-
 //Namespace for core of the system.
 namespace BankingSystem.core.humanResources;
 class PersonRole{}

--- a/umpleonline/umplibrary/BcmsBaseConfiguration.ump
+++ b/umpleonline/umplibrary/BcmsBaseConfiguration.ump
@@ -11,9 +11,10 @@
  * This file requires the referenced
  * files to be present in the same directory.
  */
+namespace bcms;
+
 use RoutesAndLocations.ump;
 
-namespace bcms;
 use CoordinationStateMachine.ump;
 use BcmsCore.ump;
 

--- a/umpleonline/umplibrary/HtmlGeneration.ump
+++ b/umpleonline/umplibrary/HtmlGeneration.ump
@@ -3,6 +3,8 @@
 // This will be extended to support more of html later
 // It serves as an illustration of Umple's generation templates
 
+strictness allow 75; // We are going to allow custom constructors
+
 // Class representing either a top level html node or a collection of subnodes
 class HtmlNode {
   String getContent() {return "";};  // should be abstract

--- a/umpleonline/umplibrary/School.ump
+++ b/umpleonline/umplibrary/School.ump
@@ -18,12 +18,14 @@ class Person {
 }
 //$?[End_of_model]$?
 //Positioning
+namespace education;
 class School
 {
   position 144 243 149 96;
   position.association Person:student__School 70,0 72,79;
 }
 
+namespace human;
 class Person
 {
   position 143 66 146 79;

--- a/umpleonline/umplibrary/manualexamples/AttributeDefinition1.ump
+++ b/umpleonline/umplibrary/manualexamples/AttributeDefinition1.ump
@@ -12,7 +12,7 @@ class Group
   Integer i;
 
   // const: Declares a constant (static final in Java).
-  const Integer max = 100;
+  const Integer Max = 100;
 
   // immutable: A constructor argument is required so
   // it can be set at construction time; cannot be

--- a/umpleonline/umplibrary/manualexamples/BasicStateMachines2.ump
+++ b/umpleonline/umplibrary/manualexamples/BasicStateMachines2.ump
@@ -2,7 +2,7 @@
 // a garage door corresponding to the diagram
 // above
 class Garage {
-  lazy Boolean entranceClear=true;
+  Boolean entranceClear=true;
   GarageDoor { 
     Closed {
       entry/{stopMotor();}  

--- a/umpleonline/umplibrary/manualexamples/ImmutablePattern2.ump
+++ b/umpleonline/umplibrary/manualexamples/ImmutablePattern2.ump
@@ -12,3 +12,5 @@ class Point2D
   Float x;
   Float y;
 }
+
+strictness allow 36; // We are OK with this warning

--- a/umpleonline/umplibrary/manualexamples/IndependentlyDefinedAssociations1.ump
+++ b/umpleonline/umplibrary/manualexamples/IndependentlyDefinedAssociations1.ump
@@ -27,3 +27,5 @@ class Description
 {
   position 51 229 109 45;
 }
+
+strictness allow 36;

--- a/umpleonline/umplibrary/manualexamples/InlineAssociations1.ump
+++ b/umpleonline/umplibrary/manualexamples/InlineAssociations1.ump
@@ -34,3 +34,5 @@ class Description
 {
   position 50 230 109 45;
 }
+
+strictness allow 36;


### PR DESCRIPTION
This branch reduces warnings during testing

To facilitate this, a new capability was added to allow umple code in quotes to be on any of the lines of the -f file in the main jar. Also a -w option was added to suppress warnings by injecting strictness statements.