### PR TITLE
Improving Travis/Appveyor/Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,41 +75,42 @@ script:
   - if [ -z "$USE_GRADLE" ]; then $ANT_BUILD packageDocs travisCopyManual; fi
  
   # Set up UmpleOnline to be packaged into its Docker image, then build the image.
-  - if [ "$HAVE_DOCKER" ]; then
-        $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline &&
-        docker build -t "umple/umpleonline-base:local"
-                     -f ../umpleonline/Dockerfile-base ../umpleonline &&
-        docker build -t "umple/umpleonline:recentbuild" 
-                     --build-arg gitbranch=$TRAVIS_BRANCH ../umpleonline;
-    fi
+#  - if [ "$HAVE_DOCKER" ]; then
+#        $ANT_BUILD -DshouldPackageUmpleOnline=true packageUmpleonline &&
+#        docker build -t "umple/umpleonline-base:local"
+#                     -f ../umpleonline/Dockerfile-base ../umpleonline &&
+#        docker build -t "umple/umpleonline:recentbuild" 
+#                     --build-arg gitbranch=$TRAVIS_BRANCH ../umpleonline;
+#    fi
 
-after_success:
-    if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
-        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
-        DOCKER_IMAGE_NAME="umple/umpleonline:recentbuild" &&
-        DOCKER_HASH_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
-        docker push "$DOCKER_IMAGE_NAME" &&
-        if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
-            docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
-        elif [ "$TRAVIS_BRANCH" = 'master' ]; then
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
-            docker push "umple/umpleonline:latest" &&
-            docker tag "$DOCKER_IMAGE_NAME" "$DOCKER_HASH_NAME" &&
-            docker push "$DOCKER_HASH_NAME";
-        elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
-            echo 'The branch name is "latest", not pushing branch tag';
-        elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
-            echo 'The branch name looks like a pull request tag, not pushing branch tag';
-        else
-            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH" &&
-            docker push "umple/umpleonline:$TRAVIS_BRANCH";
-        fi &&
-        if [ "$TRAVIS_TAG" ]; then
-            docker tag "umple/umpleonline-base:local" "umple/umpleonline-base:latest" &&
-            docker push "umple/umpleonline-base:latest";
-        fi
-    fi
+# Commenting out docker since will use bdock tool and manual pushing
+#after_success:
+#    if ( [ "$HAVE_DOCKER" ] && [ "$TRAVIS_SECURE_ENV_VARS" ] ); then
+#        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" &&
+#        DOCKER_IMAGE_NAME="umple/umpleonline:recentbuild" &&
+#        DOCKER_HASH_NAME="umple/umpleonline:$TRAVIS_COMMIT" &&
+#        docker push "$DOCKER_IMAGE_NAME" &&
+#        if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
+#            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST" &&
+#            docker push "umple/umpleonline:pr-$TRAVIS_PULL_REQUEST";
+#        elif [ "$TRAVIS_BRANCH" = 'master' ]; then
+#            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:latest" &&
+#            docker push "umple/umpleonline:latest" &&
+#            docker tag "$DOCKER_IMAGE_NAME" "$DOCKER_HASH_NAME" &&
+#            docker push "$DOCKER_HASH_NAME";
+#        elif [ "$TRAVIS_BRANCH" = 'latest' ]; then
+#            echo 'The branch name is "latest", not pushing branch tag';
+#        elif ( echo "$TRAVIS_BRANCH" | grep -Eq '^pr\-[0-9]*$' ); then
+#            echo 'The branch name looks like a pull request tag, not pushing branch tag';
+#        else
+#            docker tag "$DOCKER_IMAGE_NAME" "umple/umpleonline:$TRAVIS_BRANCH" &&
+#            docker push "umple/umpleonline:$TRAVIS_BRANCH";
+#        fi &&
+#        if [ "$TRAVIS_TAG" ]; then
+#            docker tag "umple/umpleonline-base:local" "umple/umpleonline-base:latest" &&
+#            docker push "umple/umpleonline-base:latest";
+#        fi
+#    fi
 
 matrix:
   include:
@@ -121,12 +122,12 @@ matrix:
             - ant
             - ant-optional
       # only Linux supports Docker right now
-      env:
-        - HAVE_DOCKER=1
-      services:
-        - docker
-    - os: osx
-      osx_image: xcode12.2
+#      env:
+#        - HAVE_DOCKER=1
+#      services:
+#        - docker
+#    - os: osx
+#      osx_image: xcode12.2
 
     # test gradle builds - commented out for now
 #    - os: linux

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -100,6 +100,8 @@
     <replace file="${java.path}/allExamplesList.txt" token=";" value="&#10;"/>
     <echo>Umple examples to be tested and Java tested are in "${java.path}/allExamplesList.txt"</echo>
 
+    <copy file="${java.path}/allExamplesList.txt" todir="${dist.dir}/qa"/>
+
     <!-- Compile in umple to Java and generate the Java -->
       <trycatch>
         <try>
@@ -173,6 +175,8 @@
 
     <replace file="${php.path}/allExamplesListPhp.txt" token=";" value="&#10;"/>
     <echo>Umple examples to be tested and Php Compiled are in "${php.path}/allExamplesListPhp.txt"</echo>
+
+    <copy file="${php.path}/allExamplesListPhp.txt" todir="${dist.dir}/qa"/>
 
     <!-- Compile in umple to Php and generate the Java -->
       <trycatch>

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -92,8 +92,10 @@
       <!-- The following is temporarily excluded because of an odd Java error only on the server not Mac -->
       <exclude name="W010SingletonMultiplicityOver12.ump"/>
     </fileset>  
+
+    <pathconvert pathsep=";" property="javaumpfiles2" refid="javaumpfiles"/>
     
-    <echo file="${java.path}/allExamplesList.txt">${toString:javaumpfiles}</echo>
+    <echo file="${java.path}/allExamplesList.txt">${javaumpfiles2}</echo>
 
     <replace file="${java.path}/allExamplesList.txt" token=";" value="&#10;"/>
     <echo>Umple examples to be tested and Java tested are in "${java.path}/allExamplesList.txt"</echo>
@@ -164,8 +166,10 @@
       <!-- The following is temporarily excluded because of an odd Java error only on the server not Mac -->
       <exclude name="W010SingletonMultiplicityOver12.ump"/>
     </fileset>  
+
+    <pathconvert pathsep=";" property="phpumpfiles2" refid="phpumpfiles"/>
     
-    <echo file="${php.path}/allExamplesListPhp.txt">${toString:phpumpfiles}</echo>
+    <echo file="${php.path}/allExamplesListPhp.txt">${phpumpfiles2}</echo>
 
     <replace file="${php.path}/allExamplesListPhp.txt" token=";" value="&#10;"/>
     <echo>Umple examples to be tested and Php Compiled are in "${php.path}/allExamplesListPhp.txt"</echo>

--- a/dev-tools/bdock
+++ b/dev-tools/bdock
@@ -1,0 +1,32 @@
+#~/bin/csh -fb
+set thedir=$cwd
+set thebranch=docker-`git rev-parse --abbrev-ref HEAD`-`awk '{print $3}' build/umpleversion.last.txt`
+set backedvisits=`cat umpleonline/countlog.txt`
+set backedcommands=`cat umpleonline/scripts/commandcount.txt`
+echo will build Umple docker image for system in $thedir
+echo make sure you have built umple and the manual and promoted umple first
+if (! -d umpleonline) then
+  echo This script is not being started in an umple root directory
+  exit -1
+endif
+echo 0 > umpleonline/countlog.txt
+echo 0 > umpleonline/scripts/commandcount.txt
+cd umpleonline
+# create a temporary copy of the manual
+cp -pr ../dist/cruise.umple/reference manual
+docker build -t "umple/umpleonline:recentbuild" --build-arg gitbranch=$thebranch ../umpleonline;
+rm -r manual
+cd ..
+echo $backedvisits > umpleonline/countlog.txt
+echo $backedcommands > umpleonline/scripts/commandcount.txt
+echo if the above completed successfully then run the image with the following
+echo docker run --rm -ti -p 8000:8000 -v /tmp/umpleonline-tmp81701:/var/www/ump docker.io/umple/umpleonline:recentbuild
+echo then open http://localhost:8000/umple.php
+echo
+echo When good do the following to push to docker hub
+echo docker images
+echo docker tag XXXXXXXXXXXX umple/umpleonline:latest
+echo docker push umple/umpleonline:latest
+echo docker tag XXXXXXXXXXXX umple/umpleonline:v1.XX.X
+echo docker push umple/umpleonline:v1.XX.X
+


### PR DESCRIPTION
Fixes various build aspects:

1. Removes Docker and Mac-OS from Travis (travis is currently inactive, but if we reactivate, we want to use less CPU)

2. Adding a bdock script to allow building Docker image of any branch, that can then be used locally or pushed to Dockerhub

3. Attempting to fix Appveyor so it will run the newUserManualAndExampleTests