### PR TITLE
Experiment to solve countlog reset explained in issue #1953

### DIFF
--- a/umpleonline/counter.php
+++ b/umpleonline/counter.php
@@ -15,13 +15,33 @@ $visitsString = "visits since October 2018";
 $commandsRunString = "commands run since July 2019";
 $branchpath = "/tmp/umplegitbranch.txt";
 if(file_exists($logpath)){
-	if(!is_writable($logpath)||!is_readable($logpath)) {
-		chmod($logpath, 0755);
-	}
-	$log = fopen($logpath, "r");
-	$count = fgets($log,1000);
-	fclose($log);
-	$count=$count + 1 ;
+  if(!is_writable($logpath)||!is_readable($logpath)) {
+    chmod($logpath, 0755);
+  }
+  $log = fopen($logpath, "r");
+  $count = fgets($log,1000);
+  fclose($log);
+  
+  // if we read in zero, that means we read in data
+  // just as another process had truncated it for
+  // writing, so we pause brefly and try one more time.
+  
+  if ($count == 0) {
+    usleep(1000);
+    $log = fopen($logpath, "r");
+    $count = fgets($log,1000);
+    fclose($log);
+  }
+
+  if ($count != 0) {  
+    $count=$count + 1 ;
+
+    // Write out the updated number
+    $log = fopen($logpath,"w");
+    fwrite($log, $count);
+    fclose($log);
+  }
+
   if ($count>=1000 && $count<1000000) {
   $count_new=number_format((float)$count/1000, 2, '.', '');
     echo "$count_new K $visitsString" ;
@@ -34,11 +54,6 @@ if(file_exists($logpath)){
     $count_new=$count;
     echo "$count_new $visitsString" ;
   }
-
-	// opens countlog.txt to change new hit number
-	$log = fopen($logpath,"w");
-	fwrite($log, $count);
-	fclose($log);
 }
 
 if(file_exists($commandlogpath)){


### PR DESCRIPTION
Issue #1953 points out that periodically (once every 10,000 sessions or so at peak times) the countlog.txt that counts user sessions gets reset to zero.

There could be various causes, of which the following are two possibilities: 

1. When reading a value, a process gets the value that another process has just truncated before writing an incremented value, so the read value appears to be zero, and when updated it writes out 1.
2. A write of an updated value clobbers the string but fails to write out its value, so the next process reads a zero.

This PR assumes cause 1 above is the most likely. To remedy it, we simply don't do anything if the input is zero, other than sleeping briefly and trying again once.

This is an experimental solution to  #1953.  If it doesn't work, we will have to try instead reading in the value that was just written to ensure it is what was written, or larger, and if not writing it again.