### PR TITLE
Fixes issue 2290 enabling more options on UmpleOnlin RHS

### DIFF
--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -294,6 +294,7 @@ Action.clicked = function(event)
   else if (action == "ShowEditableClassDiagram")
   {
     Action.changeDiagramType({type:"editableClass"});
+    Action.syncLiveViewSelector("ecd");
   }
   else if (action == "ShowJointJSClassDiagram")
   {
@@ -302,18 +303,27 @@ Action.clicked = function(event)
   else if (action == "ShowGvClassDiagram")
   {
     Action.changeDiagramType({type:"GvClass"});
+    Action.syncLiveViewSelector("gcd");
   }
   else if (action == "ShowGvFeatureDiagram")
   {
     Action.changeDiagramType({type:"GvFeature"});//buttonShowGvFeatureDiagram
+    Action.syncLiveViewSelector("gfd");
   }
   else if (action == "ShowGvStateDiagram")
   {
     Action.changeDiagramType({type:"GvState"});
+    Action.syncLiveViewSelector("sd");
   }
   else if (action == "ShowStructureDiagram")
   {
     Action.changeDiagramType({type:"structure"});
+    Action.syncLiveViewSelector("std");
+  }
+  else if (action == "ShowEntityRelationshipDiagram")
+  {
+    Action.changeDiagramType({type:"GvEntityRelationshipDiagram"});
+    Action.syncLiveViewSelector("erd");
   }
   else if (action == "ShowHideLayoutEditor")
   {
@@ -920,6 +930,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvStateDiagram = false;
     Page.useGvFeatureDiagram = false;
     Page.useStructureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
     changedType = true;
     jQuery("#buttonShowEditableClassDiagram").prop('checked', 'checked');
     Page.setDiagramTypeIconState('editableClass');
@@ -935,6 +946,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvStateDiagram = false;
     Page.useGvFeatureDiagram = false;
     Page.useStructureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
     changedType = true;
     jQuery("#buttonShowJointJSClassDiagram").prop('checked', 'checked');
     Page.setDiagramTypeIconState('JointJSClass');
@@ -949,12 +961,32 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvStateDiagram = false;
     Page.useGvFeatureDiagram = false;
     Page.useStructureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
     changedType = true;
     jQuery("#buttonShowGvClassDiagram").prop('checked', 'checked');
     Page.setDiagramTypeIconState('GvClass');
     jQuery(".view_opt_class").show();
 
   }
+
+  else if(newDiagramType.type == "GvEntity" || newDiagramType.type == "GvEntityRelationshipDiagram") { 
+    if(Page.useGvEntityRelationshipDiagram) return;
+    Page.useGvClassDiagram = false;
+    Page.useEditableClassDiagram = false;
+    Page.useJointJSClassDiagram = false;
+    Page.useGvClassDiagram = false;
+    Page.useGvStateDiagram = false;
+    Page.useGvFeatureDiagram = false;
+    Page.useStructureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = true;
+    changedType = true;
+    jQuery("#buttonShowGvEntityRelationshipDiagram").prop('checked', 'checked');
+    Page.setDiagramTypeIconState('GvEntity');
+    jQuery(".view_opt_class").show();
+    Page.initExamples();
+
+  }
+
   else if(newDiagramType.type == "GvState") {
     if(Page.useGvStateDiagram) return;
     Page.useEditableClassDiagram = false;
@@ -963,6 +995,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvStateDiagram = true;
     Page.useStructureDiagram = false;
     Page.useGvFeatureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
     changedType = true;
     jQuery("#buttonShowGvStateDiagram").prop('checked', 'checked');
     Page.setDiagramTypeIconState('GvState');
@@ -977,6 +1010,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvStateDiagram = false;
     Page.useStructureDiagram = false;
     Page.useGvFeatureDiagram = true;
+    Page.useGvEntityRelationshipDiagram = false;
     changedType = true;
     jQuery("#buttonShowGvFeatureDiagram").prop('checked', 'checked');
     Page.setDiagramTypeIconState('GvFeature');
@@ -992,6 +1026,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvStateDiagram = false;
     Page.useStructureDiagram = true;
     Page.useGvFeatureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
     changedType = true;
     jQuery("#buttonShowStructureDiagram").prop('checked', 'checked');
     Page.setDiagramTypeIconState('structure');
@@ -4379,6 +4414,11 @@ Action.loadExample = function loadExample()
  else if(Page.useGvFeatureDiagram) {
     diagramType="&diagramtype=GvFeature";
   }
+
+  else if(Page.useGvEntityRelationshipDiagram) {
+    diagramType="&diagramtype=entityRelationshipDiagram";
+  }
+
   else if(Page.useStructureDiagram) {
     diagramType="&diagramtype=structure&generateDefault=cpp";
   }
@@ -4404,6 +4444,7 @@ Action.loadExample = function loadExample()
   {
     var shortExampleName=exampleName;
     var newURL="?example="+shortExampleName+diagramType;
+    window.history.pushState({}, "", newURL);
   }
 
   setTimeout(function () { // Delay so it doesn't get erased
@@ -6540,6 +6581,11 @@ Mousetrap.bind(['ctrl+g'], function(e){
   return false; //equivalent to e.preventDefault();
 });
 
+Mousetrap.bind(['ctrl+v'], function(e){
+  Page.clickShowGvEntityRelationshipDiagram();
+  return false; //equivalent to e.preventDefault();
+});
+
 Mousetrap.bind(['ctrl+s'], function(e){
   Page.clickShowGvStateDiagram();
   return false; //equivalent to e.preventDefault();
@@ -6747,6 +6793,7 @@ Action.getLanguage = function()
     }
   }
   else if(Page.useGvStateDiagram) {language="language=stateDiagram"}
+  else if(Page.useGvEntityRelationshipDiagram) {language="language=entityDiagram"}
   else if(Page.useStructureDiagram) {language="language=StructureDiagram"}
  
 
@@ -7095,7 +7142,16 @@ Action.setLiveView = function(viewNameToSet)
   if (viewNameToSet=="ecd") { Page.clickShowEditableClassDiagram(); }
   else if (viewNameToSet=="gcd") { Page.clickShowGvClassDiagram(); }
   else if (viewNameToSet=="sd") { Page.clickShowGvStateDiagram(); }
+  else if (viewNameToSet=="std") { Page.clickShowStructureDiagram();}
+  else if (viewNameToSet=="erd") { Page.clickShowGvEntityRelationshipDiagram();}
+  else if (viewNameToSet=="gfd") { Page.clickShowGvFeatureDiagram();}
   else Page.catFeedbackMessage("DEBUG bad selection!!!");
 }
 
+Action.syncLiveViewSelector = function(viewCode) {
+  var selector = document.getElementById("liveViewSelector");
+  if (selector) {
+    selector.value = viewCode;
+  }
+};
 

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -7086,3 +7086,16 @@ Action.reindent = function(lines, cursorPos)
 
   Page.codeMirrorEditor6.focus();
 }
+
+// TEST DEBUG
+
+Action.setLiveView = function(viewNameToSet)
+{
+  Page.catFeedbackMessage("DEBUG:"+viewNameToSet);
+  if (viewNameToSet=="ecd") { Page.clickShowEditableClassDiagram(); }
+  else if (viewNameToSet=="gcd") { Page.clickShowGvClassDiagram(); }
+  else if (viewNameToSet=="sd") { Page.clickShowGvStateDiagram(); }
+  else Page.catFeedbackMessage("DEBUG bad selection!!!");
+}
+
+

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -43,6 +43,7 @@ Page.useGvFeatureDiagram = false;
 Page.showFeatureDependency = false;
 Page.useStructureDiagram = false;
 Page.useFeatureDiagram = false;
+Page.useGvEntityRelationshipDiagram = false;
 Page.showAttributes = true;
 Page.showMethods = false;
 Page.filterWordsOutput = "";
@@ -98,6 +99,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   if(diagramType.toLowerCase() == "gvstate" || diagramType.toLowerCase() == "state")   
   { 
     Page.useGvStateDiagram = true;
+    Page.useGvEntityRelationshipDiagram = false;
     Page.useEditableClassDiagram = false; 
     Page.setDiagramTypeIconState('GvState');
     Page.useGvFeatureDiagram = false;
@@ -107,6 +109,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   else if(diagramType.toLowerCase() == "gvclass")
   {
     Page.useGvClassDiagram = true;
+    Page.useGvEntityRelationshipDiagram = false;
     Page.useEditableClassDiagram = false;
     Page.setDiagramTypeIconState('GvClass');
     Page.useGvFeatureDiagram = false;
@@ -116,6 +119,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   else if(diagramType.toLowerCase() == "gvclasstrait")
   {
     Page.useGvClassDiagram = true;
+    Page.useGvEntityRelationshipDiagram = false;
     Page.useEditableClassDiagram = false;
     Page.setDiagramTypeIconState('GvClass');
     Page.useGvFeatureDiagram = false;
@@ -125,6 +129,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   else if(diagramType.toLowerCase() == "gvfeature")
   {
     Page.useGvFeatureDiagram = true;
+    Page.useGvEntityRelationshipDiagram = false;
     Page.useEditableClassDiagram = false;
     Page.useGvStateDiagram = false;
     Page.useStructureDiagram = false;
@@ -135,8 +140,17 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   else if(diagramType.toLowerCase() == "structurediagram")
   {
     Page.useStructureDiagram = true;
+    Page.useGvEntityRelationshipDiagram = false;
     Page.useEditableClassDiagram = false;  
     Page.setDiagramTypeIconState('structureDiagram');
+    Page.useGvFeatureDiagram = false;
+  }
+  else if(diagramType.toLowerCase() == "entityrelationshipdiagram")
+  {
+    Page.useGvEntityRelationshipDiagram = true;
+    Page.useStructureDiagram = false;
+    Page.useEditableClassDiagram = false;  
+    Page.setDiagramTypeIconState('entityRelationshipDiagram');
     Page.useGvFeatureDiagram = false;
   }
   else
@@ -288,6 +302,7 @@ Page.initPaletteArea = function()
   Page.initAction("buttonShowGvStateDiagram");
   Page.initAction("buttonShowGvFeatureDiagram");//buttonShowGvFeatureDiagram
   Page.initAction("buttonShowStructureDiagram");
+  Page.initAction("buttonShowGvEntityRelationshipDiagram");
   Page.initAction("buttonShowHideLayoutEditor");
   Page.initAction("buttonManualSync");
   Page.initAction("buttonCopyClip");
@@ -410,6 +425,10 @@ Page.initOptions = function()
 
   if(Page.useGvStateDiagram)
     jQuery("#buttonShowGvStateDiagram").prop('checked', true);
+
+  if(Page.useGvEntityRelationshipDiagram)
+    jQuery("#buttonShowGvEntityRelationshipDiagram").prop('checked', true);
+
   if(Page.useStructureDiagram)
     jQuery("#buttonShowStructureDiagram").prop('checked', true);
 
@@ -564,6 +583,7 @@ Page.initCodeMirrorEditor = function() {
     { key: "Ctrl-E", run: function() { Page.clickShowEditableClassDiagram() } },
     { key: "Ctrl-J", run: function() { Page.clickShowJointJSClassDiagram() } },
     { key: "Ctrl-G", run: function() { Page.clickShowGvClassDiagram() } },
+    { key: "Ctrl-V", run: function() { Page.clickShowGvEntityRelationshipDiagram() } },
     { key: "Ctrl-S", run: function() { Page.clickShowGvStateDiagram() } },
     { key: "Ctrl-L", run: function() { Page.clickShowStructureDiagram() } },
     { key: "Ctrl-T", run: function() { Page.clickShowHideText() } },
@@ -637,6 +657,8 @@ Page.setDiagramTypeIconState = function(diagramType){
     document.getElementById('ECD_button').className = "button2 active";
     break;
     case 'GvClass':
+    case 'entityRelationshipDiagram': // Map ERD to the 'G' button
+    case 'GvEntity': 
     document.getElementById('GCD_button').className = "button2 active";
     break;
     case 'GvState':
@@ -688,6 +710,9 @@ Page.clickShowJointJSClassDiagram = function() {
 }
 Page.clickShowGvClassDiagram = function() {
   jQuery('#buttonShowGvClassDiagram').trigger('click');
+}
+Page.clickShowGvEntityRelationshipDiagram = function() {
+  jQuery('#buttonShowGvEntityRelationshipDiagram').trigger('click');
 }
 Page.clickShowGvStateDiagram = function() {
   jQuery('#buttonShowGvStateDiagram').trigger('click');
@@ -899,7 +924,8 @@ Page.initExamples = function()
     jQuery("#itemLoadExamples5").hide();   
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
-    jQuery("#itemLoadExamples8").hide();   
+    jQuery("#itemLoadExamples8").hide();
+    jQuery("#itemLoadExamplesERD").hide();   
 
   }
   else if (Page.useGvStateDiagram) {
@@ -910,7 +936,8 @@ Page.initExamples = function()
     jQuery("#itemLoadExamples5").hide();
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
-    jQuery("#itemLoadExamples8").hide();   
+    jQuery("#itemLoadExamples8").hide();
+    jQuery("#itemLoadExamplesERD").hide();   
 
   }
  else if (Page.useGvFeatureDiagram) {
@@ -921,8 +948,21 @@ Page.initExamples = function()
     jQuery("#itemLoadExamples5").hide();
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
-    jQuery("#itemLoadExamples8").hide();   
+    jQuery("#itemLoadExamples8").hide();
+    jQuery("#itemLoadExamplesERD").hide();   
 
+  }
+
+  else if (Page.useGvEntityRelationshipDiagram) {
+    jQuery("#menu-set-erd").prop("selected",true);
+    jQuery("#itemLoadExamples").hide();
+    jQuery("#itemLoadExamples2").hide();
+    jQuery("#itemLoadExamples3").hide();
+    jQuery("#itemLoadExamples5").hide();
+    jQuery("#itemLoadExamples6").hide();   
+    jQuery("#itemLoadExamples7").hide();   
+    jQuery("#itemLoadExamples8").hide();
+    jQuery("#itemLoadExamplesERD").show();   
   }
   else {
     // TODO any examples loaded on initialization without a 
@@ -930,6 +970,7 @@ Page.initExamples = function()
     // Therefore for new example sets 5-8, we will need to change this logic
     // to determine which set to hide
     jQuery("#cdModels").prop("selected",true); 
+    jQuery("#itemLoadExamples").show();
     jQuery("#itemLoadExamples2").hide();
     jQuery("#itemLoadExamples3").hide(); 
     jQuery("#itemLoadExamples4").hide();
@@ -1448,6 +1489,16 @@ Page.getSelectedExample = function()
       }
     
     }
+
+    else if (theExampleType == "entityModels")
+    {
+       inputExample = jQuery("#inputExample4 option:selected").val(); 
+       if( !Page.useGvEntityRelationshipDiagram) {
+         jQuery("#buttonShowGvEntityRelationshipDiagram").attr('checked', true); 
+         Action.changeDiagramType({type: "GvEntity"});
+      }
+    
+    } 
   else {
 
     if(theExampleType == "smModels") {

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -145,7 +145,9 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
     Page.setDiagramTypeIconState('structureDiagram');
     Page.useGvFeatureDiagram = false;
   }
-  else if(diagramType.toLowerCase() == "entityrelationshipdiagram")
+  else if(diagramType.toLowerCase() == "gventityrelationshipdiagram"
+  || diagramType.toLowerCase() == "gventity"
+  || diagramType.toLowerCase() == "erd")
   {
     Page.useGvEntityRelationshipDiagram = true;
     Page.useStructureDiagram = false;
@@ -270,7 +272,7 @@ Page.initPaletteArea = function()
   Page.initHighlighter("buttonToggleGuardLabels");
   Page.initHighlighter("buttonToggleTraits");
   Page.initHighlighter("buttonToggleFeatureDependency");
-  Page.initHighlighter("buttonallowPinch");
+  Page.initHighlighter("buttonAllowPinch");
   Page.initHighlighter("buttonReindent");
   
   Page.initToggleTool("buttonAddClass");
@@ -583,15 +585,15 @@ Page.initCodeMirrorEditor = function() {
     { key: "Ctrl-E", run: function() { Page.clickShowEditableClassDiagram() } },
     { key: "Ctrl-J", run: function() { Page.clickShowJointJSClassDiagram() } },
     { key: "Ctrl-G", run: function() { Page.clickShowGvClassDiagram() } },
-    { key: "Ctrl-V", run: function() { Page.clickShowGvEntityRelationshipDiagram() } },
+    { key: "Ctrl-Shift-V", run: function() { Page.clickShowGvEntityRelationshipDiagram() } },
     { key: "Ctrl-S", run: function() { Page.clickShowGvStateDiagram() } },
     { key: "Ctrl-L", run: function() { Page.clickShowStructureDiagram() } },
     { key: "Ctrl-T", run: function() { Page.clickShowHideText() } },
     { key: "Shift-Ctrl-Alt-T", run: function() { Page.clickShowHideText() } },
     { key: "Ctrl-D", run: function() { Page.clickShowHideCanvas() } },
     { key: "Ctrl-N", run: function() { Page.clickShowHideMenu() } },
-    { key: "trl-Alt-N", run: function() { Page.clickShowHideMenu() } },
-    { key: "Ctrl-Shift-=", run: function() { Page.clickButtonlarger() } },
+    { key: "Ctrl-Alt-N", run: function() { Page.clickShowHideMenu() } },
+    { key: "Ctrl-Shift-=", run: function() { Page.clickButtonLarger() } },
     { key: "Ctrl-Shift--", run: function() { Page.clickButtonSmaller() } },
     { key: "Shift-Ctrl-A", run: function() { Page.clickToggleAttributes() } },
     { key: "Ctrl-M", run: function() { Page.clickToggleMethods() } },
@@ -760,7 +762,7 @@ Page.clickToggleFeatureDependency= function() {
 Page.clickToggleTransitionLabels = function() {
   jQuery('#buttonToggleTransitionLabels').trigger('click');
 }
-Page.clickToggleGuardLabels = function() {
+Page.clickToggleGuards = function() {
   jQuery('#buttonToggleGuards').trigger('click');
 }
 Page.clickToggleGuardLabels = function() {
@@ -930,8 +932,7 @@ Page.initExamples = function()
     jQuery("#itemLoadExamples5").hide();   
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
-    jQuery("#itemLoadExamples8").hide();
-    jQuery("#itemLoadExamplesERD").hide();   
+    jQuery("#itemLoadExamples8").hide();  
 
   }
   else if (Page.useGvStateDiagram) {
@@ -943,7 +944,6 @@ Page.initExamples = function()
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
     jQuery("#itemLoadExamples8").hide();
-    jQuery("#itemLoadExamplesERD").hide();   
 
   }
  else if (Page.useGvFeatureDiagram) {
@@ -955,20 +955,18 @@ Page.initExamples = function()
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
     jQuery("#itemLoadExamples8").hide();
-    jQuery("#itemLoadExamplesERD").hide();   
-
   }
 
   else if (Page.useGvEntityRelationshipDiagram) {
-    jQuery("#menu-set-erd").prop("selected",true);
-    jQuery("#itemLoadExamples").hide();
+    jQuery("#cdModels").prop("selected",true);
+    jQuery("#itemLoadExamples").show();
     jQuery("#itemLoadExamples2").hide();
     jQuery("#itemLoadExamples3").hide();
     jQuery("#itemLoadExamples5").hide();
     jQuery("#itemLoadExamples6").hide();   
     jQuery("#itemLoadExamples7").hide();   
     jQuery("#itemLoadExamples8").hide();
-    jQuery("#itemLoadExamplesERD").show();   
+
   }
   else {
     // TODO any examples loaded on initialization without a 
@@ -1500,8 +1498,9 @@ Page.getSelectedExample = function()
     {
        inputExample = jQuery("#inputExample4 option:selected").val(); 
        if( !Page.useGvEntityRelationshipDiagram) {
-         jQuery("#buttonShowGvEntityRelationshipDiagram").attr('checked', true); 
-         Action.changeDiagramType({type: "GvEntity"});
+         jQuery("#buttonShowGvEntityRelationshipDiagram").prop('checked', true); 
+         Action.changeDiagramType({type: "GvEntityRelationshipDiagram"});
+         
       }
     
     } 
@@ -1529,8 +1528,8 @@ Page.getSelectedExample = function()
 
 Page.getExampleType = function()
 {
-  var exampleType = jQuery("#exampleType option:selected").val();
-  return exampleType;
+  var inputExampleType = jQuery("#inputExampleType option:selected").val();
+  return inputExampleType;
 }
 
 Page.showCodeDone = function()
@@ -1645,7 +1644,7 @@ Page.applyGeneratedCodeAreaStyles = function(language)
     generatedArea.removeClass('generatedDiagram');
   }
   //One of the svg diagram types
-  else if(language == "stateDiagram" || language == "classDiagram" || language == "structureDiagram")
+  else if(language == "stateDiagram" || language == "classDiagram" || language == "structureDiagram" || language == "entityRelationshipDiagram")
   {
     generatedArea.removeClass('generatedCode');
     generatedArea.addClass('generatedDiagram');
@@ -1669,7 +1668,7 @@ Page.getErrorMarkup = function(code, language)
 {
   var output = "";
   
-  if(language == "classDiagram" || language == "stateDiagram")
+  if(language == "classDiagram" || language == "stateDiagram" || language == "GvEntityRelationshipDiagram")
   { // Covers Graphviz class and state diagrams
     output = code.split("<svg xmlns=")[0];
     output = output.replace(/&nbsp;\s*$/, "");

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -579,7 +579,7 @@ $output = $dataHandle->readData('model.ump');
     <option value="sd" id="menu-set-sd">State Diagram</option>  
     <option value="std" id="menu-set-std">Structure Diagram</option>  
     <option value="gfd" id="menu-set-gfd">Feature Diagram</option>
-    <option value="erd" id="menu-set-erd">ERD</option>
+    <option value="erd" id="buttonShowGvEntityRelationshipDiagram">ERD</option>
     <!--option value="gvFeature">Feature Diagram</option>
     <option value="crud">CRUD Matrix</option>
     <option value="stateTables">State Tables</option>

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -576,9 +576,11 @@ $output = $dataHandle->readData('model.ump');
           style="font-size: 11px; border-radius: 4px; padding: 2px;">
     <option value="gcd" id="menu-set-gcd" >Gv Class Diagram</option>
     <option value="ecd" id="menu-set-ecd">E Class Diagram</option>
-    <option value="sd" if="menu-set-sd">State Diagram</option>    
-    <!--option value="gvEntityRelationDiagram">ERD</option>
-    <option value="gvFeature">Feature Diagram</option>
+    <option value="sd" id="menu-set-sd">State Diagram</option>  
+    <option value="std" id="menu-set-std">Structure Diagram</option>  
+    <option value="gfd" id="menu-set-gfd">Feature Diagram</option>
+    <option value="erd" id="menu-set-erd">ERD</option>
+    <!--option value="gvFeature">Feature Diagram</option>
     <option value="crud">CRUD Matrix</option>
     <option value="stateTables">State Tables</option>
     <option value="eventSequence">Event Sequence</option>

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -569,6 +569,22 @@ $output = $dataHandle->readData('model.ump');
     <a id="GCD_button" class="button2 active" href="javascript:Page.clickShowGvClassDiagram()">G</a>&nbsp;
     <a id="SD_button" class="button2" href="javascript:Page.clickShowGvStateDiagram()">S</a>&nbsp;
     </span>
+    <span style="font-size: 12px; margin-left: 10px; font-weight: bold;">
+  Live View:
+  <select id="liveViewSelector"
+          onchange="Action.setLiveView(this.value)"
+          style="font-size: 11px; border-radius: 4px; padding: 2px;">
+    <option value="gcd" id="menu-set-gcd" >Gv Class Diagram</option>
+    <option value="ecd" id="menu-set-ecd">E Class Diagram</option>
+    <option value="sd" if="menu-set-sd">State Diagram</option>    
+    <!--option value="gvEntityRelationDiagram">ERD</option>
+    <option value="gvFeature">Feature Diagram</option>
+    <option value="crud">CRUD Matrix</option>
+    <option value="stateTables">State Tables</option>
+    <option value="eventSequence">Event Sequence</option>
+    <option value="instanceTables">Instance Diagram</option-->
+  </select>
+</span>
  
     &nbsp; 
     <span style="font-size: 30%">


### PR DESCRIPTION
It will be useful to be able to display many of the generation targets such as ERDs and CRUD UI on the right hand side. This adds a menu that will enable the user to choose more than E, G and S mode to appear aon that side, live when any edit to the model occurs.

This being done in small commits.