### PR TITLE
Issue #1662 Throw warning when rolename and classname match

### DIFF
--- a/build/reference/9019NoDuplicateAssociations.txt
+++ b/build/reference/9019NoDuplicateAssociations.txt
@@ -12,8 +12,7 @@ noreferences
 
 <p>The third example shows that error 19 can also occur with association classes. The solution to this can be found in <a href="AssociationClassDefinition.html">the manual page for association classes.</a></p>
 
-</p>
-
+<p>Note that if warning <a href="W089AssociationRolenameMatchingClassname.html">W093</a> is being raised, resolve that issue first. This will resolve the error in some cases.</p>
 
 @@example
 @@source manualexamples/E019DuplicateAssociation1.ump

--- a/build/reference/9089AssociationRolenameMatchingClassname.txt
+++ b/build/reference/9089AssociationRolenameMatchingClassname.txt
@@ -1,0 +1,23 @@
+W089 Association Rolename Matching Classname
+Errors and Warnings 51-99
+noreferences
+
+@@description
+
+<h2>Umple semantic warning issued when assigning a role to an association that matches the class name</h2>
+
+<p> The role name of an association is used to explain how a class participates in a relationship. 
+A role name that matches the class name may be unnecessary, since it provides little clarification as to the relationship between the classes.
+<br/>
+This warning can be avoided by removing or changing the role name.
+<br/><br/>
+Note that in certain cases this could raise syntactic errors such as <a href="E019DuplicateAssociation.html">E019</a>.
+</p>
+
+@@example
+@@source manualexamples/W089AssociationRolenameMatchingClassname1.ump
+@@endexample
+
+@@example @@caption Solution to The Above So the Message No Longer Appears @@endcaption
+@@source manualexamples/W089AssociationRolenameMatchingClassname2.ump
+@@endexample

--- a/cruise.umple/src/Master.ump
+++ b/cruise.umple/src/Master.ump
@@ -21,6 +21,7 @@ strictness allow 46; // For now don't worry about special attribute types
 strictness allow 36; // don't worry about multiplicity of directed associations
 strictness allow 170; // allow custom constructors
 strictness allow 31; // dont worry about namespaces
+strictness allow 89; // dont worry about role name matching class name
 
 
 use Documenter.ump;

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -670,6 +670,9 @@ class UmpleInternalParser
       checkIgnoredAssociations();
       checkSubclassSameAssociationDifferentRoleNames();
 
+      //Issue 1662
+      checkRolenameMatchingClassname();
+
       checkExtendsForCycles();
       checkSortedAssociations();
       checkAssociationsValidity();
@@ -2979,6 +2982,23 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     
   }
 
+  private void checkRolenameMatchingClassname()
+  {
+    for (Association assoc : model.getAssociations()) {
+      AssociationEnd firstEnd = assoc.getEnd(0);
+      AssociationEnd secondEnd = assoc.getEnd(1); 
+
+      if (firstEnd.getRoleName().toLowerCase().equals(firstEnd.getClassName().toLowerCase()) && !firstEnd.getIsDefaultRoleName()) 
+      {
+        getParseResult().addErrorMessage(new ErrorMessage(89,assoc.getTokenPosition(),firstEnd.getRoleName(), firstEnd.getClassName()));
+      } 
+      if (secondEnd.getRoleName().toLowerCase().equals(secondEnd.getClassName().toLowerCase()) && !secondEnd.getIsDefaultRoleName()) 
+      {
+        getParseResult().addErrorMessage(new ErrorMessage(89,assoc.getTokenPosition(),secondEnd.getRoleName(), secondEnd.getClassName()));
+      }
+    }
+  }
+
   private void checkDuplicateAssociationNames()
   {
     for(UmpleClass C : model.getUmpleClasses())
@@ -3008,7 +3028,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         AssociationEnd firstEnd = assoc.getEnd(0);
         AssociationEnd secondEnd = assoc.getEnd(1); 
 
-      if ( assoc.getIsSpecialization() )
+        if ( assoc.getIsSpecialization() )
         {
         //getParseResult().addErrorMessage(new ErrorMessage(400,assoc.getTokenPosition(),C.getName(),firstEnd.getRoleName()));
           continue;
@@ -3020,7 +3040,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         Boolean checkSecondEnd = !secondEnd.getClassName().equals(C.getName());
         Boolean associationIsReflexive = !checkFirstEnd && !checkSecondEnd;
         
-        //issue 288: firstEnd of association does not indicate current (this) class being analyzed.
+        //issue 188: firstEnd of association does not indicate current (this) class being analyzed.
         //If association is NOT reflexive, must check the differing class.  Check if role name
         //matches class name, but only if it is a user entered role name.  Current class must
         //also have multiple associations to the same class to cause java compile errors.  

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -91,6 +91,8 @@
 82: 4, "https://manual.umple.org/?E082ConflictingMethodModifersDeclaredForStateDependentMethod.html", Found conflicting modifiers for method '{0}'. Ignoring '{1}' and using '{2}' ;
 83: 2, "https://manual.umple.org/?E083InvalidMultivaluedAttributeInitialization.html", A derived attribute should not contain a list indicator. If you want to create a list initializer, it should terminate with a semicolon ;
 
+89: 4, "https://manual.umple.org/?W089AssociationRolenameMatchingClassname.html", Role name '{0}' is the same as the class name '{1}' it describes. Choose a role name that explains how the role is a special case of how this class is used ;
+
 # Model Constraints' Error messages
 90: 2, "https://manual.umple.org/?E090AttributeNameNotFoundConstraint.html", Attribute named {0} was not found in class {1}, as required in constraint ;
 91: 2, "https://manual.umple.org/?E091AttributeOfTypeNotFoundConstraint.html", Attribute with type {0} was not found in class {1}, as required in constraint ;

--- a/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname1.ump
@@ -1,0 +1,5 @@
+class Temp{
+  1 -> 1 Other other;
+}
+
+class Other{}

--- a/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname1.ump
@@ -1,5 +1,5 @@
 class Temp{
-  1 -> 1 Other other;
+  1 -- 1 Other other;
 }
 
 class Other{}

--- a/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname2.ump
@@ -1,0 +1,5 @@
+class Temp{}
+
+class Other{}
+
+association { 1 Temp -> * Other other;}

--- a/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname2.ump
@@ -2,4 +2,4 @@ class Temp{}
 
 class Other{}
 
-association { 1 Temp -> * Other other;}
+association { * Temp -> 1 Other other;}

--- a/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname3.ump
+++ b/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname3.ump
@@ -1,0 +1,5 @@
+class Temp{
+  * -> 0..2 Other myOther;
+}
+
+class Other{}

--- a/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname4.ump
+++ b/cruise.umple/test/cruise/umple/compiler/089_rolenameMatchingClassname4.ump
@@ -1,0 +1,5 @@
+class Temp{
+  * -> 0..2 Other oThEr;
+}
+
+class Other{}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3400,6 +3400,15 @@ public class UmpleParserTest
     Assert.assertEquals("something", uClass.getEnum(0).getEnumValue(0));
  }
 
+ //Issue 1662
+ @Test
+ public void rolenameMatchingClassNameWarning() {
+    assertHasWarningsParse("089_rolenameMatchingClassname1.ump", 89);
+    assertHasWarningsParse("089_rolenameMatchingClassname2.ump", 89);
+    assertHasNoWarningsParse("089_rolenameMatchingClassname3.ump");
+    assertHasWarningsParse("089_rolenameMatchingClassname4.ump", 89);
+ }
+
  // Issue 1008
  @Test
  public void namingConflictBetweenEnumerationAndClass() {

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3402,7 +3402,7 @@ public class UmpleParserTest
 
  //Issue 1662
  @Test
- public void rolenameMatchingClassNameWarning() {
+ public void rolenameMatchingClassnameWarning() {
     assertHasWarningsParse("089_rolenameMatchingClassname1.ump", 89);
     assertHasWarningsParse("089_rolenameMatchingClassname2.ump", 89);
     assertHasNoWarningsParse("089_rolenameMatchingClassname3.ump");

--- a/testbed/src/TestHarnessAssociations.ump
+++ b/testbed/src/TestHarnessAssociations.ump
@@ -2,6 +2,8 @@ namespace cruise.associations;
 
 // Ignore warnings about multiplicity bounds on directed association
 strictness ignore 36;
+// Ignore warnings about role name matching class name
+strictness ignore 89;
 
 class MentorA
 {

--- a/testbed/src/TestHarnessCompositionsLeft.ump
+++ b/testbed/src/TestHarnessCompositionsLeft.ump
@@ -2,6 +2,8 @@ namespace cruise.associations.compositions;
 
 // Ignore warnings about multiplicity bounds on directed association
 strictness ignore 36;
+// Ignore warnings about role name matching class name
+strictness ignore 89;
 
 class X_comp {}
 

--- a/umpleonline/umplibrary/Airline.ump
+++ b/umpleonline/umplibrary/Airline.ump
@@ -47,7 +47,7 @@ class PersonRole{}
 
 class Booking{
   String seatNumber;
-  * Booking -- 1 SpecificFlight;
+  * -- 1 SpecificFlight;
 }
 
 //$?[End_of_model]$?

--- a/umpleonline/umplibrary/GeometricSystem.ump
+++ b/umpleonline/umplibrary/GeometricSystem.ump
@@ -255,7 +255,7 @@ trait TComparable<TP2>{
 
 //For geometric objects that cannot have color for edges.
 trait TDrawable {
-  0..1 -> * Color color;
+  0..1 -> * Color;
   Integer getRed() {return 1;}
   Integer getBlue() {return 2;}
   Integer getGreen() {return 3;}

--- a/umpleonline/umplibrary/manualexamples/AssociationDefinition1.ump
+++ b/umpleonline/umplibrary/manualexamples/AssociationDefinition1.ump
@@ -20,7 +20,7 @@ association {
 
 // Class with composition
 class E {
-  0..1 e <@>- * A a;
+  0..1 <@>- * A;
 }
 
 // Reference to a class defined elsewhere

--- a/umpleonline/umplibrary/manualexamples/ClassesasAttributeTypes2.ump
+++ b/umpleonline/umplibrary/manualexamples/ClassesasAttributeTypes2.ump
@@ -12,7 +12,7 @@
 class Person {
   name;
   
-  * -> 1 Address address;
+  * -> 1 Address;
 }
 
 class Address {

--- a/umpleonline/umplibrary/manualexamples/InlineAssociations1.ump
+++ b/umpleonline/umplibrary/manualexamples/InlineAssociations1.ump
@@ -4,7 +4,7 @@ class Group
   // a many-to-many association
   // An item has zero or more groups and a group
   // has zero or more items
-  * -- * Item item;
+  * -- * Item;
   
   // An item has an optional description
   // The association is directed, so descriptions

--- a/umpleonline/umplibrary/manualexamples/W089AssociationRolenameMatchingClassname1.ump
+++ b/umpleonline/umplibrary/manualexamples/W089AssociationRolenameMatchingClassname1.ump
@@ -1,0 +1,13 @@
+//This example generates the warning message
+class Person {
+  name;
+}
+
+class Intern {
+  isA Person;
+  * -- 0..2 Employee employee;
+}
+
+class Employee {
+  isA Person;
+}

--- a/umpleonline/umplibrary/manualexamples/W089AssociationRolenameMatchingClassname2.ump
+++ b/umpleonline/umplibrary/manualexamples/W089AssociationRolenameMatchingClassname2.ump
@@ -1,0 +1,13 @@
+//This example shows how to avoid the warning
+class Person {
+  name;
+}
+
+class Intern {
+  isA Person;
+  * -- 0..2 Employee supervisor;
+}
+
+class Employee {
+  isA Person;
+}

--- a/umpleonline/umplibrary/manualexamples/W1011InvalidAssociationClassKey1.ump
+++ b/umpleonline/umplibrary/manualexamples/W1011InvalidAssociationClassKey1.ump
@@ -7,8 +7,8 @@ class Flight {}
 
 associationClass Booking {
   Integer number;
-  * Passenger passenger;
-  * Flight flight;
+  * Passenger;
+  * Flight;
   key {number, flight}
 }
 //$?[End_of_model]$?

--- a/umpleonline/umplibrary/manualexamples/W1011InvalidAssociationClassKey2.ump
+++ b/umpleonline/umplibrary/manualexamples/W1011InvalidAssociationClassKey2.ump
@@ -6,8 +6,8 @@ class Flight {}
 
 associationClass Booking {
   Integer number;
-  * Passenger passenger;
-  * Flight flight;
+  * Passenger;
+  * Flight;
   key {number, flight, passenger}
 }
 //$?[End_of_model]$?

--- a/umpleonline/umplibrary/manualexamples/assocSpecEx.ump
+++ b/umpleonline/umplibrary/manualexamples/assocSpecEx.ump
@@ -10,7 +10,7 @@ class Unicycle { isA Vehicle; }
 // It defines the Vehicle to Wheel relationship
 // with as much abstraction as possible.
 association {
-  0..1 Vehicle vehicle -- 0..* Wheel wheel;
+  0..1 Vehicle -- 0..* Wheel vehicleWheel;
 }
 
 // Here, we'd like to extend the functionality of
@@ -28,9 +28,9 @@ association {
 //    association;
 // -> Finally, the role names are the same.
 association
-  { 0..1 Bicycle vehicle -- 0..2 Wheel wheel; }
+  { 0..1 Bicycle vehicle -- 0..2 Wheel vehicleWheel; }
 association
-  { 0..1 Unicycle vehicle -- 0..1 Wheel wheel; }
+  { 0..1 Unicycle vehicle -- 0..1 Wheel vehicleWheel; }
 
 //$?[End_of_model]$?
 // Positioning


### PR DESCRIPTION
This branch contains a number of changes related to Issue #1662 .

### Main compiler changes

The main change is in UmpleInternalParser_CodeClass.ump, where there is a new check in the postTokenClassAnalysis(). This check loops through every association, and determines if the rolename of the association matches the classname. If so, a new warning 89 will be thrown.

The error message file en.error has a new entry for the warning (number 89)

Master.ump was updated to ignore warning 89. There are a few locations where the warning would be thrown otherwise.

### User manual updates

There is a new page in the user manual created for warning 89, with 2 code examples provided. 
Also, the user manual page for Error 19 was updated with a note to indicate that it might be caused by the rolename-classname match.

Multiple user manual examples had to be changed in order to remove rolename-classname matching. 

### Testing

A new unit test was created for the warning, including 4 new .ump files.

TestHarnessAssociations.ump and TestHarnessCompositionsLeft.ump were updated to ignore warning 89. There are a few locations where the warning would be thrown otherwise.