### PR TITLE
Facebook Logo dead link needs fixing

### DIFF
--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -421,6 +421,9 @@
       <fileset file="umplewww/files/DRAC_logo.jpeg"/>
     </copy>
     <copy todir="${dist.path}/reference/files">
+      <fileset file="umplewww/files/FB-logo.jpg"/>
+    </copy>
+    <copy todir="${dist.path}/reference/files">
       <fileset file="umplewww/files/umple_example_uml.jpg"/>
     </copy>
     <copy todir="${dist.path}/reference/syntaxhighlighter">


### PR DESCRIPTION
The main webpage used to link to a Facbook logo on their site, but they changed their URL, so we are now just loading it from our site.