### PR TITLE
Make cpp and simplecpp as a case insensitive option for generating files from umple

### DIFF
--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -230,8 +230,8 @@ class UmpleModel
     }
 
 		
-    if (language.equals("Cpp")) realLanguage="RTCpp";
-    else if (language.equals("SimpleCpp")) realLanguage="RTCpp";
+    if (language.equalsIgnoreCase("Cpp")) realLanguage="RTCpp";
+    else if (language.equalsIgnoreCase("SimpleCpp")) realLanguage="RTCpp";
     
     String className = StringFormatter.format("cruise.umple.compiler.{0}Generator",realLanguage);
     Class<?> classDefinition = null;


### PR DESCRIPTION
When generating c++ files from umple, the option of language is case-insensitive. The option can be cpp, simplecpp and rtcpp.
