### PR TITLE
Issue #2221 UmpleOnline code panel now recognizes browser focus

### DIFF
--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -485,7 +485,7 @@ Page.initLabels = function()
 // BOOKMARK: adding basic event handlers to model and layout editors:: calls to Action...
 Page.initUmpleTextArea = function()
 {
-  var modelEditor = jQuery("#umpleModelEditorText");
+  var modelEditor = jQuery("#newEditor");
   var layoutEditor = jQuery("#umpleLayoutEditorText");
   
   modelEditor.keyup(function(eventObject){
@@ -498,9 +498,9 @@ Page.initUmpleTextArea = function()
     Action.setjustUpdateNowtoSaveLater(false);
     Action.umpleCodeMirrorTypingActivity("layoutEditor");
   }); // Fixes Issue#1571 Editing on the layout editor will not update the Umple diagram
-  modelEditor.focus(function(){Action.focusOn("umpleModelEditorText", true);});
+  modelEditor.focusin(function(){Action.focusOn("umpleModelEditorText", true);});
   layoutEditor.focus(function(){Action.focusOn("umpleLayoutEditorText", true);});
-  modelEditor.blur(function(){Action.focusOn("umpleModelEditorText", false);});
+  modelEditor.focusout(function(){Action.focusOn("umpleModelEditorText", false);});
   layoutEditor.blur(function(){Action.focusOn("umpleLayoutEditorText", false);});
   
   Page.initCodeMirrorEditor();


### PR DESCRIPTION
## Changes

A few lines of code have been changed to fix a bug where the code panel of UmpleOnline could not receive browser focus. 
This bug was a cause of issue #2221 . 

The code side panel is now capable of receiving browser focus - and using some of the functions associated with managing browser focus.