### PR TITLE
Outputting grammar in docs with grouping parentheses more visible

### DIFF
--- a/cruise.umple/src/Parser_Code.ump
+++ b/cruise.umple/src/Parser_Code.ump
@@ -436,7 +436,7 @@ class Parser
   }
 
   // Converts a rule from Umple native format to html, including links to other rules
-  private String cleanupRule(String cleanedUpRule)
+  private String cleanupRule(String ruleName, String cleanedUpRule)
   {
   
     int ruleLength = cleanedUpRule.length();
@@ -476,6 +476,18 @@ class Parser
     // Colour arbitrary text blocks dirty yellow [**stuff] or [**stuff:xx]
     cleanedUpRule = cleanedUpRule.replaceAll("[\\[][*][*]?([a-zA-Z_]*)([:].*)?[\\]]", "[**<font color=\"#AAAA22\">$1</font>$2]");
 
+    // If long rule that has parentheses grouping components, then indent
+    // Omitted rules here are because of complex nesting and regexes
+    if (ruleLength > 50 
+      && !ruleName.equals("annotationComment")
+      && !ruleName.equals("toplevelBeforeCode")
+      && !ruleName.equals("iEStateMachine")
+      && !ruleName.equals("afterEveryEvent")
+      && !ruleName.equals("afterEvent")) {
+      cleanedUpRule = cleanedUpRule.replaceAll("[(]", "\n<br/>&nbsp;&nbsp(");
+      cleanedUpRule = cleanedUpRule.replaceAll("[)]", "\n<br/>&nbsp;&nbsp)");
+    }
+
     // Revert changes made during rule parsing
     cleanedUpRule = cleanedUpRule.replace("OPEN_ROUND_BRACKET", "(");
     cleanedUpRule = cleanedUpRule.replace("CLOSE_ROUND_BRACKET", ")");
@@ -493,7 +505,7 @@ class Parser
         cleanedUpRule = cleanedUpRule.replaceAll("[|]", "\n<br/>&nbsp;&nbsp;&nbsp;&nbsp|");
       }
     }
-    
+        
     return cleanedUpRule;
   }
   
@@ -591,7 +603,7 @@ class Parser
             }
             else // default is convert to html
             {
-              String cleanedUpRule = cleanupRule(splitRule[1]);
+              String cleanedUpRule = cleanupRule(ruleName, splitRule[1]);
               genRuleHtml(ruleName, answer, cleanedUpRule, hasMinus, hasHash);
             }
 


### PR DESCRIPTION
Parentheses used to group sets of rule parts in the grammar had been hard to see, making rules hard to understand. With this PR, open and closing parentheses are indented in such a way that the grouping is more visible in the user manual.