### PR TITLE
Papyrus to Umple & Umple to Papyrus functionalities through Umple Eclipse plugin

### DIFF
--- a/cruise.umple/src/UmpleImport_CodeHandlers.ump
+++ b/cruise.umple/src/UmpleImport_CodeHandlers.ump
@@ -338,13 +338,9 @@ class PapyrusImportHandler
     } 
     // load class attributes
     else if (currentElement.equals("ownedAttribute")) {
-      String attributeType = attributes.getValue(UmpleImportConstants.PAPYRUS_TYPE);
       String attributeName = attributes.getValue(UmpleImportConstants.XMI_NAME);
-      boolean isAttribute = attributeType.equals(UmpleImportConstants.PAPYRUS_PROPERTY);
 
-      if (isAttribute) {
-        currentAttributeName = attributeName;
-      }
+      currentAttributeName = attributeName;
     } else if (currentElement.equals("generalization")) {
       String attributeId = attributes.getValue(UmpleImportConstants.PAPYRUS_ID);
       String attributeType = attributes.getValue(UmpleImportConstants.PAPYRUS_TYPE);
@@ -384,28 +380,31 @@ class PapyrusImportHandler
       }
     } else if (currentElement.equals("lowerValue") || currentElement.equals("upperValue")) {
       boolean isLowerValue = currentElement.equals("lowerValue");
-      boolean isStartClass = currentOwnedEndId.equals(currentAssociation.getStartClass());
       String strValue = attributes.getValue(UmpleImportConstants.PAPYRUS_OWNED_END_VALUE);
 
-      if (strValue.equals("*")) {
-        if (isStartClass) {
-          currentAssociation.setOtherLowerBound(0);
-          currentAssociation.setOtherUpperBound(-1);
-        } else {
-          currentAssociation.setLowerBound(0);
-          currentAssociation.setUpperBound(-1);
-        }
-      } else {
-        Integer value = Integer.parseInt(strValue);
+      if (currentAssociation != null) {
+        boolean isStartClass = currentOwnedEndId.equals(currentAssociation.getStartClass());
 
-        if (isStartClass && isLowerValue) {
-          currentAssociation.setOtherLowerBound(value);
-        } else if (isStartClass && !isLowerValue) {
-          currentAssociation.setOtherUpperBound(value);
-        } else if (!isStartClass && isLowerValue) {
-          currentAssociation.setLowerBound(value);
+        if (strValue.equals("*")) {
+          if (isStartClass) {
+            currentAssociation.setOtherLowerBound(0);
+            currentAssociation.setOtherUpperBound(-1);
+          } else {
+            currentAssociation.setLowerBound(0);
+            currentAssociation.setUpperBound(-1);
+          }
         } else {
-          currentAssociation.setUpperBound(value);
+          Integer value = Integer.parseInt(strValue);
+
+          if (isStartClass && isLowerValue) {
+            currentAssociation.setOtherLowerBound(value);
+          } else if (isStartClass && !isLowerValue) {
+            currentAssociation.setOtherUpperBound(value);
+          } else if (!isStartClass && isLowerValue) {
+            currentAssociation.setLowerBound(value);
+          } else {
+            currentAssociation.setUpperBound(value);
+          }
         }
       }
     }

--- a/org.cruise.umple.eclipse.plugin/plugin.xml
+++ b/org.cruise.umple.eclipse.plugin/plugin.xml
@@ -148,6 +148,11 @@
                      label="Generate Simple Metrics"
                      style="push">
                </command>
+               <command
+                     commandId="org.cruise.umple.eclipse.plugin.commands.generate.papyrusToUmple"
+                     label="Papyrus to Umple"
+                     style="push">
+               </command>
             </menu>
          </menu>
       </menuContribution>
@@ -243,6 +248,11 @@
             defaultHandler="commands.GenerateSimpleMetrics"
             id="org.cruise.umple.eclipse.plugin.commands.simple.metrics"
             name="generate simple metrics">
+      </command>
+      <command
+            defaultHandler="commands.GenerateUmple"
+            id="org.cruise.umple.eclipse.plugin.commands.generate.papyrusToUmple"
+            name="Papyrus to Umple">
       </command>
    </extension>
    <extension

--- a/org.cruise.umple.eclipse.plugin/plugin.xml
+++ b/org.cruise.umple.eclipse.plugin/plugin.xml
@@ -134,6 +134,11 @@
                      style="push">
                </command>
                <command
+                     commandId="org.cruise.umple.eclipse.plugin.commands.generate.papyrus"
+                     label="Generate Papyrus Project"
+                     style="push">
+               </command>
+               <command
                      commandId="org.cruise.umple.eclipse.plugin.commands.umple.itself"
                      label="Generate Umple Internal Representation"
                      style="push">
@@ -228,6 +233,11 @@
             defaultHandler="commands.GenerateSQL"
             id="org.cruise.umple.eclipse.plugin.commands.generate.sql"
             name="generate sql code">
+      </command>
+      <command
+            defaultHandler="commands.GeneratePapyrus"
+            id="org.cruise.umple.eclipse.plugin.commands.generate.papyrus"
+            name="generate Papyrus project">
       </command>
       <command
             defaultHandler="commands.GenerateUmpleItself"

--- a/org.cruise.umple.eclipse.plugin/src/commands/GeneratePapyrus.java
+++ b/org.cruise.umple.eclipse.plugin/src/commands/GeneratePapyrus.java
@@ -1,0 +1,33 @@
+package commands;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.commands.IHandlerListener;
+
+public class GeneratePapyrus extends UmpleSuperHandler implements IHandler {
+
+	@Override
+	public void addHandlerListener(IHandlerListener handlerListener) {}
+
+	@Override
+	public void dispose() {}
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		compileUmpleFile(event, true, "Papyrus");
+		return null;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public boolean isHandled() {
+		return true;
+	}
+
+	@Override
+	public void removeHandlerListener(IHandlerListener handlerListener) {}
+}

--- a/org.cruise.umple.eclipse.plugin/src/commands/GenerateUmple.java
+++ b/org.cruise.umple.eclipse.plugin/src/commands/GenerateUmple.java
@@ -1,0 +1,34 @@
+package commands;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.commands.IHandlerListener;
+
+
+public class GenerateUmple extends UmpleSuperHandler implements IHandler {
+
+    @Override
+    public void addHandlerListener(IHandlerListener handlerListener) {}
+
+    @Override
+    public void dispose() {}
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        compileUmpleFile(event, true);
+        return null;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isHandled() {
+        return true;
+    }
+
+    @Override
+    public void removeHandlerListener(IHandlerListener handlerListener) {}
+}

--- a/org.cruise.umple.eclipse.plugin/src/commands/UmpleSuperHandler.java
+++ b/org.cruise.umple.eclipse.plugin/src/commands/UmpleSuperHandler.java
@@ -13,6 +13,8 @@ import org.eclipse.swt.graphics.Color;
 
 import cruise.umple.compiler.UmpleFile;
 import cruise.umple.compiler.UmpleModel;
+import cruise.umple.compiler.UmpleImportModel;
+import cruise.umple.compiler.PapyrusImportHandler;
 
 public class UmpleSuperHandler {
 	
@@ -38,6 +40,24 @@ public class UmpleSuperHandler {
 	        	refreshProjectFoler(editorInput);
 			} catch (Exception e) {
 				showErrorMessage(e.getMessage());
+			}
+		} else if (iFile.getFileExtension().toLowerCase().equals("uml")) {
+			String fileName = iFile.getName();
+			String absolutePath = iFile.getLocation().toString();
+			PapyrusImportHandler handler = new PapyrusImportHandler();
+			boolean parsingSuccess = false;
+			try {
+				UmpleImportModel umple = handler.readDataFromXML(absolutePath);
+				parsingSuccess = umple.generateUmpleFile(absolutePath + ".ump");
+				refreshProjectFoler(editorInput);
+			} catch (Exception e) {
+				showErrorMessage(e.getMessage());
+			}
+
+			if (parsingSuccess) {
+				showMessage("Success! Processed "+ absolutePath + ".");
+			} else {
+				showErrorMessage("No file generated, parsing error.");
 			}
 		} else{ 
 			showErrorMessage("Please select an Umple file. The file must have .ump extension.");


### PR DESCRIPTION
In this pr, a "Generate Papyrus project" button is introduced in Umple Eclipse plugin, it can be seen in the "Others" section.

![791650055088_ pic](https://user-images.githubusercontent.com/44094961/163630153-9d294a88-b095-4e95-868a-ed927e068cbb.jpg)

Once that button is clicked, a Papyrus project has the same name with the .ump file will be generated.

<img width="1872" alt="image" src="https://user-images.githubusercontent.com/44094961/163630133-f2d9859c-5c19-456d-a21e-c0b3de882a7f.png">

and the generated Papyrus project can be imported and its model can be visible as well

<img width="1872" alt="image" src="https://user-images.githubusercontent.com/44094961/163630362-26796dbd-750f-44f8-a5ee-c17a07a7935e.png">
