### PR TITLE
Fixes #2324 scope AI dialog events to active modal

### DIFF
--- a/umpleonline/scripts/ai/features/explain/umple_ai_explain.js
+++ b/umpleonline/scripts/ai/features/explain/umple_ai_explain.js
@@ -137,14 +137,14 @@ const AiExplain = {
     }
 
     // Create and show dialog with loading state
-    this.createDialog();
+    const dialog = this.createDialog();
 
     // Only reset conversation if there isn't one already
     // (Allows resuming minimized conversations)
     if (!this.hasOngoingConversation()) {
       this.resetConversation();
     }
-    await this.performExplanation(umpleCode);
+    await this.performExplanation(dialog, umpleCode);
   },
 
   /**
@@ -274,6 +274,8 @@ const AiExplain = {
 
     // Set up event listeners
     this.setupDialogEvents(dialog);
+
+    return dialog;
   },
 
   /**
@@ -415,16 +417,20 @@ const AiExplain = {
 
   /**
    * Perform the explanation
+   * @param {HTMLElement} dialog - The dialog element
    * @param {string} umpleCode - The Umple code to explain
    */
-  async performExplanation(umpleCode) {
-    const statusDiv = document.getElementById("explainStatusMessage");
-    const explanationContainer = document.getElementById("explanationContainer");
-    const explanationText = document.getElementById("explanationText");
-    const followUpContainer = document.getElementById("followUpContainer");
-    const btnAsk = document.getElementById("btnAsk");
-    const btnNewConversation = document.getElementById("btnNewConversation");
-    const followUpInput = document.getElementById("followUpInput");
+  async performExplanation(dialog, umpleCode) {
+    const statusDiv = dialog?.querySelector("#explainStatusMessage");
+    const explanationText = dialog?.querySelector("#explanationText");
+    const followUpContainer = dialog?.querySelector("#followUpContainer");
+    const btnAsk = dialog?.querySelector("#btnAsk");
+    const btnNewConversation = dialog?.querySelector("#btnNewConversation");
+    const followUpInput = dialog?.querySelector("#followUpInput");
+
+    if (!statusDiv || !explanationText || !followUpContainer || !btnAsk || !btnNewConversation || !followUpInput) {
+      return;
+    }
 
     // Update status
     statusDiv.textContent = "Analyzing your code...";
@@ -516,10 +522,14 @@ const AiExplain = {
    * @param {HTMLElement} dialog - The dialog element
    */
   async handleFollowUp(dialog) {
-    const statusDiv = document.getElementById("explainStatusMessage");
-    const btnAsk = document.getElementById("btnAsk");
-    const followUpInput = document.getElementById("followUpInput");
-    const explanationText = document.getElementById("explanationText");
+    const statusDiv = dialog?.querySelector("#explainStatusMessage");
+    const btnAsk = dialog?.querySelector("#btnAsk");
+    const followUpInput = dialog?.querySelector("#followUpInput");
+    const explanationText = dialog?.querySelector("#explanationText");
+
+    if (!statusDiv || !btnAsk || !followUpInput || !explanationText) {
+      return;
+    }
 
     const userQuestion = followUpInput.value.trim();
 

--- a/umpleonline/scripts/ai/features/explain/umple_ai_explain.js
+++ b/umpleonline/scripts/ai/features/explain/umple_ai_explain.js
@@ -258,7 +258,7 @@ const AiExplain = {
     buttonsDiv.appendChild(btnAsk);
 
     const btnCancel = document.createElement("div");
-    btnCancel.id = "btnCancel";
+    btnCancel.id = "btnCancelExplain";
     btnCancel.className = "jQuery-palette-button unselectable ui-button ui-corner-all ui-widget";
     btnCancel.tabIndex = 0;
     btnCancel.setAttribute("role", "button");
@@ -307,8 +307,8 @@ const AiExplain = {
     this.isMinimized = false;
 
     // Focus the follow-up input if container is visible
-    const followUpContainer = document.getElementById("followUpContainer");
-    const followUpInput = document.getElementById("followUpInput");
+    const followUpContainer = dialog.querySelector("#followUpContainer");
+    const followUpInput = dialog.querySelector("#followUpInput");
     if (followUpInput && followUpContainer && followUpContainer.style.display !== "none") {
       followUpInput.focus();
     }
@@ -320,7 +320,7 @@ const AiExplain = {
    */
   setupDialogEvents(dialog) {
     // Minimize button
-    const btnMinimize = document.getElementById("btnMinimizeExplain");
+    const btnMinimize = dialog.querySelector("#btnMinimizeExplain");
     if (btnMinimize && !btnMinimize.dataset.aiEventsBound) {
       btnMinimize.dataset.aiEventsBound = "true";
       const minimizeHandler = event => {
@@ -331,7 +331,7 @@ const AiExplain = {
     }
 
     // Ask button (follow-up)
-    const btnAsk = document.getElementById("btnAsk");
+    const btnAsk = dialog.querySelector("#btnAsk");
     if (btnAsk && !btnAsk.dataset.aiEventsBound) {
       btnAsk.dataset.aiEventsBound = "true";
       const askHandler = event => {
@@ -348,7 +348,7 @@ const AiExplain = {
     }
 
     // Enter key on follow-up input
-    const followUpInput = document.getElementById("followUpInput");
+    const followUpInput = dialog.querySelector("#followUpInput");
     if (followUpInput && !followUpInput.dataset.aiEventsBound) {
       followUpInput.dataset.aiEventsBound = "true";
       followUpInput.addEventListener("keypress", event => {
@@ -360,7 +360,7 @@ const AiExplain = {
     }
 
     // New Conversation button
-    const btnNewConversation = document.getElementById("btnNewConversation");
+    const btnNewConversation = dialog.querySelector("#btnNewConversation");
     if (btnNewConversation && !btnNewConversation.dataset.aiEventsBound) {
       btnNewConversation.dataset.aiEventsBound = "true";
       const newConvHandler = event => {
@@ -381,7 +381,7 @@ const AiExplain = {
     }
 
     // Cancel button
-    const btnCancel = document.getElementById("btnCancel");
+    const btnCancel = dialog.querySelector("#btnCancelExplain");
     if (btnCancel && !btnCancel.dataset.aiEventsBound) {
       btnCancel.dataset.aiEventsBound = "true";
       const cancelHandler = event => {

--- a/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
+++ b/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
@@ -5,17 +5,20 @@
 // AI Requirements Dialog - Dialog UI for requirements generation
 
 const RequirementsDialog = {
-  getRequirementsOutputArea() {
+  getRequirementsOutputArea(dialog = null) {
+    if (dialog && typeof dialog.querySelector === "function") {
+      return dialog.querySelector("#requirementsOutputArea");
+    }
     return document.getElementById("requirementsOutputArea");
   },
 
-  clearRequirementsOutput() {
-    const area = this.getRequirementsOutputArea();
+  clearRequirementsOutput(dialog = null) {
+    const area = this.getRequirementsOutputArea(dialog);
     if (area) area.value = "";
   },
 
-  appendRequirementsOutput(line) {
-    const area = this.getRequirementsOutputArea();
+  appendRequirementsOutput(line, dialog = null) {
+    const area = this.getRequirementsOutputArea(dialog);
     if (!area) return;
     const text = String(line || "");
     area.value = area.value ? `${area.value}\n${text}` : text;

--- a/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
+++ b/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
@@ -141,7 +141,8 @@ const RequirementsDialog = {
   },
 
   updateSelectedDisplay(dialog, requirements) {
-    const displayDiv = document.getElementById("selectedReqText");
+    const displayDiv = dialog.querySelector("#selectedReqText");
+    if (!displayDiv) return;
     const checkboxes = dialog.querySelectorAll(".req-checkbox:checked");
     const selectedIds = Array.from(checkboxes).map(cb => cb.value);
 
@@ -278,7 +279,7 @@ const RequirementsDialog = {
     buttonsDiv.appendChild(btnInsert);
 
     const btnCancel = document.createElement("div");
-    btnCancel.id = "btnCancel";
+    btnCancel.id = "btnCancelRequirements";
     btnCancel.className = "jQuery-palette-button unselectable ui-button ui-corner-all ui-widget";
     btnCancel.tabIndex = 0;
     btnCancel.setAttribute("role", "button");
@@ -304,8 +305,10 @@ const RequirementsDialog = {
     modeRadios.forEach(radio => {
       radio.addEventListener("change", e => {
         const mode = e.target.value;
-        const multipleDiv = document.getElementById("multipleReqSelection");
-        const displayDiv = document.getElementById("selectedReqText");
+        const multipleDiv = dialog.querySelector("#multipleReqSelection");
+        const displayDiv = dialog.querySelector("#selectedReqText");
+
+        if (!multipleDiv || !displayDiv) return;
 
         if (mode === "all") {
           multipleDiv.style.display = "none";
@@ -324,7 +327,7 @@ const RequirementsDialog = {
       });
     });
 
-    const btnGenerate = document.getElementById("btnGenerate");
+    const btnGenerate = dialog.querySelector("#btnGenerate");
     const generateHandler = event => {
       event.preventDefault();
       if (callbacks.onGenerate) callbacks.onGenerate();
@@ -334,7 +337,7 @@ const RequirementsDialog = {
       if (event.key === "Enter" || event.key === " ") generateHandler(event);
     });
 
-    const btnStop = document.getElementById("btnStop");
+    const btnStop = dialog.querySelector("#btnStop");
     const stopHandler = event => {
       event.preventDefault();
       if (callbacks.onStop) callbacks.onStop();
@@ -344,7 +347,7 @@ const RequirementsDialog = {
       if (event.key === "Enter" || event.key === " ") stopHandler(event);
     });
 
-    const btnInsert = document.getElementById("btnInsert");
+    const btnInsert = dialog.querySelector("#btnInsert");
     const insertHandler = event => {
       event.preventDefault();
       if (callbacks.onInsert) callbacks.onInsert();
@@ -354,7 +357,7 @@ const RequirementsDialog = {
       if (event.key === "Enter" || event.key === " ") insertHandler(event);
     });
 
-    const btnCancel = document.getElementById("btnCancel");
+    const btnCancel = dialog.querySelector("#btnCancelRequirements");
     const cancelHandler = event => {
       event.preventDefault();
       if (callbacks.onCancel) callbacks.onCancel();


### PR DESCRIPTION
## Pull request description
This PR fixes unresponsive controls in UmpleOnline AI dialogs by providing proper encapsulation, each dialog owns its own elements

Issue addressed: #2324

Root cause:
- `Explain` and `Requirements` dialogs both created `id="btnCancel"`.
- Explain supports minimize (hide, not remove), so hidden dialogs remained in the DOM.
- Global `document.getElementById(...)` lookups could bind handlers to hidden/stale nodes instead of the visible dialog.

What changed:
- `umpleonline/scripts/ai/features/explain/umple_ai_explain.js`
  - Renamed cancel button id to `btnCancelExplain`.
  - Scoped event-binding lookups to `dialog.querySelector(...)`.
  - Scoped runtime UI lookups in `performExplanation` and `handleFollowUp` to the dialog root.
  - `createDialog()` now returns the created dialog and `showDialog()` passes it through.
- `umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js`
  - Renamed cancel button id to `btnCancelRequirements`.
  - Scoped event-binding element lookups to `dialog.querySelector(...)`.
  - Updated output helpers to support dialog-scoped lookup (`getRequirementsOutputArea(dialog)`).
- `umpleonline/scripts/ai/features/requirements/umple_ai_requirements.js`
  - Replaced global dialog-element lookups with `dialog.querySelector(...)` in generate/stop/insert flows.
  - Routed requirement log output calls through dialog-scoped helpers.

## Pull request content
- No syntax/semantics changes to Umple language; user manual updates not required.
- No generated `dist/**` files changed.
- Scope is intentionally small and limited to AI dialog consistency and event wiring.

Validation performed:
- Manual repro flow from #2324 no longer binds handlers to hidden dialog elements.
