### PR TITLE
Fixes #1907 - Scxml compiler error

### DIFF
--- a/cruise.umple/src/generators/Generator_CodeScxml.ump
+++ b/cruise.umple/src/generators/Generator_CodeScxml.ump
@@ -121,7 +121,7 @@ class ScxmlGenerator
     UmpleClass parent = sm.getUmpleClass();
     return sm != null && !sm.hasStates() && !parent.hasMethods();
   }
-  
+    
   private void generateState(State state) {
   	if (isStateEmpty(state)) {
       _genStateEmptyTag(0, code, genTagAttribute("id", state.getName()));
@@ -192,7 +192,9 @@ class ScxmlGenerator
     
     if (transition.hasGuard()) {
       Guard guard = transition.getGuard();
-      cond = genTagAttribute("cond", guard.getCondition(new JavaGenerator()));
+      JavaGenerator javaGenerator = new JavaGenerator();
+      javaGenerator.setModel(model);
+      cond = genTagAttribute("cond", guard.getCondition(javaGenerator));
     }
     
     if (isTransitionEmpty(transition)) {

--- a/cruise.umple/test/cruise/umple/implementation/scxml/ScxmlTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/scxml/ScxmlTemplateTest.java
@@ -44,6 +44,7 @@ public class ScxmlTemplateTest extends TemplateTest
     SampleFileWriter.destroy(pathToInput + "/scxml/classCodeNoStateMachine.scxml");
     SampleFileWriter.destroy(pathToInput + "/scxml/classCodeEmptyStateMachine.scxml");
     SampleFileWriter.destroy(pathToInput + "/scxml/autoTransition.scxml");
+    SampleFileWriter.destroy(pathToInput + "/scxml/transitionWithGuardAndVariable.scxml");
   }
 
   @Test
@@ -110,5 +111,11 @@ public class ScxmlTemplateTest extends TemplateTest
   public void autoTransition()
   {
     assertUmpleTemplateFor("scxml/autoTransition.ump","scxml/autoTransition.scxml.txt");
+  }
+  
+  @Test
+  public void transitionWithGuardAndVariable()
+  {
+    assertUmpleTemplateFor("scxml/transitionWithGuardAndVariable.ump","scxml/transitionWithGuardAndVariable.scxml.txt");
   }
 }

--- a/cruise.umple/test/cruise/umple/implementation/scxml/transitionWithGuardAndVariable.scxml.txt
+++ b/cruise.umple/test/cruise/umple/implementation/scxml/transitionWithGuardAndVariable.scxml.txt
@@ -1,0 +1,10 @@
+<!--  EXPERIMENTAL SCXML OUTPUT, NOT READY FOR USE -->
+<?xml version="1.0" encoding="utf-8"?>
+<scxml name="sm" xmlns="http://www.w3.org/2005/07/scxml" xmlns:xi="http://www.w3.org/2001/XInclude" version="1.0">
+<state id="stateOne">
+<transition event="eventA" cond="getX()" target="stateTwo"/>
+</state>
+<state id="stateTwo">
+<transition event="eventB" target="stateOne"/>
+</state>
+</scxml>

--- a/cruise.umple/test/cruise/umple/implementation/scxml/transitionWithGuardAndVariable.ump
+++ b/cruise.umple/test/cruise/umple/implementation/scxml/transitionWithGuardAndVariable.ump
@@ -1,0 +1,11 @@
+class SMClass {
+  Boolean x;
+  sm {
+    stateOne {
+    	eventA [x] -> stateTwo;	
+    }
+    stateTwo {
+    	eventB -> stateOne;
+    }
+  }
+}


### PR DESCRIPTION
**IMPORTANT**: By submitting a patch, you agree that your work will be licensed under the [license](https://github.com/umple/umple/blob/master/LICENSE.md) used by the project.

If your pull request does not pass CI, it will **not** be merged (unless *heavily* justified). Before submitting, do a git pull to bring in other changes from master; then also do a full build and verify that the words 'error' or 'failure' do not appear anywhere in the build transcript (don't rely on BUILD SUCCESSFUL appearing). The 'bumple' script in dev-tools can help with this.

PRs should always be made from a branch you have created on umple/umple, not from a fork: This ensures that a Docker image of your PR can be automatically generated for manual testing.

## Fixes #1907 Scxml Compiler Error 

## Pull request description

There is a compilation error when umple tries to generate an Scxml state diagram that contains a guard that refers to a declared variable. The Scxml was not properly setting the model and was then throwing a null pointer exception. This pull request fixes this issue. A Test has also been added to check for this error in the future.

## Pull request content

Changes were made to the Scxml Umple generater (cruise.umple/src/generators/Generator_CodeScxml.ump)

A new test was created in cruise.umple/test/cruise/umple/implementation/scxml
