### PR TITLE
Added suboption to increase separation

### DIFF
--- a/cruise.umple/src/Generator.ump
+++ b/cruise.umple/src/Generator.ump
@@ -19,11 +19,10 @@ interface CodeGenerator
   boolean setOutput(String aString);
   boolean setSuboption(String subopt);
   boolean hasSuboption(String subopt);
-  double getSuboptionValue();
+  double getSuboptionValue(String subopt, Double defaultVal);
   void generate();
   void prepare();
   void postpare();
-
 }
 
 // Default implementation for generators with suboptions
@@ -41,29 +40,28 @@ class CodeGeneratorWithSubptions
     return suboptions.add(subopt);
   }
 
-//this is used to get the seperator value after the =  for suboption increaseseperator
-  public double getSuboptionValue(){
-    double ret = 0.5; //define the default return value 0.5 because that is graphviz default
-  String partOfString = "increaseseperator"; //we want to check which suboption contains the letters "increaseseperator"
-  String modifiedString = "";
+//this is used to get the separator value after the =  for suboptions and can be used for any other
+  public double getSuboptionValue(String subopt, Double defaultVal){
+    double ret = defaultVal; //define the default return value 0.5 because that is graphviz default
+    String partOfString = subopt; //we want to check which suboption contains the prefix
+    String modifiedString = "";
 
-  for (String s : suboptions) { //iterates through each suboption to find the suboption that contains "increaseseperator"
-            if (s.contains(partOfString)) { //checks to see if "increaseseperator is in our suboptions []
-            String originalString = s; //save the string of the full suboption. for example (increaseseperator=10)
+    for (String s : suboptions) { //iterates through each suboption to find the suboption that contains the prefix
+      if (s.contains(partOfString)) { //checks to see if prefix is in our suboptions []
+        String originalString = s; //save the string of the full suboption. for example (gvseparator=10)
         
-        // Find the position of '='
+         // Find the position of '='
         int equalsPosition = originalString.indexOf('=');
 
         // Extract everything after '='
         // Add 1 to skip the '=' character itself
         if (equalsPosition != -1) { // Check if '=' is found
-            modifiedString = originalString.substring(equalsPosition + 1);
-            ret = Double.parseDouble(modifiedString); //save the value of the double
-
+          modifiedString = originalString.substring(equalsPosition + 1);
+          ret = Double.parseDouble(modifiedString); //save the value of the double
         }
-            }
-        }
-  return ret;
+      }
+    }
+    return ret;
   }
 }
 

--- a/cruise.umple/src/Generator.ump
+++ b/cruise.umple/src/Generator.ump
@@ -19,9 +19,11 @@ interface CodeGenerator
   boolean setOutput(String aString);
   boolean setSuboption(String subopt);
   boolean hasSuboption(String subopt);
+  double getSuboptionValue();
   void generate();
   void prepare();
   void postpare();
+
 }
 
 // Default implementation for generators with suboptions
@@ -37,6 +39,31 @@ class CodeGeneratorWithSubptions
   public boolean setSuboption(String subopt)
   {
     return suboptions.add(subopt);
+  }
+
+//this is used to get the seperator value after the =  for suboption increaseseperator
+  public double getSuboptionValue(){
+    double ret = 0.5; //define the default return value 0.5 because that is graphviz default
+  String partOfString = "increaseseperator"; //we want to check which suboption contains the letters "increaseseperator"
+  String modifiedString = "";
+
+  for (String s : suboptions) { //iterates through each suboption to find the suboption that contains "increaseseperator"
+            if (s.contains(partOfString)) { //checks to see if "increaseseperator is in our suboptions []
+            String originalString = s; //save the string of the full suboption. for example (increaseseperator=10)
+        
+        // Find the position of '='
+        int equalsPosition = originalString.indexOf('=');
+
+        // Extract everything after '='
+        // Add 1 to skip the '=' character itself
+        if (equalsPosition != -1) { // Check if '=' is found
+            modifiedString = originalString.substring(equalsPosition + 1);
+            ret = Double.parseDouble(modifiedString); //save the value of the double
+
+        }
+            }
+        }
+  return ret;
   }
 }
 

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -560,6 +560,7 @@ class UmpleConsoleMain
     String languages = String.join(",", UmpleModel.validLanguages );
     String suboptionsAvail = "(With GvStateDiagram: hideactions, hideguards, showtransitionlabels, showguardlabels, Java, Cpp) ";
     suboptionsAvail += "(With GvClassDiagram or GvClassTraitDiagram or GvEntityRelationshipDiagram: hideattributes, showmethods)";
+    suboptionsAvail += " (With all Gv: gvseparator=n.n where n.n is greater than 1.0 to separate nodes more than default, or less than one to make the diagram tighter)";
 
     optparser.acceptsAll(Arrays.asList("version", "v"), "Print out the current Umple version number");
     optparser.acceptsAll(Arrays.asList("performance", "p"), "Indicate time taken to parse and generate code");

--- a/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
+++ b/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
@@ -41,13 +41,14 @@ digraph "<<=filename>>" {
     // This set ensures we track what we have visited
     HashSet visitedClasses = new HashSet();
 
-    //gets the desired separator value. Graphviz default is 0.5
-    double sepVal = getSuboptionValue("gvseparator", 0.5); 
-    //checks if the separator value is not 0.5 (Graphviz default).
+    //gets the desired separator value. Graphviz default is 0.5 but for Umple we use 1.0 for 'normal'
+    double sepVal = getSuboptionValue("gvseparator", 1.0); 
+    //checks if the separator value is not 1.0 (Umple default which will be 0.5 in Graphviz).
     // If it isn't it applies the desired separator value to nodesep and ranksep
-    if (sepVal != 0.5){
-      code.append("nodesep =" + sepVal +";"); //injects sepVal(desired separator value) into nodesep
-      code.append("ranksep =" + sepVal +";"); //injects sepVal(desired separator value) into ranksep
+    if (sepVal != 1.0){
+      Double graphVizSepVal = sepVal/2.0;
+      code.append("nodesep =" + graphVizSepVal +";"); //injects sepVal(desired separator value) into nodesep
+      code.append("ranksep =" + graphVizSepVal +";"); //injects sepVal(desired separator value) into ranksep
     }
     // Iterate through each class. 
     for (UmpleClass uClass : model.getUmpleClasses())

--- a/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
+++ b/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
@@ -35,19 +35,20 @@ digraph "<<=filename>>" {
 
     // Output basic gv file header
     _graphStart(0,code,model.getUmpleFile().getSimpleFileName());
-    
+
     // Set of classes we are visiting
     // We always visit from the top of the hierarchy first
     // This set ensures we track what we have visited
     HashSet visitedClasses = new HashSet();
 
-    //gets the desired seperator value. Graphviz default is 0.5
-    double sepVal = getSuboptionValue(); 
-    //checks if the seperator value is not 0.5 (Graphviz default). If it isn't it applies the desired seperator value to nodesep and ranksep
+    //gets the desired separator value. Graphviz default is 0.5
+    double sepVal = getSuboptionValue("gvseparator", 0.5); 
+    //checks if the separator value is not 0.5 (Graphviz default).
+    // If it isn't it applies the desired separator value to nodesep and ranksep
     if (sepVal != 0.5){
-    code.append("nodesep =" + sepVal +";"); //injects sepVal(desired seperator value) into nodesep
-    code.append("ranksep =" + sepVal +";"); //injects sepVal(desired seperator value) into ranksep
-  }
+      code.append("nodesep =" + sepVal +";"); //injects sepVal(desired separator value) into nodesep
+      code.append("ranksep =" + sepVal +";"); //injects sepVal(desired separator value) into ranksep
+    }
     // Iterate through each class. 
     for (UmpleClass uClass : model.getUmpleClasses())
     {

--- a/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
+++ b/cruise.umple/src/generators/Generator_SuperGvGenerator.ump
@@ -41,6 +41,13 @@ digraph "<<=filename>>" {
     // This set ensures we track what we have visited
     HashSet visitedClasses = new HashSet();
 
+    //gets the desired seperator value. Graphviz default is 0.5
+    double sepVal = getSuboptionValue(); 
+    //checks if the seperator value is not 0.5 (Graphviz default). If it isn't it applies the desired seperator value to nodesep and ranksep
+    if (sepVal != 0.5){
+    code.append("nodesep =" + sepVal +";"); //injects sepVal(desired seperator value) into nodesep
+    code.append("ranksep =" + sepVal +";"); //injects sepVal(desired seperator value) into ranksep
+  }
     // Iterate through each class. 
     for (UmpleClass uClass : model.getUmpleClasses())
     {

--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -31,7 +31,6 @@ class GvStateDiagramGenerator
   Boolean showGuardLabels = false;
   internal String display_language = "";
   lazy StateMachine root;
-  Boolean increaseSeps = false;
  
   internal Map<Transition,String> internalBoundaryTrans
     = new HashMap<Transition,String>();

--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -31,6 +31,7 @@ class GvStateDiagramGenerator
   Boolean showGuardLabels = false;
   internal String display_language = "";
   lazy StateMachine root;
+  Boolean increaseSeps = false;
  
   internal Map<Transition,String> internalBoundaryTrans
     = new HashMap<Transition,String>();
@@ -74,6 +75,7 @@ digraph "<<=filename>>" {
     showTransitionLabels = hasSuboption("showtransitionlabels");
     showGuardLabels = hasSuboption("showguardlabels");
     display_language = getDisplayLanguage();
+    double sepVal = getSuboptionValue(); //gets the desired seperator value. Graphviz default is 0.5
     
     // Output basic gv file header
     _graphStart(0,code,model.getUmpleFile().getSimpleFileName());
@@ -82,6 +84,13 @@ digraph "<<=filename>>" {
     // or multiple state machines in any class
     // If so, we will need to put boxes around the state machines
     int smCount = 0;
+
+//checks if the seperator value is not 0.5 (Graphviz default). If it isn't it applies the desired seperator value to nodesep and ranksep
+  if (sepVal != 0.5){ 
+    code.append("nodesep =" + sepVal +";");  //injects sepVal(desired seperator value) into nodesep
+    code.append("ranksep =" + sepVal +";");  //injects sepVal(desired seperator value) into ranksep
+  }
+
     for (UmpleClass uClass : model.getUmpleClasses()) 
     {
       for (StateMachine sm : uClass.getStateMachines()) 

--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -74,7 +74,9 @@ digraph "<<=filename>>" {
     showTransitionLabels = hasSuboption("showtransitionlabels");
     showGuardLabels = hasSuboption("showguardlabels");
     display_language = getDisplayLanguage();
-    double sepVal = getSuboptionValue(); //gets the desired seperator value. Graphviz default is 0.5
+    
+    //get the desired separator value. Graphviz default is 0.5
+    double sepVal = getSuboptionValue("gvseparator", 0.5); 
     
     // Output basic gv file header
     _graphStart(0,code,model.getUmpleFile().getSimpleFileName());
@@ -84,11 +86,12 @@ digraph "<<=filename>>" {
     // If so, we will need to put boxes around the state machines
     int smCount = 0;
 
-//checks if the seperator value is not 0.5 (Graphviz default). If it isn't it applies the desired seperator value to nodesep and ranksep
-  if (sepVal != 0.5){ 
-    code.append("nodesep =" + sepVal +";");  //injects sepVal(desired seperator value) into nodesep
-    code.append("ranksep =" + sepVal +";");  //injects sepVal(desired seperator value) into ranksep
-  }
+    //check if the separator value is not 0.5 (Graphviz default).
+    // If it isn't it applies the desired separator value to nodesep and ranksep
+    if (sepVal != 0.5){ 
+      code.append("nodesep =" + sepVal +";");  //injects sepVal(desired separator value) into nodesep
+      code.append("ranksep =" + sepVal +";");  //injects sepVal(desired separator value) into ranksep
+    }
 
     for (UmpleClass uClass : model.getUmpleClasses()) 
     {

--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -76,7 +76,7 @@ digraph "<<=filename>>" {
     display_language = getDisplayLanguage();
     
     //get the desired separator value. Graphviz default is 0.5
-    double sepVal = getSuboptionValue("gvseparator", 0.5); 
+    double sepVal = getSuboptionValue("gvseparator", 1.0); 
     
     // Output basic gv file header
     _graphStart(0,code,model.getUmpleFile().getSimpleFileName());
@@ -88,9 +88,10 @@ digraph "<<=filename>>" {
 
     //check if the separator value is not 0.5 (Graphviz default).
     // If it isn't it applies the desired separator value to nodesep and ranksep
-    if (sepVal != 0.5){ 
-      code.append("nodesep =" + sepVal +";");  //injects sepVal(desired separator value) into nodesep
-      code.append("ranksep =" + sepVal +";");  //injects sepVal(desired separator value) into ranksep
+    if (sepVal != 1.0){
+      Double graphVizSepVal = sepVal/2.0;
+      code.append("nodesep =" + graphVizSepVal +";");  //injects desired separator value into nodesep
+      code.append("ranksep =" + graphVizSepVal +";");  //injects desired separator value into ranksep
     }
 
     for (UmpleClass uClass : model.getUmpleClasses()) 

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvCdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvCdGeneratorTest.java
@@ -116,4 +116,10 @@ public class GvCdGeneratorTest extends TemplateTest
     language = null;
     assertUmplePartialTemplateFor("gv/ColourParsingTest3.ump","gv/ColourParsingTest3.gv.txt");
   } 
+  @Test
+  public void nodeSeparationCd()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/IncreaseClassSep.ump","gv/IncreaseClassSep.gv.txt");
+  }
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvErdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvErdGeneratorTest.java
@@ -132,5 +132,13 @@ public class GvErdGeneratorTest extends TemplateTest {
 	public void Relationship_Attributes_Test() {
 		language = null;
 	    assertUmplePartialTemplateFor("gv/RelationshipAttributes.ump","gv/RelationshipAttributes.gv.txt");
-	}	
+	}
+	
+  @Test
+  public void nodeSeparationErd()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/IncreaseERSep.ump","gv/IncreaseERSep.gv.txt");
+  }
+
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvSdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvSdGeneratorTest.java
@@ -247,4 +247,12 @@ public class GvSdGeneratorTest extends TemplateTest {
     language = null;
     assertUmplePartialTemplateFor("gv/ParameterTransition.ump","gv/ParameterTransition.gv.txt");
   }
+  
+  @Test
+  public void nodeSeparationSd()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/IncreaseStateSep.ump","gv/IncreaseStateSep.gv.txt");
+  }
+
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.gv.txt
@@ -1,11 +1,11 @@
 digraph "IncreaseClassSep" {
   rankdir="BT"
   node [ratio="auto" shape=record margin=0; href="javascript:Action.selectClass(&quot;\N&quot;);"];
-
+nodesep =2.0;ranksep =2.0;
   // Class: CanalNetwork
   "CanalNetwork" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    CanalNetwork    </td></tr><hr/><tr><td align="left" href="" title="String name&#13;">  name : String  </td></tr></table>>,
    tooltip="class CanalNetwork
-UML class diagram that models a canal as a&#13;network of segments, with Locks. See the&#13;State Machine section for a state machine for&#13;each lock&#13;"];
+"];
 
   // Class: SegEnd
   "SegEnd" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    SegEnd    </td></tr><hr/><tr><td align="left" href="" title="String name&#13;">  name : String  </td></tr><tr><td align="left" href="" title="GPSCoord location&#13;">  location : GPSCoord  </td></tr></table>>,

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.gv.txt
@@ -1,0 +1,264 @@
+digraph "IncreaseClassSep" {
+  rankdir="BT"
+  node [ratio="auto" shape=record margin=0; href="javascript:Action.selectClass(&quot;\N&quot;);"];
+
+  // Class: CanalNetwork
+  "CanalNetwork" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    CanalNetwork    </td></tr><hr/><tr><td align="left" href="" title="String name&#13;">  name : String  </td></tr></table>>,
+   tooltip="class CanalNetwork
+UML class diagram that models a canal as a&#13;network of segments, with Locks. See the&#13;State Machine section for a state machine for&#13;each lock&#13;"];
+
+  // Class: SegEnd
+  "SegEnd" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    SegEnd    </td></tr><hr/><tr><td align="left" href="" title="String name&#13;">  name : String  </td></tr><tr><td align="left" href="" title="GPSCoord location&#13;">  location : GPSCoord  </td></tr></table>>,
+   tooltip="class SegEnd
+"];
+
+  // Class: Segment
+  "Segment" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    Segment    </td></tr><hr/><tr><td align="left" href="" title="Float waterLevel&#13;m above sea level&#13;">  waterLevel : Float  </td></tr></table>>,
+   tooltip="class Segment
+"];
+
+  // Class: Lock
+  "Lock" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    Lock    </td></tr><hr/><tr><td align="left" href="" title="Float maxLevel&#13;">  maxLevel : Float  </td></tr><tr><td align="left" href="" title="Float minLevel&#13;">  minLevel : Float  </td></tr></table>>,
+   tooltip="class Lock
+"];
+  "Lock" -> "Segment" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: Bend
+  "Bend" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    Bend    </td></tr></table>>,
+   tooltip="class Bend
+"];
+  "Bend" -> "SegEnd" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: EntryAndExitPoint
+  "EntryAndExitPoint" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    EntryAndExitPoint    </td></tr></table>>,
+   tooltip="class EntryAndExitPoint
+"];
+  "EntryAndExitPoint" -> "SegEnd" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: MooringPoint
+  "MooringPoint" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    MooringPoint    </td></tr></table>>,
+   tooltip="class MooringPoint
+"];
+  "MooringPoint" -> "SegEnd" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: Obstacle
+  "Obstacle" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    Obstacle    </td></tr></table>>,
+   tooltip="class Obstacle
+"];
+  "Obstacle" -> "SegEnd" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: LowBridge
+  "LowBridge" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    LowBridge    </td></tr></table>>,
+   tooltip="class LowBridge
+"];
+  "LowBridge" -> "Obstacle" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: LockGate
+  "LockGate" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    LockGate    </td></tr></table>>,
+   tooltip="class LockGate
+"];
+  "LockGate" -> "Obstacle" [arrowhead="empty"; samehead="gen"];
+
+
+  // Class: Craft
+  "Craft" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    Craft    </td></tr><hr/><tr><td align="left" href="" title="GPSCoord location&#13;">  location : GPSCoord  </td></tr></table>>,
+   tooltip="class Craft
+"];
+
+  // Class: Trip
+  "Trip" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="10"><tr><td>    Trip    </td></tr></table>>,
+   tooltip="class Trip
+"];
+
+  // Class: Transponder
+  "Transponder" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    Transponder    </td></tr><hr/><tr><td align="left" href="" title="String id&#13;">  id : String  </td></tr></table>>,
+   tooltip="class Transponder
+"];
+
+  // Class: GPSCoord
+  "GPSCoord" [shape=plaintext margin=0 label=<<table border="1" cellspacing="0" cellborder="0" cellpadding="2"><tr><td cellpadding="4">    GPSCoord    </td></tr><hr/><tr><td align="left" href="" title="Float lattitide&#13;">  lattitide : Float  </td></tr><tr><td align="left" href="" title="Float longitude&#13;">  longitude : Float  </td></tr></table>>,
+   tooltip="class GPSCoord
+"];
+
+  // All associations
+  "CanalNetwork" -> "CanalNetwork" [dir="none", taillabel="0..1 ", headlabel="* subNetwork", tooltip="CanalNetwork 0..1  -- * subNetwork CanalNetwork
+
+A CanalNetwork called subNetwork may have a CanalNetwork. It can have none or just 1. 
+
+A CanalNetwork has some CanalNetworks called subNetwork. It can have none, and there is no upper bound defined.
+
+" headtooltip="CanalNetwork 0..1  -- * subNetwork CanalNetwork
+
+A CanalNetwork called subNetwork may have a CanalNetwork. It can have none or just 1. 
+
+A CanalNetwork has some CanalNetworks called subNetwork. It can have none, and there is no upper bound defined.
+
+" tailtooltip="CanalNetwork 0..1  -- * subNetwork CanalNetwork
+
+A CanalNetwork called subNetwork may have a CanalNetwork. It can have none or just 1. 
+
+A CanalNetwork has some CanalNetworks called subNetwork. It can have none, and there is no upper bound defined.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "CanalNetwork" -> "Craft" [dir="none", taillabel="0..1 ", headlabel="* activeVessels", tooltip="CanalNetwork 0..1  -- * activeVessels Craft
+
+A Craft called activeVessels may have a CanalNetwork. It can have none or just 1. 
+
+A CanalNetwork has some Crafts called activeVessels. It can have none, and there is no upper bound defined.
+
+" headtooltip="CanalNetwork 0..1  -- * activeVessels Craft
+
+A Craft called activeVessels may have a CanalNetwork. It can have none or just 1. 
+
+A CanalNetwork has some Crafts called activeVessels. It can have none, and there is no upper bound defined.
+
+" tailtooltip="CanalNetwork 0..1  -- * activeVessels Craft
+
+A Craft called activeVessels may have a CanalNetwork. It can have none or just 1. 
+
+A CanalNetwork has some Crafts called activeVessels. It can have none, and there is no upper bound defined.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "CanalNetwork" -> "SegEnd" [dir="none", taillabel="* ", headlabel="* ", tooltip="CanalNetwork *  -- *  SegEnd
+
+A SegEnd has some CanalNetworks. It can have none, and there is no upper bound defined.
+
+A CanalNetwork has some SegEnds. It can have none, and there is no upper bound defined.
+
+" headtooltip="CanalNetwork *  -- *  SegEnd
+
+A SegEnd has some CanalNetworks. It can have none, and there is no upper bound defined.
+
+A CanalNetwork has some SegEnds. It can have none, and there is no upper bound defined.
+
+" tailtooltip="CanalNetwork *  -- *  SegEnd
+
+A SegEnd has some CanalNetworks. It can have none, and there is no upper bound defined.
+
+A CanalNetwork has some SegEnds. It can have none, and there is no upper bound defined.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "Segment" -> "SegEnd" [dir="none", taillabel="1..* ", headlabel="2 ", tooltip="Segment 1..*  -- 2  SegEnd
+
+A SegEnd has at least 1 Segment and can never have none. And there is no upper bound defined.
+
+A Segment has 2 SegEnds. 
+When a Segment is created, its 2 SegEnds must be assigned.
+
+" headtooltip="Segment 1..*  -- 2  SegEnd
+
+A SegEnd has at least 1 Segment and can never have none. And there is no upper bound defined.
+
+A Segment has 2 SegEnds. 
+When a Segment is created, its 2 SegEnds must be assigned.
+
+" tailtooltip="Segment 1..*  -- 2  SegEnd
+
+A SegEnd has at least 1 Segment and can never have none. And there is no upper bound defined.
+
+A Segment has 2 SegEnds. 
+When a Segment is created, its 2 SegEnds must be assigned.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "Obstacle" -> "Craft" [dir="none", taillabel="0..1 downstreamObstacle", headlabel="* upStreamQueue", tooltip="Obstacle 0..1 downstreamObstacle -- * upStreamQueue Craft
+
+A Craft called upStreamQueue may have an Obstacle called downstreamObstacle. It can have none or just 1. 
+
+An Obstacle called downstreamObstacle has some Crafts called upStreamQueue. It can have none, and there is no upper bound defined.
+
+" headtooltip="Obstacle 0..1 downstreamObstacle -- * upStreamQueue Craft
+
+A Craft called upStreamQueue may have an Obstacle called downstreamObstacle. It can have none or just 1. 
+
+An Obstacle called downstreamObstacle has some Crafts called upStreamQueue. It can have none, and there is no upper bound defined.
+
+" tailtooltip="Obstacle 0..1 downstreamObstacle -- * upStreamQueue Craft
+
+A Craft called upStreamQueue may have an Obstacle called downstreamObstacle. It can have none or just 1. 
+
+An Obstacle called downstreamObstacle has some Crafts called upStreamQueue. It can have none, and there is no upper bound defined.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "Obstacle" -> "Craft" [dir="none", taillabel="0..1 upstreamObstacle", headlabel="* downStreamQueue", tooltip="Obstacle 0..1 upstreamObstacle -- * downStreamQueue Craft
+
+A Craft called downStreamQueue may have an Obstacle called upstreamObstacle. It can have none or just 1. 
+
+An Obstacle called upstreamObstacle has some Crafts called downStreamQueue. It can have none, and there is no upper bound defined.
+
+" headtooltip="Obstacle 0..1 upstreamObstacle -- * downStreamQueue Craft
+
+A Craft called downStreamQueue may have an Obstacle called upstreamObstacle. It can have none or just 1. 
+
+An Obstacle called upstreamObstacle has some Crafts called downStreamQueue. It can have none, and there is no upper bound defined.
+
+" tailtooltip="Obstacle 0..1 upstreamObstacle -- * downStreamQueue Craft
+
+A Craft called downStreamQueue may have an Obstacle called upstreamObstacle. It can have none or just 1. 
+
+An Obstacle called upstreamObstacle has some Crafts called downStreamQueue. It can have none, and there is no upper bound defined.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "Trip" -> "SegEnd" [dir="forward", arrowhead="open", taillabel="0..1 ", headlabel="1..* ", tooltip="Trip 0..1  -> 1..*  SegEnd
+
+A SegEnd may have a Trip. It can have none or just 1. 
+
+A Trip has at least 1 SegEnd and can never have none. And there is no upper bound defined.
+
+" headtooltip="Trip 0..1  -> 1..*  SegEnd
+
+A SegEnd may have a Trip. It can have none or just 1. 
+
+A Trip has at least 1 SegEnd and can never have none. And there is no upper bound defined.
+
+" tailtooltip="Trip 0..1  -> 1..*  SegEnd
+
+A SegEnd may have a Trip. It can have none or just 1. 
+
+A Trip has at least 1 SegEnd and can never have none. And there is no upper bound defined.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "Trip" -> "Craft" [dir="none", taillabel="0..1 ", headlabel="1 ", tooltip="Trip 0..1  -- 1  Craft
+
+A Craft may have a Trip. It can have none or just 1. 
+
+A Trip has A Craft. It must always have exactly, one, and can never have none. And there is an upper bound of at most one Craft.
+
+" headtooltip="Trip 0..1  -- 1  Craft
+
+A Craft may have a Trip. It can have none or just 1. 
+
+A Trip has A Craft. It must always have exactly, one, and can never have none. And there is an upper bound of at most one Craft.
+
+" tailtooltip="Trip 0..1  -- 1  Craft
+
+A Craft may have a Trip. It can have none or just 1. 
+
+A Trip has A Craft. It must always have exactly, one, and can never have none. And there is an upper bound of at most one Craft.
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+  "Transponder" -> "Craft" [dir="none", taillabel="0..1 ", headlabel="0..1 ", tooltip="Transponder 0..1  -- 0..1  Craft
+
+A Craft may have a Transponder. It can have none or just 1. 
+
+A Transponder may have a Craft. It can have none or just 1. 
+
+" headtooltip="Transponder 0..1  -- 0..1  Craft
+
+A Craft may have a Transponder. It can have none or just 1. 
+
+A Transponder may have a Craft. It can have none or just 1. 
+
+" tailtooltip="Transponder 0..1  -- 0..1  Craft
+
+A Craft may have a Transponder. It can have none or just 1. 
+
+A Transponder may have a Craft. It can have none or just 1. 
+
+" tailurl="javascript:void()" headurl="javascript:void()" ];
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.ump
@@ -1,0 +1,70 @@
+generate GvClassDiagram -s "increaseseperator=2";
+namespace example;
+
+class CanalNetwork {
+  name;
+  0..1 -- * CanalNetwork subNetwork;
+  0..1 -- * Craft activeVessels;
+  * -- * SegEnd;
+}
+
+class SegEnd {
+  name;
+  GPSCoord location;
+}
+
+class Segment {
+  Float waterLevel; // m above sea level 
+  1..* -- 2 SegEnd;
+}
+
+class Lock {
+  isA Segment;
+  Float maxLevel;
+  Float minLevel;
+}
+
+class Bend {
+  isA SegEnd;
+}
+
+class EntryAndExitPoint {
+  isA SegEnd;
+}
+
+class MooringPoint {
+  isA SegEnd;
+}
+
+class Obstacle {
+  isA SegEnd;
+  0..1 downstreamObstacle -- * Craft upStreamQueue;
+  0..1 upstreamObstacle -- * Craft downStreamQueue;  
+}
+
+class LowBridge {
+  isA Obstacle;
+}
+
+class LockGate {
+  isA Obstacle;
+}
+
+class Craft {
+  lazy GPSCoord location;
+}
+
+class Trip {
+  0..1 -> 1..* SegEnd;
+  0..1 -- 1 Craft;
+}
+
+class Transponder {
+  id;
+  0..1 -- 0..1 Craft;
+}
+
+class GPSCoord {
+   Float lattitide;
+   Float longitude;
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.ump
@@ -1,4 +1,4 @@
-generate GvClassDiagram -s "gvseparator=2.0";
+generate GvClassDiagram -s "gvseparator=4.0";
 namespace example;
 
 class CanalNetwork {

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseClassSep.ump
@@ -1,4 +1,4 @@
-generate GvClassDiagram -s "increaseseperator=2";
+generate GvClassDiagram -s "gvseparator=2.0";
 namespace example;
 
 class CanalNetwork {

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.gv.txt
@@ -1,0 +1,21 @@
+digraph "IncreaseERSep" {
+  rankdir="BT"
+  node [ratio="auto" shape=record margin=0; href="javascript:Action.selectClass(&quot;\N&quot;);"];
+nodesep =2.0;ranksep =2.0;
+  // Class: X
+  "X" [shape=rectangle, label="   X   ",
+   tooltip="class X
+"];
+
+  // Attributes for X
+  "aX" [shape=ellipse, label="   a\ :\ String   ", tooltip="String a&#13;"];
+  "X" -> "aX" [arrowhead="none"];
+
+  "dateX" [shape=ellipse, label="   date\ :\ Date   ", tooltip="Date date&#13;"];
+  "X" -> "dateX" [arrowhead="none"];
+
+  "timeX" [shape=ellipse, label="   time\ :\ Time   ", tooltip="Time time&#13;"];
+  "X" -> "timeX" [arrowhead="none"];
+
+  // All associations
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.ump
@@ -1,4 +1,4 @@
-generate GvEntityRelationshipDiagram -s "gvseparator=2";
+generate GvEntityRelationshipDiagram -s "gvseparator=4";
 namespace example;
 
 class X {

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.ump
@@ -1,0 +1,8 @@
+generate GvEntityRelationshipDiagram -s "increaseseperator=2";
+namespace example;
+
+class X {
+  a;
+  Date date;
+  Time time;
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseERSep.ump
@@ -1,4 +1,4 @@
-generate GvEntityRelationshipDiagram -s "increaseseperator=2";
+generate GvEntityRelationshipDiagram -s "gvseparator=2";
 namespace example;
 
 class X {

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.gv.txt
@@ -1,0 +1,59 @@
+digraph "IncreaseStateSep" {
+  compound = true;
+nodesep =2.0;ranksep =2.0;
+  // Class: GarageDoor
+
+    // Top and Bottom Level StateMachine: status
+    
+    // Start states are shown as a black circle
+    node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+    start_GarageDoor_status [ tooltip = "Class GarageDoor, SM status, State start" ];
+    
+        
+    // Format for normal states
+    node [ratio="auto" shape = rectangle, width=1,style=rounded];
+    
+      // State: Open
+
+      GarageDoor_status_Open [label = Open, tooltip = "Class GarageDoor, SM status, State Open", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Open\")"];
+      // End State: Open
+
+      // State: Closing
+
+      GarageDoor_status_Closing [label = Closing, tooltip = "Class GarageDoor, SM status, State Closing", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closing\")"];
+      // End State: Closing
+
+      // State: Closed
+
+      GarageDoor_status_Closed [label = Closed, tooltip = "Class GarageDoor, SM status, State Closed", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closed\")"];
+      // End State: Closed
+
+      // State: Opening
+
+      GarageDoor_status_Opening [label = Opening, tooltip = "Class GarageDoor, SM status, State Opening", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Opening\")"];
+      // End State: Opening
+
+      // State: HalfOpen
+
+      GarageDoor_status_HalfOpen [label = HalfOpen, tooltip = "Class GarageDoor, SM status, State HalfOpen", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^HalfOpen\")"];
+      // End State: HalfOpen
+    // End Top and Bottom Level StateMachine: status
+
+  // All transitions
+    start_GarageDoor_status -> GarageDoor_status_Open [  tooltip = "start to Open", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    GarageDoor_status_Opening -> GarageDoor_status_Open [  label = "reachTop", tooltip = "From Opening to Open on reachTop", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachTop*^*Opening*^*Open*^*\")" ] ;
+  
+  GarageDoor_status_Open -> GarageDoor_status_Closing [  label = "buttonOrObstacle", tooltip = "From Open to Closing on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Open*^*Closing*^*\")" ] ;
+  
+  GarageDoor_status_Closing -> GarageDoor_status_Closed [  label = "reachBottom", tooltip = "From Closing to Closed on reachBottom", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachBottom*^*Closing*^*Closed*^*\")" ] ;
+  
+  GarageDoor_status_Closing -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closing to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closing*^*Opening*^*\")" ] ;
+  
+  GarageDoor_status_Closed -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closed to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closed*^*Opening*^*\")" ] ;
+  
+  GarageDoor_status_HalfOpen -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From HalfOpen to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*HalfOpen*^*Opening*^*\")" ] ;
+  
+  GarageDoor_status_Opening -> GarageDoor_status_HalfOpen [  label = "buttonOrObstacle", tooltip = "From Opening to HalfOpen on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Opening*^*HalfOpen*^*\")" ] ;
+  
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.ump
@@ -1,4 +1,4 @@
-generate GvStateDiagram -s "gvseparator=2";
+generate GvStateDiagram -s "gvseparator=4";
 namespace example;
 
 class GarageDoor

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.ump
@@ -1,0 +1,25 @@
+generate GvStateDiagram -s "increaseseperator=2";
+namespace example;
+
+class GarageDoor
+{
+   status {
+      	Open { buttonOrObstacle -> Closing;  }
+      
+	Closing {
+          buttonOrObstacle -> Opening;
+          reachBottom -> Closed;
+      	}
+
+      	Closed { buttonOrObstacle -> Opening; }
+
+      	Opening {
+          buttonOrObstacle -> HalfOpen;
+          reachTop -> Open;
+      	}
+
+      	HalfOpen { buttonOrObstacle -> Opening; }
+  }
+
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.ump
@@ -1,4 +1,4 @@
-generate GvStateDiagram -s "increaseseperator=2";
+generate GvStateDiagram -s "gvseparator=2";
 namespace example;
 
 class GarageDoor


### PR DESCRIPTION
# Description
I added a suboptions to increase separation for ranksep and nodesep. 
- Example use : java -jar umple.jar -g GvStateDiagram gd.ump -s gvseparator=2

The ability for suboptions to have numeric arguments is also available to be used in other options