### PR TITLE
Warning for used mixsets with no declaration #1873

### DIFF
--- a/build/reference/9918MixsetUseNoDeclaration.txt
+++ b/build/reference/9918MixsetUseNoDeclaration.txt
@@ -4,14 +4,12 @@ noreferences
 
 @@description
 
-<h2> Warning reporting that code labels inside methods should have unique names.</h2>
+<h2> Warning reporting that mixset use statement activate a mixset that has not been declared.</h2>
 
-<p> Code Labels allow aspects to inject code in specific locations inside method bodies. However, the code injection is only applied to the first encountered label. Therefore, a code label should not be reused multiple times (inside a method). </p>
-
-<p>If you encounter this warning, you can easily rename code labels with unique names for each label inside the method body.  <br/>
+<p>If you encounter this warning, you can easily comment on the use statement which causes this warning, or you can declare the mixset with an empty body.  <br/>
 </p>
 
 
 @@example
-@@source manualexamples/W1512CodeLabelsInsideMethodAreNotUnique.ump
+@@source manualexamples/W1513MixsetUsedWithNoDeclaration.ump
 @@endexample

--- a/build/reference/9918MixsetUseNoDeclaration.txt
+++ b/build/reference/9918MixsetUseNoDeclaration.txt
@@ -1,0 +1,17 @@
+W1513 Mixset Used With No Declaration 
+Errors and Warnings 1000+
+noreferences
+
+@@description
+
+<h2> Warning reporting that code labels inside methods should have unique names.</h2>
+
+<p> Code Labels allow aspects to inject code in specific locations inside method bodies. However, the code injection is only applied to the first encountered label. Therefore, a code label should not be reused multiple times (inside a method). </p>
+
+<p>If you encounter this warning, you can easily rename code labels with unique names for each label inside the method body.  <br/>
+</p>
+
+
+@@example
+@@source manualexamples/W1512CodeLabelsInsideMethodAreNotUnique.ump
+@@endexample

--- a/build/reference/9918MixsetUseNoDeclaration.txt
+++ b/build/reference/9918MixsetUseNoDeclaration.txt
@@ -4,11 +4,10 @@ noreferences
 
 @@description
 
-<h2> Warning reporting that mixset use statement activate a mixset that has not been declared.</h2>
+<h2> Warning reporting that a mixset use statement tries to activate a mixset that has not been declared.</h2>
 
-<p>If you encounter this warning, you can easily comment on the use statement which causes this warning, or you can declare the mixset with an empty body.  <br/>
+<p>If you encounter this warning, you can easily comment out the use statement that causes this warning, or you can declare the mixset with an empty body.  <br/>
 </p>
-
 
 @@example
 @@source manualexamples/W1513MixsetUsedWithNoDeclaration.ump

--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -394,6 +394,13 @@ class UmpleInternalParser
     {
       postTokenTestSequeceAnalysis();
     }
+    mixset Mixset
+    {
+      if (getParseResult().getWasSuccess())
+      {
+        checkMixsetsNotUsed();
+      } 
+    }
     // We have to look at the error messages again to see if
     // any need to be removed
     analyzeParseResult();

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -217,7 +217,8 @@
 
 1511 : 2, "http://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
 1512 : 4, "http://manual.umple.org/?W1512CodeLabelsInsideMethodAreNotUnique.html", Multiple code labels having the same name should be avoided for the method '{0}' at line '{1}'. Please consider unique names for code labels. ; 
- 
+1513 : 4, "http://manual.umple.org/?W1513MixsetUsedWithNoDeclaration.html", The mixset '{0}' has a use statement at line '{1}', however there is no declaration for this mixset. To avoid this warning, you many remove the use statement or you may add a declaration for mixset '{0}'. ; 
+
 
 # Messages to be emitted when embedded code from another language is compiled and you are passing on the error. These have not yet been activated.
 2001: 5, "http://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;

--- a/cruise.umple/src/mixset/Mixset.ump
+++ b/cruise.umple/src/mixset/Mixset.ump
@@ -42,8 +42,12 @@ class Mixset {
   isA MixsetOrFile;
   boolean isFeature = false;  // Specify a mixset to be a feature. Default value is false.. 
 
+  List<MixsetInMethod> mixsetInMethod; // to store inline mixset inside methods
+  boolean isEmpty; // to specify a mixset that has definition but no body.
+
   after constructor {  
     setIsMixset(true);
+    setIsEmpty(false);
   }
   
   // Used fragments are those that have been parsed because a use statement was previously 

--- a/cruise.umple/src/mixset/Mixset.ump
+++ b/cruise.umple/src/mixset/Mixset.ump
@@ -42,8 +42,8 @@ class Mixset {
   isA MixsetOrFile;
   boolean isFeature = false;  // Specify a mixset to be a feature. Default value is false.. 
 
-  List<MixsetInMethod> mixsetInMethod; // to store inline mixset inside methods
-  boolean isEmpty; // to specify a mixset that has definition but no body.
+  List<MixsetInMethod> mixsetInMethod = new ArrayList<MixsetInMethod>(); // to store inline mixset inside methods
+  boolean isEmpty = false; // to specify a mixset that has definition but no body.
 
   after constructor {  
     setIsMixset(true);

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -328,7 +328,7 @@ class UmpleInternalParser
     MixsetFragment mixsetFragment = createMixsetFragment(token);
     if(mixset == null)
     return null;
-    else (mixsetFragment == null)
+    else if (mixsetFragment == null)
     mixset.setIsEmpty(true);
     else
     mixsetFragment.setMixset(mixset);
@@ -596,13 +596,13 @@ class UmpleInternalParser
   && m.getMixsetFragments().size() < 1).collect(Collectors.toList());
     if (notUsedMixset.size() < 1)
       return;
-    for (Mixset m : notUsedMixset)
+    for (Mixset aMixset : notUsedMixset)
     {
-      if(m.mixsetInMethod.size() < 1  )
+      if(aMixset.getMixsetInMethod().size() < 1)
       {
         // raise a warning
-        Position p = new Position(m.getUseUmpleFile().getFileName(), m.getUseUmpleLine(), 0, 0);
-        setFailedPosition(p,1512, m.getName(),"11111 ");
+        Position wPosition = new Position(aMixset.getUseUmpleFile().getFileName(), aMixset.getUseUmpleLine(), 0, 0);
+        setFailedPosition(wPosition,1512, aMixset.getName(),"11111 ");
         }
     }
   }

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -326,8 +326,10 @@ class UmpleInternalParser
   
   private MixsetFragment createMixsetFragment(Token token,  Mixset mixset) {  
     MixsetFragment mixsetFragment = createMixsetFragment(token);
-    if(mixsetFragment == null || mixset == null)
+    if(mixset == null)
     return null;
+    else (mixsetFragment == null)
+    mixset.setIsEmpty(true);
     else
     mixsetFragment.setMixset(mixset);
     return mixsetFragment;
@@ -584,7 +586,27 @@ class UmpleInternalParser
     edge.setTargetFeatureNode(newFeatureNode);
     edge.setFeatureModel(model.getFeatureModel());
     model.getFeatureModel().addFeaturelink(edge);
-  }  
+  }
+
+  // This method raises warning for use statements for misets that do not have actual definitions.
+  private void checkMixsetsNotUsed() {
+    UmpleModel uModel = this.getModel();
+    Stream<Mixset> mixsetsStream = uModel.getMixsetOrFiles().stream().filter(m ->m.getIsMixset()).map(m->(Mixset)m ); 
+    List<Mixset> notUsedMixset = mixsetsStream.filter(m -> !m.getIsEmpty()).filter(m -> m.getUseUmpleFile() != null 
+  && m.getMixsetFragments().size() < 1).collect(Collectors.toList());
+    if (notUsedMixset.size() < 1)
+      return;
+    for (Mixset m : notUsedMixset)
+    {
+      if(m.mixsetInMethod.size() < 1  )
+      {
+        // raise a warning
+        Position p = new Position(m.getUseUmpleFile().getFileName(), m.getUseUmpleLine(), 0, 0);
+        setFailedPosition(p,1512, m.getName(),"11111 ");
+        }
+    }
+  }
+
 }
 
 mixset AspectInjection {
@@ -747,6 +769,7 @@ mixset Template {
          if(mixset.getUseUmpleFile() != null)
          {
            mixsetIsUsed = true;
+           mixset.getMixsetInMethod().add(mixsetInMethod);
            //first process children
            for(MixsetInMethod childMixsetInMethod : mixsetInMethod.getChildMixsets())
              sourceCodeBody = handelMixsetInsideMethod(umodel, childMixsetInMethod, sourceCodeBody);

--- a/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
+++ b/cruise.umple/src/mixset/UmpleInternalParser_CodeMixset.ump
@@ -602,7 +602,7 @@ class UmpleInternalParser
       {
         // raise a warning
         Position wPosition = new Position(aMixset.getUseUmpleFile().getFileName(), aMixset.getUseUmpleLine(), 0, 0);
-        setFailedPosition(wPosition,1512, aMixset.getName(),"11111 ");
+        setFailedPosition(wPosition,1513, aMixset.getName(),""+ aMixset.getUseUmpleLine());
         }
     }
   }

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -780,7 +780,7 @@ public class UmpleMixsetTest {
   public void mixsetUsedHasNoDefinition()
   {  
     UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"mixsetUseNoDefinition.ump");
-    int line = 1;
+    int line = 17;
     int errorCode = 1513;
     int offset= 0;
     int charOff = 0;

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -638,26 +638,32 @@ public class UmpleMixsetTest {
     UmpleFile umpleFile = new UmpleFile(umpleParserTest.pathToInput,"parseMixsetsInsideTemplate.ump");
     UmpleModel model = new UmpleModel(umpleFile);
     model.setShouldGenerate(true);
-    model.run();
-    String generatedFile =  umpleParserTest.pathToInput+"/TemplateMixset.java";
-    SampleFileWriter.assertFileExists(generatedFile);
-    String templateGeneratedCode = SampleFileWriter.readContent(new File(generatedFile));
-    //  included mixsets
-    Assert.assertTrue(templateGeneratedCode.contains("Print out the following "));
-    Assert.assertTrue(templateGeneratedCode.contains("M1 is used, this line should be included"));
-    Assert.assertTrue(templateGeneratedCode.contains("M2 is used, this line should be included"));
-    // not included mixsets
-    Assert.assertFalse(templateGeneratedCode.contains("M3 is not used, this line NOT should be included"));
-    Assert.assertFalse(templateGeneratedCode.contains("I am outer , this line should NOT be included"));
-    Assert.assertFalse(templateGeneratedCode.contains("I am inner , this line should NOT be included"));
-    // no mixset definitions i
-    Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
-    Assert.assertFalse(templateGeneratedCode.contains("mixset M2"));
-    Assert.assertFalse(templateGeneratedCode.contains("mixset M3"));
-    Assert.assertFalse(templateGeneratedCode.contains("mixset Outer"));
-    Assert.assertFalse(templateGeneratedCode.contains("mixset Inner"));
-    //delete generated file
-    SampleFileWriter.destroy(generatedFile);
+    try
+    {
+       model.run();
+    }
+    catch (UmpleCompilerException e)
+    {
+      String generatedFile =  umpleParserTest.pathToInput+"/TemplateMixset.java";
+      SampleFileWriter.assertFileExists(generatedFile);
+      String templateGeneratedCode = SampleFileWriter.readContent(new File(generatedFile));
+      //  included mixsets
+      Assert.assertTrue(templateGeneratedCode.contains("Print out the following "));
+      Assert.assertTrue(templateGeneratedCode.contains("M1 is used, this line should be included"));
+      Assert.assertTrue(templateGeneratedCode.contains("M2 is used, this line should be included"));
+      // not included mixsets
+      Assert.assertFalse(templateGeneratedCode.contains("M3 is not used, this line NOT should be included"));
+      Assert.assertFalse(templateGeneratedCode.contains("I am outer , this line should NOT be included"));
+      Assert.assertFalse(templateGeneratedCode.contains("I am inner , this line should NOT be included"));
+      // no mixset definitions i
+      Assert.assertFalse(templateGeneratedCode.contains("mixset M1"));
+      Assert.assertFalse(templateGeneratedCode.contains("mixset M2"));
+      Assert.assertFalse(templateGeneratedCode.contains("mixset M3"));
+      Assert.assertFalse(templateGeneratedCode.contains("mixset Outer"));
+      Assert.assertFalse(templateGeneratedCode.contains("mixset Inner"));
+      //delete generated file
+      SampleFileWriter.destroy(generatedFile);
+    }
 
     
   }
@@ -768,6 +774,18 @@ public class UmpleMixsetTest {
     int numberOfFeatures = model1.getFeatureModel().getNode().size();
     Assert.assertTrue(file1Test);
     Assert.assertEquals(numberOfFeatures, 6); // 5 features + root feature 
+  }
+  
+  @Test
+  public void mixsetUsedHasNoDefinition()
+  {
+    
+    UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"mixsetUseNoDefinition.ump");
+    int line = 17;
+    int errorCode = 1512;
+    int offset= 0;
+    int charOff = 0;
+    umpleParserTest.assertHasWarningsParse(file.getFileName(), new Position(file.getFileName(),line,offset,charOff),errorCode);
   }
 
 

--- a/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/UmpleMixsetTest.java
@@ -778,11 +778,10 @@ public class UmpleMixsetTest {
   
   @Test
   public void mixsetUsedHasNoDefinition()
-  {
-    
+  {  
     UmpleFile file = new UmpleFile(umpleParserTest.pathToInput,"mixsetUseNoDefinition.ump");
-    int line = 17;
-    int errorCode = 1512;
+    int line = 1;
+    int errorCode = 1513;
     int offset= 0;
     int charOff = 0;
     umpleParserTest.assertHasWarningsParse(file.getFileName(), new Position(file.getFileName(),line,offset,charOff),errorCode);

--- a/cruise.umple/test/cruise/umple/compiler/mixset/mixsetUseNoDefinition.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/mixsetUseNoDefinition.ump
@@ -1,0 +1,18 @@
+use M1;
+use M6;
+use M2;
+
+mixset M2 {
+  class Aclass{
+  }
+}
+
+
+mixset M3 {}
+
+mixset M4{ } 
+
+mixset M6{
+
+use M7;
+}

--- a/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_MultipleOp.ump
+++ b/cruise.umple/test/cruise/umple/compiler/mixset/reqStArgumentParse_MultipleOp.ump
@@ -1,6 +1,6 @@
 require [ 1..3 of {M1,M2,M3 } and M4 xor M5 or M6];
 
-mixset M1 {} mixset M2 {} mixset M3 {} mixset M4 {} mixset M5 {} 
+mixset M1 {} mixset M2 {} mixset M3 {} mixset M4 {} mixset M5 {} mixset M6 {} 
 
 use M1 ; use M2 ; use M3 ; use M4 ; use M5 ;use M6;
 

--- a/umpleonline/umplibrary/manualexamples/W1513MixsetUsedWithNoDeclaration.ump
+++ b/umpleonline/umplibrary/manualexamples/W1513MixsetUsedWithNoDeclaration.ump
@@ -1,9 +1,9 @@
-// There are two options to get ride of this warning:
-//option1: commant on the below use statement:
+// There are two options to get rid of this warning:
+//option1: comment out the use statement below:
 use M1;
 
 // option2: remove the comment below to declare M1 with empty body :
 //mixset M1 { }
 
 //$?[End_of_model]$?
-// @@@skipcompile - there in no code to generate in this example.
+// @@@skipcompile - there is no code to generate in this example.

--- a/umpleonline/umplibrary/manualexamples/W1513MixsetUsedWithNoDeclaration.ump
+++ b/umpleonline/umplibrary/manualexamples/W1513MixsetUsedWithNoDeclaration.ump
@@ -1,0 +1,9 @@
+// There are two options to get ride of this warning:
+//option1: commant on the below use statement:
+use M1;
+
+// option2: remove the comment below to declare M1 with empty body :
+//mixset M1 { }
+
+//$?[End_of_model]$?
+// @@@skipcompile - there in no code to generate in this example.


### PR DESCRIPTION
This PR fixes the issue #1873 (Raising warning for when a mixset not found). It detects mixsets that are supplied in the command line with no actual declaration.