### PR TITLE
Hyperlink Warning 1016 Bug

### DIFF
--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -207,7 +207,7 @@
 1014: 3, "http://manual.umple.org/?W1014ExcludedMethodNotFoundInjection.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
 # Issue 1483
 1015: 3, "http://manual.umple.org/?BasicStateMachines.html", Methods in standalone state machines might not be correctly generated. State machines can be used in traits or put directly in a class to achieve the same effect. ;
-1016: 3, "http://manual.umple.org/?UnmatchedorExtraBrackets.html", Extra Open Or Closing Bracket encountered. ;
+1016: 3, "http://manual.umple.org/?W1016UnmatchedorExtraBrackets.html", Extra Open Or Closing Bracket encountered. ;
 
 1500 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: '{0}' not understood ; 
 1501 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -3,275 +3,275 @@
 # 1,2: Error; 3: Warning, code likely incorrect. 4 Warning: Code may be incorrect. 5. Umple compiled, but embedded code had problems.: 
 # Use PageBeingDeveloped.html for new messages before manual pages are created
 
-0: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Generic Umple Error '{0}' ; 
-1: 4, "http://manual.umple.org/?W001SingletonWithNon-LazyAttribute.html", Lazy keyword is needed on singleton class attribute '{0}' as the attribute cannot added at construction time ; 
-2: 4, "http://manual.umple.org/?W002SingletonWithRequiredObject.html", Association is referencing a singleton class with multiplicity 1 '{0}' ; 
-3: 4, "http://manual.umple.org/?W003RedundantLazyWithInitialization.html", The lazy keyword is redundant when the attribute is being initialized - in class '{0}' ;
-4: 1, "http://manual.umple.org/?E004InvalidMultiplicity.html", Invalid multiplicity '{0}' ; 
-5: 1, "http://manual.umple.org/?E005UndefinedClassinAssociation.html", Association end '{0}' is not a class or interface ; 
-6: 2, "http://manual.umple.org/?E006MissingDefault.html", No default value is specified for a defaulted attribute '{0}' ; 
-7: 3, "http://manual.umple.org/?W007KeyAlreadySpecified.html", Key already specified in class '{0}' ; 
-8: 1, "http://manual.umple.org/?E008AssociationClassMissingEnd.html", Association class '{0}' is missing an end ; 
-9: 2, "http://manual.umple.org/?E009ReflexiveLowerBound.html", Reflexive association with multiplicity '{0}' has lower bound > 0 ; 
-10: 3, "http://manual.umple.org/?W010SingletonMultiplicityOver1.html", Singleton class '{0}' cannot have multiplicity greater than 1 ; 
-11: 1, "http://manual.umple.org/?E011ClassisSubclassOfSelf.html", {0} '{1}' cannot cyclically extend itself ; 
-12: 1, "http://manual.umple.org/?E012ClassIndirectlySubclassofSelf.html", {0} '{1}' cannot cyclically extend {0} '{2}' ; 
-13: 2, "http://manual.umple.org/?E013NonImmutableAssociation.html", Class at directed end of immutable association must be an immutable class ;
-14: 3, "http://manual.umple.org/?E014ImmutableSubclassofMutable.html", Existing associations, state machines, or superclass for class '{0}' prevents class-level immutability ;
-15: 3, "http://manual.umple.org/?W015ImmutableClassStateMachine.html", Immutable class '{0}' may not contain state machines ;
-16: 1, "http://manual.umple.org/?E016NonImmutableSuperclass.html", Immutability rules prevent class '{0}' from subclassing '{1}' ;
-17: 2, "http://manual.umple.org/?E017NonImmutableBidirectionality.html", Two-way associations may not be immutable ;
-18: 2, "http://manual.umple.org/?E018ReflexiveImmutable.html", Reflexive immutable associations may not be mandatory ;
-19: 2, "http://manual.umple.org/?E019DuplicateAssociation.html", There are multiple associations between class '{0}' and class '{1}'. Unique role names need to be added at '{0}' side to distinguish the different association ends in that class. ;
-20: 1, "http://manual.umple.org/?E020InterfaceAssociationNotOneWay.html", The class-interface association declared in '{0}' must have the '->' arrow ;
+0: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Generic Umple Error '{0}' ; 
+1: 4, "https://manual.umple.org/?W001SingletonWithNon-LazyAttribute.html", Lazy keyword is needed on singleton class attribute '{0}' as the attribute cannot added at construction time ; 
+2: 4, "https://manual.umple.org/?W002SingletonWithRequiredObject.html", Association is referencing a singleton class with multiplicity 1 '{0}' ; 
+3: 4, "https://manual.umple.org/?W003RedundantLazyWithInitialization.html", The lazy keyword is redundant when the attribute is being initialized - in class '{0}' ;
+4: 1, "https://manual.umple.org/?E004InvalidMultiplicity.html", Invalid multiplicity '{0}' ; 
+5: 1, "https://manual.umple.org/?E005UndefinedClassinAssociation.html", Association end '{0}' is not a class or interface ; 
+6: 2, "https://manual.umple.org/?E006MissingDefault.html", No default value is specified for a defaulted attribute '{0}' ; 
+7: 3, "https://manual.umple.org/?W007KeyAlreadySpecified.html", Key already specified in class '{0}' ; 
+8: 1, "https://manual.umple.org/?E008AssociationClassMissingEnd.html", Association class '{0}' is missing an end ; 
+9: 2, "https://manual.umple.org/?E009ReflexiveLowerBound.html", Reflexive association with multiplicity '{0}' has lower bound > 0 ; 
+10: 3, "https://manual.umple.org/?W010SingletonMultiplicityOver1.html", Singleton class '{0}' cannot have multiplicity greater than 1 ; 
+11: 1, "https://manual.umple.org/?E011ClassisSubclassOfSelf.html", {0} '{1}' cannot cyclically extend itself ; 
+12: 1, "https://manual.umple.org/?E012ClassIndirectlySubclassofSelf.html", {0} '{1}' cannot cyclically extend {0} '{2}' ; 
+13: 2, "https://manual.umple.org/?E013NonImmutableAssociation.html", Class at directed end of immutable association must be an immutable class ;
+14: 3, "https://manual.umple.org/?E014ImmutableSubclassofMutable.html", Existing associations, state machines, or superclass for class '{0}' prevents class-level immutability ;
+15: 3, "https://manual.umple.org/?W015ImmutableClassStateMachine.html", Immutable class '{0}' may not contain state machines ;
+16: 1, "https://manual.umple.org/?E016NonImmutableSuperclass.html", Immutability rules prevent class '{0}' from subclassing '{1}' ;
+17: 2, "https://manual.umple.org/?E017NonImmutableBidirectionality.html", Two-way associations may not be immutable ;
+18: 2, "https://manual.umple.org/?E018ReflexiveImmutable.html", Reflexive immutable associations may not be mandatory ;
+19: 2, "https://manual.umple.org/?E019DuplicateAssociation.html", There are multiple associations between class '{0}' and class '{1}'. Unique role names need to be added at '{0}' side to distinguish the different association ends in that class. ;
+20: 1, "https://manual.umple.org/?E020InterfaceAssociationNotOneWay.html", The class-interface association declared in '{0}' must have the '->' arrow ;
 
-21: 2, "http://manual.umple.org/?E021InvalidReflexiveAssociation.html", Reflexive association to class '{0}' must use a role name or else the keyword self ;
-22: 2, "http://manual.umple.org/?E022DuplicateAttribute.html", Class '{0}' has duplicate attribute name {1} ;
-23: 2, "http://manual.umple.org/?E023AttributeAssociationNameClash.html", Class '{0}' has attribute name {1} that duplicates an association name, or vice-versa ;
-24: 2, "http://manual.umple.org/?E024SortKeyNotofUmpleType.html", Sort key attribute '{0}' in class {1} must be of type Integer, Short, Long, Double, Float or String ;
-25: 2, "http://manual.umple.org/?E025SortKeyNotFound.html", Class '{0}' does not contain attribute {1} that is used as sort key ;
-26: 2, "http://manual.umple.org/?E026DuplicateKeyItem.html", Duplicate item '{0}' in key statement(s) in class '{1}' ;
-27: 3, "http://manual.umple.org/?W027KeyIdentifierIncorrect.html", Item '{0}' in key statement is not defined in class '{1}' ;
-28: 2, "http://manual.umple.org/?E028ConstraintIdentifierIncorrect.html", Attribute '{0}' in constraint is not defined in class '{1}' ;
-29: 2, "http://manual.umple.org/?E029ConstraintTypeMismatch.html", Constraint contains comparison between incompatible types ;
+21: 2, "https://manual.umple.org/?E021InvalidReflexiveAssociation.html", Reflexive association to class '{0}' must use a role name or else the keyword self ;
+22: 2, "https://manual.umple.org/?E022DuplicateAttribute.html", Class '{0}' has duplicate attribute name {1} ;
+23: 2, "https://manual.umple.org/?E023AttributeAssociationNameClash.html", Class '{0}' has attribute name {1} that duplicates an association name, or vice-versa ;
+24: 2, "https://manual.umple.org/?E024SortKeyNotofUmpleType.html", Sort key attribute '{0}' in class {1} must be of type Integer, Short, Long, Double, Float or String ;
+25: 2, "https://manual.umple.org/?E025SortKeyNotFound.html", Class '{0}' does not contain attribute {1} that is used as sort key ;
+26: 2, "https://manual.umple.org/?E026DuplicateKeyItem.html", Duplicate item '{0}' in key statement(s) in class '{1}' ;
+27: 3, "https://manual.umple.org/?W027KeyIdentifierIncorrect.html", Item '{0}' in key statement is not defined in class '{1}' ;
+28: 2, "https://manual.umple.org/?E028ConstraintIdentifierIncorrect.html", Attribute '{0}' in constraint is not defined in class '{1}' ;
+29: 2, "https://manual.umple.org/?E029ConstraintTypeMismatch.html", Constraint contains comparison between incompatible types ;
 
-30: 4, "http://manual.umple.org/?W030RedefinedNamespace.html", Ignored attempt to redefine the namespace of {0} {1} to {2}. Use --redefine to force this ;
-31: 4, "http://manual.umple.org/?W031NamespaceNotUsed.html", Declared namespace {0} was not used ;
-32: 1, "http://manual.umple.org/?E032ReservedRoleName.html", The role name '{0}' has a conflict. Please don't use plural form of class name as a role name ;
-33: 3, "http://manual.umple.org/?W033MissingSuperclass.html", The indicated superclass {0} of class {1} does not exist and has been ignored. Declare {0} to be external if it is defined outside this Umple system ;
-34: 2, "http://manual.umple.org/?E034MultipleInheritance.html", Multiple inheritance not allowed in Umple so  code can be generated for languages that do not permit it. So class {0} cannot be a subclass of class {1} as well as other classes. Consider using multiple implementations of an interface or using traits ;
-35: 4, "http://manual.umple.org/?W035UninitializedConstant.html", 'const' variable '{0}' of type '{1}' was not initialized and its value was thus set to '{2}' ;
-36: 3, "http://manual.umple.org/?W036UnmanagedMultiplicity.html", The specific multiplicity bounds {0} cannot be managed by generated code, since this is a directed association ;
-37: 2, "http://manual.umple.org/?E037UninitializedConstantObject.html", 'const' variable '{0}' of type '{1}' was not initialized. Since '{1}' is not a built-in Umple data type no default value could be found. '{0}' must be initialized. ;
-38: 2, "http://manual.umple.org/?E038AutogeneratedAttributeNameConflict.html", Attribute '{0}' has a name conflict with attribute auto generated by '{1}' variable '{2}';
-39: 3, "http://manual.umple.org/?W039MissingInterface.html", The interface {0} extends  an interface {1} that does not exist and has been ignored. Declare {1} to be external if it is defined outside this Umple system ;
+30: 4, "https://manual.umple.org/?W030RedefinedNamespace.html", Ignored attempt to redefine the namespace of {0} {1} to {2}. Use --redefine to force this ;
+31: 4, "https://manual.umple.org/?W031NamespaceNotUsed.html", Declared namespace {0} was not used ;
+32: 1, "https://manual.umple.org/?E032ReservedRoleName.html", The role name '{0}' has a conflict. Please don't use plural form of class name as a role name ;
+33: 3, "https://manual.umple.org/?W033MissingSuperclass.html", The indicated superclass {0} of class {1} does not exist and has been ignored. Declare {0} to be external if it is defined outside this Umple system ;
+34: 2, "https://manual.umple.org/?E034MultipleInheritance.html", Multiple inheritance not allowed in Umple so  code can be generated for languages that do not permit it. So class {0} cannot be a subclass of class {1} as well as other classes. Consider using multiple implementations of an interface or using traits ;
+35: 4, "https://manual.umple.org/?W035UninitializedConstant.html", 'const' variable '{0}' of type '{1}' was not initialized and its value was thus set to '{2}' ;
+36: 3, "https://manual.umple.org/?W036UnmanagedMultiplicity.html", The specific multiplicity bounds {0} cannot be managed by generated code, since this is a directed association ;
+37: 2, "https://manual.umple.org/?E037UninitializedConstantObject.html", 'const' variable '{0}' of type '{1}' was not initialized. Since '{1}' is not a built-in Umple data type no default value could be found. '{0}' must be initialized. ;
+38: 2, "https://manual.umple.org/?E038AutogeneratedAttributeNameConflict.html", Attribute '{0}' has a name conflict with attribute auto generated by '{1}' variable '{2}';
+39: 3, "https://manual.umple.org/?W039MissingInterface.html", The interface {0} extends  an interface {1} that does not exist and has been ignored. Declare {1} to be external if it is defined outside this Umple system ;
 
-40: 2, "http://manual.umple.org/?E040SingletonHasSubclasses.html", Singleton classes have a private constructor and cannot be extended. So class {0} cannot be a subclass of singleton class {1} ;
-41: 2, "http://manual.umple.org/?E041NonVoidMethodDeclaredasQueued.html", A non-void method cannot be declared as queued;
-42: 4, "http://manual.umple.org/?W042NamespaceCannotBeDefault.html",Class or interface {0} must not be in default namespace. Its namespace has been changed to {1};
-44: 3, "http://manual.umple.org/?W044AttributeDuplicatedinSuperclass.html", Class '{0}' has attribute name {1} that duplicates an attribute inherited from a superclass '{2}'. New definition is being disregarded ;
-45: 4, "http://manual.umple.org/?W045InitializedValueinKey.html", Attribute '{0}' in class '{1}' is in the key. Initializing it will result in all instances having this same value and being treated as equal ;
-46: 4, "http://manual.umple.org/?W046AttributeHasTemplateType.html", Attribute {0} in class {1} is declared using a collection template type {2}. Use a directed association (->) or multi-valued attribute([]) to follow proper modelling conventions ;
-47: 4, "http://manual.umple.org/?W047EmptyKeyStatement.html", Empty key statement in class {0} ;
-48: 2, "http://manual.umple.org/?E048AttributeGeneratesDuplicateMethod.html", Attribute '{0}' in class '{1}' generates method '{2}' which is a duplicate;
-49: 4, "http://manual.umple.org/?W049DuplicatedMethodName.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file. New definition at line {4} of '{5}' file is being disregarded;
+40: 2, "https://manual.umple.org/?E040SingletonHasSubclasses.html", Singleton classes have a private constructor and cannot be extended. So class {0} cannot be a subclass of singleton class {1} ;
+41: 2, "https://manual.umple.org/?E041NonVoidMethodDeclaredasQueued.html", A non-void method cannot be declared as queued;
+42: 4, "https://manual.umple.org/?W042NamespaceCannotBeDefault.html",Class or interface {0} must not be in default namespace. Its namespace has been changed to {1};
+44: 3, "https://manual.umple.org/?W044AttributeDuplicatedinSuperclass.html", Class '{0}' has attribute name {1} that duplicates an attribute inherited from a superclass '{2}'. New definition is being disregarded ;
+45: 4, "https://manual.umple.org/?W045InitializedValueinKey.html", Attribute '{0}' in class '{1}' is in the key. Initializing it will result in all instances having this same value and being treated as equal ;
+46: 4, "https://manual.umple.org/?W046AttributeHasTemplateType.html", Attribute {0} in class {1} is declared using a collection template type {2}. Use a directed association (->) or multi-valued attribute([]) to follow proper modelling conventions ;
+47: 4, "https://manual.umple.org/?W047EmptyKeyStatement.html", Empty key statement in class {0} ;
+48: 2, "https://manual.umple.org/?E048AttributeGeneratesDuplicateMethod.html", Attribute '{0}' in class '{1}' generates method '{2}' which is a duplicate;
+49: 4, "https://manual.umple.org/?W049DuplicatedMethodName.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file. New definition at line {4} of '{5}' file is being disregarded;
 
 # State-Machine related messages
-50: 4, "http://manual.umple.org/?W050TargetStateNotFound.html", State '{0}' has not been declared, it is being treated as an new state ;
-51: 2, "http://manual.umple.org/?E051EventParametersMustMatch.html", Event parameter(s) '{0}' inconsistent with previous declaration of the same event ; 
-52: 2, "http://manual.umple.org/?E052StateMachineNameClash.html", Association or attribute can not have same name as state machine '{0}' ;
-53: 2, "http://manual.umple.org/?E053NoConcurrencyAtTopLevel.html", State machine {0} has concurrent states, but concurrency is only allowed in nested substates or in 'active' blocks ;
-54: 4, "http://manual.umple.org/?W054DuplicateEvents.html", Transition {0} will be ignored due to an unguarded duplicate event;
-55: 4, "http://manual.umple.org/?W055DuplicateEventsWithinSubstates.html", Transition {0} in super-state will be ignored due to unguarded duplicate events in all sub-states ;
-56: 4, "http://manual.umple.org/?W056NoEventsinQueuedStateMachine.html", Queued State machine {0} has no events to be queued ;
-57: 4, "http://manual.umple.org/?W057NoEventsinPooledStateMachine.html", Pooled State machine {0} has no events to be pooled ;
-58: 1, "http://manual.umple.org/?E058RegularQueuedandPooledStateMachinesinClass.html", class {0} cannot have queued state machine, pooled state machine, and regular state machine in the same class ;
-59: 1, "http://manual.umple.org/?E059QueuedandPooledStateMachinesinClass.html", class {0} cannot have both queued state machine and pooled state machine in the same class ;
-60: 1, "http://manual.umple.org/?E060PooledandRegularStateMachinesinClass.html", class {0} cannot have both pooled state machine and regular state machine in the same class ;
-61: 1, "http://manual.umple.org/?E061QueuedandRegularStateMachinesinClass.html", class {0} cannot have queued state machine and regular state machine in the same class ;
-62: 4, "http://manual.umple.org/?W062UnspecifiedEventinPooledStateMachine.html", (unspecified) must not be used in combination with Pooled State machine {0} - it is treated such as other regular events - it is pooled ;
-63: 1, "http://manual.umple.org/?E063ReservedNameHistoryState.html", {0} is a reserved name for History or Deep History States ;
-64: 1, "http://manual.umple.org/?E064NonExistentHistoryState.html", You declared a History (H) or Deep History (HStar) state in a non existent state within state machine {0} ;
-65: 1, "http://manual.umple.org/?E065NoSubstatesHistoryState.html", You declared a History (H) or Deep History (HStar) state at a state without substates within state machine {0} ;
-66: 4, "http://manual.umple.org/?W066TransitionMultiplePossibleDestinations.html", Transition to '{0}' has multiple possible destinations. Please use dot notation to clarify what state the transition should go to ;
-67: 4, "http://manual.umple.org/?W067NonReachableState.html",  State '{0}' from StateMachine '{1}' is non-reachable. ;
-68: 4, "http://manual.umple.org/?W068DestinationStateNotFound.html", Destination state '{0}' of transition on line '{1}' has not been found. This transition is being disregarded ;
-69: 4, "http://manual.umple.org/?W069AutoTransitionConflict.html", Auto-Transition to '{0}' on line '{1}' conflicts with a previous exisiting transition. This transition is being disregarded ;
-70: 4, "http://manual.umple.org/?W054DuplicateEvents.html", Guarded Transition {0} will be ignored due to a duplicate event with an equivalent guard ;
+50: 4, "https://manual.umple.org/?W050TargetStateNotFound.html", State '{0}' has not been declared, it is being treated as an new state ;
+51: 2, "https://manual.umple.org/?E051EventParametersMustMatch.html", Event parameter(s) '{0}' inconsistent with previous declaration of the same event ; 
+52: 2, "https://manual.umple.org/?E052StateMachineNameClash.html", Association or attribute can not have same name as state machine '{0}' ;
+53: 2, "https://manual.umple.org/?E053NoConcurrencyAtTopLevel.html", State machine {0} has concurrent states, but concurrency is only allowed in nested substates or in 'active' blocks ;
+54: 4, "https://manual.umple.org/?W054DuplicateEvents.html", Transition {0} will be ignored due to an unguarded duplicate event;
+55: 4, "https://manual.umple.org/?W055DuplicateEventsWithinSubstates.html", Transition {0} in super-state will be ignored due to unguarded duplicate events in all sub-states ;
+56: 4, "https://manual.umple.org/?W056NoEventsinQueuedStateMachine.html", Queued State machine {0} has no events to be queued ;
+57: 4, "https://manual.umple.org/?W057NoEventsinPooledStateMachine.html", Pooled State machine {0} has no events to be pooled ;
+58: 1, "https://manual.umple.org/?E058RegularQueuedandPooledStateMachinesinClass.html", class {0} cannot have queued state machine, pooled state machine, and regular state machine in the same class ;
+59: 1, "https://manual.umple.org/?E059QueuedandPooledStateMachinesinClass.html", class {0} cannot have both queued state machine and pooled state machine in the same class ;
+60: 1, "https://manual.umple.org/?E060PooledandRegularStateMachinesinClass.html", class {0} cannot have both pooled state machine and regular state machine in the same class ;
+61: 1, "https://manual.umple.org/?E061QueuedandRegularStateMachinesinClass.html", class {0} cannot have queued state machine and regular state machine in the same class ;
+62: 4, "https://manual.umple.org/?W062UnspecifiedEventinPooledStateMachine.html", (unspecified) must not be used in combination with Pooled State machine {0} - it is treated such as other regular events - it is pooled ;
+63: 1, "https://manual.umple.org/?E063ReservedNameHistoryState.html", {0} is a reserved name for History or Deep History States ;
+64: 1, "https://manual.umple.org/?E064NonExistentHistoryState.html", You declared a History (H) or Deep History (HStar) state in a non existent state within state machine {0} ;
+65: 1, "https://manual.umple.org/?E065NoSubstatesHistoryState.html", You declared a History (H) or Deep History (HStar) state at a state without substates within state machine {0} ;
+66: 4, "https://manual.umple.org/?W066TransitionMultiplePossibleDestinations.html", Transition to '{0}' has multiple possible destinations. Please use dot notation to clarify what state the transition should go to ;
+67: 4, "https://manual.umple.org/?W067NonReachableState.html",  State '{0}' from StateMachine '{1}' is non-reachable. ;
+68: 4, "https://manual.umple.org/?W068DestinationStateNotFound.html", Destination state '{0}' of transition on line '{1}' has not been found. This transition is being disregarded ;
+69: 4, "https://manual.umple.org/?W069AutoTransitionConflict.html", Auto-Transition to '{0}' on line '{1}' conflicts with a previous exisiting transition. This transition is being disregarded ;
+70: 4, "https://manual.umple.org/?W054DuplicateEvents.html", Guarded Transition {0} will be ignored due to a duplicate event with an equivalent guard ;
 
-71: 4, "http://manual.umple.org/?W071DuplicateMethodDifferentType.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file, which returns a different type. New definition at line {4} of '{5}' file is being disregarded ;
-72: 4, "http://manual.umple.org/?W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
-73: 2, "http://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
-74: 2, "http://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
-75: 2, "http://manual.umple.org/?E075UserDefinedStateMachineCannotBeNamedTimer.html", Cannot name state machine on line '{0}' as timer because this name is reserved for internal use. Please choose another name ;
+71: 4, "https://manual.umple.org/?W071DuplicateMethodDifferentType.html", A {6} implementation of Method '{0}' in class '{1}' is already defined at line {2} of '{3}' file, which returns a different type. New definition at line {4} of '{5}' file is being disregarded ;
+72: 4, "https://manual.umple.org/?W072RefactoredFinalState.html", Removed do activities, exit actions, transitions, and/or nested state machines from final State '{0}' of StateMachine '{1}' ;
+73: 2, "https://manual.umple.org/?E073DuplicateParallelStateMachineName.html", Composite state '{0}' contains parallel state machines with the same name '{1}' on lines '{2}' and '{3}' ; 
+74: 2, "https://manual.umple.org/?E074UserDefinedStateCannotBeNamedFinal.html", Cannot name user-defined state on line '{0}' as Final because it is a reserved keyword ;
+75: 2, "https://manual.umple.org/?E075UserDefinedStateMachineCannotBeNamedTimer.html", Cannot name state machine on line '{0}' as timer because this name is reserved for internal use. Please choose another name ;
 
-80: 2, "http://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The association between a class and an abstract class declared in '{0}' must be a directed association or have one end whose multiplicity lower bound is 0 ;
-81: 2, "http://manual.umple.org/?E081InvalidMultivaluedAttributeAssignment.html", Invalid multivalued attribute assignment of attribute '{1}' in class '{0}' ;
+80: 2, "https://manual.umple.org/?E080InvalidAbstractClassAssociation.html", The association between a class and an abstract class declared in '{0}' must be a directed association or have one end whose multiplicity lower bound is 0 ;
+81: 2, "https://manual.umple.org/?E081InvalidMultivaluedAttributeAssignment.html", Invalid multivalued attribute assignment of attribute '{1}' in class '{0}' ;
 
-82: 4, "http://manual.umple.org/?E082ConflictingMethodModifersDeclaredForStateDependentMethod.html", Found conflicting modifiers for method '{0}'. Ignoring '{1}' and using '{2}' ;
-83: 2, "http://manual.umple.org/?E083InvalidMultivaluedAttributeInitialization.html", A derived attribute should not contain a list indicator. If you want to create a list initializer, it should terminate with a semicolon ;
+82: 4, "https://manual.umple.org/?E082ConflictingMethodModifersDeclaredForStateDependentMethod.html", Found conflicting modifiers for method '{0}'. Ignoring '{1}' and using '{2}' ;
+83: 2, "https://manual.umple.org/?E083InvalidMultivaluedAttributeInitialization.html", A derived attribute should not contain a list indicator. If you want to create a list initializer, it should terminate with a semicolon ;
 
 # Model Constraints' Error messages
-90: 2, "http://manual.umple.org/?E090AttributeNameNotFoundConstraint.html", Attribute named {0} was not found in class {1}, as required in constraint ;
-91: 2, "http://manual.umple.org/?E091AttributeOfTypeNotFoundConstraint.html", Attribute with type {0} was not found in class {1}, as required in constraint ;
-92: 2, "http://manual.umple.org/?E092ClassIsNotSubclassConstraint.html", Class {0} was not found to be a subclass of class {1}, as required in constraint ;
-93: 2, "http://manual.umple.org/?E093ClassIsNotSuperclassConstraint.html", Class {0} was not found to be a superclass of class {1}, as required in constraint ;
-94: 2, "http://manual.umple.org/?E094NoAssociationFoundConstraint.html", Class {0} was not found to have an association to class {1}, as required in constraint ;
+90: 2, "https://manual.umple.org/?E090AttributeNameNotFoundConstraint.html", Attribute named {0} was not found in class {1}, as required in constraint ;
+91: 2, "https://manual.umple.org/?E091AttributeOfTypeNotFoundConstraint.html", Attribute with type {0} was not found in class {1}, as required in constraint ;
+92: 2, "https://manual.umple.org/?E092ClassIsNotSubclassConstraint.html", Class {0} was not found to be a subclass of class {1}, as required in constraint ;
+93: 2, "https://manual.umple.org/?E093ClassIsNotSuperclassConstraint.html", Class {0} was not found to be a superclass of class {1}, as required in constraint ;
+94: 2, "https://manual.umple.org/?E094NoAssociationFoundConstraint.html", Class {0} was not found to have an association to class {1}, as required in constraint ;
 
 # Enumeration Errors and Warnings
-95: 2, "http://manual.umple.org/?E095DuplicateEnumerations.html", Detected duplicate enumeration '{0}' on line '{1}' ;
-96: 2, "http://manual.umple.org/?E096EnumerationNameConflict.html", Enumeration name '{0}' on line '{1}' conflicts with model element on line '{2}' ;
-97: 2, "http://manual.umple.org/?E097EnumerationAndStateMachineConflict.html", Enumeration '{0}' on line '{1}' conflicts with state machine '{2}' in class '{3}' ;
-102: 4, "http://manual.umple.org/?W102EnumerationCausesMethodParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for method '{3}' on line '{4}' instead of class '{5}' ;
-103: 4, "http://manual.umple.org/?W103EnumerationCausesEventParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for event '{3}' in state machine '{4}' instead of class '{5}' ;
-104: 2, "http://manual.umple.org/?E104EnumerationInBidirectionalAssociation.html", Cannot use enumeration '{0}' on line '{1}' in bidirectional association on line '{2}' in class '{3}' ;
-105: 2, "http://manual.umple.org/?E105EnumerationInComposition.html", Cannot use enumeration '{0}' on line '{1}' in composition on line '{2}' in class '{3}' ;
-106: 4, "http://manual.umple.org/?W106EnumerationInUnidirectionalAssociation.html", Assuming enumeration '{0}' on line '{1}' is used in unidirectional association on line '{2}' instead of class '{3}' ; 
+95: 2, "https://manual.umple.org/?E095DuplicateEnumerations.html", Detected duplicate enumeration '{0}' on line '{1}' ;
+96: 2, "https://manual.umple.org/?E096EnumerationNameConflict.html", Enumeration name '{0}' on line '{1}' conflicts with model element on line '{2}' ;
+97: 2, "https://manual.umple.org/?E097EnumerationAndStateMachineConflict.html", Enumeration '{0}' on line '{1}' conflicts with state machine '{2}' in class '{3}' ;
+102: 4, "https://manual.umple.org/?W102EnumerationCausesMethodParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for method '{3}' on line '{4}' instead of class '{5}' ;
+103: 4, "https://manual.umple.org/?W103EnumerationCausesEventParameterAmbiguity.html", Assuming enumeration '{0}' on line '{1}' as the type of parameter '{2}' for event '{3}' in state machine '{4}' instead of class '{5}' ;
+104: 2, "https://manual.umple.org/?E104EnumerationInBidirectionalAssociation.html", Cannot use enumeration '{0}' on line '{1}' in bidirectional association on line '{2}' in class '{3}' ;
+105: 2, "https://manual.umple.org/?E105EnumerationInComposition.html", Cannot use enumeration '{0}' on line '{1}' in composition on line '{2}' in class '{3}' ;
+106: 4, "https://manual.umple.org/?W106EnumerationInUnidirectionalAssociation.html", Assuming enumeration '{0}' on line '{1}' is used in unidirectional association on line '{2}' instead of class '{3}' ; 
 
 # Messages relating to format of identifiers.
-100: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Class name '{0}' must be alphanumeric and start with an alpha character, or _ (underscore) ;
-101: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Class name '{0}' should start with a capital letter ;
+100: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Class name '{0}' must be alphanumeric and start with an alpha character, or _ (underscore) ;
+101: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Class name '{0}' should start with a capital letter ;
 
-110: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' must be alphanumeric and start with an alpha character or _ (underscore) ;
-111: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' should start with a capital letter ;
-112: 2, "http://manual.umple.org/?E112DuplicateConstantsinInterface.html", Interface '{0}' has duplicate constant name {1} ;
+110: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' must be alphanumeric and start with an alpha character or _ (underscore) ;
+111: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' should start with a capital letter ;
+112: 2, "https://manual.umple.org/?E112DuplicateConstantsinInterface.html", Interface '{0}' has duplicate constant name {1} ;
 
-# [TODO - issue 337] 120: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' must be alphanumeric and start with a letter ;
-# [TODO - issue 337] 121: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' should start with a lower-case letter ;
+# [TODO - issue 337] 120: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' must be alphanumeric and start with a letter ;
+# [TODO - issue 337] 121: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' should start with a lower-case letter ;
 
-130: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' must be alphanumeric, starting with a lower-case letter ;
-131: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' should start with a lower-case letter ;
-132: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' contains special characters. Association declaration must be separated by spaces ;
+130: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' must be alphanumeric, starting with a lower-case letter ;
+131: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' should start with a lower-case letter ;
+132: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' contains special characters. Association declaration must be separated by spaces ;
 
-140: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute type name '{0}' must be alphanumeric, starting with a letter ;
-141: 4, "http://manual.umple.org/?W141ValueTypeMismatch.html", Mismatch between type '{0}' and value {1} ;
-142: 3, "http://manual.umple.org/?W142Typeisaccessspecifier.html", Attribute '{0}' has a type of {public|private|protected}. This looks like a variable of type '{1}' and is likely an error. In Umple attributes are private by default, and are Strings if no type is specified. ;
+140: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute type name '{0}' must be alphanumeric, starting with a letter ;
+141: 4, "https://manual.umple.org/?W141ValueTypeMismatch.html", Mismatch between type '{0}' and value {1} ;
+142: 3, "https://manual.umple.org/?W142Typeisaccessspecifier.html", Attribute '{0}' has a type of {public|private|protected}. This looks like a variable of type '{1}' and is likely an error. In Umple attributes are private by default, and are Strings if no type is specified. ;
 
-150: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", State machine name '{0}' must be alphanumeric and start with a letter ;
-152: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", State name '{0}' must be alphanumeric and start with a letter ;
+150: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", State machine name '{0}' must be alphanumeric and start with a letter ;
+152: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", State name '{0}' must be alphanumeric and start with a letter ;
 
-160: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Constant name '{0}' must be alphanumeric, starting with a upper-case letter ;
-161: 4, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Constant name '{0}' should start with a upper-case letter ;
+160: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Constant name '{0}' must be alphanumeric, starting with a upper-case letter ;
+161: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Constant name '{0}' should start with a upper-case letter ;
 
 
-170: 3, "http://manual.umple.org/?CustomConstructor.html", Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.;
-180: 2, "http://manual.umple.org/?E180DuplicateAssociationNameClassHierarchy", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
+170: 3, "https://manual.umple.org/?CustomConstructor.html", Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.;
+180: 2, "https://manual.umple.org/?E180DuplicateAssociationNameClassHierarchy", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
 
 # Messages related to traits starting with 200
-200: 2, "http://manual.umple.org/?E200TraitIdentifierInvalid.html", The name of trait '{0}' must be alphanumeric and start with an alpha character, or _ . ;
-201: 4, "http://manual.umple.org/?W201TraitNameSyntax.html", The name of trait '{0}' should be started with a capital letter. ;
-202: 1, "http://manual.umple.org/?E202Traitnotdefined.html", The trait named '{0}' is not available. ;
-203: 1, "http://manual.umple.org/?E203Nothavinganuniqueidentifier.html", There is a {0} and a trait with the same name '{1}'. Solution: Please just change the name of trait or {0} and give it an unique name. ;
-204: 1, "http://manual.umple.org/?E204SelfUseofTraits.html", The trait named '{0}' cannot use itself. Solution: Please check the name of used trait or change your design not to have this use. ;
+200: 2, "https://manual.umple.org/?E200TraitIdentifierInvalid.html", The name of trait '{0}' must be alphanumeric and start with an alpha character, or _ . ;
+201: 4, "https://manual.umple.org/?W201TraitNameSyntax.html", The name of trait '{0}' should be started with a capital letter. ;
+202: 1, "https://manual.umple.org/?E202Traitnotdefined.html", The trait named '{0}' is not available. ;
+203: 1, "https://manual.umple.org/?E203Nothavinganuniqueidentifier.html", There is a {0} and a trait with the same name '{1}'. Solution: Please just change the name of trait or {0} and give it an unique name. ;
+204: 1, "https://manual.umple.org/?E204SelfUseofTraits.html", The trait named '{0}' cannot use itself. Solution: Please check the name of used trait or change your design not to have this use. ;
 #need to be added to manual
-205: 1, "http://manual.umple.org/?E205CycleinTraits.html", Trait '{0}' cannot cyclically extend '{1}'. ;
-206: 1, "http://manual.umple.org/?E206SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must implement interface '{5}';
+205: 1, "https://manual.umple.org/?E205CycleinTraits.html", Trait '{0}' cannot cyclically extend '{1}'. ;
+206: 1, "https://manual.umple.org/?E206SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must implement interface '{5}';
 
 # 207 has not been used.
-207: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Variable '{0}' inside of the constraint in trait '{1}' is not available in class '{2}' or trait '{1}'. ;
-208: 1, "http://manual.umple.org/?E208RequiredMethodsNotAvailable.html", Required method '{0}' in trait '{1}' is not available in class '{2}'. ;
+207: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Variable '{0}' inside of the constraint in trait '{1}' is not available in class '{2}' or trait '{1}'. ;
+208: 1, "https://manual.umple.org/?E208RequiredMethodsNotAvailable.html", Required method '{0}' in trait '{1}' is not available in class '{2}'. ;
 # 209 has not been used.
-209: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Defined name '{0}' in trait '{1}' is not available in the trait's header. ;
-210: 1, "http://manual.umple.org/?E210ConflictinMethods.html", In {0} '{1}', there is a conflict on method '{2}' which comes from two different traits '{3}' and '{4}'. ;
-211: 1, "http://manual.umple.org/?E211TwoorMoreModifications.html", In the modification level of trait '{0}', method '{1}' has been defined two times. ;
-212: 1, "http://manual.umple.org/?E212MethodsNotAvailable.html", Method '{0}' is not available in trait '{1}' for modification. ;
-213: 1, "http://manual.umple.org/?E213BidirectionalAssociationinTraits.html", The bidirectional association inside trait '{0}' must be with a class. ;
+209: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Defined name '{0}' in trait '{1}' is not available in the trait's header. ;
+210: 1, "https://manual.umple.org/?E210ConflictinMethods.html", In {0} '{1}', there is a conflict on method '{2}' which comes from two different traits '{3}' and '{4}'. ;
+211: 1, "https://manual.umple.org/?E211TwoorMoreModifications.html", In the modification level of trait '{0}', method '{1}' has been defined two times. ;
+212: 1, "https://manual.umple.org/?E212MethodsNotAvailable.html", Method '{0}' is not available in trait '{1}' for modification. ;
+213: 1, "https://manual.umple.org/?E213BidirectionalAssociationinTraits.html", The bidirectional association inside trait '{0}' must be with a class. ;
 
-214: 1, "http://manual.umple.org/?E214TwoIdenticalParameterNames.html", It is impossible to have two parameters with the same name '{0}' in trait'{1}'. ;
-215: 1, "http://manual.umple.org/?E215TemplateParameterNotAvailable.html", Parameter '{0}' is not available. ;
-216: 1, "http://manual.umple.org/?E216TwiceBindingofaParameter.html", Parameter '{0}' cannot be allocated two times. ;
-217: 1, "http://manual.umple.org/?E217ConflictinTypesofAttributes.html", There is a conflict for attribute '{0}' in traits '{1}' because of assigning two different types '{2}' and '{3}'. ;
-218: 3, "http://manual.umple.org/?W218ConflictinAttributes.html", The attribute '{0}' which comes from trait '{1}' is also available in {2} '{3}'. ;
-219: 1, "http://manual.umple.org/?E219NoBindingforParameters.html", Please assign a value for type parameter '{0}' in trait '{1}' ;
-220: 1, "http://manual.umple.org/?E220TwoMethodsWiththeSameName.html", The new name '{0}' for method '{1}' is already available in the trait. ;
-221: 1, "http://manual.umple.org/?E221AvailabilityofBoundType.html", Binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' is not available in the system.;
-222: 1, "http://manual.umple.org/?E222SatisfactionofRequiredInterfaces.html", Class '{0}' must implement interface '{1}' so as to be able to use trait '{2}'.;
-223: 1, "http://manual.umple.org/?E223AvailabilityofTypes.html", The type of '{0}' in template parameter '{1}' in trait '{2}' has not been defined.;
-224: 1, "http://manual.umple.org/?E224MultipleInheritanceConstraint.html", Template parameter '{0}' in trait '{1}' has an multiple inheritance restriction, according to classes '{2}' and '{3}', which is not supported. Restrictions must cover single inheritance and multiple interface.;
-225: 1, "http://manual.umple.org/?E225SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must be a subclass of class '{5}';
+214: 1, "https://manual.umple.org/?E214TwoIdenticalParameterNames.html", It is impossible to have two parameters with the same name '{0}' in trait'{1}'. ;
+215: 1, "https://manual.umple.org/?E215TemplateParameterNotAvailable.html", Parameter '{0}' is not available. ;
+216: 1, "https://manual.umple.org/?E216TwiceBindingofaParameter.html", Parameter '{0}' cannot be allocated two times. ;
+217: 1, "https://manual.umple.org/?E217ConflictinTypesofAttributes.html", There is a conflict for attribute '{0}' in traits '{1}' because of assigning two different types '{2}' and '{3}'. ;
+218: 3, "https://manual.umple.org/?W218ConflictinAttributes.html", The attribute '{0}' which comes from trait '{1}' is also available in {2} '{3}'. ;
+219: 1, "https://manual.umple.org/?E219NoBindingforParameters.html", Please assign a value for type parameter '{0}' in trait '{1}' ;
+220: 1, "https://manual.umple.org/?E220TwoMethodsWiththeSameName.html", The new name '{0}' for method '{1}' is already available in the trait. ;
+221: 1, "https://manual.umple.org/?E221AvailabilityofBoundType.html", Binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' is not available in the system.;
+222: 1, "https://manual.umple.org/?E222SatisfactionofRequiredInterfaces.html", Class '{0}' must implement interface '{1}' so as to be able to use trait '{2}'.;
+223: 1, "https://manual.umple.org/?E223AvailabilityofTypes.html", The type of '{0}' in template parameter '{1}' in trait '{2}' has not been defined.;
+224: 1, "https://manual.umple.org/?E224MultipleInheritanceConstraint.html", Template parameter '{0}' in trait '{1}' has an multiple inheritance restriction, according to classes '{2}' and '{3}', which is not supported. Restrictions must cover single inheritance and multiple interface.;
+225: 1, "https://manual.umple.org/?E225SatisfactionofBoundType.html", The binding type '{0}' for template parameter '{1}' of trait '{2}' in {3} '{4}' must be a subclass of class '{5}';
 #226 and 227 must be explored.
-226: 3, "http://manual.umple.org/?PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' is the native state machine in {2} '{3}'.Therefore, it's disregarded.;
-227: 3, "http://manual.umple.org/?PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' in the {2} '{3}' has already been imported from the trait '{4}'.Therefore, it's disregarded.;
-228: 3, "http://manual.umple.org/?W228DifferentInitialStates.html", Since there are two state machines/composite states with the same name '{0}' and having two initial states is not acceptable. These two state machines/composite states are merged as a parallel state machine.;
-229: 1, "http://manual.umple.org/?E229TwoTimesRenaming.html", In the modification level of trait '{0}', the state machine/state/event '{1}' has been defined two times. ;
-230: 1, "http://manual.umple.org/?E230AvailabilityofStateMachines.html", In the modification level of trait '{0}', the state machine/state '{1}' does not exist. ;
-231: 1, "http://manual.umple.org/?E231AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machine '{1}', the event '{2}' does not exist. ;
-232: 1, "http://manual.umple.org/?E232AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machines, the event '{1}' does not exist. ;
-233: 1, "http://manual.umple.org/?E233RemovingInitialState.html", In the modification level of trait '{0}', the {1} state {2} cannot be removed.;
-234: 1, "http://manual.umple.org/?E234CompositingNon-DeterministicTransitions.html", In the composition level of trait, the event '{0}' which comes from '{1}' and '{2}' results in none-determinism so the composition is not allowed.;
-235: 1, "http://manual.umple.org/?E235SuperCallConflict.html", In the composition level of trait, the event '{0}' in state '{1}' which comes from traits '{2}' and '{3}' results in a conflict.;
-236: 1, "http://manual.umple.org/?E236TwoStateEntries.html", In the composition level of trait, the '{0}' activity/action in state '{1}', which comes from traits '{2}' and '{3}', results in a conflict.;
-237: 1, "http://manual.umple.org/?E237ComposingTwoStateEntries.html", In the modification level of trait '{0}', state '{1}' has already have another region with the name '{2}'.;
+226: 3, "https://manual.umple.org/?PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' is the native state machine in {2} '{3}'.Therefore, it's disregarded.;
+227: 3, "https://manual.umple.org/?PageBeingDeveloped.html", The state machine '{0}' that comes from the trait '{1}' in the {2} '{3}' has already been imported from the trait '{4}'.Therefore, it's disregarded.;
+228: 3, "https://manual.umple.org/?W228DifferentInitialStates.html", Since there are two state machines/composite states with the same name '{0}' and having two initial states is not acceptable. These two state machines/composite states are merged as a parallel state machine.;
+229: 1, "https://manual.umple.org/?E229TwoTimesRenaming.html", In the modification level of trait '{0}', the state machine/state/event '{1}' has been defined two times. ;
+230: 1, "https://manual.umple.org/?E230AvailabilityofStateMachines.html", In the modification level of trait '{0}', the state machine/state '{1}' does not exist. ;
+231: 1, "https://manual.umple.org/?E231AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machine '{1}', the event '{2}' does not exist. ;
+232: 1, "https://manual.umple.org/?E232AvailabilityofEvents.html", In the modification level of trait '{0}' and its state machines, the event '{1}' does not exist. ;
+233: 1, "https://manual.umple.org/?E233RemovingInitialState.html", In the modification level of trait '{0}', the {1} state {2} cannot be removed.;
+234: 1, "https://manual.umple.org/?E234CompositingNon-DeterministicTransitions.html", In the composition level of trait, the event '{0}' which comes from '{1}' and '{2}' results in none-determinism so the composition is not allowed.;
+235: 1, "https://manual.umple.org/?E235SuperCallConflict.html", In the composition level of trait, the event '{0}' in state '{1}' which comes from traits '{2}' and '{3}' results in a conflict.;
+236: 1, "https://manual.umple.org/?E236TwoStateEntries.html", In the composition level of trait, the '{0}' activity/action in state '{1}', which comes from traits '{2}' and '{3}', results in a conflict.;
+237: 1, "https://manual.umple.org/?E237ComposingTwoStateEntries.html", In the modification level of trait '{0}', state '{1}' has already have another region with the name '{2}'.;
 
 # Messages related to MOTL starting with 300
-301: 4,  "http://manual.umple.org/?W301TracingEntityNotFound.html", Tracing of non-existent model entity ;
-302: 4,  "http://manual.umple.org/?W302TracerNotRecognized.html", Tracer not recognized - Console tracer is defaulted ;
-303: 1,  "http://manual.umple.org/?PageBeingDeveloped.html", Parsing error: Incorrect attribute trace prefix '{0}' (Prefix can be set/get/both) ;
+301: 4,  "https://manual.umple.org/?W301TracingEntityNotFound.html", Tracing of non-existent model entity ;
+302: 4,  "https://manual.umple.org/?W302TracerNotRecognized.html", Tracer not recognized - Console tracer is defaulted ;
+303: 1,  "https://manual.umple.org/?PageBeingDeveloped.html", Parsing error: Incorrect attribute trace prefix '{0}' (Prefix can be set/get/both) ;
 
 # Messages relating to deprecated features starting with 901
-901: 4, "http://manual.umple.org/?W901DeprecatedKeywordConstant.html", Keyword "constant" deprecated, please use "const" ;
+901: 4, "https://manual.umple.org/?W901DeprecatedKeywordConstant.html", Keyword "constant" deprecated, please use "const" ;
 
 # Messages relating to general parsing issues
-1002: 5, "http://manual.umple.org/?W1002-3UnexpectedEmbeddedCode.html", Embedded method with code or unparsed code found when strictness is 'modelOnly' ;
-1003: 5, "http://manual.umple.org/?W1002-3UnexpectedEmbeddedCode.html", Unparsed extra code found when strictness is 'noExtraCode' ;
-1004: 2, "http://manual.umple.org/?E1004-5MessagesnotasExpected.html", Expected message '{0}' not found ;
-1005: 2, "http://manual.umple.org/?E1004-5MessagesnotasExpected.html", Disallowed warning message '{0}' encountered ;
-1006: 3, "http://manual.umple.org/?W1006StateMachineNotParsed.html", State machine syntax could not be processed. It has been considered as Extra Code ;
-1007: 3, "http://manual.umple.org/?W1007ElementNotParsed.html", Attribute or Association syntax could not be processed. It has been considered as Extra Code ;
-1008: 3, "http://manual.umple.org/?W1008MethodNotParsed.html", Method syntax could not be processed. It has been considered as Extra Code ;
-1009: 4, "http://manual.umple.org/?W1009GetterSetterMethodNameConflict.html", Method '{0}' has a name conflict with automatic generated getter/setter methods for attribute '{1}' in class '{2}'. Please use a different method name ;
-1010: 3, "http://manual.umple.org/?W1010ConstraintSyntaxCouldNotBeProcessed.html", Constraint syntax, {0}, could not be processed. It has been considered as Extra Code ;
-1011: 3, "http://manual.umple.org/?W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
-1012: 3, "http://manual.umple.org/?W1012MethodNotFoundInjection.html", Method '{0}' cannot be found. Injection was ignored. ;
-1013: 3, "http://manual.umple.org/?W1013ParameterSpecificationDoesNotApply.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
-1014: 3, "http://manual.umple.org/?W1014ExcludedMethodNotFoundInjection.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
+1002: 5, "https://manual.umple.org/?W1002-3UnexpectedEmbeddedCode.html", Embedded method with code or unparsed code found when strictness is 'modelOnly' ;
+1003: 5, "https://manual.umple.org/?W1002-3UnexpectedEmbeddedCode.html", Unparsed extra code found when strictness is 'noExtraCode' ;
+1004: 2, "https://manual.umple.org/?E1004-5MessagesnotasExpected.html", Expected message '{0}' not found ;
+1005: 2, "https://manual.umple.org/?E1004-5MessagesnotasExpected.html", Disallowed warning message '{0}' encountered ;
+1006: 3, "https://manual.umple.org/?W1006StateMachineNotParsed.html", State machine syntax could not be processed. It has been considered as Extra Code ;
+1007: 3, "https://manual.umple.org/?W1007ElementNotParsed.html", Attribute or Association syntax could not be processed. It has been considered as Extra Code ;
+1008: 3, "https://manual.umple.org/?W1008MethodNotParsed.html", Method syntax could not be processed. It has been considered as Extra Code ;
+1009: 4, "https://manual.umple.org/?W1009GetterSetterMethodNameConflict.html", Method '{0}' has a name conflict with automatic generated getter/setter methods for attribute '{1}' in class '{2}'. Please use a different method name ;
+1010: 3, "https://manual.umple.org/?W1010ConstraintSyntaxCouldNotBeProcessed.html", Constraint syntax, {0}, could not be processed. It has been considered as Extra Code ;
+1011: 3, "https://manual.umple.org/?W1011InvalidAssociationClassKey.html", AssociationClass '{0}' missing needed '{1}' key, provided {2} ;
+1012: 3, "https://manual.umple.org/?W1012MethodNotFoundInjection.html", Method '{0}' cannot be found. Injection was ignored. ;
+1013: 3, "https://manual.umple.org/?W1013ParameterSpecificationDoesNotApply.html", Parameter specification does not apply to code injections with the '{0}' keyword. The injection was applied to all generated methods. ;
+1014: 3, "https://manual.umple.org/?W1014ExcludedMethodNotFoundInjection.html", Excluded method '{0}' cannot be found. The exclusion was ignored. ;
 # Issue 1483
-1015: 3, "http://manual.umple.org/?BasicStateMachines.html", Methods in standalone state machines might not be correctly generated. State machines can be used in traits or put directly in a class to achieve the same effect. ;
-1016: 3, "http://manual.umple.org/?W1016UnmatchedorExtraBrackets.html", Extra Open Or Closing Bracket encountered. ;
+1015: 3, "https://manual.umple.org/?BasicStateMachines.html", Methods in standalone state machines might not be correctly generated. State machines can be used in traits or put directly in a class to achieve the same effect. ;
+1016: 3, "https://manual.umple.org/?W1016UnmatchedorExtraBrackets.html", Extra Open Or Closing Bracket encountered. ;
 
-1500 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: '{0}' not understood ; 
-1501 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 
-1502 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: Structure of '{0}' invalid ;
-1503 : 1, "http://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
-1510 : 3, "http://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
+1500 : 1, "https://manual.umple.org/?E15xxParsingError.html", Parsing error: '{0}' not understood ; 
+1501 : 1, "https://manual.umple.org/?E15xxParsingError.html", Parsing error: Arguments to '{0}' not understood ; 
+1502 : 1, "https://manual.umple.org/?E15xxParsingError.html", Parsing error: Structure of '{0}' invalid ;
+1503 : 1, "https://manual.umple.org/?E15xxParsingError.html", Parsing error: {0}, did you mean {1} ;  
+1510 : 3, "https://manual.umple.org/?E1510UseFileMissing.html", File '{0}' referred to in use statement was not found ; 
 
-1511 : 2, "http://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
-1512 : 4, "http://manual.umple.org/?W1512CodeLabelsInsideMethodAreNotUnique.html", Multiple code labels having the same name should be avoided for the method '{0}' at line '{1}'. Please consider unique names for code labels. ; 
-1513 : 4, "http://manual.umple.org/?W1513MixsetUsedWithNoDeclaration.html", The mixset '{0}' has a use statement at line '{1}', however there is no declaration for this mixset. To avoid this warning, you many remove the use statement or you may add a declaration for mixset '{0}'. ; 
+1511 : 2, "https://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
+1512 : 4, "https://manual.umple.org/?W1512CodeLabelsInsideMethodAreNotUnique.html", Multiple code labels having the same name should be avoided for the method '{0}' at line '{1}'. Please consider unique names for code labels. ; 
+1513 : 4, "https://manual.umple.org/?W1513MixsetUsedWithNoDeclaration.html", The mixset '{0}' has a use statement at line '{1}', however there is no declaration for this mixset. To avoid this warning, you many remove the use statement or you may add a declaration for mixset '{0}'. ; 
 
 
 # Messages to be emitted when embedded code from another language is compiled and you are passing on the error. These have not yet been activated.
-2001: 5, "http://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;
-2002: 5, "http://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in C++ embedded in Umple: '{0}' ;
+2001: 5, "https://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;
+2002: 5, "https://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in C++ embedded in Umple: '{0}' ;
 
 
 # Messages related to templates
-3500: 2, "http://manual.umple.org/?E3500InvalidTemplateName.html", Template name '{0}' must be alphanumeric and start with an alpha character, or _  ;
-3501: 2, "http://manual.umple.org/?E3501TemplateMethodCannotBeMain.html", Template emit method can not be a main.;
-3502: 1, "http://manual.umple.org/?E3502TemplateNameCannotBeResolved.html", Template name '{0}' can not be resolved.;
-3503: 2, "http://manual.umple.org/?E3503TemplateReferenceRefersToItself.html", Template reference '{0}' cannot refer to itself.;
-3504: 2, "http://manual.umple.org/?E3504TemplateReferenceCannotBeResolved.html", Template reference '{0}' can not be resolved.;
-3505: 1, "http://manual.umple.org/?E3505TemplateReferenceCycle.html", Template reference '{0}' can not cyclically refer to '{1}'.;
-3506: 4, "http://manual.umple.org/?W3506DuplicateTemplateName.html", Class '{0}' has duplicate template name {1} ;
-3507: 2, "http://manual.umple.org/?E3507DuplicateEmitMethodName.html", Class '{0}' has duplicate method name {1} ;
-3508: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Emit name '{0}' must be alphanumeric and start with an alpha character, or _  ;
+3500: 2, "https://manual.umple.org/?E3500InvalidTemplateName.html", Template name '{0}' must be alphanumeric and start with an alpha character, or _  ;
+3501: 2, "https://manual.umple.org/?E3501TemplateMethodCannotBeMain.html", Template emit method can not be a main.;
+3502: 1, "https://manual.umple.org/?E3502TemplateNameCannotBeResolved.html", Template name '{0}' can not be resolved.;
+3503: 2, "https://manual.umple.org/?E3503TemplateReferenceRefersToItself.html", Template reference '{0}' cannot refer to itself.;
+3504: 2, "https://manual.umple.org/?E3504TemplateReferenceCannotBeResolved.html", Template reference '{0}' can not be resolved.;
+3505: 1, "https://manual.umple.org/?E3505TemplateReferenceCycle.html", Template reference '{0}' can not cyclically refer to '{1}'.;
+3506: 4, "https://manual.umple.org/?W3506DuplicateTemplateName.html", Class '{0}' has duplicate template name {1} ;
+3507: 2, "https://manual.umple.org/?E3507DuplicateEmitMethodName.html", Class '{0}' has duplicate method name {1} ;
+3508: 2, "https://manual.umple.org/?PageBeingDeveloped.html", Emit name '{0}' must be alphanumeric and start with an alpha character, or _  ;
 
 # Messages related to structure
-3601: 2, "http://manual.umple.org/?WE1xxIdentifierInvalid.html", Port name '{0}' must be alphanumeric and start with a letter.;
-3602: 2, "http://manual.umple.org/?PageBeingDeveloped.html", Invalid Port direction '{0}' must be in, out, or port.;
-3603: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding from component '{0}' can not be resolved.;
-3604: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding to component '{0}' can not be resolved.;
-3605: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding from port can not be resolved.;
-3606: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Port binding to port can not be resolved.;
-3607: 1, "http://manual.umple.org/?E3607PortNameCannotBeResolved.html", Port name '{0}' from class '{1}' can not be resolved.;
+3601: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Port name '{0}' must be alphanumeric and start with a letter.;
+3602: 2, "https://manual.umple.org/?PageBeingDeveloped.html", Invalid Port direction '{0}' must be in, out, or port.;
+3603: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding from component '{0}' can not be resolved.;
+3604: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding to component '{0}' can not be resolved.;
+3605: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding from port can not be resolved.;
+3606: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding to port can not be resolved.;
+3607: 1, "https://manual.umple.org/?E3607PortNameCannotBeResolved.html", Port name '{0}' from class '{1}' can not be resolved.;
 
 # Messages related to fixml
-4500: 1,  "http://manual.umple.org/?E4500TagNotClosedCorrectly.html", The tag '{0}' is not closed correctly.  ;
+4500: 1,  "https://manual.umple.org/?E4500TagNotClosedCorrectly.html", The tag '{0}' is not closed correctly.  ;
 
 # Warning messages related to distributed systems
 
-7002: 4, "http://manual.umple.org/?AssociationDistToNonDistributed.html", Distributed class '{0}' has an association with non-distributed class '{1}'. ;
-7001: 4, "http://manual.umple.org/?StaticAttributeExists.html", System is distributed but class '{0}' has a static attribute {1}. This might result in multiple instances;
-7003: 4, "http://manual.umple.org/?DistributedWOAssociation.html", Distributed class '{0}' has no associations {1} It is better to define it as regular class if it is not called remotely;
+7002: 4, "https://manual.umple.org/?AssociationDistToNonDistributed.html", Distributed class '{0}' has an association with non-distributed class '{1}'. ;
+7001: 4, "https://manual.umple.org/?StaticAttributeExists.html", System is distributed but class '{0}' has a static attribute {1}. This might result in multiple instances;
+7003: 4, "https://manual.umple.org/?DistributedWOAssociation.html", Distributed class '{0}' has no associations {1} It is better to define it as regular class if it is not called remotely;
 
 # Special testing messages for debugging
-8001: 1, "http://manual.umple.org/?PageBeingDeveloped.html", Debug error : '{0}' ;
-8005: 5, "http://manual.umple.org/?PageBeingDeveloped.html", Debug warning : '{0}' ;
+8001: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Debug error : '{0}' ;
+8005: 5, "https://manual.umple.org/?PageBeingDeveloped.html", Debug warning : '{0}' ;
 
 # Messages related to code generator
-9000: 1, "http://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Parsing). {0} ;
-9100: 1, "http://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Analysis). {0} ;
-9200: 1, "http://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Generation). {0} ;
+9000: 1, "https://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Parsing). {0} ;
+9100: 1, "https://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Analysis). {0} ;
+9200: 1, "https://manual.umple.org/?E9x00CompilerError.html", Compiler Error (Generation). {0} ;
 
 # Message to emit when you are parsing a construct but are not yet processing it in a sensible way/
-9999: 5, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Feature under development. '{0}' found and ignored. processed as: '{1}' ;
+9999: 5, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Feature under development. '{0}' found and ignored. processed as: '{1}' ;
 
 # Messages related to test in Umple model
-6001: 4, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Missing implementation for tests found in interface. Class {0} must implement : {1};
-6002: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test case . {0} ;
-6003: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing assertion . {0} ;
-6004: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test inside method . {0} ;
-6005: 2, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test case in interface . {0} ;
-6006: 4, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Class {0} has test sequence {1} but no tests were detected. ;
-6006: 4, "http://manual.umple.org/?W9999FeatureUnderDevelopment.html", Class {0}:  test case {2} is not included in test sequence {1}. ;
+6001: 4, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Missing implementation for tests found in interface. Class {0} must implement : {1};
+6002: 2, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test case . {0} ;
+6003: 2, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing assertion . {0} ;
+6004: 2, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test inside method . {0} ;
+6005: 2, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Error parsing test case in interface . {0} ;
+6006: 4, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Class {0} has test sequence {1} but no tests were detected. ;
+6006: 4, "https://manual.umple.org/?W9999FeatureUnderDevelopment.html", Class {0}:  test case {2} is not included in test sequence {1}. ;
 


### PR DESCRIPTION
Pull Request for #2063 

## Issue2063Hyperlink1016Warning

Small mistake where en.error had the wrong Hyperlink. After double checking the user manual
With Link: https://cruise.umple.org/umple/W1016UnmatchedorExtraBrackets.html
A change in en.error has been made from "http://manual.umple.org/?UnmatchedorExtraBrackets.html" 
to "http://manual.umple.org/?W1016UnmatchedorExtraBrackets.html".