### PR TITLE
Changes to make the build stull work in Java 8

### DIFF
--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -865,7 +865,7 @@ class Requirement{
     String reqText = new String();
 
     for (Requirement req : reqSelected){
-      reqText = req.getStatement().strip();
+      reqText = req.getStatement().trim();
 
       reqText = req.getIdentifier() + ": " + reqText;
 


### PR DESCRIPTION
This ensures that the Umple compiler can still be compiled by java 8, before the String strip() method was available