### PR TITLE
Traits library capability

### DIFF
--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -593,7 +593,11 @@ class ParserDataPackage
       }
       else
       {
-        resourceStream = getClass().getResourceAsStream(file);
+        String resourceToLoad=file;
+        if(file.contains("lib:")) {
+          resourceToLoad = "/"+file.substring(file.indexOf("lib:")+4);
+        }
+        resourceStream = getClass().getResourceAsStream(resourceToLoad);
         reader = new BufferedReader(new InputStreamReader(resourceStream));
       }
       String line = reader.readLine();

--- a/build.gradle
+++ b/build.gradle
@@ -381,7 +381,24 @@ task copyDocs(type: Copy) {
     
     }
 }
+task copyReusableUmpLib(type: Copy) {
+    group = "Custom"
+    description = "Copying library files that need to be included in the umple jar"
+    from "umpleonline/umplibrary/reusable"
+    into rootProject.ext.classfileOutputDir
+    include '**/*.ump'
+   
+    doFirst {
+        println("Copying library .ump files from cruise.umple/src to ${rootProject.ext.classfileOutputDir}")
+        if (inputs.sourceFiles.isEmpty()){
+            throw new StopExecutionException(); 
+           } 
+    
+    }
+}
+
 tasks.getByName("compileJava").dependsOn 'copyDocs'
+tasks.getByName("compileJava").dependsOn 'copyReusableUmpLib'
 tasks.getByName("compileJava").dependsOn ':UmpleParser:copyUmpleOutput'
 tasks.getByName("compileJava").dependsOn ':UmpleToJava:copyUmpleOutput'
 tasks.getByName("compileJava").dependsOn ':UmpleToPhp:copyUmpleOutput'

--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -266,6 +266,7 @@
     <copy todir="${bin.path}" overwrite="true">
 	    <fileset dir="${project.path}/src"><include name="**/*.grammar"/></fileset>
 	    <fileset dir="${project.path}/src"><include name="**/*.error"/></fileset>
+	    <fileset dir="${basedir}/umpleonline/umplibrary/reusable"><include name="**/*.ump"/></fileset>
     </copy>
     <delete file="cruise.umple/src/rules.grammar"/>
     <delete file="cruise.umple/bin/rules.grammar"/>
@@ -512,7 +513,7 @@
 
     <jar destfile="${dist.dir}/${dist.umple.jar}"
          basedir="${bin.path}"
-         includes="cruise/umple/** en.error *.grammar *.error templates/** org/apache/** joptsimple/** **/*.grammar"
+         includes="cruise/umple/** en.error *.grammar *.error templates/** org/apache/** joptsimple/** **/*.grammar *.ump"
          excludes="**/*Test.class">
       <manifest>
         <attribute name="Built-By" value="Cruise - University of Ottawa"/>
@@ -537,7 +538,7 @@
 
     <jar  destfile="${dist.dir}/${dist.umple.sync.jar}" 
           basedir="${bin.path}" 
-          includes="cruise/umple/** en.error org/apache/tools/ant/** *.grammar *.error templates/** org/apache/** joptsimple/** **/*.grammar">
+          includes="cruise/umple/** en.error org/apache/tools/ant/** *.grammar *.error templates/** org/apache/** joptsimple/** **/*.grammar *.ump">
       <manifest>
         <attribute name="Built-By" value="Cruise - University of Ottawa"/>
         <attribute name="Version" value="${umple.version}"/>

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -261,7 +261,7 @@ class UmpleConsoleMain
     final UmpleFile umpleFile = new UmpleFile(filename);
     //this loop is used to add linked umple files and to show names of them.
     cfg.getLinkedFilesAsFile().stream()
-        .filter(File::exists)
+        .filter(f->f.getName().endsWith(".ump"))
         .map(File::getPath)
         .forEach(umpleFile::addLinkedFiles);
     //this loop is used to add mixset names as liked umple files.

--- a/umpleonline/umplibrary/AirlineByPattern.ump
+++ b/umpleonline/umplibrary/AirlineByPattern.ump
@@ -1,0 +1,37 @@
+/* Example of using builtin Umple pattern files
+*/
+
+use lib:AbstractionOccurrence.ump;
+use lib:TransportationPatternA.ump
+
+// ***********
+
+class AirlineRoute {
+  isA Route <Stop = Airport>;
+}
+
+class RegularFlight {
+  isA RegularlyScheduledRun <
+    Route = AirlineRoute,
+    ScheduledStop = AirportStop
+   >;
+}
+
+class AirportStop {
+  isA ScheduledStop <Stop = Airport>;
+}
+
+class Airport {
+  isA Stop;
+}
+
+class SpecificFlight {
+  isA ActualRun <
+    RegularlyScheduledRun = RegularFlight,
+    Vehicle = Airplane
+  >;
+}
+
+class Airplane {
+  isA Vehicle;
+}

--- a/umpleonline/umplibrary/BusSystemByPattern.ump
+++ b/umpleonline/umplibrary/BusSystemByPattern.ump
@@ -1,0 +1,39 @@
+/* Example of using builtin Umple pattern files
+to create a bus system
+*/
+
+use lib:AbstractionOccurrence.ump;
+use lib:TransportationPatternA.ump
+
+// ***********
+
+class BusRoute {
+  Integer routeNumber;
+  isA Route <Stop = BusStop>;
+}
+
+class RegularlyTimedBusRun {
+  isA RegularlyScheduledRun <
+    Route = BusRoute,
+    ScheduledStop = TimedStopAtBusStop
+   >;
+}
+
+class TimedStopAtBusStop {
+  isA ScheduledStop <Stop = BusStop>;
+}
+
+class BusStop {
+  isA Stop;
+}
+
+class BusRun {
+  isA ActualRun <
+    RegularlyScheduledRun = RegularlyTimedBusRun,
+    Vehicle = Bus
+  >;
+}
+
+class Bus {
+  isA Vehicle;
+}

--- a/umpleonline/umplibrary/reusable/AbstractionOccurrence.ump
+++ b/umpleonline/umplibrary/reusable/AbstractionOccurrence.ump
@@ -1,0 +1,15 @@
+// Generic pattern for abstractions and occurrences
+// In any Umple program say 'use lib:AbstractionOccurrence.ump;' to include this pattern.
+
+// Something that has many occurrences
+// Examples include a TV show that has episodes, where the show has a name you don't want to repeat in each episode
+// Or a route that has runs, or a published book in a library where there are many copies
+trait Abstraction {}
+
+// Something representing occurrences of an abstraction
+// where both the abstraction and the occurrences need their own instances
+// It is common for modellers to make mistakes and just have one class
+// Or to consider the Occurrences as instances of the abstractions, but these are antipatterns
+trait Occurrence <Abstraction> {
+ 1 -- * Abstraction;
+}

--- a/umpleonline/umplibrary/reusable/PlayerRole.ump
+++ b/umpleonline/umplibrary/reusable/PlayerRole.ump
@@ -1,0 +1,12 @@
+// Generic pattern for players and roles
+// In any Umple program say 'use lib:PlayerRole.ump;' to include this pattern.
+
+// A player is an object that can have many roles
+// A person can be an employee and a student
+trait Player {}
+
+// A captures some functionality that a player may have
+// either temporarily or in conjunction with other roles
+trait Role <Player> {
+ * -- 1 Player;
+}

--- a/umpleonline/umplibrary/reusable/TransportationPatternA.ump
+++ b/umpleonline/umplibrary/reusable/TransportationPatternA.ump
@@ -1,0 +1,42 @@
+// This is a library of traits that can be used to build the core of transportation systems
+
+// A route such as a flight or bus route
+trait Route <Stop> {
+ routeID; // generic ID for all runs on this route, e.g. bus route number the public sees
+ * -- * Stop;
+}
+
+// A run pattern at a particular time of day that
+// is repeated on multiple days
+trait RegularlyScheduledRun <Route, ScheduledStop> {
+ isA Abstraction;
+ runId; // e.g. a flight number / Bus systems tend to hide this from public
+ String plannedDaysOfWeek; // e.g. "135" for Mon, Wed, Fri
+ * -- 1 Route;
+ Boolean forwardDirection; // only relevent if routeID is same in both directions
+ 1 -- * ScheduledStop; // contains the times of the stops in order; not all runs may stop at all stops on route.
+}
+
+// A stop on a particular regular run
+trait ScheduledStop <Stop> {
+ * -- 1 Stop;
+ Time expectedArrivalTime; // null for departure only
+ Time expectedDepartureTime; // May be same as arrival time for busses. Null for arrival only
+}
+
+trait Stop {
+  stopName; // e.g. Airport, bus station etc.
+}
+
+// People can book on this for flights. It can be late or cancelled
+trait ActualRun <RegularlyScheduledRun, Vehicle>  {
+  isA Occurrence <Abstraction = RegularlyScheduledRun>;
+  Date runDate;
+  Boolean isCancelled;
+  * -- 1 Vehicle vehicleUsed;
+}
+
+// Specific plane, bus, etc.
+trait Vehicle {
+  vehicleID;
+}


### PR DESCRIPTION
This adds a 'reusable' directory under umplibrary to contain files that will be always available in use statements that are prefixed by lib:

These can contain useful traits, and some initial examples are given

While setting this up a bug was fixed: Previously missing files on the command line were silently ignored.