### PR TITLE
Fix null env error in fbumple.csh

### DIFF
--- a/dev-tools/fbumple
+++ b/dev-tools/fbumple
@@ -3,10 +3,11 @@ if ! $?UMPLEROOT then
   setenv UMPLEROOT ~/umple
 endif
 cd $UMPLEROOT/build
-if ($OSTYPE == 'cygwin' || $OSTYPE == 'msys' | $OSTYPE == 'win32') then
-  set buildenv="wlocal"
-else
-  set buildenv="local"
+set buildenv="local"
+if ( $?OSTYPE ) then
+  if ($OSTYPE == 'cygwin' || $OSTYPE == 'msys' | $OSTYPE == 'win32') then
+    set buildenv="wlocal"
+  endif
 endif
 echo Doing FIRST build of Umple at $UMPLEROOT using ant -Dmyenv=$buildenv
 echo This resets dependencies and is needed only after installing a fresh repo or


### PR DESCRIPTION
The `fbumple` determines the `buildenv` by checking env `OSTYPE`. This env is not available in some systems like ubuntu. This will cause the script fail.

The `bumple` has a null check and default fallback. This is why it can run succeed.

The PR contains the fix similar to the solution `bumple` uses to check if the env is null upfront and use default value.