### PR TITLE
Fixing XSS security of example URL argument

### DIFF
--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -513,7 +513,8 @@ function extractFilename()
     // If the argument is example=X then copy the example and open it
     elseif (isset($_REQUEST['example']) && $_REQUEST["example"] != "")
     {
-        $fileToCopy = getExamplePath(htmlspecialchars($_REQUEST['example']).'.ump');
+        $theActualExample=preg_replace("/[^a-zA-Z0-9_\-]/",'',$_REQUEST["example"]);
+        $fileToCopy = getExamplePath($theActualExample.'.ump');
         if(!file_exists($fileToCopy)){
             $fileToCopy = getExamplePath('NullExample.ump');
         }
@@ -524,6 +525,7 @@ function extractFilename()
     }
     elseif (isset($_REQUEST['text']) && $_REQUEST["text"] != "")
     {
+        // The actual Umple code (must be very short) follows the ?text= in the URL
         $dataHandle = dataStore()->createData();
         $dataHandle->writeData('model.ump', urldecode(urldecode($_REQUEST["text"])));
     }
@@ -535,21 +537,23 @@ function extractFilename()
     }
 
     // The only other option is that there is a filename option
+    // This will load the relevant file from the intenet through http or https.
     else
     {
+        $rootOfOnlineUmpToLoad = $_REQUEST["filename"];
         $dataHandle = dataStore()->createData();
         $dataToWrite = '';
-        if(!substr($_REQUEST["filename"],-4)==".ump") {
-            $dataToWrite = "// URL in filename argument must end in .ump and the initial http:// must be omitted";
+        if(strcmp(substr($rootOfOnlineUmpToLoad,-4),".ump")) {
+            $dataToWrite = "// URL in filename argument must end in .ump and the initial http:// or https:// must be omitted";
         }
         else
         {
-            $dataToWrite = file_get_contents("http://" . $_REQUEST["filename"]);
-            if(substr($http_response_header[0],-2)!="OK") {
+            $dataToWrite = file_get_contents("https://" . $rootOfOnlineUmpToLoad);
+            if($dataToWrite == null || substr($http_response_header[0],-2)!="OK") {
                 // try https
-                $dataToWrite = file_get_contents("https://" . $_REQUEST["filename"]);
-                if(substr($http_response_header[0],-2)!="OK") {         
-                    $dataToWrite = "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load http://" . $_REQUEST["filename"];
+                $dataToWrite = file_get_contents("http://" . $rootOfOnlineUmpToLoad);
+                if($dataToWrite == null || substr($http_response_header[0],-2)!="OK") {         
+                    $dataToWrite = "// URL of the Umple file to be loaded in the URL after ?filename= must omit the initial http:// or https:// and end with .ump.\n// The file must be accessible from our server.\n// Could not load https://" . $rootOfOnlineUmpToLoad ." xxxx" . substr($rootOfOnlineUmpToLoad,-4);
                 }
             }
         }

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -28,15 +28,17 @@ $diagramtype = "";
 $isCachedExample = false;
 $imageoutput="";
 $messageURL="";
+$actualExample="";
 if (isset($_REQUEST['example']) && $_REQUEST["example"] != "") {
-  $cachedimage= "umplibrary/imagecache/".htmlspecialchars($_REQUEST['example']).".svg";
+  $actualExample=preg_replace("/[^a-zA-Z0-9_\-]/",'',$_REQUEST["example"]);
+  $cachedimage= "umplibrary/imagecache/".$actualExample.".svg";
   if (file_exists($cachedimage))
   {
     $isCachedExample=true;
   }
   else
   {
-    $cachedimage= "umplibrary/imagecachesm/".htmlspecialchars($_REQUEST['example']).".svg";
+    $cachedimage= "umplibrary/imagecachesm/".$actualExample.".svg";
     if (file_exists($cachedimage))
     {
       $isCachedExample=true;
@@ -44,7 +46,7 @@ if (isset($_REQUEST['example']) && $_REQUEST["example"] != "") {
     }
     else
     {
-      $cachedimage= "umplibrary/imagecachestructure/".htmlspecialchars($_REQUEST['example']).".svg";
+      $cachedimage= "umplibrary/imagecachestructure/".$actualExample.".svg";
       if (file_exists($cachedimage))
       {
         $isCachedExample=true;
@@ -54,7 +56,7 @@ if (isset($_REQUEST['example']) && $_REQUEST["example"] != "") {
   }
   if($isCachedExample) {
     $imageoutput = "<br/><iframe src=\"".$cachedimage."\"></iframe><br\>";
-    $messageURL = "<a href=\"?example=".$_REQUEST['example'].$diagramtype."\">URL for ".$_REQUEST['example']." example</a>";
+    $messageURL = "<a href=\"?example=".$actualExample.$diagramtype."\">URL for ".$actualExample." example</a>";
   }
 }
 
@@ -873,8 +875,8 @@ $output = $dataHandle->readData('model.ump');
       <?php if(isset($_REQUEST["task"])) { ?> true <?php } else { ?> false <?php } ?>,
       <?php if($canCreateTask) { ?> true <?php } else { ?> false <?php } ?>
       ); 
-      <?php if (isset($_REQUEST['example']) && $_REQUEST["example"] != ""){?> 
-      Page.setExamples("<?php echo $_REQUEST['example'] ?>")
+      <?php if (isset($_REQUEST['example']) && $actualExample != ""){?> 
+      Page.setExamples("<?php echo $actualExample ?>")
       <?php } ?> 
       //
   </script>


### PR DESCRIPTION
An XSS (Cross-site scripting) security fault had been detected in the example= URL argument to Umpleonline. This PR prevents arbitrary scripts from being executed in the client's browser when the 'example=' URL argument is specified with a malicious script. 

This fixes

https://www.openbugbounty.org/reports/3829015/
and
https://www.openbugbounty.org/reports/3654183/