### PR TITLE
Fixes hangs that can occur when compiling generated Java

### DIFF
--- a/cruise.umple/src/Compiler.ump
+++ b/cruise.umple/src/Compiler.ump
@@ -218,7 +218,13 @@ class CodeCompiler {
       
       // Method 1: Use tool provider
       if(!useExec) {
-        PipedInputStream in = new PipedInputStream(8192);
+        // Determine a safe size of the output stream to capture any error messages
+        // The larger the file the more error messages are likely
+        // There were crashes when the buffer was not large enough for the number of messages
+        File theFile = new File(filename);
+        int bufferSizeToUse = Math.max(16384,((int)theFile.length() )*3);
+
+        PipedInputStream in = new PipedInputStream(bufferSizeToUse);
         out = new PipedOutputStream(in);
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         compiler.run(null, null, out, "-cp",base,filename);


### PR DESCRIPTION
The process compiling generated Java (initiated when compiled using -c -) would hang if an excessive number of Java error messages were generated, due to exceeding a fixed 8192 buffer size. This PR increases the buffer to be a multiple of the java file size.

This had caused a hang in UmpleOnline when executing code (which compiles the generate Java first, to present any error messages arising from the user-supplied Java) as well as the command-line compiler.