### PR TITLE
Fixes #2040 avoiding a null pointer exception in duplicated inherited association search

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -2430,6 +2430,11 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
 
         for (int i=0; i < numCurAssocVar; i++) {
           AssociationVariable curAssocVar = uClass.getAssociationVariable(uClassAssocVarClassNames[i], uClassAssocVarNames[i]);
+          if (curAssocVar == null)
+          {
+             // Issue 2040  ... looking in an extraneous superclass
+             continue;
+          }
 
           AssociationVariable supAssocVar = superClass.getAssociationVariable(curAssocVar.getType(), curAssocVar.getName());
           if (supAssocVar == null) continue;


### PR DESCRIPTION
Fixes a bug where a null pointer exception occurred when searching for duplicate inherited associations, but where there was a further superclass