### PR TITLE
Ensure certain images appear in manual and main page

### DIFF
--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -414,6 +414,12 @@
     <copy todir="${dist.path}/reference/files">
       <fileset file="umplewww/files/Octocat.jpg"/>
     </copy>
+     <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/NSERC_BLACK.png"/>
+    </copy>
+    <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/DRAC_logo.jpeg"/>
+    </copy>
     <copy todir="${dist.path}/reference/files">
       <fileset file="umplewww/files/umple_example_uml.jpg"/>
     </copy>


### PR DESCRIPTION
Two images were not being moved into place in the manual and main webpage during the build process. This fixes.