### PR TITLE
Allow slashes in example pattern

### DIFF
--- a/umpleonline/scripts/compiler_config.php
+++ b/umpleonline/scripts/compiler_config.php
@@ -513,7 +513,7 @@ function extractFilename()
     // If the argument is example=X then copy the example and open it
     elseif (isset($_REQUEST['example']) && $_REQUEST["example"] != "")
     {
-        $theActualExample=preg_replace("/[^a-zA-Z0-9_\-]/",'',$_REQUEST["example"]);
+        $theActualExample=preg_replace("/[^a-zA-Z0-9_\-\/]/",'',$_REQUEST["example"]);
         $fileToCopy = getExamplePath($theActualExample.'.ump');
         if(!file_exists($fileToCopy)){
             $fileToCopy = getExamplePath('NullExample.ump');

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -30,7 +30,7 @@ $imageoutput="";
 $messageURL="";
 $actualExample="";
 if (isset($_REQUEST['example']) && $_REQUEST["example"] != "") {
-  $actualExample=preg_replace("/[^a-zA-Z0-9_\-]/",'',$_REQUEST["example"]);
+  $actualExample=preg_replace("/[^a-zA-Z0-9_\-\/]/",'',$_REQUEST["example"]);
   $cachedimage= "umplibrary/imagecache/".$actualExample.".svg";
   if (file_exists($cachedimage))
   {


### PR DESCRIPTION
This fixes the previous PR ... slashes need to be allowed in examples to allow for umplibrary/manualexamples to be displayed from the user manual