### PR TITLE
Fix #2147: Make URLs in requirement descriptions clickable

### DIFF
--- a/cruise.umple/src/generators/Generator_CodePlainRequirementsDoc.ump
+++ b/cruise.umple/src/generators/Generator_CodePlainRequirementsDoc.ump
@@ -19,6 +19,7 @@ class PlainRequirementsDocGenerator
   depend cruise.umple.util.*;
   depend cruise.umple.compiler.exceptions.*;
   depend cruise.umple.parser.Token;
+	depend java.util.regex.*;
   
   
   UmpleModel model = null;
@@ -52,8 +53,9 @@ class PlainRequirementsDocGenerator
     for (Requirement req : ReqTreeSet){
     	if (req.hasReqImplementations() || !hasreqHideNotImpl) {
     	  // Below string stores the requirement statement and language and translates to html
-    	  String mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());
-    	  doc.createParagraphElement("<b>"+"" + req.getIdentifier() + ": " + mainReqText+"</b>", false);
+				String mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());
+				mainReqText = linkifyHttpUrls(mainReqText);
+				doc.createParagraphElement("<b>" + req.getIdentifier() + ": " + mainReqText + "</b>", false);
     	  // Check if the requirement is implemented
           if(req.hasReqImplementations()) {
             // Append the text with this prompt
@@ -347,7 +349,27 @@ class PlainRequirementsDocGenerator
     writeModel();
     return;
   }
-  
+	String linkifyHttpUrls(String htmlish){
+		if (htmlish == null || htmlish.length() == 0) { return ""; }
+
+		// Match either normal "https://" OR entity-encoded "https:&#47;&#47;"
+		Pattern p = Pattern.compile("\\b(https?:\\/\\/[^\\s<>\"]+|https?:&#47;&#47;[^\\s<>\"]+)");
+		Matcher m = p.matcher(htmlish);
+
+		StringBuffer out = new StringBuffer();
+		while (m.find()){
+			String shown = m.group(1);
+
+			// Build a real href by decoding the encoded slashes (minimum needed for GitHub URLs)
+			String href = shown.replace("&#47;", "/").replace("\"","%22");
+
+			String a = "<a href=\"" + href + "\" target=\"_blank\" rel=\"noopener noreferrer\">" + shown + "</a>";
+			m.appendReplacement(out, Matcher.quoteReplacement(a));
+		}
+		m.appendTail(out);
+		return out.toString();
+	}
+
   void writeModel(){
     try {
       String path = model.getUmpleFile().getPath();

--- a/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
+++ b/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
@@ -143,6 +143,44 @@ const RequirementsDialog = {
     return container;
   },
 
+  renderTextWithLinks(container, text) {
+    // Clear safely
+    container.textContent = "";
+
+    if (!text) return;
+
+    // Basic http/https URL matcher
+    const urlRegex = /(https?:\/\/[^\s<>"')\]]+)/g;
+
+    let lastIndex = 0;
+    let match;
+
+    while ((match = urlRegex.exec(text)) !== null) {
+      const url = match[0];
+      const start = match.index;
+
+      // Text before the URL
+      if (start > lastIndex) {
+        container.appendChild(document.createTextNode(text.slice(lastIndex, start)));
+      }
+
+      // The URL as a link
+      const a = document.createElement("a");
+      a.href = url;
+      a.textContent = url;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      container.appendChild(a);
+
+      lastIndex = start + url.length;
+    }
+
+    // Remaining text
+    if (lastIndex < text.length) {
+      container.appendChild(document.createTextNode(text.slice(lastIndex)));
+    }
+  },
+
   updateSelectedDisplay(dialog, requirements) {
     const displayDiv = dialog.querySelector("#selectedReqText");
     if (!displayDiv) return;
@@ -150,10 +188,11 @@ const RequirementsDialog = {
     const selectedIds = Array.from(checkboxes).map(cb => cb.value);
 
     if (selectedIds.length === 0) {
-      displayDiv.textContent = "No requirements selected";
+      this.renderTextWithLinks(displayDiv, "No requirements selected");
     } else {
       const selectedReqs = requirements.filter(r => selectedIds.includes(r.id));
-      displayDiv.textContent = selectedReqs.map(r => `${r.id}: ${r.text}`).join("\n\n");
+      const content = selectedReqs.map(r => `${r.id}: ${r.text}`).join("\n\n");
+      this.renderTextWithLinks(displayDiv, content);
     }
   },
 
@@ -315,7 +354,7 @@ const RequirementsDialog = {
 
         if (mode === "all") {
           multipleDiv.style.display = "none";
-          displayDiv.textContent = `All requirements (${requirements.length})`;
+          this.renderTextWithLinks(displayDiv, `All requirements (${requirements.length})`);
         } else if (mode === "multiple") {
           multipleDiv.style.display = "block";
           this.updateSelectedDisplay(dialog, requirements);

--- a/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
+++ b/umpleonline/scripts/ai/features/requirements/umple_ai_requirements_dialog.js
@@ -58,7 +58,7 @@ const RequirementsDialog = {
 
     const textDiv = document.createElement("div");
     textDiv.className = "requirement-text";
-    textDiv.textContent = requirement.text;
+    this.renderTextWithLinks(textDiv, requirement.text);
     display.appendChild(textDiv);
 
     container.appendChild(display);
@@ -118,7 +118,14 @@ const RequirementsDialog = {
       strong.textContent = req.id;
       span.appendChild(strong);
       const summaryText = req.text.substring(0, 100) + (req.text.length > 100 ? "..." : "");
-      span.appendChild(document.createTextNode(`: ${summaryText}`));
+      const linkifiedNode = document.createElement("span");
+      span.appendChild(linkifiedNode);
+      if(req.text.length <= 100) {
+        this.renderTextWithLinks(linkifiedNode,`: ${summaryText}`);
+      }
+      else {
+        linkifiedNode.appendChild(document.createTextNode(`: ${summaryText}`));
+      }
       label.appendChild(span);
 
       multipleDiv.appendChild(label);


### PR DESCRIPTION
Fixes #2147

URLs inside requirement descriptions are now clickable in:

1) **UmpleOnline** (“Selected Requirements” panel)  
2) **PlainRequirementsDoc** generator output (generated HTML)

---

## Implementation

### UmpleOnline
- Added `renderTextWithLinks(container, text)`
- Wraps `http://` and `https://` URLs in `<a>` tags
- Uses `target="_blank"` and `rel="noopener noreferrer"`

### PlainRequirementsDoc
- Linkifies URLs inside `req { ... }` statements
- Ensures generated HTML output contains clickable links

---

## Manual Testing

### UmpleOnline
- Select specific requirements → links clickable
- Multiple selections → links render correctly
- Deselect → display updates properly
- Close/reopen dialog → no regression

### PlainRequirementsDoc
- Generated HTML contains clickable links for URLs in requirement descriptions