### PR TITLE
Issue #2220 Descriptive error for association specialization multiplicity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1876,6 +1876,7 @@ task rtcppUserManualAndExampleTests {
             "E105EnumerationInComposition1.ump",
             "E023AttributeAssociationNameClash1.ump",
             "E214Twosametemplateparameters.ump",
+            "E181AssociationSpecializationInvalidMultiplicity1.ump",
             "src-gen-umple",
             "allExamplesList.txt"]
         runUserManualAndExampleTests("rtcpp", "RTCpp", excludes)

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -438,6 +438,7 @@
       <exclude name="E018ReflexiveImmutable1.ump"/>
       <exclude name="E083InvalidMultivaluedAttributeInitialization1.ump"/>
       <exclude name="E180DuplicateRoleNameSubclass.ump"/>
+      <exclude name="E181AssociationSpecializationInvalidMultiplicity1.ump"/>
       <exclude name="E3504TemplateReferenceCannotBeResolved1.ump"/>
       <exclude name="E219NoBindingParameters.ump"/>
       <exclude name="E3507DuplicateEmitMethodName1.ump"/>

--- a/build/reference/9181AssociationSpecializationInvalidMultiplicity.txt
+++ b/build/reference/9181AssociationSpecializationInvalidMultiplicity.txt
@@ -1,0 +1,25 @@
+E181 Association Specialization Invalid Multiplicity
+Errors and Warnings 100-999
+noreferences
+
+@@description
+
+<h2>Umple error raised when an association specialization has an invalid multiplicity</h2>
+
+<p> 
+When performing an Association Specialization, <a href="AssociationSpecializations.html">the multiplicities are more specific than that of the previously defined association.</a>
+If the multiplicities on either side of the specialized association are less strict/specific, the association is considered invalid and this error is raised.
+<br/><br/>
+If you intend to perform specialization, this error can be avoided by narrowing the multiplicity to be more specific than that of the superclass association.
+<br/>
+If you did not intend to perform specialization, you may have reused a rolename in the association. See <a href="E019DuplicateAssociation.html">E019</a>.
+</p>
+
+
+@@example 
+@@source manualexamples/E181AssociationSpecializationInvalidMultiplicity1.ump
+@@endexample
+
+@@example @@caption Solution to the above so the message no longer appears @@endcaption
+@@source manualexamples/E181AssociationSpecializationInvalidMultiplicity2.ump
+@@endexample

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -2771,6 +2771,25 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         secondLowerBoundOK = (b2LB <= a2LB);
         secondUpperBoundOK = (b2UB >= a2UB);
 
+        // Special case for * multiplicity; any upper bound is more specific than 0..*
+        if ( b1UB == -1 ) 
+        { 
+          firstUpperBoundOK = true;
+        }
+        if ( b2UB == -1 ) 
+        { 
+          secondUpperBoundOK = true;
+        }
+        // Issue 2220: 0..* is LESS specific than 0..X;
+        if ( a1UB == -1 && b1UB != -1) 
+        { 
+          firstUpperBoundOK = false;
+        }
+        if ( a2UB == -1 && b2UB != -1) 
+        { 
+          secondUpperBoundOK = false;
+        }
+
         Boolean firstMulChToOne = false;
         Boolean secondMulChToOne = false;
         Boolean firstMulChToN = false;
@@ -2797,23 +2816,11 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         // changed to MN (or M*)
         if (a2UB >= a2LB && a2LB != 0 && a2UB > 1 && ((b2LB == 0 && b2UB > 1) || b2UB == -1))
           secondMulChToN = true;    
-           
-        // special case for * multiplicity
-        if ( b1UB == -1 ) 
-        { 
-          firstUpperBoundOK = true;
-        }
-        
-        if ( b2UB == -1 ) 
-        { 
-          secondUpperBoundOK = true;
-        }
         
         if ( b1UB == -1 || (b1LB == 0 && b1UB != 1))
         { 
           secondNeedsSetCode = true;
         } 
-        
         if ( b2UB == -1 || (b2LB == 0 && b2UB != 1))
         {
           firstNeedsSetCode = true;

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -2807,7 +2807,6 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
         if ( b2UB == -1 ) 
         { 
           secondUpperBoundOK = true;
-
         }
         
         if ( b1UB == -1 || (b1LB == 0 && b1UB != 1))
@@ -2826,8 +2825,17 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
           boundsOK = true;
         }
         
-        if ( subclassOK && namesOK && boundsOK )
+        if ( subclassOK && namesOK )
         {
+          if (!boundsOK) {
+            // The user has either: entered an invalid bound, or reused a rolename unintentionally
+            if (!firstLowerBoundOK || !firstUpperBoundOK) {
+              getParseResult().addErrorMessage(new ErrorMessage(181, A.getTokenPosition(), currentLeftClass.getName(), currentRightClass.getName(), b1LB+"", b1UB+""));
+            } else if (!secondLowerBoundOK || !secondUpperBoundOK) {
+              getParseResult().addErrorMessage(new ErrorMessage(181, A.getTokenPosition(), currentLeftClass.getName(), currentRightClass.getName(), b2LB+"", b2UB+""));
+            }
+          }
+
           // then it's a redefinition
           // so B is a parent
           aFirstEnd.setSuperClassName(bFirstEnd.getClassName());

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -139,6 +139,9 @@
 170: 3, "https://manual.umple.org/?CustomConstructor.html", Custom constructors should normally not be provided in Umple. Consider using before or after keywords to adjust what the constructor does, or adjusting constructor parameters using keywords like lazy.;
 180: 2, "https://manual.umple.org/?E180DuplicateAssociationNameClassHierarchy", Class '{0}' is a subclass of class '{1}' and may not have multiple associations with the same name '{2}' ;
 
+# Messages related to association specializations
+181: 2, "https://manual.umple.org/?E181AssociationSpecializationInvalidMultiplicity.html", Invalid multiplicity for association specialization between classes '{0}' and '{1}'. Enter a multiplicity narrower than {2}..{3} or change the rolenames to remove the specialization;
+
 # Messages related to traits starting with 200
 200: 2, "https://manual.umple.org/?E200TraitIdentifierInvalid.html", The name of trait '{0}' must be alphanumeric and start with an alpha character, or _ . ;
 201: 4, "https://manual.umple.org/?W201TraitNameSyntax.html", The name of trait '{0}' should be started with a capital letter. ;
@@ -224,7 +227,6 @@
 1511 : 2, "https://manual.umple.org/?E1511InlineMixsetIsNotSupported.html", Inline syntax for the mixset '{0}' is not supported. Please enclose the body of '{0}' with curly brackets. ; 
 1512 : 4, "https://manual.umple.org/?W1512CodeLabelsInsideMethodAreNotUnique.html", Multiple code labels having the same name should be avoided for the method '{0}' at line '{1}'. Please consider unique names for code labels. ; 
 1513 : 4, "https://manual.umple.org/?W1513MixsetUsedWithNoDeclaration.html", The mixset '{0}' has a use statement at line '{1}', however there is no declaration for this mixset. To avoid this warning, you may remove the use statement or you may add a declaration for mixset '{0}'. ; 
-
 
 # Messages to be emitted when embedded code from another language is compiled and you are passing on the error. These have not yet been activated.
 2001: 5, "https://manual.umple.org/?W20xxErrorinEmbeddedCode.html", Error in Java embedded in Umple: '{0}' ;

--- a/cruise.umple/test/cruise/umple/compiler/181_associationSpecializationMultiplicity1.ump
+++ b/cruise.umple/test/cruise/umple/compiler/181_associationSpecializationMultiplicity1.ump
@@ -1,0 +1,5 @@
+class A {}
+class B {isA A;}
+class Z {}
+association { 0..1 A vehicleA -- 0..2 Z temp;}
+association { 0..1 B vehicleA -- 0..3 Z temp;}

--- a/cruise.umple/test/cruise/umple/compiler/181_associationSpecializationMultiplicity2.ump
+++ b/cruise.umple/test/cruise/umple/compiler/181_associationSpecializationMultiplicity2.ump
@@ -1,0 +1,8 @@
+class A {
+  0..1 vehicleA -- 0..2 Z temp;
+}
+class B {
+  isA A;
+  0..1 vehicleA -- 0..* Z temp;
+}
+class Z {}

--- a/cruise.umple/test/cruise/umple/compiler/181_associationSpecializationMultiplicityFix.ump
+++ b/cruise.umple/test/cruise/umple/compiler/181_associationSpecializationMultiplicityFix.ump
@@ -1,0 +1,5 @@
+class A {}
+class B {isA A;}
+class Z {}
+association { 0..1 A vehicleA -- 0..2 Z temp;}
+association { 0..1 B vehicleA -- 0..1 Z temp;}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3410,6 +3410,14 @@ public class UmpleParserTest
     assertHasWarningsParse("089_rolenameMatchingClassname4.ump", 89);
  }
 
+ //Issue 2220
+ @Test
+ public void associationSpecializationMultiplicityError() {
+    assertFailedParse("181_associationSpecializationMultiplicity1.ump", 181);
+    assertFailedParse("181_associationSpecializationMultiplicity2.ump", 181);
+    assertParse("181_associationSpecializationMultiplicityFix.ump");
+ }
+
  // Issue 1008
  @Test
  public void namingConflictBetweenEnumerationAndClass() {

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -3415,7 +3415,7 @@ public class UmpleParserTest
  public void associationSpecializationMultiplicityError() {
     assertFailedParse("181_associationSpecializationMultiplicity1.ump", 181);
     assertFailedParse("181_associationSpecializationMultiplicity2.ump", 181);
-    assertParse("181_associationSpecializationMultiplicityFix.ump");
+    assertSimpleParse("181_associationSpecializationMultiplicityFix.ump");
  }
 
  // Issue 1008

--- a/umpleonline/umplibrary/manualexamples/E180DuplicateRoleNameSubclassValidSpecialization.ump
+++ b/umpleonline/umplibrary/manualexamples/E180DuplicateRoleNameSubclassValidSpecialization.ump
@@ -1,12 +1,12 @@
 // This example shows a valid specialization
 // of the friends association in which the
-// multiplicity 0..3 is refined to *, so a
-// student may have any number of dogs but
-// Persons in general are limited to 3.
+// multiplicity 0..3 is refined to 0..2, so a
+// person in general may have 0 to 3 dogs but
+// students are limited to 2.
 // This conforms to the Liskov substitution
-// principle: The preconditions on Person
-// operations such as addDog limiting to 3
-// are being relaxed in the subclass Student.
+// principle: The data invariant on Person
+// which limits them to 3 dogs
+// is still true in the subclass Student.
 
 class Person {
 	* -> 0..3 Dog friends;
@@ -14,7 +14,7 @@ class Person {
 
 class Student {
 	isA Person;
-	* -> * Dog friends;
+	* -> 0..2 Dog friends;
 }
 
 class Dog {

--- a/umpleonline/umplibrary/manualexamples/E181AssociationSpecializationInvalidMultiplicity1.ump
+++ b/umpleonline/umplibrary/manualexamples/E181AssociationSpecializationInvalidMultiplicity1.ump
@@ -1,0 +1,11 @@
+// This example generates the error
+
+class Vehicle {}
+class Wheel {}
+class Bicycle {isA Vehicle;}
+
+// Parent multiplicity of 0..1 to 0..2
+association { 0..1 Vehicle vehicleA -- 0..2 Wheel vehicleWheel;}
+
+// Broader child multiplicity of 0..1 to 0..3
+association { 0..1 Bicycle vehicleA -- 0..3 Wheel vehicleWheel;}

--- a/umpleonline/umplibrary/manualexamples/E181AssociationSpecializationInvalidMultiplicity2.ump
+++ b/umpleonline/umplibrary/manualexamples/E181AssociationSpecializationInvalidMultiplicity2.ump
@@ -1,0 +1,11 @@
+// This example shows how to resolve the error
+
+class Vehicle {}
+class Wheel {}
+class Bicycle {isA Vehicle;}
+
+// Parent multiplicity of 0..1 to 0..2
+association { 0..1 Vehicle vehicleA -- 0..2 Wheel vehicleWheel;}
+
+// Narrower child multiplicity of 0..1 to 0..1
+association { 0..1 Bicycle vehicleA -- 0..1 Wheel vehicleWheel;}


### PR DESCRIPTION
This branch contains a resolution to Issue #2220 

## Change: New Error

Added the new error 181.
Also included a new user manual entry, and test cases for this error.

## Change: Multiplicity "0..*" is LESS narrow/specific than "0..X"

The association specialization code has been changed so that "0..\*" is less narrow/specific than "0..X". 
Example:
```
class TestA{}
class TestB{}
class TestC{isA TestA;}
association {0..1 TestA role1 -- 0..1 TestB role2;}
association {0..1 TestC role1 -- 0..* TestB role2;}
```
This is now considered invalid and will throw an error.

The user manual page for error 180 had an incorrect example which stated that such a specialization was acceptable. This has been changed.
