### PR TITLE
Make missing file a warning only

### DIFF
--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -213,7 +213,7 @@
 1501 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 
 1502 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Structure of '{0}' invalid ;
 1503 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
-1510 : 1, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
+1510 : 3, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
 
 1511 : 2, "http://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
 1512 : 4, "http://manual.umple.org/?W1512CodeLabelsInsideMethodAreNotUnique.html", Multiple code labels having the same name should be avoided for the method '{0}' at line '{1}'. Please consider unique names for code labels. ; 

--- a/cruise.umple/test/cruise/umple/stats/MetricsCollectorTest.java
+++ b/cruise.umple/test/cruise/umple/stats/MetricsCollectorTest.java
@@ -128,7 +128,7 @@ public class MetricsCollectorTest
     String[] logs = collector.getLogs();
     
     Assert.assertEquals(1,logs.length);
-    Assert.assertEquals("Error 1510 on line 1 of file \'unknown.ump\':\nFile 'unknown.ump' referred to in use statement was not found\n: unknown.ump", logs[0]);
+    Assert.assertEquals("Warning 1510 on line 1 of file \'unknown.ump\':\nFile 'unknown.ump' referred to in use statement was not found\n: unknown.ump", logs[0]);
   }
   
 }


### PR DESCRIPTION
Until this PR, a use statement that references a file that is not found will result in an error, aborting all compilation.

That is not necessarily a good idea. There are use cases for making it simply a warning, such as when the content is optional, or to improve agility of development. If the missing file is fatal, other problems will surely occur.