### PR TITLE
Ensuring Graphviz gen works with -c and --path options

### DIFF
--- a/cruise.umple/src/Compiler.ump
+++ b/cruise.umple/src/Compiler.ump
@@ -111,6 +111,71 @@ class CodeCompiler {
     return (retval == 0);
   }
   
+  // Compiles graphviz files to various outputs: .svg (default), using dot
+  public static boolean genDotDiagram (UmpleModel model,
+    GenerateTarget gt, boolean beQuiet, String graphicFormat) {
+
+    String generator = gt.getLanguage();
+    
+    String fileroot = model.getUmpleFile().getFileName();
+    if (fileroot.endsWith(".ump")) {
+      fileroot = fileroot.substring(0, fileroot.length() - 4);
+    }
+
+    if(generator.equals("GvClassDiagram")) {
+      fileroot+="cd";
+    }
+
+    String path=model.getUmpleFile().getPath() + File.separator + gt.getPath();
+    
+    String inputFullPath=path + File.separator + fileroot + ".gv";
+    String outputFullPath=path + File.separator + fileroot + "."+ graphicFormat;
+
+    int retval=0;
+
+    try {
+      if(path.contains(" ") && !beQuiet) {
+        System.err.println("Warning: Compiling generated Graphviz files from a directory or path containing a space character may produce an error message from the PhP compiler.");
+      }
+      
+      BufferedReader reader;
+      
+      Process p = Runtime.getRuntime().exec("dot -T"+graphicFormat+" "+inputFullPath+" -o "+outputFullPath);
+      reader=new BufferedReader(new InputStreamReader(p.getInputStream())); 
+
+      // All output of the above should go to standard output
+      try {
+        retval=p.waitFor(); 
+      }
+      catch (InterruptedException e) {}
+
+      String line;
+      if(reader.ready()) {
+        line = reader.readLine();
+      }
+      else {
+        line = null;
+      }
+
+      while (line!=null) {
+        if(reader.ready()) {
+          line = reader.readLine();
+        }
+        else {
+          line = null;
+        }
+      }
+    } catch (IOException e) {
+      println(e.getMessage());
+      if(e.getMessage().startsWith("Cannot run program")) {
+        println("It is necessary to install the graphviz package that includes the dot program in order to convert .gv files directly to graphical output files");
+      }
+      retval = 999;
+    }
+    return (retval == 0);
+  }
+
+  
   private static boolean compileJava(UmpleElement aClass, UmpleModel model, boolean useExec, boolean beQuiet, String args) {
     String path="";
     String base="";

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -329,6 +329,9 @@ class UmpleConsoleMain
             if (generatorCodeToCompile.equals("Java") || generatorCodeToCompile.equals("Php")) {
               compileSuccess = CodeCompiler.compile(model, generatorCodeToCompile,cfg.getUseExec(), cfg.getBeQuiet(), cfg.getCompile().get());
             }
+            else if (generatorCodeToCompile.startsWith("Gv")) {
+              compileSuccess = CodeCompiler.genDotDiagram(model, gt, cfg.getBeQuiet(), "svg");
+            }
           }
         }
       }
@@ -558,7 +561,7 @@ class UmpleConsoleMain
     optparser.acceptsAll(Arrays.asList("override"), "If a output language <lang> is specified using option -g, output will only generate language <lang>");
     optparser.acceptsAll(Arrays.asList("removeprevious", "r"), "used with -g; remove previously generated code before generating new. Can help prevent leftover code causing errors. Does not work with generators specified inside a file.");
     optparser.acceptsAll(Arrays.asList("path"), "If a output language is specified using option -g, output source code will be placed to path").withRequiredArg().ofType(String.class);
-    optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles").withRequiredArg().ofType(String.class);
+    optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles; compiles Java to .class, lints Php, converts Graphviz to .svg").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("f","file"), "Read in a file containing sets of umple-files to process, one set per line. Each is an independent compilation. Intended for testing.").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("e","exitonfirstfailure"), "Used with -f. Exit with nonzero on first failure of a compile specified in the file passed to -f. Otherwise exits after completing all compilations with nonzero if any failed.");    
     optparser.acceptsAll(Arrays.asList("q","quiet"), "Be quiet. Only output compilation information in case of failure");

--- a/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
+++ b/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
@@ -115,7 +115,9 @@ digraph "<<=filename>>" {
   {
     try
     {
-      String path = model.getUmpleFile().getPath();
+      String path = StringFormatter.addPathOrAbsolute(
+        getModel().getUmpleFile().getPath(), 
+        getOutput());
       File file = new File(path);
       file.mkdirs();
       String modelFilename = path + File.separator + model.getUmpleFile().getSimpleFileName()

--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -705,7 +705,9 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
   {
     try
     {
-      String path = model.getUmpleFile().getPath();
+      String path = StringFormatter.addPathOrAbsolute(
+        getModel().getUmpleFile().getPath(), 
+        getOutput());
       File file = new File(path);
       file.mkdirs();
       String modelFilename = path + File.separator + model.getUmpleFile().getSimpleFileName() + ".gv";


### PR DESCRIPTION
Generation of graphviz (class diagrams, state diagrams, etc) will now put output where the --path option on the command line tells it to (this fixes an inconsistency, since other generators do respect --path)

Also, generation of graphviz now also respects the -c - option, meaning that svg files can be created directly from the command line if graphviz is installed. If combined with the -u option, this means that a single command can now create an svg of a diagram directly without even creating an umple file first.