### PR TITLE
Fixing diagram and javadoc generation of compiler

### DIFF
--- a/dev-tools/dumple
+++ b/dev-tools/dumple
@@ -1,19 +1,48 @@
-#!/bin/csh -fb
-if ! $?UMPLEROOT then
-  setenv UMPLEROOT ~/umple
-endif
-echo Building Diagrams at $UMPLEROOT
+#!/bin/zsh -fb
+#shopt -s extglob
+if [ -z ${UMPLEROOT+x} ]
+then
+  export UMPLEROOT=~/umple
+fi
+echo Building Diagrams and javadoc at $UMPLEROOT
+echo On the main server check the user manual page under cruise-homedir/umple
 
 cd $UMPLEROOT/cruise.umple/src
 
-umple -g GvClassDiagram --override -c - --path $UMPLEROOT/dist/cruise.umple/reference DiagramMaster.ump
-mv $UMPLEROOT/dist/cruise.umple/reference/DiagramMastercd.svg $UMPLEROOT/dist/cruise.umple/reference/Mastercd.svg
-rm $UMPLEROOT/dist/cruise.umple/reference/DiagramMastercd.gv
+#umple -g GvClassDiagram --override -c - --path $UMPLEROOT/dist/cruise.umple/reference DiagramMaster.ump
+#mv $UMPLEROOT/dist/cruise.umple/reference/DiagramMastercd.svg $UMPLEROOT/dist/cruise.umple/reference/Mastercd.svg
+#rm $UMPLEROOT/dist/cruise.umple/reference/DiagramMastercd.gv
 
-umple -g GvClassDiagram --override -c - --path $UMPLEROOT/dist/cruise.umple/reference DiagramCoreMaster.ump
-rm $UMPLEROOT/dist/cruise.umple/reference/DiagramCoreMastercd.gv
+#umple -g GvClassDiagram --override -c - --path $UMPLEROOT/dist/cruise.umple/reference DiagramCoreMaster.ump
+#rm $UMPLEROOT/dist/cruise.umple/reference/DiagramCoreMastercd.gv
 
-umple -g GvClassDiagram --override -c - --path $UMPLEROOT/dist/cruise.umple/reference DiagramStateMaster.ump
-rm $UMPLEROOT/dist/cruise.umple/reference/DiagramStateMastercd.gv
+#umple -g GvClassDiagram --override -c - --path $UMPLEROOT/dist/cruise.umple/reference DiagramStateMaster.ump
+#rm $UMPLEROOT/dist/cruise.umple/reference/DiagramStateMastercd.gv
 
 echo To open user diagram master open $UMPLEROOT/dist/cruise.umple/reference/umple-compiler-classDiagram.shtml
+
+#Now build javadoc
+echo About to remake the javadoc
+unset GREP_OPTIONS
+ls $UMPLEROOT/cruise.umple/src-gen-umple/*/*/*.java \
+ $UMPLEROOT/cruise.umple/src-gen-umple/*/*/*/*.java \
+ $UMPLEROOT/cruise.umple/src-gen-umple/*/*/*/*/*.java \
+ $UMPLEROOT/cruise.umple/src-gen-umple/*/*/*/*/*/*.java \
+ $UMPLEROOT/cruise.umple/src-gen-umpletl/*/*/*/*/*.java \
+ $UMPLEROOT/dist/libs/vendors/jopt-simple/src/main/java/joptsimple//*.java \
+ $UMPLEROOT/dist/libs/vendors/jopt-simple/src/main/java/joptsimple/*/*.java \
+ $UMPLEROOT/cruise.umple.nebula/src/cruise/umple/*/*.java \
+  | grep -v builder/Builder.java \
+  | grep -v UmplecAntTask.java \
+ | xargs \
+/usr/bin/javadoc \
+  -cp $UMPLEROOT/dist/libs/test/junit.jar \
+  -exclude org.junit \
+  -taglet UmplesourceTaglet \
+  -header 'Umple compiler API generated java files. Always edit <a href="https://github.com/umple/umple/tree/master/cruise.umple/src">Umple source</a>'\
+ -d $UMPLEROOT/dist/cruise.umple/reference/umple-compiler-javadoc
+
+cd $UMPLEROOT/dist/cruise.umple/reference
+cp $UMPLEROOT/umplewww/mapjavadoc.php .
+
+echo Done remaking the javadoc

--- a/umplewww/umple-state-classDiagram.shtml
+++ b/umplewww/umple-state-classDiagram.shtml
@@ -18,7 +18,7 @@ Action.selectClass = function(className) {
       <p>Zoom in (ctrl-+ or cmd-+) to see detail. Click on a class to go to the API reference for that class. Hover over a class to see its comment.</p>
 
       <svg  style="overflow-x: scroll; overflow-y: scroll;" width=6500 height=4500>
-           <!--#include virtual="DiagramCoreMastercd.svg" -->
+           <!--#include virtual="DiagramStateMastercd.svg" -->
       </svg>
 
 


### PR DESCRIPTION
The script for regenerating the javadoc and diagrams after each build 'dumple' has been fixed. Also one of the html files was pointing to the wrong diagram.