### PR TITLE
Fixed git location of simplechat

### DIFF
--- a/build/build.testbed.xml
+++ b/build/build.testbed.xml
@@ -32,7 +32,7 @@
 
   <property name="php.simpletest.version" value="1.2" />
   <property name="php.simpletest.url" 
-            value="https://github.com/simpletest/simpletest/archive/v${php.simpletest.version}.0.tar.gz" />
+            value="https://codeload.github.com/simpletest/simpletest/tar.gz/refs/tags/v${php.simpletest.version}.0" />
   <property name="php.libs.dir" value="${dist.dir}/libs/php" />
 
   <path id="project.classpath">


### PR DESCRIPTION
Github moved the location of a dependency; this was causing Appveyor to fail