### PR TITLE
Changed java templates to allow for unique immutable attributes

### DIFF
--- a/UmpleToJava/UmpleTLTemplates/attribute_Set_All.ump
+++ b/UmpleToJava/UmpleTLTemplates/attribute_Set_All.ump
@@ -36,7 +36,7 @@ class UmpleToJava {
     
     if (av.isImmutable())
     {
-      if (av.getIsLazy())
+      if (av.getIsLazy() || av.getIsUnique())
       {
         #>><<@ UmpleToJava.attribute_SetImmutable >><<#
       }

--- a/UmpleToJava/UmpleTLTemplates/constructor_DeclareDefault.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_DeclareDefault.ump
@@ -102,8 +102,8 @@ class UmpleToJava {
   } 
   
   for (Attribute av : uClass.getAttributes())
-  {
-    if (av.getIsAutounique() || av.getIsUnique() || av.isConstant() || "theInstance".equals(gen.translate("attributeOne",av)) || av.getIsDerived())
+  { // Issue 2046, workaround for unique immutable 
+    if (av.getIsAutounique() || av.getIsUnique() && !av.isImmutable() || av.isConstant() || "theInstance".equals(gen.translate("attributeOne",av)) || av.getIsDerived())
     {
       continue;
     }
@@ -120,7 +120,7 @@ class UmpleToJava {
       hasBody = true;
       #>><<@ UmpleToJava.constructor_AttributeAssignDefaulted >><<# 
     }
-    else if (av.isImmutable() && av.getIsLazy())
+    else if (av.isImmutable() && av.getIsLazy() || av.getIsUnique())
     {
       hasBody = true;
       #>><<@ UmpleToJava.constructor_AttributeUnassignedImmutable >><<#

--- a/UmpleToJava/UmpleTLTemplates/constructor_DeclareDefault.ump
+++ b/UmpleToJava/UmpleTLTemplates/constructor_DeclareDefault.ump
@@ -120,7 +120,7 @@ class UmpleToJava {
       hasBody = true;
       #>><<@ UmpleToJava.constructor_AttributeAssignDefaulted >><<# 
     }
-    else if (av.isImmutable() && av.getIsLazy() || av.getIsUnique())
+    else if (av.isImmutable() && (av.getIsLazy() || av.getIsUnique()))
     {
       hasBody = true;
       #>><<@ UmpleToJava.constructor_AttributeUnassignedImmutable >><<#

--- a/UmpleToJava/UmpleTLTemplates/members_AllHelpers.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllHelpers.ump
@@ -17,7 +17,7 @@ class UmpleToJava {
 
   for (Attribute av : uClass.getAttributes())
   { // Issue 2046 unique immutable
-    if (av.isImmutable() && av.isIsLazy() || av.getIsUnique())
+    if (av.isImmutable() && (av.isIsLazy() || av.getIsUnique()))
     {
       if (isFirst)
       {

--- a/UmpleToJava/UmpleTLTemplates/members_AllHelpers.ump
+++ b/UmpleToJava/UmpleTLTemplates/members_AllHelpers.ump
@@ -16,8 +16,8 @@ class UmpleToJava {
   }
 
   for (Attribute av : uClass.getAttributes())
-  {
-    if (av.isImmutable() && av.isIsLazy())
+  { // Issue 2046 unique immutable
+    if (av.isImmutable() && av.isIsLazy() || av.getIsUnique())
     {
       if (isFirst)
       {

--- a/testbed/src/TestHarnessAttributes.ump
+++ b/testbed/src/TestHarnessAttributes.ump
@@ -135,6 +135,10 @@ class ItemWithUniqueId {
   unique id;
 }
 
+class ItemWithUniqueImmutableId {
+  unique immutable id;
+}
+
 class ConstDefault
 {
   const int I1;

--- a/testbed/test/cruise/attributes/test/UniqueImmutableTest.java
+++ b/testbed/test/cruise/attributes/test/UniqueImmutableTest.java
@@ -1,0 +1,51 @@
+package cruise.attributes.test;
+
+import org.junit.*;
+import java.sql.*;
+
+public class UniqueImmutableTest
+{
+  private ItemWithUniqueImmutableId one, two;
+  
+  @Before
+  public void setUp() {
+    one = new ItemWithUniqueImmutableId("1");
+    two = new ItemWithUniqueImmutableId("2");
+  }
+
+  @After
+  public void tearDown() {
+    one.delete();
+    two.delete();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCreateWithDuplicates() {
+    ItemWithUniqueImmutableId duplicate = new ItemWithUniqueImmutableId("1"); 
+  }
+  
+  @Test
+  public void testHasWithGetWith() {
+    Assert.assertTrue(ItemWithUniqueImmutableId.hasWithId("1"));
+    Assert.assertFalse(ItemWithUniqueImmutableId.hasWithId("3"));
+    Assert.assertEquals(ItemWithUniqueImmutableId.getWithId("1"), one);
+    Assert.assertEquals(ItemWithUniqueImmutableId.getWithId("2"), two);
+    Assert.assertNull(ItemWithUniqueImmutableId.getWithId("3"));
+  }
+  
+  @Test
+  public void testSetId() {
+    // Attempt to change id to "1", which is already used.
+    // This should fail and so id should still be "2".
+    Assert.assertFalse(two.setId("1"));
+    Assert.assertEquals(two.getId(), "2");
+    // Attempt to change id to "3", which is free, but attribute is immutable
+    // This should fail and so id should still be "2".
+    Assert.assertFalse(two.setId("3"));
+    Assert.assertEquals(two.getId(), "2");
+    Assert.assertFalse(ItemWithUniqueImmutableId.hasWithId("3"));
+    // Since "3" is still free, create ItemWithUniqueImmutableId with "3". 
+    ItemWithUniqueImmutableId three = new ItemWithUniqueImmutableId("3");
+    three.delete();
+  }
+}


### PR DESCRIPTION
Changed templates to allow unique immutable attributes.

Design is based on generation of the lazy immutable attribute with requirements from unique. 

