### PR TITLE
Adding support for IDE repos of Umple direct from markdown

### DIFF
--- a/build/filters/remove-attr.lua
+++ b/build/filters/remove-attr.lua
@@ -1,0 +1,8 @@
+function remove_attr (x)
+  if x.attr then
+    x.attr = pandoc.Attr()
+    return x
+  end
+end
+
+return {{Inline = remove_attr, Block = remove_attr}}

--- a/build/reference/0102umpleTools.txt
+++ b/build/reference/0102umpleTools.txt
@@ -5,41 +5,65 @@ noreferences
 
 @@description
 
-<p>Umple files conventionally use the extension .ump. To create a model or 
-a system you would use one or more of the following tools to view, edit 
-and compile .ump files.</p>
+<p>Umple files conventionally use the extension .ump. You use one or more of the following tools to edit, view 
+and compile sets of .ump files.</p>
 
 <ul>
 
 <li><b>UmpleOnline.</b> <a href="https://try.umple.org">UmpleOnline</a> 
 allows you to instantly experiment with Umple on the web. You can explore 
 examples or create your own and save them in the "cloud". You can generate 
-code as well as several other outputs. <a href="UsingUmpleOnline.html">The UmpleOnline
+diagrams, code in several languages and several other outputs. <a href="UsingUmpleOnline.html">The UmpleOnline
 section of this User manual describes how to use UmpleOnline</a>. Note that UmpleOnline
 can be run locally on your machine by using a Docker image. <a href="https://hub.docker.com/r/umple/umpleonline/">See the DockerHub page for information.</a></li>
 
-<li><b>Eclipse.</b> To use Umple with Eclipse, you need to load an Umple 
+<br />
+
+<li><b>Command-line based compiler</b> You can use Umple from the 
+command line. The following are some ways to install it:
+
+<ul>
+  <li><i>Latest version:</i> <a href="https://try.umple.org/scripts/umple.jar">Download this to run same Umple version as on UmpleOnline</a>; it is typically updated a few times each month. After downloading, run using Java 11 or later using <pre>java -jar umple.jar filename.ump</pre></li>
+
+  <br />
+
+  <li><i>Stable release:</i></a> <a href="https://github.com/umple/umple/releases/latest">Download this if you want to use our latest official release</a>; typically updated 1-4 times per year.</li>
+
+  <br />
+
+  <li><i>Homebrew installation:</i></a>Run <pre>brew install umple</pre> on a Mac (also available for Linux). This will install the latest stable release, and will update automatically after any new release. Once installed, run as <pre>umple filename.ump</pre></li>
+
+  <br />
+
+  <li>Windows versions on chocolatey and Linux versions under apt may be available.</li>
+</ul>
+
+  <br />
+
+  The command line compiler has numerous options, including: to obtain help (--help), to generate any of Umple's possible outputs (-g), to compile the generated code to an executable (-c -), to specify suboptions to control details of generated code (-s), and to specify umple code to compile directly on the command line (rather than from a file) (-u). The command line compiler can handle thousands of files and millions of lines of Umple code if needed (Umple is written in itself, demonstrating this works well). The command line compiler can be incorporated into product toolchains using technology like Gradle or ant.
+
+</li>
+
+<br />
+
+<li>Plugin for the <b>Zed text editor</b>. <a href="Zed.html">See the Zed page in this user manual.</a>.</li>
+
+
+<br />
+
+<li>Plugin for <b>Visual Studio Code</b>. This plugin allows basic <a href="https://marketplace.visualstudio.com/items?itemName=digized.umple">editing and compilation of Umple in Visual Studio Code</a>. This will be replaced by a superior plugin soon.</li>
+
+<br />
+
+<li>Plugin for <b>Sublime Text</b>. Try this <a href="https://github.com/umple/umple.sublime">Umple Plugin if you use Sublime Text</a>.</li>
+
+<br />
+
+<li>Plugin for <b>Eclipse.</b> To use Umple with Eclipse, you need to load an Umple 
 Eclipse plugin. This can be obtained from our <a 
-href="https://umple.org/dl">downloads site</a>.</li>
+href="https://umple.org/dl">downloads site</a>. It has not been maintained recently and support may be dropped.</li>
 
-<br />
 
-<li><b>Command-line based compiler</b> You can always use Umple from the 
-command line, typically from an ant script. Simply <a
-href="https://github.com/umple/umple/releases/latest">download the latest 
-officially released version of the umple jar</a>, and run it as "java -jar umple.jar *.ump".  A shell script called umple is also available in the dev-tools directory to make the preceding easier. The dev-tools directory also has other tools to automate useful tasks for building and using Umple. Additionally you can download and install the Umple jar file and the umple shell script using chocolatey (Windows), or brew (Mac). </li>
-
-<br />
-
-<li><a href="https://try.umple.org/scripts/umple.jar">For the adventurous, the bleeding-edge continuous build version of the Umple command-line compiler can be obtained here</a>.</li>
-
-<br />
-
-<li><b>Plugin for Microsoft Visual Studio Code</b>. This plugin allows basic <a href="https://marketplace.visualstudio.com/items?itemName=digized.umple">editing and compilation of Umple in Visual Studio Code</a>.</li>
-
-<br />
-
-<li><b>Plugin for Sublime Text</b>. Try this <a href="https://github.com/umple/umple.sublime">Umple Plugin if you use Sublime Text</a>.</li>
 
 </ul>
 

--- a/build/reference/0194Philosophy.txt
+++ b/build/reference/0194Philosophy.txt
@@ -1,0 +1,7 @@
+Philosophy
+User Manual Basics
+noreferences
+@@tooltip Principles guiding Umple
+@@markdownURL https://raw.githubusercontent.com/wiki/umple/umple/PhilosophyAndVision.md
+@@description
+<!-- No description as the description will be loaded from markdown conversion -->

--- a/build/reference/5073Zed.txt
+++ b/build/reference/5073Zed.txt
@@ -1,0 +1,7 @@
+Zed
+IDEs and Text Editors
+noreferences
+@@tooltip Support for the Zed Text Editor
+@@markdownURL https://raw.githubusercontent.com/umple/umple.zed/refs/heads/master/README.md
+@@description
+<!-- No description as the description will be loaded from markdown conversion -->

--- a/build/reference/order.group
+++ b/build/reference/order.group
@@ -18,6 +18,7 @@ Distribution%Capabilities to generate code for components that will run on diffe
 Composite Structure%Capabilities to define components with nested elements and communication channels;
 Tracing%Capabilities to specify run-time tracing of API calls for attributes, associations, state machines and methods;
 UmpleOnline%Capabilities of the Umple web-based interface that runs at try.umple.org and in Docker;
+IDEs and Text Editors%Umple support in IDEs and text editors such as VSCode and Zed;
 AI%Capabilities for AI-assisted modeling in UmpleOnline;
 Generators%Capabilities of Umple to generate code;
 Persistence%Capabilities to load and save instances of Umple classes;

--- a/cruise.umple/src/Documenter.ump
+++ b/cruise.umple/src/Documenter.ump
@@ -65,6 +65,9 @@ class Content
   // URL of Youtube Video (if any)
   videoURL = null;
   
+  // URL of Markdown file to import (if any)
+  markdownURL = null;
+  
   // Tooltip to display when hovering (if any)
   tooltip = null;
 }
@@ -111,7 +114,8 @@ class Template
   const HtmlTemplate = htmlTemplate();
   const ExampleTemplate = exampleTemplate();
   const SyntaxTemplate = syntaxTemplate();
-  const VideoURLTemplate = videoURLTemplate();  
+  const VideoURLTemplate = videoURLTemplate();
+  const MarkdownURLTemplate = markdownURLTemplate();
   const NavigationHeaderTemplate = navigationHeaderTemplate();
   const NavigationItemTemplate = navigationItemTemplate();
   const NavigationItemTemplateNoAnchor = navigationItemTemplateNoAnchor();

--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -365,7 +365,7 @@ class Documenter
       int retval=0;
       String htmlFromMarkdown="<p>Unable to read "+theMarkdownURLIfAny+"</p>";
       try {
-        Process p = Runtime.getRuntime().exec("pandoc -f markdown -t html "+ theMarkdownURLIfAny);
+        Process p = Runtime.getRuntime().exec("pandoc --lua-filter=build/filters/remove-attr.lua -f markdown-auto_identifiers -t html "+ theMarkdownURLIfAny);
         BufferedReader reader=new BufferedReader(new InputStreamReader(p.getInputStream())); 
 
         // All output of the above should go to standard output
@@ -375,7 +375,9 @@ class Documenter
         catch (InterruptedException e) {}
       
         if(retval !=0) {
-          htmlFromMarkdown = "<p>Unable to read input markdown file "+theMarkdownURLIfAny+"</p>\n";
+          String pandocProbMsg="Unable to read input markdown file "+theMarkdownURLIfAny+" for "+selectedContent.getTitle()+". Return value from pandoc is: "+retval;
+          System.err.println(pandocProbMsg+" cwd="+System.getProperty("user.dir"));
+          htmlFromMarkdown = "<p>"+pandocProbMsg+"</p>\n";
         }
         else {
           String line="";
@@ -401,6 +403,13 @@ class Documenter
       }
       htmlFromMarkdown=htmlFromMarkdown.replace("<h2","<br /><h2");
       htmlFromMarkdown=htmlFromMarkdown.replace("<h3","<br /><h3");
+      htmlFromMarkdown=htmlFromMarkdown.replace("<pre><code>","<span class=\"notranslate\" translate=\"no\"><pre name=\"code\" class=\"c-sharp\">");      
+      htmlFromMarkdown=htmlFromMarkdown.replace("</code></pre>","</pre></span>");
+      
+      
+      String nonRawPage=theMarkdownURLIfAny.replace("raw.githubusercontent.com","github.com");
+      nonRawPage=nonRawPage.replace("refs/heads/master","blob/master");
+      htmlFromMarkdown=htmlFromMarkdown+"<br /><p><i>Original markdown source for this page: <a href=\""+nonRawPage+"\" target=\"originalmg\">"+nonRawPage+"</a></i></p>";
       
       String markdownURLHtml = Template.MarkdownURLTemplate.replace("@@MARKDOWN_URL@@",htmlFromMarkdown);      
       htmlOutput = htmlOutput.replace("@@MARKDOWNURL@@", markdownURLHtml);
@@ -732,7 +741,7 @@ class Template
   private static String markdownURLTemplate()
   {
     // The markdown will be converted to html when the template is invoked
-    // This template allows surrounding html to be added if this proves useful
+    // This template allows surrounding html to be added if this proves useful, such as a span with formatting
     String template = "@@MARKDOWN_URL@@";
     return template;
   }  

--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -354,6 +354,57 @@ class Documenter
         "<span class=\"notranslate\" translate=\"no\">" +
         videoURLHtml+ "</span>");
     }
+
+    String theMarkdownURLIfAny = selectedContent.getMarkdownURL();
+    if (theMarkdownURLIfAny == null)
+    {
+      htmlOutput = htmlOutput.replace("@@MARKDOWNURL@@", "");
+    }
+    else
+    {
+      int retval=0;
+      String htmlFromMarkdown="<p>Unable to read "+theMarkdownURLIfAny+"</p>";
+      try {
+        Process p = Runtime.getRuntime().exec("pandoc -f markdown -t html "+ theMarkdownURLIfAny);
+        BufferedReader reader=new BufferedReader(new InputStreamReader(p.getInputStream())); 
+
+        // All output of the above should go to standard output
+        try {
+          retval=p.waitFor();
+        }
+        catch (InterruptedException e) {}
+      
+        if(retval !=0) {
+          htmlFromMarkdown = "<p>Unable to read input markdown file "+theMarkdownURLIfAny+"</p>\n";
+        }
+        else {
+          String line="";
+          if(reader.ready()) {
+            line = reader.readLine();
+          }
+
+          StringBuilder builder = new StringBuilder();
+
+          while (line!=null) {
+            builder.append(line+"\n");
+            if(reader.ready()) {
+              line = reader.readLine();
+            }
+            else {
+              line = null;
+            }
+          }
+          htmlFromMarkdown = builder.toString();
+        }
+      } catch (IOException e) {
+        htmlFromMarkdown = "<p>IO Exception reading input markdown file "+theMarkdownURLIfAny+"</p>\n";
+      }
+      htmlFromMarkdown=htmlFromMarkdown.replace("<h2","<br /><h2");
+      htmlFromMarkdown=htmlFromMarkdown.replace("<h3","<br /><h3");
+      
+      String markdownURLHtml = Template.MarkdownURLTemplate.replace("@@MARKDOWN_URL@@",htmlFromMarkdown);      
+      htmlOutput = htmlOutput.replace("@@MARKDOWNURL@@", markdownURLHtml);
+    }
     
     String exampleOutput = "";
     for (ManualExample manualExample : selectedContent.getExamples())
@@ -495,7 +546,7 @@ class ContentParser
   private int init()
   {
     addRule("groupOrder : ( [**group] ; )*");
-    addRule("content : [*title] [*group] [=noreferences]? (@@tooltip [**tooltip])?  @@description [**description] (@@videoURL [**videoURL])? (@@syntax [**syntax])? [[example]]* @@Filename [*filename]");
+    addRule("content : [*title] [*group] [=noreferences]? (@@tooltip [**tooltip])? (@@markdownURL [**markdownURL])?   @@description [**description] (@@videoURL [**videoURL])? (@@syntax [**syntax])? [[example]]* @@Filename [*filename]");
     addRule("example- : @@example ( @@caption [**caption] @@endcaption )? [**example] @@endexample");
     init += 1;
     return init;
@@ -531,7 +582,11 @@ class ContentParser
         if(t.getValue("videoURL") != null) {
           content.setVideoURL(t.getValue("videoURL"));
         }
-        
+
+        if(t.getValue("markdownURL") != null) {
+          content.setMarkdownURL(t.getValue("markdownURL"));
+        }
+
         if (t.getValue("noreferences") != null)
         {
           content.setShouldIncludeReferences(false);
@@ -674,6 +729,13 @@ class Template
     return template;
   }  
   
+  private static String markdownURLTemplate()
+  {
+    // The markdown will be converted to html when the template is invoked
+    // This template allows surrounding html to be added if this proves useful
+    String template = "@@MARKDOWN_URL@@";
+    return template;
+  }  
 
   private static String htmlTemplate()
   {
@@ -800,6 +862,7 @@ class Template
         "      <h1><font size=\"+1\">@@TITLE@@</font></h1>" + "\n" +
         "      <p class=\"description\">@@DESCRIPTION@@</p>" + "\n" +
         "" + "\n" +
+        "@@MARKDOWNURL@@" + "\n" +
         "@@EXAMPLE@@" + "\n" +
         "@@VIDEOURL@@" + "\n" +
         "@@SYNTAX@@" + "\n";

--- a/cruise.umple/src/Documenter_Code.ump
+++ b/cruise.umple/src/Documenter_Code.ump
@@ -401,15 +401,19 @@ class Documenter
       } catch (IOException e) {
         htmlFromMarkdown = "<p>IO Exception reading input markdown file "+theMarkdownURLIfAny+"</p>\n";
       }
+      
+      // Tidy up the page
       htmlFromMarkdown=htmlFromMarkdown.replace("<h2","<br /><h2");
       htmlFromMarkdown=htmlFromMarkdown.replace("<h3","<br /><h3");
       htmlFromMarkdown=htmlFromMarkdown.replace("<pre><code>","<span class=\"notranslate\" translate=\"no\"><pre name=\"code\" class=\"c-sharp\">");      
       htmlFromMarkdown=htmlFromMarkdown.replace("</code></pre>","</pre></span>");
       
-      
-      String nonRawPage=theMarkdownURLIfAny.replace("raw.githubusercontent.com","github.com");
-      nonRawPage=nonRawPage.replace("refs/heads/master","blob/master");
-      htmlFromMarkdown=htmlFromMarkdown+"<br /><p><i>Original markdown source for this page: <a href=\""+nonRawPage+"\" target=\"originalmg\">"+nonRawPage+"</a></i></p>";
+      // Determine user editable page unless this was a wiki page
+      if (!theMarkdownURLIfAny.contains("wiki")) {
+        String nonRawPage=theMarkdownURLIfAny.replace("raw.githubusercontent.com","github.com");
+        nonRawPage=nonRawPage.replace("refs/heads/master","blob/master");
+        htmlFromMarkdown=htmlFromMarkdown+"<br /><p><i>Original markdown source for this page: <a href=\""+nonRawPage+"\" target=\"originalmg\">"+nonRawPage+"</a></i></p>";
+      }
       
       String markdownURLHtml = Template.MarkdownURLTemplate.replace("@@MARKDOWN_URL@@",htmlFromMarkdown);      
       htmlOutput = htmlOutput.replace("@@MARKDOWNURL@@", markdownURLHtml);


### PR DESCRIPTION
This will allow pages written in markdown (.md) to appear directly to the Umple user manual. It adds a new tag to the Umple manual page format @@markdownURL to allow content to be loaded from an external markdown source instead of just from the current page.

Thjis uses [pandoc https://pandoc.org/MANUAL.html](https://pandoc.org/MANUAL.html), so going forward anyone bulding the user manual will have had to add it using brew, apt or similar tools [instructions here](https://github.com/jgm/pandoc/blob/main/INSTALL.md). It forces pandoc to create minimal html using a Lua script, so that Umple's manual page css styles are still used for formatting. Sometimes the markdown needs to be slightly improved to correspond to what pandoc thinks of as good quality markdown.

As a first use of the feature, this PR adds the umple.Zed Readme.md page to the Umple user manual . The Zed Readme.md remains the master. Any time someone rebuilds the readme page, the user manual will be updated with any new content.

It can also import wiki pages. This PR adds the Philosophy wiki page (still edited as a wiki, but now mirrored in the user manual as it is so important)

We will then add the pages for other Umple organization IDE support repos such as VSCode, NeoVim and BBEdit when they are developed and fully tested.