### PR TITLE
Better CLI msgs regarding generators

### DIFF
--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -370,7 +370,7 @@ class UmpleConsoleMain
       
       if(compileSuccess && !cfg.getBeQuiet()) {
         for (String key : model. getHashMap().keySet()) {
-          System.out.println("  Compiled to target language "+key);
+          System.out.println("  Finished generating "+key);
           if(key.compareTo("Java")==0) {
             for (UmpleClass mainClass: CodeCompiler.getMainClasses(model)) {
               System.out.println("  Main method found. Run Java "+mainClass.getName());

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -235,6 +235,7 @@ class UmpleModel
     
     String className = StringFormatter.format("cruise.umple.compiler.{0}Generator",realLanguage);
     Class<?> classDefinition = null;
+    String msgIfNotFound = "Code generator "+realLanguage+ " not found. Check spelling. Specify --help.";
     try {
       classDefinition = Class.forName(className);
       CodeGenerator generator = (CodeGenerator) classDefinition.newInstance();
@@ -242,11 +243,19 @@ class UmpleModel
       return generator;
     }
     catch (ClassNotFoundException cnf) {
-      System.err.println("Code generator "+realLanguage+ " not found. Check spelling. Specify --help.");
-      throw new RuntimeException(cnf);
+      System.err.println(msgIfNotFound);
+      try {
+        classDefinition = Class.forName("cruise.umple.compiler.NothingGenerator");
+        CodeGenerator generator = (CodeGenerator) classDefinition.newInstance();
+        generator.setModel(this);
+        return generator;
+      }
+      catch(Exception ex3) {
+      throw new RuntimeException("Unable to instantiate the Nothing code generator.",ex3);
+      }
     }
     catch (Exception ex2) {
-      System.err.println("Code generator "+realLanguage+ " not found. Check spelling. Specify --help.");
+      System.err.println(msgIfNotFound);
       throw new RuntimeException("Unable to instantiate "+realLanguage+ ".",ex2);
     }
   }

--- a/cruise.umple/test/cruise/umple/UmpleConsoleMainTest.java
+++ b/cruise.umple/test/cruise/umple/UmpleConsoleMainTest.java
@@ -125,7 +125,7 @@ public class UmpleConsoleMainTest {
 		    UmpleConsoleMain.main(args);
 
       Assert.assertEquals("Processing -> testclass1.ump"+System.lineSeparator()
-              + "  Compiled to target language Java"+System.lineSeparator()
+              + "  Finished generating Java"+System.lineSeparator()
               + "Success! Processed testclass1.ump."+System.lineSeparator()
               + "Success! Processed testclass2.ump."+System.lineSeparator(),
           outErrIntercept.toString());


### PR DESCRIPTION
If a generator name is mis-spelled using the -g option on the command line interface (CLI), the message displayed would have included a stack trace. This PR eliminates that, so the message is clearer (and doesn't suggest contacting developers).

Also, the message says 'Finished generating' rather than 'Compiled to' since the previous message was not fully accurate.