### PR TITLE
Adding restorecompiler to dev-tools

### DIFF
--- a/dev-tools/restorecompiler
+++ b/dev-tools/restorecompiler
@@ -1,0 +1,11 @@
+#!/bin/bash
+# restores the latest compiler from dist/libs to dist
+# use if a bad compiler is built
+if [ -z ${UMPLEROOT+x} ]
+then
+  export UMPLEROOT=~/umple
+fi
+echo will restore compiler from the previous release from dist/libs to dist
+cp -pr $UMPLEROOT/dist/libs/`ls -t $UMPLEROOT/dist/libs | head -1` $UMPLEROOT/dist
+
+


### PR DESCRIPTION
This adds a command to dev-tools that will quickly restore the umple compiler as used by developers, if the developers have wrecked it by adding bugs (or simply want to get rid of debug traces they had added)