### PR TITLE
Documenting a feature of state machines and improving command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ UmpleCodeExecution/config.cfg.bak
 UmpleCodeExecution/config.cfg
 UmpleCollabServer/config.cfg.bak
 UmpleCollabServer/config.cfg
+testbed_cpp/test/runAllTests
 
 # generated Umple code that is not saved
 src-gen-umple/

--- a/build/reference/3015ComposingStateMachines.txt
+++ b/build/reference/3015ComposingStateMachines.txt
@@ -1,0 +1,27 @@
+Composing State Machines
+State Machines
+noreferences
+
+@@description
+<p>      
+State machines can be built from parts. Elements of state machines can be added in several ways:</p>
+
+<ul>
+
+<li><p>By repeating the state machine definition in the same class, adding more detail. In the example below, the state machine sm has part of its definition starting at line 2, and part of its definition starting at line 26.</p></li>
+
+<li><p>By using standalone transitions. Line 20 shows that outside the context of any state, a transition can be defined. Just add the origin state before the arrow. This one indicates that when e3 occurs, if in state b, then go to state a. This notation can be used to help separate concerns, and place focus on a particular transition. Another example of this is at line 31, where event e5 can cause a transition from state bsub1 to state a. Note that line 34 shows another way of indicating a standalone transition, by adding more detail to state a (that had already beed defined starting at line 3).</p></li>
+
+<li><p>By using mixins where a more detail to a class (and its contained state machine) is added. Starting at line 26, there is a new definition adding more detail to class X, which in turn adds more detail to state machine sm starting at line 29.</p></li>
+
+<li><p>By using <a href="BasicMixsets.html">mixsets</a>: Mixsets are like mixins but can be either excluded or included in the system. To include a mixset,add a use statement (as i line 49) or command line option. An example starts at line 39, where yet more detail is added to class X and its state machine sm. This is activated with the use statement at line 49.</p></li>
+
+</ul>
+
+@@syntax
+
+[[stateMachineDefinition]] [[state]] [[stateEntity] [[transition]] [[standAloneTransition]]
+
+@@example @@caption Illustration of various ways of adding details to a state machine @@endcaption
+@@source manualexamples/composedStateMachine.ump &diagramtype=state
+@@endexample

--- a/cruise.umple/src/Main_Code.ump
+++ b/cruise.umple/src/Main_Code.ump
@@ -380,7 +380,7 @@ class UmpleConsoleMain
           System.out.println("  Finished generating "+key);
           if(key.compareTo("Java")==0) {
             for (UmpleClass mainClass: CodeCompiler.getMainClasses(model)) {
-              System.out.println("  Main method found. Run Java "+mainClass.getName());
+              System.out.println("  Main method found. Run java "+mainClass.getName());
             }
           }
         }
@@ -575,11 +575,11 @@ class UmpleConsoleMain
 
     optparser.acceptsAll(Arrays.asList("g", "generate"), "Specify the output language: " + languages).withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("u", "umple"), "Include umple code directly as a single string, instead of or addition to in files.").withRequiredArg().ofType(String.class);
-    
+    optparser.acceptsAll(Arrays.asList("d","debug"), "Debug. For developers of the compiler. Turns on internal debug statements wrapped in blocks that check model.isDebugMode().");    
     optparser.acceptsAll(Arrays.asList("override"), "If a output language <lang> is specified using option -g, output will only generate language <lang>");
     optparser.acceptsAll(Arrays.asList("removeprevious", "r"), "used with -g; remove previously generated code before generating new. Can help prevent leftover code causing errors. Does not work with generators specified inside a file.");
     optparser.acceptsAll(Arrays.asList("path"), "If a output language is specified using option -g, output source code will be placed to path").withRequiredArg().ofType(String.class);
-    optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles; compiles Java to .class, lints Php, converts Graphviz to .svg").withRequiredArg().ofType(String.class);
+    optparser.acceptsAll(Arrays.asList("c","compile"), "Indicate to the entry class to compile, or with argument - to compile all outputfiles; compiles Java to .class, lints Php and Python, converts Graphviz to .svg").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("f","file"), "Read in a file containing sets of umple-files to process, one set per line. Each is an independent compilation. Intended for testing.").withRequiredArg().ofType(String.class);
     optparser.acceptsAll(Arrays.asList("e","exitonfirstfailure"), "Used with -f. Exit with nonzero on first failure of a compile specified in the file passed to -f. Otherwise exits after completing all compilations with nonzero if any failed.");    
     optparser.acceptsAll(Arrays.asList("q","quiet"), "Be quiet. Only output compilation information in case of failure");

--- a/umpleonline/umplibrary/manualexamples/composedStateMachine.ump
+++ b/umpleonline/umplibrary/manualexamples/composedStateMachine.ump
@@ -1,0 +1,49 @@
+class X {
+  sm {
+    a {
+      // Ordinary transition
+      e1-> bsub1;
+    }
+    b {
+      bsub1 {
+        // transition in substate
+        e2 -> bsub2;
+      }
+      bsub2 {}
+    }
+    // Standalone transition
+    // at to level
+    e3 b -> a;
+    
+    // Standalone transition
+    // between substate
+    e4 bsub2 -> bsub1;
+  }
+}
+
+// Mixin for class that mixes in
+// more details into the state machine
+class X {
+  // Supplemental detail for same
+  // state machine
+  sm {
+    // Standalone transition
+    e5 bsub1 -> a;
+    
+    // Another way of adding a transition
+    a {e6 -> bsub2;}
+  }
+}
+
+// Mixset to optionally add more detail
+mixset extra class X {
+  sm {
+    // Adding a new state
+    c {}
+    // Adding a transition
+    e7 b -> c;
+  }
+}
+
+// Activating the above mixset
+use extra;


### PR DESCRIPTION
This documents standalone transitions in the user manual.

It also adds a -d or --debug option to the command line so compiler developers can more easily switch on and off debug code. 

And it makes sure that the message stating to run java Classname to execute code has java in lowercase, as the command to run is lowercase.