### PR TITLE
Fixes #2327 prevent extra blank lines in AI Explain markdown

### DIFF
--- a/umpleonline/scripts/styles.css
+++ b/umpleonline/scripts/styles.css
@@ -1619,6 +1619,14 @@ textarea#umpleLayoutEditorText {
   line-height: 1.5;
 }
 
+.ai-explain-dialog .explanation-text p {
+  margin: 0 0 10px;
+}
+
+.ai-explain-dialog .explanation-text p:last-child {
+  margin-bottom: 0;
+}
+
 .ai-explain-dialog .explanation-text pre {
   background-color: #f0f0f0;
   border: #ccc solid 1px;


### PR DESCRIPTION
## Pull request description

Fixes #2327 by removing extra blank lines in UmpleOnline AI Explain markdown rendering.

The previous markdown renderer converted all `\n` to `<br/>`, which could create overlap between adjacent markdown blocks and produce extra spacing (for example `<br/><br/>`).

This PR switches AI markdown rendering to block-aware behavior so spacing is consistent and semantic:
- blank lines separate paragraphs,
- single line breaks inside a paragraph become `<br/>`,
- block elements (headers, tables, code blocks) stay as standalone blocks.

## Pull request content

### Changes made

1. **Block-aware markdown rendering** in:
   - `umpleonline/scripts/ai/utils/umple_ai_markdown_utils.js`

2. **Paragraph spacing CSS** in:
   - `umpleonline/scripts/styles.css`

### Validation

- `a\n\nb` renders as two paragraphs (no overlapping break artifacts),
- `a\nb` renders as one paragraph with `<br/>`,
- headers/tables/code blocks render as separate blocks with clean spacing.

<img width="593" height="598" alt="image" src="https://github.com/user-attachments/assets/43b67876-f4d4-4fd4-a3d4-fccb54c17707" />


<img width="592" height="607" alt="image" src="https://github.com/user-attachments/assets/36463ae1-9961-4b08-a06a-2fcac89c7d4e" />

### Scope

- Only affects AI Explain markdown HTML formatting.
- No compiler syntax/semantic changes.
- No generated files changed.
