### PR TITLE
Fixing so loads examples still in Php7

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -619,7 +619,7 @@ else if (isset($_REQUEST["umpleCode"]))
 else if (isset($_REQUEST["exampleCode"]))
 {
   $exampleName=$_REQUEST["exampleCode"];
-  if (str_starts_with($exampleName, 'http')) {
+  if (substr($exampleName,0,4) == 'http') {
      // Load from a separate URL (new off-repo examples)
      // This code is similar to if #_REQUEST is load as earlier
      $outputUmple = file_get_contents($exampleName);


### PR DESCRIPTION
THe function str_starts_with was introduced in compile.php ... however this only works in php8 and was preventing php7 installations from loading examples in umpleonline

This PR uses substr so that the code continues to work in php7