### PR TITLE
Fixes #2350 remove stale states check for generated code

### DIFF
--- a/umpleonline/scripts/codemirror6/editor.bundle.js
+++ b/umpleonline/scripts/codemirror6/editor.bundle.js
@@ -25258,7 +25258,6 @@ var cm6 = (function (exports) {
    exports.getSyncedVersion = getSyncedVersion;
    exports.onDarkModePreferenceChange = onDarkModePreferenceChange;
    exports.prefersDarkMode = prefersDarkMode;
-   exports.programmaticChangeAnnotation = skipDebouncedTypingAnnotation;
    exports.receiveUpdates = receiveUpdates;
    exports.sendableUpdates = sendableUpdates;
    exports.setDarkMode = setDarkMode;

--- a/umpleonline/scripts/codemirror6/editor.mjs
+++ b/umpleonline/scripts/codemirror6/editor.mjs
@@ -271,6 +271,5 @@ export { createEditorState, createEditorView,
   EditorView, ViewPlugin, ViewUpdate, Text, ChangeSet, StateEffect,
   receiveUpdates, sendableUpdates, collab, getSyncedVersion, Compartment,editableCompartment,
   prefersDarkMode, onDarkModePreferenceChange, setDarkMode, setDarkModePreference,
-  skipDebouncedTypingAnnotation,
-  skipDebouncedTypingAnnotation as programmaticChangeAnnotation
+  skipDebouncedTypingAnnotation
 }

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -17,7 +17,6 @@ Action.diagramInSync = true;
 Action.freshLoad = false;
 Action.gentime = new Date().getTime();
 Action.savedCanonical = "";
-Action.generatedOutputCanonical = "";
 Action.gdprHidden = false;
 Action.update = "";
 Action.neighbors=[];
@@ -37,32 +36,6 @@ let justUpdatetoSaveLaterForTextCallback = false;
 
 Action.setjustUpdatetoSaveLaterForTextCallback = function(state){
   justUpdatetoSaveLaterForTextCallback = state;
-}
-
-Action.getCanonicalUmpleCode = function()
-{
-  return Action.trimMultipleNonPrintingAndComments(Page.getUmpleCode());
-}
-
-Action.updateGeneratedOutputCanonical = function(generatedCanonical)
-{
-  if (typeof generatedCanonical === "string")
-  {
-    Action.generatedOutputCanonical = generatedCanonical;
-  }
-  else
-  {
-    Action.generatedOutputCanonical = Action.getCanonicalUmpleCode();
-  }
-}
-
-Action.isGeneratedOutputStale = function()
-{
-  if (!Action.generatedOutputCanonical)
-  {
-    return false;
-  }
-  return Action.getCanonicalUmpleCode() !== Action.generatedOutputCanonical;
 }
 
 Action.clicked = function(event)
@@ -4098,7 +4071,6 @@ Action.generateCode = function(languageStyle, languageName)
   var generateCodeSelector = "#buttonGenerateCode";
   var actualLanguage = languageName;
   var additionalCallback;
-  var canonicalAtGenerateRequest = Action.getCanonicalUmpleCode();
   if (Page.getAdvancedMode() == 0 && (languageName === "Cpp"))
   {
     actualLanguage = "Experimental-"+languageName;
@@ -4136,9 +4108,7 @@ Action.generateCode = function(languageStyle, languageName)
 
   Action.ajax(
     function(response) {
-      Action.generateCodeCallback(
-        response, languageStyle, additionalCallback, canonicalAtGenerateRequest
-      );
+      Action.generateCodeCallback(response, languageStyle, additionalCallback);
     },
     format("language={0}&languageStyle={1}", actualLanguage, languageStyle),
     "true"
@@ -4170,11 +4140,10 @@ Action.executeCodeCallback = function(response)
   window.location.href='#codeExecutionArea';
 }
 
-Action.generateCodeCallback = function(response, language, optionalCallback, generatedCanonical)
+Action.generateCodeCallback = function(response, language, optionalCallback)
 {
   Page.showGeneratedCode(response.responseText,language);
   Page.hideExecutionArea();
-  Action.updateGeneratedOutputCanonical(generatedCanonical);
   Action.gentime = new Date().getTime();
 
   if(optionalCallback !== undefined)
@@ -5646,9 +5615,7 @@ Action.updateUmpleDiagramCallback = function(response)
     }
 
     Page.setFeedbackMessage("");
-    if (Action.isGeneratedOutputStale()) {
-      Page.hideGeneratedCode();
-    }
+    Page.hideGeneratedCode();
 
     // Enable dynamic checkboxes of mixsets and named filters
     // Find any phrases describing
@@ -7206,4 +7173,3 @@ Action.syncLiveViewSelector = function(viewCode) {
     selector.value = viewCode;
   }
 };
-


### PR DESCRIPTION
## Pull request description

After commit `3eab93f`, UmpleOnline sometimes kept showing an old compiler error at the bottom even after the next compile succeeded.

We introduced logic to avoid hiding generated output when it doesn't need to be updated.  
However, the call to `Page.hideGeneratedCode()` was also responsible for hiding the previous error output area.

So once we guarded that call with a stale-check condition, this side effect happened:

- generated output considered "not stale" -> `hideGeneratedCode()` not called
- old error message remained visible after a successful compile

## Pull request content

This PR is intentionally small and focused on issue #2350 only. It reverts the stale check logic from commit 3eab93f **only**.