### PR TITLE
Issue #1964 Code injection using after or around with single return

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
+++ b/UmpleToJava/UmpleTLTemplates/class_MethodDeclaration.ump
@@ -316,9 +316,9 @@ class UmpleToJava {
               for(int i = -1; (i = properMethodBody.indexOf("return", i + 1)) != -1; ) {
               	//Check if return statement is on its own line
               	int lastChar = i - 1;
-              	while (properMethodBody.charAt(lastChar) == ' ')
+              	while (lastChar != -1 && properMethodBody.charAt(lastChar) == ' ')
               	  lastChar--;
-              	if (properMethodBody.charAt(lastChar) != '\n') // If it has any non-space characters before it, it's invalid
+              	if (lastChar == -1  || properMethodBody.charAt(lastChar) != '\n') // If it has any non-space characters before it, it's invalid
               	  continue;
               
                 // determine the indentation of the return


### PR DESCRIPTION
Umple Isssue https://github.com/umple/umple/issues/1964
Code injection using after or around causes compiler crash when injecting into method with just a return. The index of the string used for charAt function reaches -1 when there is only a return for after and around code injection. The conditions are added to prevent the index from being used for charAt when it is -1.