### PR TITLE
Updating social media links

### DIFF
--- a/umplewww/index.html
+++ b/umplewww/index.html
@@ -66,8 +66,6 @@ href="https://try.umple.org" >Umple Online</a></b></div>
         <div class="level2"><b><a 
 href="https://manual.umple.org" >User Manual</a></b></div>
         
-        <div class="level2"><b><a href="https://hub.docker.com/r/umple/umpleonline/" >Docker site</a></b></div>  
-
         <div class="level2"><b><a href="https://github.com/umple/umple" >Github 
 site</a></b></div>
 
@@ -81,7 +79,6 @@ site</a></b></div>
 
         <div class="level2"><b><a href="https://github.com/umple/Umple/wiki/examples"> 
 Additional Examples</a></b></div>
-
 
         <div class="level2"><b><a 
 href="https://github.com/umple/Umple/wiki/PhilosophyAndVision">Philosophy 
@@ -107,7 +104,19 @@ href="https://github.com/umple/umple/releases">Releases
         <div class="level2"><b><a 
 href="https://cruise.umple.org/scripts/umple.jar">Latest built jar 
 </a></b></div>
-        
+
+        <div class="level2"><b><a 
+href="https://formulae.brew.sh/formula/umple">Homebrew (Mac/Linux) 
+</a></b></div>
+
+        <div class="level2"><b><a 
+href="https://community.chocolatey.org/packages?q=umple">Chocolatey (Windows) 
+</a></b></div>
+
+        <div class="level2"><b><a 
+href="https://hub.docker.com/r/umple/umpleonline/">Docker image 
+</a></b></div>
+
         <div class="level2"><b><a 
 href="https://cruise.umple.org/umpleonline/download_umple.shtml">Instructions 
 </a></b></div>
@@ -139,7 +148,13 @@ href="https://www.mendeley.com/groups/3493941/umple/papers/">Mendeley
         <div class="level2"><a href="https://www.facebook.com/umple.org" target="social">Facebook
          </a></div>
 
-        <div class="level2"><a href="https://twitter.com/umpleorg" target="social">Twitter
+        <div class="level2"><a href="https://x.com/umpleorg" target="social">X (formerly Twitter)
+         </a></div>
+
+        <div class="level2"><a href="https://www.linkedin.com/groups/13038747/" target="social">LinkedIn
+         </a></div>
+
+        <div class="level2"><a href="mailto:timothy.lethbridge@uottawa.ca?subject=Please invite me to the Umple users Discord server&body=Please invite me to the Umple discord server. I am interested in Umple and will respect other users. Here is a little about me: PROVIDE YOUR LOCATION AND A GITHUB PAGE, LINKEDIN PAGE OR UNIVERSITY OR CORPORATE WEB PAGE WITH YOUR NAME AND EMAIL OTHERWISE YOUR REQUEST WILL BE DELETED">Discord (request invite)
          </a></div>
 
         <div class="level2"><a href="https://www.quora.com/search?q=umple" target="social">Quora questions</a></div>


### PR DESCRIPTION
Added the following links on the main Umple web page

Linkedin:
https://www.linkedin.com/groups/13038747/

Chocolatey:
https://community.chocolatey.org/packages?q=umple

Homebrew:
https://formulae.brew.sh/formula/umple

as well as a mailto link to request an invitation to the Discord server