### PR TITLE
Improve Counter and  Privacy Note

### DIFF
--- a/umpleonline/counter.php
+++ b/umpleonline/counter.php
@@ -86,10 +86,10 @@ if(file_exists($versionpath)){
 	$currentversion = fgets($vfile,1000);
 	fclose($vfile);
 	$releaseMajMin = preg_replace('/(\d+\.\d+\.\d+).*/i','${1}',$currentversion);
-	$currentgit=@exec("git rev-parse --short HEAD")." ".@exec("git log -1 --format=%cd --date=relative");
+	$currentgit=@exec("git rev-parse --short HEAD")." ".@exec("git rev-parse --abbrev-ref HEAD")." ".@exec("git log -1 --format=%cd --date=relative");
   $currentversion = preg_replace('/(\d+\.\d+\.\d+\.\d+\.).*/i','${1}'.$currentgit,$currentversion);
 
-	echo " | <a target=\"releasepage\" href=\"https://github.com/umple/umple/releases/v$releaseMajMin\">v$currentversion</a>" ;
+	echo " | <a target=\"releasepage\" href=\"https://github.com/umple/umple/releases/v$releaseMajMin\">v$currentversion</a> | <a href=\"https://umple.org/privacy\" target=\"privacy\">Privacy Policy</a>" ;
 }
 
 


### PR DESCRIPTION
Adds a link permanentl in UmpleOnline at the bottom pointing to the privacy policy. Until now, it was always available in the manual, but only actively pointed out at Cookie Acceptance time for a new user. GDPR rules suggest it always be visible. 

Also the branch name checked out will also now appear.