### PR TITLE
Ensuring warning 44 appears whenever subclass has the same attribute

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -1254,25 +1254,35 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
             UmpleClass extend = child.getExtendsClass();
             while(extend!=null && child != extend && limit > 0) 
             {
+              // Look through all the parent classes to see if there are duplicate attributes
               limit--;
               for(Attribute extendAttr : extend.getAttributes()) 
               {
-                
+                // look one by one at the attributes inherited from a parent (extend)
                 String currentName = aAttribute.getName();
                 if (extendAttr.getName().equals(currentName)) 
                 {
+                  // There is an inherited attribute with the same name, but it might be OK if
+                  // it is being 'refined' e.g. given a different type or value
                   if(extendAttr.getType().equals(aAttribute.getType()))
                   {
-                    if(aAttribute.getValue() == null)
+                    if(aAttribute.getValue() == null) {
+                      // Not a refinement by setting a value, so it is a duplicate
                       attRepetition.add(aAttribute);
-                    else
+                      // issue 2173
+                      // warn of the duplicate
+                      setFailedPosition(aAttribute.getPosition(), 44, child.getName(), currentName, extend.getName());
+                    }
+                    else {
+                      // OK the value is being changed
                       aAttribute.setIsRefinement(true);
+                    }
                   }
                   else
                   {
-                  attRepetition.add(aAttribute);
+                    // The new attribute has same name but different type
+                    attRepetition.add(aAttribute);
                     setFailedPosition(aAttribute.getPosition(), 44, child.getName(), currentName, extend.getName());
-                
                   }
                 }
               }

--- a/cruise.umple/test/cruise/umple/compiler/007_isA_ComplexCycle_WithKey.ump
+++ b/cruise.umple/test/cruise/umple/compiler/007_isA_ComplexCycle_WithKey.ump
@@ -1,6 +1,6 @@
 class Inherited2
 {
-  Integer id;
+  Integer ix;
   isA Loop;
 }
 

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -1411,8 +1411,8 @@ public class UmpleParserTest
   // in a superclass.
   public void attributeSharedName()
   {
-	  assertNoWarningsParse("429_sharedAttributeName.ump");
-	  assertNoWarningsParse("429_sharedAttributeName_ML.ump");
+	  assertHasWarningsParse("429_sharedAttributeName.ump",44);
+	  assertHasWarningsParse("429_sharedAttributeName_ML.ump",44);
 
   	  //Issue 587
   	  assertHasWarningsParse("429_sharedAttributeName_MultCases1.ump", 44);


### PR DESCRIPTION
Warning 44 was only being emitted when a subclass had an attribute with the same name but a different type.

However, issue #2173 pointed out that such a warning should be emitted even if the type is the same, since otherwise the user might not realize they are adding a duplicate. The duplicate does not appear in the diagram as it is deleted during parsing, so it results in a difference between text and diagram.