### PR TITLE
Fixing tracing so works on server

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -87,7 +87,12 @@ class UmpleModel
   
   internal List<File> linkedFiles = new ArrayList<File>();
 
-  
+  // Whether tracer output should be generated if needed
+  // These are set to false when tracer classes are created by generators
+  Boolean generateConsole = true;
+  Boolean generateFile = true;
+  Boolean generateString = true;
+  Boolean generateLog4j = true;
   
   // The Umple Enumerations contained within the model
   1 -> * UmpleEnumeration enums;

--- a/cruise.umple/src/generators/GeneratorHelper_CodeTrace.ump
+++ b/cruise.umple/src/generators/GeneratorHelper_CodeTrace.ump
@@ -28,16 +28,18 @@ private static void postpareTrace(UmpleModel aModel)
   //*********************************************** 
   // Process traces based on tracer selected
   // Current Tracers supported ( Console / File / String / Log4j / LTTNG  )
-  static private boolean generateConsole = true;
-  static private boolean generateFile = true;
-  static private boolean generateString = true;
-  static private boolean generateLog4j = true ;
 
-  public static boolean getWillGenerateString(){
-  	return generateString;
+  public static boolean getWillGenerateString(UmpleModel aModel){
+  	return aModel.getGenerateString();
   }
   
   public static  void prepareAllTracers(CodeTranslator t, UmpleModel model, UmpleClass aClass, Map<String,String> templateLookups){
+  
+    Boolean generateConsole = model.getGenerateConsole();
+    Boolean generateFile = model.getGenerateFile();
+    Boolean generateString = model.getGenerateString();
+    Boolean generateLog4j = model.getGenerateLog4j() ;
+  
     for(TraceDirective td: aClass.getAllTraceDirectives())
     {
       if(templateLookups.containsKey("dependTracer"))
@@ -64,7 +66,7 @@ private static void postpareTrace(UmpleModel aModel)
       {
         if(generateConsole)
         {
-          generateConsole=false;
+          model.setGenerateConsole(false);
           prepareConsoleTracer(model,templateLookups);
         }
       }
@@ -72,7 +74,7 @@ private static void postpareTrace(UmpleModel aModel)
       {
         if(generateFile)
         {
-          generateFile=false;          
+          model.setGenerateFile(false);
           if(model.getTracer().numberOfTracerArguments()>0)
           {
             templateLookups.put("filename","\""+td.getTracerDirective().getTracerArgument(0).getArgument()+"\"");
@@ -88,13 +90,13 @@ private static void postpareTrace(UmpleModel aModel)
       {
         if(generateString)
         {
-          generateString=false;
+          model.setGenerateString(false);
           prepareStringTracer(model,templateLookups);
         }
       }
       else if ("log4j".equals(td.getTracerType()))
       {
-        generateLog4j=false;
+        model.setGenerateLog4j(false);
         prepareLog4jTracer(model,templateLookups);
       }
     }

--- a/cruise.umple/src/generators/Generator_CodeJava.ump
+++ b/cruise.umple/src/generators/Generator_CodeJava.ump
@@ -28,7 +28,7 @@ class JavaGenerator
   private static Map<String,String> AsIsSingularLookupMap;
   private static Map<String,String> AsIsPluralLookupMap;
   private static List<String> OneOrManyLookup;  
-  
+
   static
   {
     UpperCaseSingularLookupMap = new HashMap<String, String>();

--- a/cruise.umple/test/cruise/umple/compiler/GeneratorHelperTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/GeneratorHelperTest.java
@@ -128,9 +128,9 @@ public class GeneratorHelperTest
     model.setTracer(new TracerDirective("string"));
     model.addUmpleClass(uClass1);
     model.addUmpleClass(uClass2);
-    Assert.assertEquals(true,GeneratorHelper.getWillGenerateString());
+    Assert.assertEquals(true,GeneratorHelper.getWillGenerateString(model));
     GeneratorHelper.prepareAllTracers(null, model, uClass1, lookups);
-    Assert.assertEquals(false,GeneratorHelper.getWillGenerateString());
+    Assert.assertEquals(false,GeneratorHelper.getWillGenerateString(model));
     GeneratorHelper.prepareAllTracers(null, model, uClass2, lookups);
     Assert.assertEquals(3,model.numberOfUmpleClasses());
     //UmpleClass c = model.getUmpleClass("StringTracer");


### PR DESCRIPTION
For some years, there had been a problem with tracing. It worked on the command line. It worked on the server the first time, but not subsequently. The problem was tracked down to the use of global variables that persisted certain data from model to model. This PR ensures that the state of tracer use is tied to the partcular model.