### PR TITLE
Issue #2210 Detect capitalization differences in role names

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -3058,10 +3058,12 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           }
         }
 
+        //Issue 2210: existingNames now uses the lowercase of role names
+
         // check names on other-class end of associations to other classes
         if (!isSymmetricReflexive && (checkFirstEnd || associationIsReflexive) && assoc.getIsLeftNavigable())
         { 
-          if (existingNames.contains(firstEnd.getRoleName()) || hasMultipleAssocToSameClass)
+          if (existingNames.contains(firstEnd.getRoleName().toLowerCase()) || hasMultipleAssocToSameClass)
           {
             getParseResult().addErrorMessage(new ErrorMessage(19,assoc.getTokenPosition(),firstEnd.getClassName(), C.getName()));
             return;
@@ -3073,12 +3075,12 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           }
           else
           {
-            existingNames.add(firstEnd.getRoleName());
+            existingNames.add(firstEnd.getRoleName().toLowerCase());
           }
         }
         if (!isSymmetricReflexive && (checkSecondEnd || associationIsReflexive) && assoc.getIsRightNavigable())
         {
-          if (existingNames.contains(secondEnd.getRoleName()) || hasMultipleAssocToSameClass)
+          if (existingNames.contains(secondEnd.getRoleName().toLowerCase()) || hasMultipleAssocToSameClass)
           {
             getParseResult().addErrorMessage(new ErrorMessage(19,assoc.getTokenPosition(), secondEnd.getClassName(), C.getName()));
             return;
@@ -3090,7 +3092,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           }
           else
           {
-            existingNames.add(secondEnd.getRoleName());
+            existingNames.add(secondEnd.getRoleName().toLowerCase());
           }
         }
         
@@ -3105,7 +3107,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
             roleNameToCheck = secondEnd.getRoleName();
           }
 
-          if(existingNames.contains(roleNameToCheck))
+          if(existingNames.contains(roleNameToCheck.toLowerCase()))
           {
             getParseResult().addErrorMessage(new ErrorMessage(19,assoc.getTokenPosition(),C.getName(),roleNameToCheck));
             return;
@@ -3117,7 +3119,7 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           }
           else
           {
-            existingNames.add(roleNameToCheck);
+            existingNames.add(roleNameToCheck.toLowerCase());
           }
         }
 

--- a/cruise.umple/test/cruise/umple/compiler/024_multiAssocToAnotherClassCapitalizationRoleName.ump
+++ b/cruise.umple/test/cruise/umple/compiler/024_multiAssocToAnotherClassCapitalizationRoleName.ump
@@ -1,0 +1,5 @@
+class A{
+  0..1  -- * B assoc;
+  0..1  -- * B Assoc;
+}
+class B{}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -2797,6 +2797,7 @@ public class UmpleParserTest
     assertFailedParse("024_multipleAssociationsWithSameName.ump", new Position("024_multipleAssociationsWithSameName.ump",7,2,79), 19);
     assertFailedParse("024_roleNameSameAsClassWithMultiAssocToSameClass.ump", 19);
     assertFailedParse("024_multiAssocToAnotherClassNeedRoleName.ump", 19);
+    assertFailedParse("024_multiAssocToAnotherClassCapitalizationRoleName.ump", 19);
     
     List<ErrorMessage> errorMessage = parseErrorMessage("024_multiAssocToSameClassNeedRoleName.ump");
     Assert.assertEquals("There are multiple associations between class 'B' and class 'A'. Unique role names need to be added at 'B' side to distinguish the different association ends in that class.",errorMessage.get(0).getFormattedMessage());


### PR DESCRIPTION
This branch contains the fix to to Issue https://github.com/umple/umple/issues/2210.

## Changes

The only change to the compiler is that role names are now converted to lower case before being compared for similarity.
This resolves the issue.

There is also a new test case