### PR TITLE
Making StateTables and EventSequence generatable on command line and in generate statement

### DIFF
--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -32,9 +32,9 @@ strictnessDisableAuto : disable [**expression]
 
 // The generate clause can be used to generate multiple outputs
 // The --override is used to say that subsequent generate statements will be ignored
-generate : generate [=language:Java|Nothing|Php|RTCpp|SimpleCpp|Ruby|Python|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvFeatureDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|Umple|UmpleSelf|USE|Test|SimpleMetrics|PlainRequirementsDoc|Uigu2|ExternalGrammar] ( [=suboptionIndicator:-s|--suboption] " [**suboption] " )* ;
+generate : generate [=language:Java|Nothing|Php|RTCpp|SimpleCpp|Ruby|Python|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvFeatureDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|StateTables|EventSequence|Umple|UmpleSelf|USE|Test|SimpleMetrics|PlainRequirementsDoc|Uigu2|ExternalGrammar] ( [=suboptionIndicator:-s|--suboption] " [**suboption] " )* ;
  
-generate_path : generate [=language:Java|Nothing|Php|RTCpp|SimpleCpp|Ruby|Python|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvFeatureDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|Umple|UmpleSelf|USE|Test|SimpleMetrics|PlainRequirementsDoc|Uigu2|ExternalGrammar] " [**output] " [=override:--override|--override-all]? ( [=suboptionIndicator:-s|--suboption]  " [**suboption] " )* ;
+generate_path : generate [=language:Java|Nothing|Php|RTCpp|SimpleCpp|Ruby|Python|Cpp|Json|StructureDiagram|Yuml|Violet|Umlet|Simulate|TextUml|Scxml|GvStateDiagram|GvClassDiagram|GvFeatureDiagram|GvClassTraitDiagram|GvEntityRelationshipDiagram|Alloy|NuSMV|NuSMVOptimizer|Papyrus|Ecore|Xmi|Xtext|Sql|StateTables|EventSequence|Umple|UmpleSelf|USE|Test|SimpleMetrics|PlainRequirementsDoc|Uigu2|ExternalGrammar] " [**output] " [=override:--override|--override-all]? ( [=suboptionIndicator:-s|--suboption]  " [**suboption] " )* ;
 
 // Use statements allow incorporation of other Umple files. See [*UseStatements*]
 useStatement : use [use] ( , [extraUse] )*


### PR DESCRIPTION
When these two generators were created they were not put in the grammar, with the result that it was not possible to generate them from the command line or with the generate statement. This small PR corrects that.