### PR TITLE
Make compiler warning text theme-aware

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -1019,16 +1019,16 @@ function getErrorHtml($errorFilename, $offset = 1)
             $severityInt = intval($result["severity"]);
             if($severityInt > 2) {
               $severity = "Warning";
-              $textcolor = "<font color=\"black\">";
+              $textcolor = "<span class=\"umple-message-warning\">";
             }
             else
             {
               $severity = "Error";
-              $textcolor = "<font color=\"red\">";
+              $textcolor = "<span class=\"umple-message-error\">";
             }
             $msg = htmlspecialchars($result["message"]);
                         
-            $errhtml .= $textcolor." {$severity} on <a href=\"javascript:Action.setCaretPosition({$line});Action.updateLineNumberDisplay();\">line {$line}</a> : {$msg}.</font> <i><a href=\"{$url}\" target=\"helppage\">More information ({$errorCode})</a></i></br>";
+            $errhtml .= $textcolor." {$severity} on <a href=\"javascript:Action.setCaretPosition({$line});Action.updateLineNumberDisplay();\">line {$line}</a> : {$msg}.</span> <i><a href=\"{$url}\" target=\"helppage\">More information ({$errorCode})</a></i></br>";
         }
      }
     

--- a/umpleonline/scripts/dark-mode.css
+++ b/umpleonline/scripts/dark-mode.css
@@ -510,3 +510,7 @@ select {
 #executionMessage * {
   color: #ddd !important;
 }
+
+/* Theme-aware compiler message colors (used by compiler.php error/warning output) */
+.umple-message-warning { color: var(--umple-dark-text) !important; }
+.umple-message-error { color: #ff6b6b !important; }

--- a/umpleonline/scripts/styles.css
+++ b/umpleonline/scripts/styles.css
@@ -7,6 +7,10 @@ p, ol, ul, div, h1, h2, h3, h4, b {
    font-size: 10pt; color: #000000; 
 }
 
+/* Theme-aware compiler message colors (used by compiler.php error/warning output) */
+.umple-message-warning { color: inherit; }
+.umple-message-error { color: #cc0000; }
+
 .theme-mode-toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Replace hard-coded black font color in `compiler.php` with theme-aware CSS classes so warnings are readable in dark mode.

## Changes
- `umpleonline/scripts/compiler.php` - Replace `<font>` tags with CSS classes
- `umpleonline/scripts/styles.css` - Add light theme styles
- `umpleonline/scripts/dark-mode.css` - Add dark theme overrides

Fixes #2293
<img width="1059" height="198" alt="image" src="https://github.com/user-attachments/assets/2a58c6a2-cd0a-45f1-9751-88ea48a55316" />

<img width="1014" height="173" alt="image" src="https://github.com/user-attachments/assets/d2322ff5-3602-4831-94e3-a0384b1a3558" />
