### PR TITLE
limiting cpu, memory and output lines in Java exec

### DIFF
--- a/UmpleCodeExecution/app.js
+++ b/UmpleCodeExecution/app.js
@@ -83,7 +83,13 @@ app.post('/run' , (req, res)  =>
                     {
                         output += `<strong>For main method in class ${mainFunction}:</strong>\n`
                         output += `${err || ""}\n`;
-                        output += `${data}\n`
+                        linelimit=1000;
+                        lines = data.split("\n");
+                        output += lines.slice(0,linelimit).join("\n")+"\n";
+                        if(lines.length > linelimit+1) {
+                          output += "...\n"+lines[lines.length-1]+"\n";
+                          output += "A total of "+(lines.length-1)+" output lines were generated. The listing above has been limited to the first "+linelimit+" lines, plus the very last line\n";
+                        };
                         totalServed++;
                         console.log("Processed request ", totalServed);
                         if(totalServed >= mainFunctions.length) {

--- a/UmpleCodeExecution/dockerTimeout.sh
+++ b/UmpleCodeExecution/dockerTimeout.sh
@@ -5,7 +5,7 @@ set -e
 to=$1
 shift
 
-cont=$(sudo docker run --rm -d "$@")
+cont=$(sudo docker run --rm --cpus=0.5 --memory=150m -d "$@")
 code=$(sudo timeout "$to" sudo docker wait "$cont" || true)
 sudo docker kill $cont &> /dev/null
 echo -n 'status: '


### PR DESCRIPTION
Before this, it was possible for java executed from UmpleOnline in docker to generate millions of lines of output, which could break a browser or at least make it behave excessively slowly.

Also it was possible for it to recursively exec the JVM eating up a huge amount of CPU and memory (each spawned JVM could use another CPU, eating up all CPUs available). This change adds some constraints that limit those vulnerabilities.

The line output limit is now 1000 lines, after which the output is truncated (although the last line is shown too)
Memory usage is limited to 150MB, otherwise the process will be killed by Docker. This should be sufficient for most purposes.
CPU usage is limited to peak at half a CPU (this could be reduced further if needed later, but experiments showed that this seemed to work well ... reducing to 0.1 CPU seemed to result in no execution because starting a JVM sometimes peaked at over that limit).
