### PR TITLE
Issue #2233 Allowed nested class types in python function overrides

### DIFF
--- a/UmpleToPython/txl/MethodTranslation.txl
+++ b/UmpleToPython/txl/MethodTranslation.txl
@@ -769,29 +769,39 @@ function addOverloadArg javaParam [method_parameter]
             [translateArrayType type]
             [translateListType type]
             [translateBaseTypesOverload type]
+            [translateNestedType type]
     deconstruct optAdding  
         adding [overload_data_arg]
     by
         res [. adding]
 end function
 
+% Fallback function to match nested identifiers
+function translateNestedType javaType [nested_identifier]
+    replace [opt overload_data_arg]
+    by
+        javaType
+end function
+
 %Translates a java base type to a python overloading arg
 function translateBaseTypesOverload javaType [nested_identifier]
     replace [opt overload_data_arg]
+    deconstruct javaType
+        baseType [id]
     by
-        javaType [translateBaseTypes]
+        baseType [translateBaseTypes]
 end function
 
 %Translates java base type to python
 function translateBaseTypes 
-    replace [nested_identifier]
-        baseType [nested_identifier]
+    replace [id]
+        baseType [id]
     by
         baseType [translateStringType] [translateBooleanType] [translateDoubleType]
 end function
 
 function translateStringType
-    replace [nested_identifier]
+    replace [id]
         'String
     by 
         'str
@@ -825,14 +835,14 @@ function translateListType javaType [nested_identifier]
 end function
 
 function translateBooleanType 
-    replace [nested_identifier]
+    replace [id]
         'boolean
     by  
         'bool
 end function
 
 function translateDoubleType 
-    replace [nested_identifier]
+    replace [id]
         'double
     by  
         'float

--- a/UmpleToPython/txl/MethodTranslation.txl
+++ b/UmpleToPython/txl/MethodTranslation.txl
@@ -749,9 +749,10 @@ end define
 
 %Overload data arg describes the type of an parameter. All together a repeat of these is used to describe the types of all the parameters of a method
 %The types used are pythonic types (so bool instead of boolean). 
-%The optional second id is to specify if the arg is a list. (ex: "list bool" is a list of booleans)
+%The optional first id is to specify if the arg is a list. (ex: "list bool" is a list of booleans)
+% Issue 2233: Switched [id] to [nested_identifier] to allow nested types
 define overload_data_arg
-    [id] [opt id]
+    [opt id] [nested_identifier]
 end define
 
 %Given a java param, adds the appropriate python type to the list of method param types
@@ -777,22 +778,20 @@ end function
 %Translates a java base type to a python overloading arg
 function translateBaseTypesOverload javaType [nested_identifier]
     replace [opt overload_data_arg]
-    deconstruct javaType
-        baseType [id]
     by
-        baseType [translateBaseTypes]
+        javaType [translateBaseTypes]
 end function
 
 %Translates java base type to python
 function translateBaseTypes 
-    replace [id]
-        baseType [id]
+    replace [nested_identifier]
+        baseType [nested_identifier]
     by
-        baseType [translateStringType]  [translateBooleanType] [translateDoubleType]
+        baseType [translateStringType] [translateBooleanType] [translateDoubleType]
 end function
 
 function translateStringType
-    replace [id]
+    replace [nested_identifier]
         'String
     by 
         'str
@@ -826,14 +825,14 @@ function translateListType javaType [nested_identifier]
 end function
 
 function translateBooleanType 
-    replace [id]
+    replace [nested_identifier]
         'boolean
     by  
         'bool
 end function
 
 function translateDoubleType 
-    replace [id]
+    replace [nested_identifier]
         'double
     by  
         'float
@@ -1006,7 +1005,7 @@ end function
 function createNormalTypeCheck arg [overload_data_arg] counter [number]
     replace [opt value]
     deconstruct arg
-        type [id]
+        type [nested_identifier]
     construct castedType [value]
         type
     by
@@ -1016,7 +1015,7 @@ end function
 function createListTypeCheck arg [overload_data_arg] counter [number]
     replace [opt value]
     deconstruct arg
-        'list type [id]
+        'list type [nested_identifier]
     construct castedType [value]
         type
     by

--- a/cruise.umple/test/cruise/umple/implementation/py/PythonClassTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/py/PythonClassTemplateTest.java
@@ -28,6 +28,8 @@ public class PythonClassTemplateTest extends ClassTemplateTest
     SampleFileWriter.destroy(pathToInput + "/Switch.py");
     SampleFileWriter.destroy(pathToInput + "/py/Student.py");
     SampleFileWriter.destroy(pathToInput + "/py/Object.py");
+    SampleFileWriter.destroy(pathToInput + "/py/Foo.py");
+    SampleFileWriter.destroy(pathToInput + "/py/Bar.py");
     //SampleFileWriter.destroy(pathToInput + "/py/python_code/example/Mentor.py");
     //SampleFileWriter.destroy(pathToInput + "/py/python_code/example/Student.py");
   }
@@ -103,6 +105,13 @@ public class PythonClassTemplateTest extends ClassTemplateTest
     assertUmpleTemplateFor("py/ClassTemplateTest_StateMachineDoesNotImplementInterface.ump", 
                            "py/ClassTemplateTest_StateMachineDoesNotImplementInterface.py.txt",
                            "Router");
+  }
+
+  @Test
+  public void TestUmpleEnumerations_9(){
+    assertUmpleTemplateFor("py/TestUmpleEnumerations_9.ump", 
+                           "py/TestUmpleEnumerations_9.py.txt",
+                           "Bar");
   }
 
   @Test @Ignore

--- a/cruise.umple/test/cruise/umple/implementation/py/TestUmpleEnumerations_9.py.txt
+++ b/cruise.umple/test/cruise/umple/implementation/py/TestUmpleEnumerations_9.py.txt
@@ -1,0 +1,112 @@
+#PLEASE DO NOT EDIT THIS CODE
+#This code was generated using the UMPLE 1.35.0.7523.c616a4dce modeling language!
+# line 7 "mydoc.ump"
+
+class Bar():
+    #------------------------
+    # MEMBER VARIABLES
+    #------------------------
+    #Bar Associations
+    #------------------------
+    # CONSTRUCTOR
+    #------------------------
+    def __init__(self):
+        self._foos = None
+        self._foos = []
+
+    #------------------------
+    # INTERFACE
+    #------------------------
+    # Code from template association_GetMany 
+    def getFoo(self, index):
+        aFoo = self._foos[index]
+        return aFoo
+
+    def getFoos(self):
+        newFoos = tuple(self._foos)
+        return newFoos
+
+    def numberOfFoos(self):
+        number = len(self._foos)
+        return number
+
+    def hasFoos(self):
+        has = len(self._foos) > 0
+        return has
+
+    def indexOfFoo(self, aFoo):
+        index = (-1 if not aFoo in self._foos else self._foos.index(aFoo))
+        return index
+
+    # Code from template association_MinimumNumberOfMethod 
+    @staticmethod
+    def minimumNumberOfFoos():
+        return 0
+
+    # Code from template association_AddManyToOne 
+    def addFoo1(self, aMyBaz, aMyStr):
+        from Foo import Foo
+        return Foo(aMyBaz, aMyStr, self)
+
+    def addFoo2(self, aFoo):
+        wasAdded = False
+        if (aFoo) in self._foos :
+            return False
+        existingBar = aFoo.getBar()
+        isNewBar = not (existingBar is None) and not self == existingBar
+        if isNewBar :
+            aFoo.setBar(self)
+        else :
+            self._foos.append(aFoo)
+        wasAdded = True
+        return wasAdded
+
+    def removeFoo(self, aFoo):
+        wasRemoved = False
+        #Unable to remove aFoo, as it must always have a bar
+        if not self == aFoo.getBar() :
+            self._foos.remove(aFoo)
+            wasRemoved = True
+        return wasRemoved
+
+    # Code from template association_AddIndexControlFunctions 
+    def addFooAt(self, aFoo, index):
+        wasAdded = False
+        if self.addFoo(aFoo) :
+            if index < 0 :
+                index = 0
+            if index > self.numberOfFoos() :
+                index = self.numberOfFoos() - 1
+            self._foos.remove(aFoo)
+            self._foos.insert(index, aFoo)
+            wasAdded = True
+        return wasAdded
+
+    def addOrMoveFooAt(self, aFoo, index):
+        wasAdded = False
+        if (aFoo) in self._foos :
+            if index < 0 :
+                index = 0
+            if index > self.numberOfFoos() :
+                index = self.numberOfFoos() - 1
+            self._foos.remove(aFoo)
+            self._foos.insert(index, aFoo)
+            wasAdded = True
+        else :
+            wasAdded = self.addFooAt(aFoo, index)
+        return wasAdded
+
+    def delete(self):
+        i = len(self._foos)
+        while i > 0 :
+            aFoo = self._foos[i - 1]
+            aFoo.delete()
+            i -= 1
+
+    def addFoo(self, *argv):
+        from Foo import Foo
+        if len(argv) == 2 and isinstance(argv[0], Foo.Baz) and isinstance(argv[1], str) :
+            return self.addFoo1(argv[0], argv[1])
+        if len(argv) == 1 and isinstance(argv[0], Foo) :
+            return self.addFoo2(argv[0])
+        raise TypeError("No method matches provided parameters")

--- a/cruise.umple/test/cruise/umple/implementation/py/TestUmpleEnumerations_9.ump
+++ b/cruise.umple/test/cruise/umple/implementation/py/TestUmpleEnumerations_9.ump
@@ -1,0 +1,9 @@
+class Foo {
+	enum Baz {A, B}
+	Baz myBaz;
+	String myStr;
+}
+
+class Bar {
+	1 -- * Foo;
+}


### PR DESCRIPTION
This is in relation to Issue https://github.com/umple/umple/issues/2233

## The Cause

This bug was likely caused by a failure to match nested class types in the python function overrides. When generating the override, the TXL code expected a simple identifier (ex: Foo) instead of a nested_identifier (ex: Foo.Bar). When passed a nested_identifier, the TXL would fail to match this token, thus leaving the override blank. 

## Changes to TXL code

This issue can be quickly resolved by adding a "fallback" function to the TXL override mechanism. If the nested_identifier fails to match with any of the replacement rules, it will use the "translateNestedType" function to match the full nested_identifier with no changes. 

Note that "no changes" means that nested_identifiers such as "Myclass.String.Foo" shall not have any components translated. The "String" token in this nested_identifier will not be converted to the Python "str".

## Changes to Test cases

Added a test case to the PythonClassTemplateTest file.

Note: This test should be standardized with the java UmpleTestEnumerations files. See Issue https://github.com/umple/umple/issues/2243
