### PR TITLE
Adding deprecation suppression to tracing examples issue #2018

### DIFF
--- a/cruise.umple/src/generators/Generator_CodeJava.ump
+++ b/cruise.umple/src/generators/Generator_CodeJava.ump
@@ -3379,6 +3379,8 @@ the if(parent.getHasProxyPattern()) is neccessary to check if the parent's real 
     TraceLookupMap.put("templatelttng","LTTngUst.{0}( {1} );");
     TraceLookupMap.put("timestamp","System.currentTimeMillis()");
     TraceLookupMap.put("identifier","System.identityHashCode({0})");
+    // The following is deprecated as of Java 19; as of Java 19 threadId should be used
+    // But we need to wait at least 3 years after intro of Java 19 ... see issue #2018
     TraceLookupMap.put("thread","Thread.currentThread().getId()");
     TraceLookupMap.put("self","this");
     TraceLookupMap.put("increment","{0}++;");

--- a/umpleonline/umplibrary/manualexamples/Tracers1.ump
+++ b/umpleonline/umplibrary/manualexamples/Tracers1.ump
@@ -1,11 +1,16 @@
 // this example generates traces using the
 // File tracer
+
 tracer File;
 
+@SuppressWarnings("deprecation")
 class Student
 {
   Integer id;
   trace id;
 }
+
+// The suppressWarnings annotation allows this example
+// to keep working as of Java 19 as per Umple issue £2018
 //$?[End_of_model]$?
 // @@@skipphpcompile - Skipped due to issue 698

--- a/umpleonline/umplibrary/manualexamples/Tracers2.ump
+++ b/umpleonline/umplibrary/manualexamples/Tracers2.ump
@@ -2,6 +2,7 @@
 // native logging API
 tracer JavaAPI;
 
+@SuppressWarnings("deprecation")
 class Student
 {
   Integer id;

--- a/umpleonline/umplibrary/manualexamples/TracingAssociations1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAssociations1.ump
@@ -5,6 +5,7 @@ class Student {
   Integer id;
 }
 
+@SuppressWarnings("deprecation")
 class Professor {
   1 -- * Student supervisor;
   

--- a/umpleonline/umplibrary/manualexamples/TracingAssociations2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAssociations2.ump
@@ -5,6 +5,7 @@ class Student {
   Integer id;
 }
 
+@SuppressWarnings("deprecation")
 class Professor {
   1 -- * Student supervisor;
   

--- a/umpleonline/umplibrary/manualexamples/TracingAssociations3.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAssociations3.ump
@@ -5,6 +5,7 @@ class Student {
   Integer id;
 }
 
+@SuppressWarnings("deprecation")
 class Professor {
   1 -- * Student supervisor;
   

--- a/umpleonline/umplibrary/manualexamples/TracingAttributes1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributes1.ump
@@ -1,4 +1,5 @@
 // This traces setId() and setName()
+@SuppressWarnings("deprecation")
 class Student
 {
   Integer id;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributes2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributes2.ump
@@ -1,4 +1,5 @@
 // This traces  getId() method
+@SuppressWarnings("deprecation")
 class Student
 {
   Integer id;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributes3.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributes3.ump
@@ -1,4 +1,5 @@
 // This example traces getId() and setId()
+@SuppressWarnings("deprecation")
 class Student
 {
   Integer id;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributeswithConditions2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributeswithConditions2.ump
@@ -2,6 +2,7 @@
 // this example injects trace code in attribute
 // setter with specified postcondition
 
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributeswithOccurrences1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributeswithOccurrences1.ump
@@ -2,6 +2,7 @@
 // this example traces attribute name whenever
 // its value is changed for 5 times 
 
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributeswithOccurrences2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributeswithOccurrences2.ump
@@ -2,6 +2,7 @@
 // this example traces attribute name whenever
 // its value is accessed for 5 times 
 
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributeswithtimeline1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributeswithtimeline1.ump
@@ -1,3 +1,4 @@
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingAttributeswithtimeline2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingAttributeswithtimeline2.ump
@@ -2,6 +2,7 @@
 // attribute name until condition becomes true
 // and then always continue tracing 
 
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingBasics1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingBasics1.ump
@@ -1,4 +1,4 @@
-
+@SuppressWarnings("deprecation")
 class Student
 {
   Integer id;

--- a/umpleonline/umplibrary/manualexamples/TracingBasics2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingBasics2.ump
@@ -1,4 +1,4 @@
-
+@SuppressWarnings("deprecation")
 class Student
 {
   lazy Integer id;

--- a/umpleonline/umplibrary/manualexamples/TracingConstraints1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingConstraints1.ump
@@ -1,3 +1,4 @@
+@SuppressWarnings("deprecation")
 class Student
 {
   name;
@@ -16,6 +17,7 @@ class Student
   trace name for 5;
 }
 
+@SuppressWarnings("deprecation")
 class Professor {
   name;
   1 -- * Student supervisor;

--- a/umpleonline/umplibrary/manualexamples/TracingConstraints2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingConstraints2.ump
@@ -1,3 +1,4 @@
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingConstraints3.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingConstraints3.ump
@@ -1,3 +1,4 @@
+@SuppressWarnings("deprecation")
 class Student
 {
   name;

--- a/umpleonline/umplibrary/manualexamples/TracingMethods1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingMethods1.ump
@@ -1,6 +1,7 @@
 // this example shows how to trace
 // non-generated method entry
 
+@SuppressWarnings("deprecation")
 class JavaMethod
 {
   trace method();

--- a/umpleonline/umplibrary/manualexamples/TracingMethods2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingMethods2.ump
@@ -3,6 +3,7 @@
 // statement, trace code is injected before
 // the return
 
+@SuppressWarnings("deprecation")
 class JavaMethod
 {
   trace exit method();

--- a/umpleonline/umplibrary/manualexamples/TracingStateMachines1.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingStateMachines1.ump
@@ -1,3 +1,4 @@
+@SuppressWarnings("deprecation")
 class LightBulb
 {
   Integer v = 0;

--- a/umpleonline/umplibrary/manualexamples/TracingStateMachines2.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingStateMachines2.ump
@@ -1,3 +1,4 @@
+@SuppressWarnings("deprecation")
 class LightBulb
 {
   status

--- a/umpleonline/umplibrary/manualexamples/TracingStateMachines3.ump
+++ b/umpleonline/umplibrary/manualexamples/TracingStateMachines3.ump
@@ -1,6 +1,7 @@
 // this example will trace all states of
 // State machine GarageDoor 
 
+@SuppressWarnings("deprecation")
 class GarageDoor
 {
     // UML state machine digram for a Garage door,

--- a/umpleonline/umplibrary/manualexamples/W301TracingEntityNotFound2.ump
+++ b/umpleonline/umplibrary/manualexamples/W301TracingEntityNotFound2.ump
@@ -1,6 +1,7 @@
 //The warning is resolved
 //by correcting the name of the
 //attribute to be traced
+@SuppressWarnings("deprecation")
 class A {
   Integer identifier;
   

--- a/umpleonline/umplibrary/manualexamples/W302TracerNotRecognized1.ump
+++ b/umpleonline/umplibrary/manualexamples/W302TracerNotRecognized1.ump
@@ -1,7 +1,9 @@
+
 //The tracer used is not recognized,
 //the Console tracer will be used
 tracer OtherTracer;
 
+@SuppressWarnings("deprecation")
 class A {
   Integer id;
   

--- a/umpleonline/umplibrary/manualexamples/W302TracerNotRecognized2.ump
+++ b/umpleonline/umplibrary/manualexamples/W302TracerNotRecognized2.ump
@@ -2,6 +2,7 @@
 //the warning
 tracer File;
 
+@SuppressWarnings("deprecation")
 class A {
   Integer id;
   


### PR DESCRIPTION
This resolves issue #2018 for a few years.

The full build was failing on tracing examples that use Thread.getID ... as of Java19 the recommended code is Thread.threadId.

However, Thread.threadId didn't exist until Java19, so we can't move all umple generation to use it for two generations of long term maintenance JVMS ... so we will leave issue #2018 open until around Java25, at which time the issue shows how to change the generation to the new method. Meanwhile this PR injects annotations into the relevant classes to stop unnecessary messages which have been failing the bulld for those using Java19