### PR TITLE
Add plugin for Papyrus to Umple feature

### DIFF
--- a/cruise.umple/src/UmpleImport_CodeHandlers.ump
+++ b/cruise.umple/src/UmpleImport_CodeHandlers.ump
@@ -338,13 +338,9 @@ class PapyrusImportHandler
     } 
     // load class attributes
     else if (currentElement.equals("ownedAttribute")) {
-      String attributeType = attributes.getValue(UmpleImportConstants.PAPYRUS_TYPE);
       String attributeName = attributes.getValue(UmpleImportConstants.XMI_NAME);
-      boolean isAttribute = attributeType.equals(UmpleImportConstants.PAPYRUS_PROPERTY);
 
-      if (isAttribute) {
-        currentAttributeName = attributeName;
-      }
+      currentAttributeName = attributeName;
     } else if (currentElement.equals("generalization")) {
       String attributeId = attributes.getValue(UmpleImportConstants.PAPYRUS_ID);
       String attributeType = attributes.getValue(UmpleImportConstants.PAPYRUS_TYPE);
@@ -384,28 +380,31 @@ class PapyrusImportHandler
       }
     } else if (currentElement.equals("lowerValue") || currentElement.equals("upperValue")) {
       boolean isLowerValue = currentElement.equals("lowerValue");
-      boolean isStartClass = currentOwnedEndId.equals(currentAssociation.getStartClass());
       String strValue = attributes.getValue(UmpleImportConstants.PAPYRUS_OWNED_END_VALUE);
 
-      if (strValue.equals("*")) {
-        if (isStartClass) {
-          currentAssociation.setOtherLowerBound(0);
-          currentAssociation.setOtherUpperBound(-1);
-        } else {
-          currentAssociation.setLowerBound(0);
-          currentAssociation.setUpperBound(-1);
-        }
-      } else {
-        Integer value = Integer.parseInt(strValue);
+      if (currentAssociation != null) {
+        boolean isStartClass = currentOwnedEndId.equals(currentAssociation.getStartClass());
 
-        if (isStartClass && isLowerValue) {
-          currentAssociation.setOtherLowerBound(value);
-        } else if (isStartClass && !isLowerValue) {
-          currentAssociation.setOtherUpperBound(value);
-        } else if (!isStartClass && isLowerValue) {
-          currentAssociation.setLowerBound(value);
+        if (strValue.equals("*")) {
+          if (isStartClass) {
+            currentAssociation.setOtherLowerBound(0);
+            currentAssociation.setOtherUpperBound(-1);
+          } else {
+            currentAssociation.setLowerBound(0);
+            currentAssociation.setUpperBound(-1);
+          }
         } else {
-          currentAssociation.setUpperBound(value);
+          Integer value = Integer.parseInt(strValue);
+
+          if (isStartClass && isLowerValue) {
+            currentAssociation.setOtherLowerBound(value);
+          } else if (isStartClass && !isLowerValue) {
+            currentAssociation.setOtherUpperBound(value);
+          } else if (!isStartClass && isLowerValue) {
+            currentAssociation.setLowerBound(value);
+          } else {
+            currentAssociation.setUpperBound(value);
+          }
         }
       }
     }

--- a/org.cruise.umple.eclipse.plugin/plugin.xml
+++ b/org.cruise.umple.eclipse.plugin/plugin.xml
@@ -148,6 +148,11 @@
                      label="Generate Simple Metrics"
                      style="push">
                </command>
+               <command
+                     commandId="org.cruise.umple.eclipse.plugin.commands.generate.papyrusToUmple"
+                     label="Papyrus to Umple"
+                     style="push">
+               </command>
             </menu>
          </menu>
       </menuContribution>
@@ -243,6 +248,11 @@
             defaultHandler="commands.GenerateSimpleMetrics"
             id="org.cruise.umple.eclipse.plugin.commands.simple.metrics"
             name="generate simple metrics">
+      </command>
+      <command
+            defaultHandler="commands.GenerateUmple"
+            id="org.cruise.umple.eclipse.plugin.commands.generate.papyrusToUmple"
+            name="Papyrus to Umple">
       </command>
    </extension>
    <extension

--- a/org.cruise.umple.eclipse.plugin/src/commands/GenerateUmple.java
+++ b/org.cruise.umple.eclipse.plugin/src/commands/GenerateUmple.java
@@ -1,0 +1,34 @@
+package commands;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.commands.IHandlerListener;
+
+
+public class GenerateUmple extends UmpleSuperHandler implements IHandler {
+
+    @Override
+    public void addHandlerListener(IHandlerListener handlerListener) {}
+
+    @Override
+    public void dispose() {}
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        compileUmpleFile(event, true);
+        return null;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isHandled() {
+        return true;
+    }
+
+    @Override
+    public void removeHandlerListener(IHandlerListener handlerListener) {}
+}

--- a/org.cruise.umple.eclipse.plugin/src/commands/UmpleSuperHandler.java
+++ b/org.cruise.umple.eclipse.plugin/src/commands/UmpleSuperHandler.java
@@ -13,6 +13,8 @@ import org.eclipse.swt.graphics.Color;
 
 import cruise.umple.compiler.UmpleFile;
 import cruise.umple.compiler.UmpleModel;
+import cruise.umple.compiler.UmpleImportModel;
+import cruise.umple.compiler.PapyrusImportHandler;
 
 public class UmpleSuperHandler {
 	
@@ -38,6 +40,24 @@ public class UmpleSuperHandler {
 	        	refreshProjectFoler(editorInput);
 			} catch (Exception e) {
 				showErrorMessage(e.getMessage());
+			}
+		} else if (iFile.getFileExtension().toLowerCase().equals("uml")) {
+			String fileName = iFile.getName();
+			String absolutePath = iFile.getLocation().toString();
+			PapyrusImportHandler handler = new PapyrusImportHandler();
+			boolean parsingSuccess = false;
+			try {
+				UmpleImportModel umple = handler.readDataFromXML(absolutePath);
+				parsingSuccess = umple.generateUmpleFile(absolutePath + ".ump");
+				refreshProjectFoler(editorInput);
+			} catch (Exception e) {
+				showErrorMessage(e.getMessage());
+			}
+
+			if (parsingSuccess) {
+				showMessage("Success! Processed "+ absolutePath + ".");
+			} else {
+				showErrorMessage("No file generated, parsing error.");
 			}
 		} else{ 
 			showErrorMessage("Please select an Umple file. The file must have .ump extension.");


### PR DESCRIPTION
1. Get an example Umple from Umple Online
   <img width="1289" alt="Screen Shot 2022-04-17 at 9 28 10 PM" src="https://user-images.githubusercontent.com/30584659/163740618-3861c8a8-0786-4b7c-9541-f353d699a92f.png">

2. Convert Umple file to Papyrus xml file through Umple command line
    <img width="901" alt="Screen Shot 2022-04-17 at 9 29 14 PM" src="https://user-images.githubusercontent.com/30584659/163740674-dc2fa597-eeb8-4db9-ac6b-35b00ebd8751.png">
    <img width="507" alt="Screen Shot 2022-04-17 at 9 29 49 PM" src="https://user-images.githubusercontent.com/30584659/163740710-a7f728b2-7a44-4fe3-b935-2c133bc4bf57.png">

3. Import Papyrus file into a project in Eclipse
    <img width="1310" alt="Screen Shot 2022-04-17 at 9 31 14 PM" src="https://user-images.githubusercontent.com/30584659/163740810-dffa9cdd-9f65-4c76-b57d-672c8145bf15.png">


4. Use "Papyrus to Umple" plugin in Umple/other menu
    <img width="1295" alt="Screen Shot 2022-04-17 at 9 31 40 PM" src="https://user-images.githubusercontent.com/30584659/163740835-de9ef038-0b0f-49d8-9e90-913030018de6.png">

5. Copy generated Umple file back to Umple Online
    <img width="1303" alt="Screen Shot 2022-04-17 at 9 34 35 PM" src="https://user-images.githubusercontent.com/30584659/163740991-b315f69c-3688-414d-9a00-262ec31cf5af.png">

6. Check the generated shape at the right part of Umple Online
    <img width="1285" alt="Screen Shot 2022-04-17 at 9 35 09 PM" src="https://user-images.githubusercontent.com/30584659/163741023-7f383dfc-912d-4d02-839f-dc187ba8a25b.png">

