### PR TITLE
Avoiding excessive copies of warning 33 Fixes #2195

### DIFF
--- a/cruise.umple/src/UmpleInternalParser_Code.ump
+++ b/cruise.umple/src/UmpleInternalParser_Code.ump
@@ -161,6 +161,15 @@ class UmpleInternalParser
     getParseResult().setPosition(position);
     getParseResult().addErrorMessage(new ErrorMessage(errorCode,position,messages));
   }
+  
+  // Generate a generic error for debug purposes that just contains the string s
+  public void emitDebugError(String s) {
+    setFailedPosition(new Position("debug",0,0,0), 8001, s);
+  }
+  // Generate a generic warning for debug purposes that just contains the string s
+  public void emitDebugWarning(String s) {
+    setFailedPosition(new Position("debug",0,0,0), 8005, s);
+  }
 
   // Analyze all child tokens of the "root" token.  This delegates to a individual
   // Each token is analyzed as long as "shouldProcessAgain" is set to true during the analysis

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -1235,7 +1235,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
   }
 
   // Check for the existence of a a parent class
-   private void checkExtendsClass(){
+   private void checkExtendsClass(UmpleClass classToCheck){
     for(UmpleClass child : model.getUmpleClasses()) 
     {
       if(child.getExtendsToken() != null) 
@@ -1292,12 +1292,16 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           
           for(Attribute att : attRepetition)
             child.deleteAttribute(att);
-            
           continue;
         }
         else{
           Token t = child.getExtendsToken();
-          getParseResult().addErrorMessage(new ErrorMessage(33,t.getPosition(),t.getValue(),child.getName()));      
+
+          // Issue #2195 indicated that message 33 was being repeated unnecessarily (computing from each subclass)
+          if(classToCheck == child) {
+            // Only do it in one case, otherwise will duplicate error 33
+            getParseResult().addErrorMessage(new ErrorMessage(33,t.getPosition(),t.getValue(),child.getName()));
+          }
         }
       }
     }
@@ -2107,7 +2111,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       try
       {
         child.setExtendsToken(extendsToken.get(i));
-        checkExtendsClass();                            //Issue 543
+        checkExtendsClass(child);                            //Issue 543
       }
       catch(Exception e){}
           }


### PR DESCRIPTION
This prevents warning 33 from being repeated over and over again in situations where there are multiple warning 33 to issue.

Before this if there were 2 cases it would issue one warning for one and 2 for the second. If there were 3 cases it would issue 1+2+3=6 cases, and so on.