### PR TITLE
Allowing Use Statements to load URLs

### DIFF
--- a/UmpleParser/src/GrammarParsing.ump
+++ b/UmpleParser/src/GrammarParsing.ump
@@ -25,7 +25,7 @@ class Analyzer
   depend java.util.*;
   depend cruise.umple.parser.*;
   depend cruise.umple.parser.Token;
-  depend java.io.*;  
+  depend java.io.*;
   depend java.lang.reflect.*;
   depend java.lang.IllegalStateException;
   
@@ -150,7 +150,8 @@ interface ParserAction
 class ParserDataPackage
 {  
   depend java.util.*;
-  depend java.io.*;  
+  depend java.io.*;
+  depend java.net.URL;
   depend cruise.umple.parser.Position;
   depend cruise.umple.parser.ParseResult;
   depend cruise.umple.parser.ErrorMessage;

--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -591,6 +591,11 @@ class ParserDataPackage
       {
         reader = new BufferedReader(new FileReader(file));
       }
+      else if (file.contains("https:")) {
+        String urlToLoad=file.substring(file.indexOf("https:"));
+        resourceStream = new URL(urlToLoad).openStream();
+        reader = new BufferedReader(new InputStreamReader(resourceStream));
+      }
       else
       {
         String resourceToLoad=file;


### PR DESCRIPTION
This allows https URLs to be specified in use statements (not just files and Mixsets).

This will allow people to maintain libraries on the web that can be accessed by any model. The libraries could be raw .ump files in Github for example