### PR TITLE
Removing config.cfg from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ umpleonline/scripts/commandcount.txt
 umpleonline/scripts/specialPort.txt
 umpleonline/scripts/versionRunning.txt
 UmpleCodeExecution/config.cfg.bak
+UmpleCodeExecution/config.cfg
 
 # generated Umple code that is not saved
 src-gen-umple/

--- a/UmpleCodeExecution/config.cfg
+++ b/UmpleCodeExecution/config.cfg
@@ -1,6 +1,0 @@
-umplePath=umpleonline/ump
-tempPath=/tmp
-mainContainerName=code_execution
-tempContainerName=java_execution
-portToUse=4400
-timeoutValue=20


### PR DESCRIPTION
Every time someone checked out master, config.cfg was being marked as a conflict because it has to be locally modified. This takes it out of configuration management.

Users will have to use config.cfg.template and copy it to config.cfg