### PR TITLE
Html and build leftover cleanup

### DIFF
--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -683,6 +683,7 @@ class Template
         "<head>" + "\n" +
         "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />" + "\n" +
         "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />" + "\n" +
+        "  <meta name=\"description\" content=\"Umple User Manual page for @@TITLE@@\"/>" + "\n" +
         "  <link rel=\"stylesheet\" type=\"text/css\" href=\"files/layout.css\" />" + "\n" +
         "  <script type=\"text/javascript\" src=\"files/script.js\"></script>" + "\n" +
         "  <title>Umple User Manual: @@TITLE@@</title>" + "\n" +
@@ -713,7 +714,7 @@ class Template
         "Umple </a></div>" + "\n" +
         
 // Code from Google to inject translation - script is at end
-"<div id=\"google_translate_element\"></div>" +
+"<div id=\"google_translate_element\" style=\"min-height: 23px\"></div>" +
 // End of code from Google
         "@@NAVIGATION@@" + "\n" +
         "<div class=\"level1\"><a href=\"UmpleUserManualCombined.html\">Combined Version</a></div>\n" +  
@@ -733,7 +734,7 @@ class Template
         "      <h2><i>User Manual @@PREVNEXT@@</i></h2>"  + "\n" +
         
 // Code from Google to inject custom search -- scripts are at end
-"<gcse:search></gcse:search>" + "\n" +
+"<div style=\"min-height: 61px\"><gcse:search></gcse:search></div>" + "\n" +
 // End code from Google
         Template.HtmlCoreTemplate +
         "      </td>" + "\n" +

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvCdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvCdGeneratorTest.java
@@ -35,6 +35,8 @@ public class GvCdGeneratorTest extends TemplateTest
     SampleFileWriter.destroy(pathToInput + "/gv/ColourParsingcd.gv");
     SampleFileWriter.destroy(pathToInput + "/gv/ColourParsingTest2cd.gv");
     SampleFileWriter.destroy(pathToInput + "/gv/ColourParsingTest3cd.gv");
+
+    SampleFileWriter.destroy(pathToInput + "/gv/IncreaseClassSepcd.gv");
   }
 
   @Test

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvErdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvErdGeneratorTest.java
@@ -34,6 +34,8 @@ public class GvErdGeneratorTest extends TemplateTest {
 	    SampleFileWriter.destroy(pathToInput + "/gv/RelationshipRangeerd.gv");
 	    SampleFileWriter.destroy(pathToInput + "/gv/RelationshipReflexiveerd.gv");
 	    SampleFileWriter.destroy(pathToInput + "/gv/RelationshipAttributeserd.gv");
+	    
+	    SampleFileWriter.destroy(pathToInput + "/gv/IncreaseERSeperd.gv");
 	}
 
 	// Also tests multi-valued attribute, derived attribute

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvSdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvSdGeneratorTest.java
@@ -50,6 +50,9 @@ public class GvSdGeneratorTest extends TemplateTest {
     SampleFileWriter.destroy(pathToInput + "/gv/GuardedAutoTransition.gv");
     SampleFileWriter.destroy(pathToInput + "/gv/TimedTransition.gv");
     SampleFileWriter.destroy(pathToInput + "/gv/ParameterTransition.gv");
+    
+    SampleFileWriter.destroy(pathToInput + "/gv/IncreaseStateSep.gv");
+    
   }
 
   /********* STATE TESTS **********/

--- a/umpleonline/download_umple.html
+++ b/umpleonline/download_umple.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="description" content="Describes various ways to download Umple for use on the command line, in Docker, in Eclipse and in VS-Code">
   <link href="scripts/styles_download.css" rel="stylesheet" type="text/css" />
   <title>Downloading and Installing Umple</title>
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
@@ -45,14 +46,14 @@
 </head>
 <body>
 
-  <span class="header" summary="University of Ottawa banner"><a href="http://www.umple.org" target="_blank"><img src="scripts/umpleonline_logo.jpg" alt="Umple logo" class="UmpleLogo" /></a><img src="scripts/bg_header_title.jpg" class="uOttawa" alt="Blank" /></span>
+  <span class="header" summary="University of Ottawa banner"><a href="https://www.umple.org" target="_blank"><img src="scripts/umpleonline_logo.jpg" alt="Umple logo" class="UmpleLogo" /></a><img src="scripts/bg_header_title.jpg" class="uOttawa" alt="Blank" /></span>
 
-<h1> Downloading and installing <a href="http://www.umple.org">Umple</a></h1>
+<h1> Downloading and installing <a href="https://www.umple.org">Umple</a></h1>
 
   <p class="intro">
     Below are instructions for downloading and installing Umple, a model-oriented programming technology that lets you model
-    in code.  Here is <a href="http://umple.org">more information</a>
-    about Umple, or try it online without downloading, using the <a href="https://try.umple.org">UmpleOnline tool.</a>
+    in code.  Here is <a href="https://umple.org">more information
+    about Umple</a>, or try it online without downloading, using the <a href="https://try.umple.org">UmpleOnline tool.</a>
   </p>
 
   <p class="intro">Umple can be used on Mac-OS, Windows or Linux. You have several downloading options described below, including directly downloading a jar, using homebrew, using Docker, using VSCode, or using Eclipse </p>
@@ -64,7 +65,7 @@
 
 
 
-<h3>A. Downloading Umple for Command-Line use</h3>
+<h2>A. Downloading Umple for Command-Line use</h2>
 
 <p><b>Prerequisite dependency:</b> An up-to-date Java 8 JDK or higher. The compiler has been tested and is also known to work under Java versions up to Java 16. If Java is not installed, then on Ubuntu first run <tt>apt install default-jdk</tt> or on Mac run <tt>brew install openjdk</tt>  or on Windows <tt>choco install openjdk</tt> .</p>
 
@@ -127,7 +128,7 @@
   <br />&nbsp;<br />
 
 
-  <h3>B. Running UmpleOnline in your own computer's Docker installation</h3>
+  <h2>B. Running UmpleOnline in your own computer's Docker installation</h2>
 
 <p><b>Requirement</b>: <a href="https://www.docker.com/get-docker">Docker</a> installed on your computer.
 
@@ -162,14 +163,14 @@
 
 <p>You can also accomplish the above  by downloading and installing our script called <a href="https://raw.githubusercontent.com/umple/umple/master/dev-tools/udock">udock</a> and passing it the optional argument -d {dir} for your local storage directory (otherwise data will be stored in a temporary directory)<p>
 
-<p>More information about Umple in Docker can be found at <a href="http://docker.umple.org">http://docker.umple.org</a></p>
+<p>More information about Umple in Docker can be found at <a href="https://umple.org/docker">https://umple.org/docker</a></p>
 
 <p>New Docker images are produced for each release of Umple, with occasional interim images. A list of Docker images can be found at <a href="https://hub.docker.com/r/umple/umpleonline/tags/"> the Umpleonline DockerHub site</a>. The image tagged 'latest' will be downloaded by default.</p>
 
 
   <br />&nbsp;<br />
 
-<h3>C. Running in VSCode.</h3>
+<h2>C. Running in VSCode.</h2>
 
 <p>A <a href="https://marketplace.visualstudio.com/items?itemName=digized.umple">Visual Studio Code plugin for Umple</a> is available.</p>
 
@@ -178,7 +179,7 @@
 
 <br />&nbsp;<br />
 
-   <h3>D. Installing and running the Umple compiler in Eclipse</h3>
+   <h2>D. Installing and running the Umple compiler in Eclipse</h2>
 
    <p><b>Requirements</b>: Java (as above), and the latest Eclipse with modeling tools.</p>
 
@@ -191,7 +192,7 @@
 
   <br />&nbsp;<br />
 
-<h3>E. The Umplificator</h3>
+<h2>E. The Umplificator</h2>
 
 <p>Another tool available is the umplificator, for reverse engineering code to Umple. <a 
 href="../umplificator_1.29.1.4260.b21abf3a3.jar">The Umplificator can be downloaded
@@ -201,9 +202,9 @@ here.</a></p>
 
   <br />&nbsp;<br />
 
-  <h3>User Manual </h3>
+  <h2>User Manual </h2>
 
-  <p>Refer to the <a href="http://manual.umple.org">Umple user manual</a> for comprehensive help programming in Umple. The <a href="http://api.umple.org">API quick reference</a> and <a href="http://grammar.umple.org">grammar quick reference</a> may be of particular help for power users.</p>
+  <p>Refer to the <a href="https://manual.umple.org">Umple user manual</a> for comprehensive help programming in Umple. The <a href="https://umple.org/api">API quick reference</a> and <a href="https://umple.org/grammar">grammar quick reference</a> may be of particular help for power users.</p>
 
 
 

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -465,23 +465,23 @@ $output = $dataHandle->readData('model.ump');
             </li>
             <?php } ?>
             <li id="buttonCopyClip" class="copyClip">
-              <img src="scripts/copy.png"/> 
+              <img src="scripts/copy.png" alt="Copy to Clipboard icon"/> 
                Copy to Clipboard
             </li>           
             <li id="buttonCopy" class="copy">
-              <img src="scripts/copy.png"/> 
+              <img src="scripts/copy.png" alt="Source to Copy icon"/> 
                Source to Copy
             </li>
             <li id="buttonCopyEncodedURL" class="copyEncoded">
-              <img src="scripts/copy.png"/> 
+              <img src="scripts/copy.png" alt="Copy Encoded URL icon"/> 
               Encoded URL
             </li>
             <li id="buttonCopyCommandLine" class="copyCommandLine">
-              <img src="scripts/copy.png"/> 
+              <img src="scripts/copy.png" alt="Copy Command Line Script icon"/> 
               Command Script
             </li>
             <li id="buttonCopyLocalBrowser" class="copyLocalBrowser">
-              <img src="scripts/copy.png"/> 
+              <img src="scripts/copy.png" alt="Store in Local Browser icon"/> 
               Store in Browser
             </li>
             
@@ -650,15 +650,15 @@ $output = $dataHandle->readData('model.ump');
           <ul id="mainDrawMenu" class="second toggle">
             <li class="subtitle"> Draw </li>
             <li id="buttonAddClass" class="toggleToolItem view_opt_class_palette layoutListItem" name="paletteItem" title="Select and click on the canvas to add a new class." tabindex="0">
-              <img src="scripts/class.png"/> 
+              <img src="scripts/class.png" alt="Icon to click on to create a new class in editable mode"/> 
               Class
             </li>
             <li id="buttonAddAssociation" class="toggleToolItem view_opt_class_palette layoutListItem" name="paletteItem" title="Select and click on a class to draw an association." tabindex="0">
-              <img src="scripts/assoc.png"/> 
+              <img src="scripts/assoc.png" alt="Icon to click on to create an association in editable mode"/> 
               Association
             </li>
             <li id="buttonAddTransition" class="toggleToolItem view_opt_state layoutListItem" name="paletteItem" title="Select and click on a state to draw a transition." tabindex="0">
-               <img src="scripts/assoc.png"/>
+               <img src="scripts/assoc.png" alt="Icon to click on to create a new transition in certain state modes"/>
                Transition
              </li>            
             <!-- <li id="buttonBendAssociation" class="toggleToolItem" name="paletteItem">
@@ -666,27 +666,27 @@ $output = $dataHandle->readData('model.ump');
               Bend Assoc.
             </li> -->
             <li id="buttonAddGeneralization" class="toggleToolItem view_opt_class_palette layoutListItem" name="paletteItem" title="Select and click on the child class to draw a generalization line to the parent class." tabindex="0">
-              <img src="scripts/generalization.png"/> 
+              <img src="scripts/generalization.png" alt="Icon to click on to create a generalization (subclass relationship) in editable mode"/> 
               Generalization
             </li>
             <li id="buttonDeleteEntity" class="toggleToolItem view_opt_class_palette layoutListItem" name="paletteItem" title="Select and click on an element to remove it from your model." tabindex="0">
-              <img src="scripts/delete.png"/>
+              <img src="scripts/delete.png" alt="Icon to click on to delete and item in editable mode"/>
                Delete
              </li>
             <li id="buttonUndo" name="paletteItem" tabindex="0">
-              <img src="scripts/undo.png"> 
+              <img src="scripts/undo.png" alt="Icon to click on to undo the last action"> 
               Undo
             </li>
             <li id="buttonRedo" name="paletteItem" tabindex="0">
-              <img src="scripts/redo.png"> 
+              <img src="scripts/redo.png" alt="Icon to click on to redo an undone item in editable mode"> 
               Redo
             </li>
             <li id="buttonReindent" name="paletteItem" tabindex="0">
-              <img src="scripts/sync_diagram.png" /> 
+              <img src="scripts/sync_diagram.png" alt="Icon to click on to reindent the code"/> 
               Reindent Code
             </li>
             <li id="buttonSyncDiagram" name="paletteItem" tabindex="0">
-              <img src="scripts/sync_diagram.png" /> 
+              <img src="scripts/sync_diagram.png" alt="Icon to sync the diagram manually when automatic syncing is off"/> 
               Sync Diagram 
             </li>
         </ul>
@@ -804,19 +804,19 @@ $output = $dataHandle->readData('model.ump');
             
             <?php if ($canCreateTask) { ?>
               <li id="buttonCreateTask">
-                <img src="scripts/copy.png"/>
+                <img src="scripts/copy.png" alt="Icon to click on to create a task"/>
                 Create a Task
               </li>
             <?php } ?>
 
             <li id="buttonLoadTask">
-              <img src="scripts/copy.png"/>
+              <img src="scripts/copy.png" alt="Icon to click on to load a task"/>
               Load a Task
             </li>
 
             <?php if (isset($_REQUEST["task"])) { ?>
             <li id="buttonRequestAllZip">
-              <img src="scripts/copy.png"/> 
+              <img src="scripts/copy.png" alt="Icon to click on to get a zip file with task submissions"/> 
               Request all Directories as a zip under this task
             </li>
             <?php } ?>

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -1,7 +1,7 @@
 <?php
 // Copyright: All contributors to the Umple Project
 // This file is made available subject to the open source license found at:
-// http://umple.org/license
+// https://umple.org/license
 //
 // Main program that generates UmpleOnline
 require_once ("scripts/compiler_config.php");
@@ -77,7 +77,7 @@ if (isset($_REQUEST["model"]) && substr(explode("-", $_REQUEST["model"])[0], 0, 
 
 // example=xxx means load the .ump file named xxx
 
-// filename=xxx means load the URL named xxx (but without the leading http://
+// filename=xxx means load the URL named xxx (but without the leading http:// or https://
 
 // model=nnnn means load the saved bookmark
 
@@ -259,19 +259,19 @@ $output = $dataHandle->readData('model.ump');
           ?>
         </span>
         <span id="gdprtext" class="pretext">        
-          This tool stores your data in cookies and on a server. <a href="javascript:Action.hidegdpr()">I understand</a>. &nbsp; <a href="http://privacy.umple.org" target="privacy">Click to learn about privacy.</a>
+          This tool stores your data in cookies and on a server. <a href="javascript:Action.hidegdpr()">I understand</a>. &nbsp; <a href="https://umple.org/privacy" target="privacy">Click to learn about privacy.</a>
         <br/></span>
     
     <span style="font-size: 30%; white-space:nowrap;">
-    <a class="button2" style="padding-top:auto; padding-bottom: auto;" href="http://dl.umple.org" target="dlpage" title="Go to the page that gives instructions on how to download Umple for use in Docker, or Eclipse or on the command line">Download</a>&nbsp;
+    <a class="button2" style="padding-top:auto; padding-bottom: auto;" href="https://umple.org/dl" target="dlpage" title="Go to the page that gives instructions on how to download Umple for use in Docker, or Eclipse or on the command line">Download</a>&nbsp;
     <a class="button2" style="padding-top:auto; padding-bottom: auto;" href="https://alumni.uottawa.ca/donation-form?fid=bp71rD2pbt0%3d&fdesc=vj8yiR3kw2%2bPwQCmy1Z8CfKc0F1zufF0wBCY%2fxboCy4%2bHJZne7BoLhQuKHwuRN4R5bhBEciI1Gn5RbPGt1TgEQ%3d%3d" target="donatepage" title="Go to a University of Ottawa page that will enable you to donate to support Umple; even a few dollars will be much appreciated">Donate</a>&nbsp;
     
     </span>&nbsp; &nbsp;
           For help:
-    <?php if(strpos($_SERVER['REQUEST_URI'], 'umple.php') !== false && strpos($_SERVER['REQUEST_URI'], 'umpleonline/umple.php') === false ) {$manpage="/manual/GettingStarted.html";} else {$manpage="http://manual.umple.org";} ?>                
+    <?php if(strpos($_SERVER['REQUEST_URI'], 'umple.php') !== false && strpos($_SERVER['REQUEST_URI'], 'umpleonline/umple.php') === false ) {$manpage="/manual/GettingStarted.html";} else {$manpage="https://manual.umple.org";} ?>                
     <span style="font-size: 30%; white-space:nowrap;">
     <a class="button2" style="line-height: 1; padding-top:auto; padding-bottom: auto;" href="<?php echo $manpage ?>" target="helppage" title="Open the Umple user manual in a separate tab" >User manual</a>&nbsp;
-    <a class="button2" style="line-height: 1; padding-top:auto; padding-bottom: auto;" href="http://questions.umple.org"
+    <a class="button2" style="line-height: 1; padding-top:auto; padding-bottom: auto;" href="https://umple.org/questions"
        target="questionpage" title="Open a separate tab on the StackOverflow page where you can ask Umple community members questions">Ask questions</a>&nbsp;
     <a class="button2" style="line-height: 1; padding-top:auto; padding-bottom: auto;" href="https://github.com/umple/umple/issues/new" target="issuepage" title="Open a separate tab on the page where you can report an Umple bug or request an improvement">Report issue</a>&nbsp;
     </span>

--- a/umplewww/index.html
+++ b/umplewww/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Umple home page, with an overview of key features, and links to resources">
   <link rel="stylesheet" type="text/css" href="files/layout.css" />
   <script type="text/javascript" src="files/script.js"></script>
   <title>Umple: Merging Modeling with Programming</title>
@@ -51,7 +51,7 @@ img {border:none;}
   <table>
   <tbody>
   <tr>
-    <td class="indicatorBlocks"><img src="files/indicator_blocks.gif" 
+    <td class="indicatorBlocks"><img src="files/indicator_blocks.gif" alt="Graphics for spacing"
 /></td>
 
     <td class="menu">
@@ -248,12 +248,12 @@ use, or a Docker image of UmpleOnline, or plugins for tools like Eclipse and Vis
      <span style="white-space:nowrap;">
      <a class="button" 
 href="https://github.com/umple/umple" title="Unple is an open source project hosted by GitHub.">Code&nbsp;<img 
-src="files/Octocat.jpg" height=12/></a></span>&nbsp;
+src="files/Octocat.jpg" alt="Github Octocat logo" height=12/></a></span>&nbsp;
 
      <span style="white-space:nowrap;">
      <a class="button" href="https://www.facebook.com/umple.org" target="social" title="News about major releases, major 
 contributions and so on are posted to Umple's Facebook Group.">News&nbsp;<img 
-src="https://en.facebookbrand.com/wp-content/uploads/2016/05/FB-fLogo-Blue-broadcast-2.png" 
+src="https://en.facebookbrand.com/wp-content/uploads/2016/05/FB-fLogo-Blue-broadcast-2.png" alt="Facebook logo" 
 height=12/></a></span>
 
      <span style="white-space:nowrap;">
@@ -286,9 +286,8 @@ the
 classroom.</p>
 
 
-      <p>Umple works <a href="https://try.umple.org">online</a>, as an <a 
-href="https://cruise.umple.org/umpleonline/download_umple.shtml">Eclipse plugin</a>, and as a 
-stand-alone command-line Jar. For further information and downloads, see the left margin.</p>
+      <p>Umple works <a href="https://try.umple.org">online</a>, or can be <a 
+href="https://cruise.umple.org/umpleonline/download_umple.shtml">downloaded for use on the command line, in Eclipse, in VS-Code and in Docker</a>.</p>
 
       
 &nbsp;<br/>


### PR DESCRIPTION
This cleans up some build and html issues:

1. There were some bad links on the main umpleonline page that were created after we had to change the x.umple.org format of URL shortcuts to umple.org/x format. Also there were some http links on that page, when all should be https.

2. Three files had been created by certain graphviz tests that should have been deleted. They now are deleted.

3. Adds meta description tags to main pages and user manual pages to improve Google analysis.

4. Reduces layout shift in user manual pages by ensuring the google translate and search areas are in divs that have a min-height. This will improve UX as when pages load, they will not jump around. It will also improve Google's analysis results.

5. Adds some alt tags for images in the main UmpleOnline page to improve accessibility

7. Fixed accessibility issues in the downloads page.