### PR TITLE
Update manual 5100Coloring.txt to add W3C colours

### DIFF
--- a/build/reference/5100Colouring.txt
+++ b/build/reference/5100Colouring.txt
@@ -5,4 +5,4 @@ noreferences
 @@description
 <p>Umple has a special directive that allows you to highlight certain elements (currently only classes) in UmpleOnline and GraphViz output. Simply write 'displayColor xxx;' in a class where xxx is any html colour such as "red" or "#BBCCFF". UK spelling displayColour also works.</p>
 
-
+<p>The <a href="https://www.w3.org/wiki/CSS/Properties/color/keywords">valid set of colors can be found online at the W3C official site</a>.</p>


### PR DESCRIPTION
This simply adds a link to the W3C colours page in the manual, to help people to locate valid colours for Umple classes in diagrams.