### PR TITLE
Solving requirements crash #2051 and convering print to proper warning #2052

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -223,37 +223,27 @@ class UmpleInternalParser
 
   private void analyzeImplementReq(Token t){
     int counter=0;
+    String badReq="";
 
     if (t.hasSubTokens()){
       for (Token sub : t.getSubTokens()){
         if (!sub.getValue().equals("STATIC") && model.getAllRequirements().containsKey(sub.getValue())){
             lastRequirements.add(model.getAllRequirements().get(sub.getValue()));
         }
-        else if (!sub.getValue().equals("STATIC")) counter++;
+        else if (!sub.getValue().equals("STATIC")) {
+          counter++;
+          badReq+=" "+sub.getValue();
+        }
       }
     }
 
     if (counter != 0){
-      System.out.println("ERROR: Cannot find specified requirement identifier");
+      setFailedPosition(t.getPosition(), 401, badReq);
     }
   }
 
-  private void analyzeImplementReq(Token t, UmpleClass aClass){
-    int counter=0;
-
-    if (t.hasSubTokens()){
-      for (Token sub : t.getSubTokens()){
-        if (!sub.getValue().equals("STATIC") && aClass.getSourceModel().getAllRequirements().containsKey(sub.getValue())){
-            lastRequirements.add(model.getAllRequirements().get(sub.getValue()));
-        }
-        else if (!sub.getValue().equals("STATIC")) counter++;
-      }
-    }
-
-    if (counter != 0){
-      analyzeAttribute(t, aClass);
-    }
-
+  private void analyzeImplementReq(Token t, UmpleClass aClass) {
+    analyzeImplementReq(t);
   }
   
   /*

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -188,6 +188,9 @@
 302: 4,  "https://manual.umple.org/?W302TracerNotRecognized.html", Tracer not recognized - Console tracer is defaulted ;
 303: 1,  "https://manual.umple.org/?PageBeingDeveloped.html", Parsing error: Incorrect attribute trace prefix '{0}' (Prefix can be set/get/both) ;
 
+# Message related to requirements start with 400
+401: 4, "https://manual.umple.org/?PageBeingDeveloped.html", Cannot find specified requirement identifier(s): {0} ;
+
 # Messages relating to deprecated features starting with 901
 901: 4, "https://manual.umple.org/?W901DeprecatedKeywordConstant.html", Keyword "constant" deprecated, please use "const" ;
 


### PR DESCRIPTION
This fixes #2051 where there was a crash case in the requirements feature: It was trying to analyse a requirements implementation as an attribute.

It also turns the print statement into a proper Umple warning message (#2052)