### PR TITLE
Enable download generated papyrus zip file from model folder

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -303,6 +303,13 @@ else if (isset($_REQUEST["umpleCode"]))
     
     if ($language == "Experimental-Cpp" || $language == "Experimental-Sql") {
       $sourceCode = executeCommand("echo \"{$language} is under development. Output is currently only available to developers of Umple\" 2> {$errorFilename}");
+    } elseif ($language == "Papyrus") {
+      $sourceCode = executeCommand("java -jar umplesync.jar -generate {$language} {$filename} 2> {$errorFilename}");
+      $papyrusProjectRootPath = $workDir->getPath();
+      $command = "cd {$papyrusProjectRootPath}; rm {$language}FromUmple.zip; zip -r {$language}FromUmple.zip model";
+      exec($command);
+      $archivelink = $workDir->makePermalink($language.'FromUmple.zip');
+      echo "<a href=\"$archivelink\" class=\"zipDownloadLink\" title=\"Download the generated code as a zip file. You can then unzip the result, compile it and run it on your own computer.\">Download the following Papyrus project as a zip file</a >";
     }
     else {
       $sourceCode = executeCommand("java -jar umplesync.jar -generate {$language} {$filename} 2> {$errorFilename}");


### PR DESCRIPTION
In this PR, we fixed a little problem about downloading a generated Papyrus zip file from Umple Online.

In the previous version of Umple Online, we can only download the generated UML file from Umple Online instead of a fully packaged project Umple generated

<img width="1919" alt="Screen Shot 2022-04-19 at 5 24 49 PM" src="https://user-images.githubusercontent.com/30584659/164104595-e7c56e29-9507-422a-8932-a9bcc71d679e.png">


Herewith this PR, we can download the generated Papyrus project in zip format from Umple Online.
<img width="1917" alt="Screen Shot 2022-04-19 at 5 20 36 PM" src="https://user-images.githubusercontent.com/30584659/164103909-a8ad7618-b0af-483d-8208-7f4459ce1f00.png">

After clicking the download link, a zip file will be downloaded to your machine with the path you provided.
<img width="1912" alt="Screen Shot 2022-04-19 at 5 23 26 PM" src="https://user-images.githubusercontent.com/30584659/164104225-cf92a1c8-d00d-4bf9-94de-2f90f9398bd0.png">
<img width="506" alt="Screen Shot 2022-04-19 at 5 23 59 PM" src="https://user-images.githubusercontent.com/30584659/164104307-cc684ed1-c5dd-4bd4-a0c5-b51788aa576d.png">



