### PR TITLE
Issue #2273: Fixed double redraw when loading examples by ignoring non user codemirror doc updates

### DIFF
--- a/umpleonline/scripts/codemirror6/editor.bundle.js
+++ b/umpleonline/scripts/codemirror6/editor.bundle.js
@@ -25218,18 +25218,34 @@ var cm6 = (function (exports) {
      update(update) {
        
        if (update.docChanged) {
-           
-           const newContent = update.state.doc.toString();
-           
-           if (newContent !== this.lastContent) {
-           const currentPositionofCursor = this.view.state.selection.main.head;
+            // Debug: Issue 2273: only react to user edits to avoid triggering processTyping
+            let userEdit = false;
+            if (update.transactions) {
+                userEdit = update.transactions.some(tr =>
+                (typeof Transaction !== "undefined" && tr.annotation && tr.annotation(Transaction.userEvent)) ||
 
-           this.lastContent = newContent;
+                // fallback 
+                tr.isUserEvent("input") || tr.isUserEvent("delete") || tr.isUserEvent("paste") ||
+                tr.isUserEvent("drop") || tr.isUserEvent("cut") || tr.isUserEvent("undo") ||
+                tr.isUserEvent("redo"));
+            }
 
-           debouncedProcessTyping("newEditor", false ,currentPositionofCursor); // call the debounced function
-         }
-       }
-       Action.updateLineNumberDisplay();
+            if (!userEdit) {
+                Action.updateLineNumberDisplay();
+                return;
+            }
+
+            const newContent = update.state.doc.toString();
+
+            if (newContent !== this.lastContent) {
+                const currentPositionofCursor = this.view.state.selection.main.head;
+
+                this.lastContent = newContent;
+
+                debouncedProcessTyping("newEditor", false, currentPositionofCursor);
+            }
+        }
+        Action.updateLineNumberDisplay();
      }
 
      

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -608,15 +608,21 @@ Page.initCodeMirrorEditor = function() {
       });
   }
       
-  // Sets the codemirror 6 text without any change trigger (hopefully)
-  Page.setCodeMirror6Text = function (textToSet) {
-    Page.codeMirrorEditor6.dispatch({ 
+  // Sets CodeMirror 6 text; optionally skip debounced typing processing.
+  Page.setCodeMirror6Text = function (textToSet, skipDebouncedTyping) {
+    var dispatchPayload = { 
       changes: { 
         from: 0, 
         to: Page.codeMirrorEditor6.state.doc.length, 
         insert: textToSet
         }
-    } )
+    };
+    if (skipDebouncedTyping
+      && cm6.skipDebouncedTypingAnnotation
+      && typeof cm6.skipDebouncedTypingAnnotation.of === "function") {
+      dispatchPayload.annotations = cm6.skipDebouncedTypingAnnotation.of(true);
+    }
+    Page.codeMirrorEditor6.dispatch(dispatchPayload);
   }
 
    Page.codeMirrorEditor6.dom.addEventListener('mousedown', function () {
@@ -1114,7 +1120,7 @@ Page.splitUmpleCode = function(umpleCode)
 // Called by fuunctions such as loadExampeCallback and loadFileCallback
 // Also called by updateUmpleTextCallback which is triggered by diagram edit by directUpdateCommandCallback  
 // Updates all text editors, and then can call a function called reason
-Page.setUmpleCode = function(umpleCode, reason)
+Page.setUmpleCode = function(umpleCode, reason, skipDebouncedTyping)
 {
   // DEBUG
   // console.log("Inside Page.setUmpleCode() ...")
@@ -1128,13 +1134,13 @@ Page.setUmpleCode = function(umpleCode, reason)
     // issue#1409  Do not Set the umple code if codeChange is false(i.e. reason is false)
     if (!((typeof reason === 'boolean') && reason == false))
     {
-      Page.setCodeMirror6Text(modelAndPositioning[0]);
+      Page.setCodeMirror6Text(modelAndPositioning[0], skipDebouncedTyping);
     }
   }
   // Refactoring definitive text location
   // Update Codemirror 6 and the backup variable
   // console.log("Setting modelCode to codeMirror 6 ...")
-  Action.updateCurrentUmpleTextBeingEdited(modelAndPositioning[0]);
+  Action.updateCurrentUmpleTextBeingEdited(modelAndPositioning[0], skipDebouncedTyping);
 
   if (typeof reason === 'function'){
     reason();


### PR DESCRIPTION
Edit: Fixes #2273 and Fixes #2336
When loading examples, codemirror performs doc updates that were treated like user typing. This triggered debouncedProcessTyping causing Action.processTyping to run redundantly and resulting in a double redraw.
I have put a gate on the debouncedProcessTyping call so it only runs for real user edit transactions. 

Files changed: 
scripts/codemirror6/editor.mjs 
scripts/codemirror6/editor.bundle.js