### PR TITLE
Fixed Issue #1904 fixed NullPointerException when generating SQL 

### DIFF
--- a/UmpleToSql/UmpleTLTemplates/members_AllForeignKeys.ump
+++ b/UmpleToSql/UmpleTLTemplates/members_AllForeignKeys.ump
@@ -32,17 +32,19 @@ but sometimes when two tables have a foreign key referring to the same table */
             allAttributesOneQuoted += gen.translate("attributeOneQuoted", foreignPK) + ", ";
           }
         }
-
-        if (!av.isTwoDirectionalAssociation(av.getRelatedAssociation())){
-          appendln(realSb, "ALTER TABLE {0} ADD CONSTRAINT `fk_{5}_{2}_{6}` FOREIGN KEY (`{3}`) REFERENCES {1}({4});", gen.translate("typeWithPackage", uClass),
-                                                                                                                          gen.translate("typeWithPackage", associatedUClass), 
-                                                                                                                          gen.translate("type", associatedUClass), 
-                                                                                                                          allAttributesOne.substring(0, allAttributesOne.length()-4), 
-                                                                                                                          allAttributesOneQuoted.substring(0, allAttributesOneQuoted.length()-2),
-                                                                                                                          uClass.getName().toLowerCase(),
-                                                                                                                          allAttributesOneWithoutClassName.substring(0, allAttributesOneWithoutClassName.length()-1));
-          
+        if(foreignPKList.size() > 0){
+          if (!av.isTwoDirectionalAssociation(av.getRelatedAssociation())){
+            appendln(realSb, "ALTER TABLE {0} ADD CONSTRAINT `fk_{5}_{2}_{6}` FOREIGN KEY (`{3}`) REFERENCES {1}({4});", gen.translate("typeWithPackage", uClass),
+                                                                                                                            gen.translate("typeWithPackage", associatedUClass), 
+                                                                                                                            gen.translate("type", associatedUClass), 
+                                                                                                                            allAttributesOne.substring(0, allAttributesOne.length()-4), 
+                                                                                                                            allAttributesOneQuoted.substring(0, allAttributesOneQuoted.length()-2),
+                                                                                                                            uClass.getName().toLowerCase(),
+                                                                                                                            allAttributesOneWithoutClassName.substring(0, allAttributesOneWithoutClassName.length()-1));
+            
+          }
         }
+
 
       }
     }

--- a/UmpleToSql/UmpleTLTemplates/members_AllForeignKeys.ump
+++ b/UmpleToSql/UmpleTLTemplates/members_AllForeignKeys.ump
@@ -32,17 +32,14 @@ but sometimes when two tables have a foreign key referring to the same table */
             allAttributesOneQuoted += gen.translate("attributeOneQuoted", foreignPK) + ", ";
           }
         }
-        if(foreignPKList.size() > 0){
-          if (!av.isTwoDirectionalAssociation(av.getRelatedAssociation())){
-            appendln(realSb, "ALTER TABLE {0} ADD CONSTRAINT `fk_{5}_{2}_{6}` FOREIGN KEY (`{3}`) REFERENCES {1}({4});", gen.translate("typeWithPackage", uClass),
-                                                                                                                            gen.translate("typeWithPackage", associatedUClass), 
-                                                                                                                            gen.translate("type", associatedUClass), 
-                                                                                                                            allAttributesOne.substring(0, allAttributesOne.length()-4), 
-                                                                                                                            allAttributesOneQuoted.substring(0, allAttributesOneQuoted.length()-2),
-                                                                                                                            uClass.getName().toLowerCase(),
-                                                                                                                            allAttributesOneWithoutClassName.substring(0, allAttributesOneWithoutClassName.length()-1));
-            
-          }
+        if (!av.isTwoDirectionalAssociation(av.getRelatedAssociation()) && foreignPKList.size() > 0){
+          appendln(realSb, "ALTER TABLE {0} ADD CONSTRAINT `fk_{5}_{2}_{6}` FOREIGN KEY (`{3}`) REFERENCES {1}({4});", gen.translate("typeWithPackage", uClass),
+                                                                                                                          gen.translate("typeWithPackage", associatedUClass), 
+                                                                                                                          gen.translate("type", associatedUClass), 
+                                                                                                                          allAttributesOne.substring(0, allAttributesOne.length()-4), 
+                                                                                                                          allAttributesOneQuoted.substring(0, allAttributesOneQuoted.length()-2),
+                                                                                                                          uClass.getName().toLowerCase(),
+                                                                                                                          allAttributesOneWithoutClassName.substring(0, allAttributesOneWithoutClassName.length()-1)); 
         }
 
 

--- a/cruise.umple/src/generators/Generator_CodeSql.ump
+++ b/cruise.umple/src/generators/Generator_CodeSql.ump
@@ -1032,7 +1032,7 @@ class SqlGenerator
     genClass.setLookup("constructorSignature_caller", signatureCaller.toString());
   }
 
-  private Key accountForInheritance(UmpleClass uClass){
+private Key accountForInheritance(UmpleClass uClass){
     UmpleClass parent = uClass.getExtendsClass();
     if (uClass == null){
       return null;
@@ -1051,30 +1051,39 @@ class SqlGenerator
       if (parent_pk == null){
         return null;
       }
-      else{ 
+      while(parent != null){
         String pkNames="";
         String pkTypes="";
-        for (String parentPkMember : parent_pk.getMembers()){
-          pkNames += parentPkMember+", ";
-        }
-        //trim pkNames and pkTypes
-        pkNames = pkNames.substring(0, pkNames.length() - 2);
-
-        if (uClass.getAssociationVariable(pkNames) == null){
           for (String parentPkMember : parent_pk.getMembers()){
-            pkTypes += parent.getAttribute(parentPkMember).getType() + ", ";
+            pkNames += parentPkMember+", ";
           }
-          pkTypes = pkTypes.substring(0, pkTypes.length() - 2); 
+          //trim pkNames and pkTypes
+          pkNames = pkNames.substring(0, pkNames.length() - 2);
+          
+          if (uClass.getAssociationVariable(pkNames) == null){
+            for (String parentPkMember : parent_pk.getMembers()){
+              if(parent.getAttribute(parentPkMember) != null){
+                pkTypes += parent.getAttribute(parentPkMember).getType() + ", ";             
+              }
+            }
+            if(pkTypes.length() > 2){
+              pkTypes = pkTypes.substring(0, pkTypes.length() - 2); 
+            }
 
-          Multiplicity optionalToOne = new Multiplicity();
-          optionalToOne.setBound("1");
-          AssociationVariable newAssoc = new AssociationVariable (pkNames, pkTypes, "", "", optionalToOne, true);
-          uClass.addAssociationVariable(newAssoc);
-          AssociationVariable avFromParent = parent.getAssociationVariable(pkNames);
-          newAssoc.setOneDirectionalRelatedAssociation(avFromParent);
-        }
+            Multiplicity optionalToOne = new Multiplicity();
+            optionalToOne.setBound("1");
+            AssociationVariable newAssoc = new AssociationVariable (pkNames, pkTypes, "", "", optionalToOne, true);
+            uClass.addAssociationVariable(newAssoc);
+            AssociationVariable avFromParent = parent.getAssociationVariable(pkNames);
+            newAssoc.setOneDirectionalRelatedAssociation(avFromParent);            
+          }
+          //Check for multiple inheritence
+          parent = parent.getExtendsClass();
+          if(parent != null){
+            parent_pk = parent.getKey();              
+          }
+      }
         return createNewIntPK(uClass);
-        }
     }
   }
 

--- a/cruise.umple/src/generators/Generator_CodeSql.ump
+++ b/cruise.umple/src/generators/Generator_CodeSql.ump
@@ -1032,7 +1032,7 @@ class SqlGenerator
     genClass.setLookup("constructorSignature_caller", signatureCaller.toString());
   }
 
-private Key accountForInheritance(UmpleClass uClass){
+  private Key accountForInheritance(UmpleClass uClass){
     UmpleClass parent = uClass.getExtendsClass();
     if (uClass == null){
       return null;
@@ -1051,39 +1051,34 @@ private Key accountForInheritance(UmpleClass uClass){
       if (parent_pk == null){
         return null;
       }
-      while(parent != null){
+      else{
         String pkNames="";
         String pkTypes="";
+        for (String parentPkMember : parent_pk.getMembers()){
+          pkNames += parentPkMember+", ";
+        }
+        //trim pkNames and pkTypes
+        pkNames = pkNames.substring(0, pkNames.length() - 2);
+        
+        if (uClass.getAssociationVariable(pkNames) == null){
           for (String parentPkMember : parent_pk.getMembers()){
-            pkNames += parentPkMember+", ";
+            if(parent.getAttribute(parentPkMember) != null){
+              pkTypes += parent.getAttribute(parentPkMember).getType() + ", ";             
+            }
           }
-          //trim pkNames and pkTypes
-          pkNames = pkNames.substring(0, pkNames.length() - 2);
+          if(pkTypes.length() > 2){
+            pkTypes = pkTypes.substring(0, pkTypes.length() - 2); 
+          }
           
-          if (uClass.getAssociationVariable(pkNames) == null){
-            for (String parentPkMember : parent_pk.getMembers()){
-              if(parent.getAttribute(parentPkMember) != null){
-                pkTypes += parent.getAttribute(parentPkMember).getType() + ", ";             
-              }
-            }
-            if(pkTypes.length() > 2){
-              pkTypes = pkTypes.substring(0, pkTypes.length() - 2); 
-            }
-
-            Multiplicity optionalToOne = new Multiplicity();
-            optionalToOne.setBound("1");
-            AssociationVariable newAssoc = new AssociationVariable (pkNames, pkTypes, "", "", optionalToOne, true);
-            uClass.addAssociationVariable(newAssoc);
-            AssociationVariable avFromParent = parent.getAssociationVariable(pkNames);
-            newAssoc.setOneDirectionalRelatedAssociation(avFromParent);            
-          }
-          //Check for multiple inheritence
-          parent = parent.getExtendsClass();
-          if(parent != null){
-            parent_pk = parent.getKey();              
-          }
-      }
+          Multiplicity optionalToOne = new Multiplicity();
+          optionalToOne.setBound("1");
+          AssociationVariable newAssoc = new AssociationVariable (pkNames, pkTypes, "", "", optionalToOne, true);
+          uClass.addAssociationVariable(newAssoc);
+          AssociationVariable avFromParent = parent.getAssociationVariable(pkNames);
+          newAssoc.setOneDirectionalRelatedAssociation(avFromParent);            
+        }
         return createNewIntPK(uClass);
+      }
     }
   }
 

--- a/cruise.umple/test/cruise/umple/implementation/DoubleChainGenTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/DoubleChainGenTest.java
@@ -18,7 +18,7 @@ public class DoubleChainGenTest extends TemplateTest
   public void Parent()
   {
     assertUmpleTemplateFor("DoubleChainGenTest.ump",languagePath + "/DoubleChainGenTest_Parent."+ languagePath +".txt","Person");
- }
+  }
   
   @Test
   public void Middle()

--- a/cruise.umple/test/cruise/umple/implementation/DoubleGenTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/DoubleGenTest.java
@@ -18,7 +18,7 @@ public class DoubleGenTest extends TemplateTest
   public void Parent()
   {
     assertUmpleTemplateFor("DoubleGenTest.ump",languagePath + "/DoubleGenTest_Parent."+ languagePath +".txt","Person");
- }
+  }
   
   @Test
   public void Child()

--- a/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/TemplateTest.java
@@ -183,6 +183,7 @@ public class TemplateTest
     SampleFileWriter.destroy(pathToInput + "/CompositePKGenTest.sql");
     SampleFileWriter.destroy(pathToInput + "/DoubleGenTest.sql");
     SampleFileWriter.destroy(pathToInput + "/DoubleChainGenTest.sql");
+    SampleFileWriter.destroy(pathToInput + "/sql/DoubleChainGenEmptyTest.sql");
     SampleFileWriter.destroy(pathToInput + "/SingleGenTest.sql");
 
     SampleFileWriter.destroy(pathToInput + "/ruby/ruby_code");

--- a/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest.ump
+++ b/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest.ump
@@ -1,0 +1,17 @@
+generate Sql;
+
+namespace example;
+
+class Person{
+    name;
+    int age;
+}
+
+class Employee{
+    isA Person;
+}
+
+class Admin{
+    int number;
+    isA Employee;
+}

--- a/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest_Child.sql.txt
+++ b/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest_Child.sql.txt
@@ -1,0 +1,17 @@
+-- PLEASE DO NOT EDIT THIS CODE
+-- This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!
+
+CREATE DATABASE IF NOT EXISTS `example`;
+USE `example`;
+
+CREATE TABLE IF NOT EXISTS `example`.`admin`
+(
+  /*------------------------*/
+  /* MEMBER VARIABLES       */
+  /*------------------------*/
+  
+  /*admin Attributes*/
+  number INT,
+  PRIMARY KEY(number)
+
+);

--- a/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest_Middle.sql.txt
+++ b/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest_Middle.sql.txt
@@ -1,0 +1,20 @@
+-- PLEASE DO NOT EDIT THIS CODE
+-- This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!
+
+CREATE DATABASE IF NOT EXISTS `example`;
+USE `example`;
+
+CREATE TABLE IF NOT EXISTS `example`.`employee`
+(
+  /*------------------------*/
+  /* MEMBER VARIABLES       */
+  /*------------------------*/
+
+  /*employee Associations*/
+  person_name VARCHAR(255),
+    PRIMARY KEY(/*No Possible Primary Key*/)
+
+);
+
+
+ALTER TABLE `example`.`employee` ADD CONSTRAINT `fk_employee_person_name` FOREIGN KEY (`person_name`) REFERENCES `example`.`person`(`name`);

--- a/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest_Parent.sql.txt
+++ b/cruise.umple/test/cruise/umple/implementation/sql/DoubleChainGenEmptyTest_Parent.sql.txt
@@ -1,0 +1,18 @@
+-- PLEASE DO NOT EDIT THIS CODE
+-- This code was generated using the UMPLE @UMPLE_VERSION@ modeling language!
+
+CREATE DATABASE IF NOT EXISTS `example`;
+USE `example`;
+
+CREATE TABLE IF NOT EXISTS `example`.`person`
+(
+  /*------------------------*/
+  /* MEMBER VARIABLES       */
+  /*------------------------*/
+  
+  /*person Attributes*/
+  name VARCHAR(255),
+  age INT,
+  PRIMARY KEY(name)
+
+);

--- a/cruise.umple/test/cruise/umple/implementation/sql/SqlDoubleChainGenTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/sql/SqlDoubleChainGenTest.java
@@ -13,4 +13,23 @@ public class SqlDoubleChainGenTest extends DoubleChainGenTest
     language = "Sql";
     languagePath = "sql";
   }
+
+  @Test //Specific test for SQL generation with an empty class in the middle of a double chain
+  public void Parent()
+  {
+    assertUmpleTemplateFor("sql/DoubleChainGenEmptyTest.ump", "sql/DoubleChainGenEmptyTest_Parent.sql.txt","Person");
+  }
+  
+  @Test
+  public void Middle()
+  {
+    assertUmpleTemplateFor("sql/DoubleChainGenEmptyTest.ump", "sql/DoubleChainGenEmptyTest_Middle.sql.txt","Employee");
+  } 
+  
+  @Test
+  public void Child()
+  {
+    assertUmpleTemplateFor("sql/DoubleChainGenEmptyTest.ump", "sql/DoubleChainGenEmptyTest_Child.sql.txt","Admin");
+  }  
+
 }


### PR DESCRIPTION
Pull request for [#1904](https://github.com/umple/umple/issues/1904)

Fixed NullPointerException caused by an empty class in the middle of an inheritance chain when generating SQL.

Changed logic to ignore empty attributes and keys of the empty class.
