### PR TITLE
Fixes #2194 - Extend Error 3607 message for missing destination class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1872,6 +1872,7 @@ task rtcppUserManualAndExampleTests {
             "E233RemoveInitialState.ump",
             "E008AssociationClassMissingEnd1.ump",
             "E3607PortNameCannotBeResolved1.ump",
+            "E3607NoDestinationClassName.ump",
             "E210ConflictMethods4.ump",
             "E229RenamingTwoTimesStates.ump",
             "E028ConstraintIdentifierIncorrect1.ump",

--- a/build/build.exampletests.xml
+++ b/build/build.exampletests.xml
@@ -538,7 +538,7 @@
       <exclude name="E105EnumerationInComposition1.ump"/>
       <exclude name="E023AttributeAssociationNameClash1.ump"/>
       <exclude name="E214Twosametemplateparameters.ump"/>
-      
+      <exclude name="E3607NoDestinationClassName.ump"/>
     </fileset>  
 
     <pathconvert pathsep=";" property="cppumpfiles2" refid="cppumpfiles"/>

--- a/build/reference/9367PortNameCannotBeResolved.txt
+++ b/build/reference/9367PortNameCannotBeResolved.txt
@@ -1,4 +1,4 @@
-E3607 Port Name Cannot Be Resolved
+E3607 Missing Class in Association or Port Name Cannot Be Resolved
 Errors and Warnings 1000+
 noreferences
 
@@ -8,8 +8,11 @@ noreferences
 
 <p>
 A port used in a class must be defined before usage by port bindings and
-active methods. <br/>
-The cause of the error is possibly a typographical mistake.
+active methods. This is shown in the first example below, with a resolution in the second example.</p>
+
+<p>
+This error might also be raised if you intended to write an association from one class to another, but omitted the destination class. This is shown in the third example. The solution would be to add another class and then give the name of that class as the destination of the association.
+
 </p>
 
 
@@ -21,6 +24,6 @@ The cause of the error is possibly a typographical mistake.
 @@source manualexamples/E3607PortNameCannotBeResolved2.ump
 @@endexample
 
-@@example
+@@example  @@caption Example where this an association with a missing Class that should have followed the *  @@endcaption
 @@source manualexamples/E3607NoDestinationClassName.ump
 @@endexample

--- a/build/reference/9367PortNameCannotBeResolved.txt
+++ b/build/reference/9367PortNameCannotBeResolved.txt
@@ -4,7 +4,7 @@ noreferences
 
 @@description
 
-<h2>Umple semantic error raised when a port name cannot be resolved</h2>
+<h2>This error can occur in two situations: a semantic error raised when a port name cannot be resolved, or a syntax error caused by an invalid association</h2>
 
 <p>
 A port used in a class must be defined before usage by port bindings and
@@ -19,4 +19,8 @@ The cause of the error is possibly a typographical mistake.
 
 @@example  @@caption Solution to The Above So the Message No Longer Appears @@endcaption
 @@source manualexamples/E3607PortNameCannotBeResolved2.ump
+@@endexample
+
+@@example
+@@source manualexamples/E3607NoDestinationClassName.ump
 @@endexample

--- a/build/reference/9367PortNameCannotBeResolved.txt
+++ b/build/reference/9367PortNameCannotBeResolved.txt
@@ -11,7 +11,7 @@ A port used in a class must be defined before usage by port bindings and
 active methods. This is shown in the first example below, with a resolution in the second example.</p>
 
 <p>
-This error might also be raised if you intended to write an association from one class to another, but omitted the destination class. This is shown in the third example. The solution would be to add another class and then give the name of that class as the destination of the association.
+This error might also be raised if you intended to create an association from one class to another, but omitted the destination class. This is shown in the third example. The solution would be to add another class and then give the name of that class as the destination of the association after the asterisk.
 
 </p>
 

--- a/build/reference/9367PortNameCannotBeResolved.txt
+++ b/build/reference/9367PortNameCannotBeResolved.txt
@@ -11,7 +11,7 @@ A port used in a class must be defined before usage by port bindings and
 active methods. This is shown in the first example below, with a resolution in the second example.</p>
 
 <p>
-This error might also be raised if you intended to create an association from one class to another, but omitted the destination class. This is shown in the third example. The solution would be to add another class and then give the name of that class as the destination of the association after the asterisk.
+This error might also be raised if you intended to create an association from the current class to another, but omitted the destination class. This is shown in the third example. The solution would be to add another class and then give the name of that class as the destination of the association after the asterisk.
 
 </p>
 

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -251,7 +251,7 @@
 3604: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding to component '{0}' can not be resolved.;
 3605: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding from port can not be resolved.;
 3606: 1, "https://manual.umple.org/?PageBeingDeveloped.html", Port binding to port can not be resolved.;
-3607: 1, "https://manual.umple.org/?E3607PortNameCannotBeResolved.html", Port name '{0}' from class '{1}' can not be resolved.;
+3607: 1, "https://manual.umple.org/?E3607PortNameCannotBeResolved.html", Port name '{0}' from class '{1}' can not be resolved or else you intended to create an association but omitted destination class.;
 
 # Messages related to fixml
 4500: 1,  "https://manual.umple.org/?E4500TagNotClosedCorrectly.html", The tag '{0}' is not closed correctly.  ;

--- a/umpleonline/umplibrary/manualexamples/E3607NoDestinationClassName.ump
+++ b/umpleonline/umplibrary/manualexamples/E3607NoDestinationClassName.ump
@@ -1,0 +1,5 @@
+//Destination class name is missing, 
+//causing the error
+class X {
+  1 -> *;
+}


### PR DESCRIPTION
**Summary:**
This PR improves the clarity of Error 3607 by extending the error message to better explain the situation where an association is intended but the destination class name is missing. This fixes issue #2194 . 

**Files changed:**
`build.gradle` - edited to exclude E3607NoDestinationClassName.ump example file from getting compiled
`cruise.umple/src/en.error` - edited to fix error message
`build/reference/9367PortNameCannotBeResolved.txt` - edited to make changes to user manual, linked new example
`umpleonline/umplibrary/manualexamples/E3607NoDestinationClassName.ump` - new example
`build/build.exampletests.xml `- edited to exclude E3607NoDestinationClassName.ump example file from getting compiled

**Before:**
**Error Message:**
<img width="1298" height="268" alt="image" src="https://github.com/user-attachments/assets/4f2a29b5-67a5-4134-8c05-6c013c45e3cc" />

**User Manual**
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/bc8013ae-9ed0-4c86-81f0-e57d716e4c50" />

**After:**
**Error message:**
<img width="1564" height="270" alt="image" src="https://github.com/user-attachments/assets/3ba27018-e6b3-445b-8e6d-bbb9440042fc" />

**User Manual:**
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/df760d03-8396-4279-8c82-063bead15f8e" />
