### PR TITLE
Fix Live View synchronization with Diagram toggle, add Live View tooltip, and correct ERD toggle highlighting

### DIFF
--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -311,12 +311,16 @@ Action.clicked = function(event)
     Layout.showHideTextEditor();
     Page.showText = !Page.showText;
     Page.setShowHideIconState('SHT_button');
+    // After toggling Text (T) - doesn't change visibility rule, but keeps things consistent
+    if (typeof Action.updateLiveViewVisibility === 'function') { Action.updateLiveViewVisibility(); }
   }
   else if (action == "ShowHideCanvas")
   {
     Layout.showHideCanvas();
     Page.showCanvas = !Page.showCanvas;
     Page.setShowHideIconState('SHD_button');
+    // After toggling Diagram (D)
+    if (typeof Action.updateLiveViewVisibility === 'function') { Action.updateLiveViewVisibility(); }
   }
   else if (action == "ShowEditableClassDiagram")
   {
@@ -1008,7 +1012,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvEntityRelationshipDiagram = true;
     changedType = true;
     jQuery("#buttonShowGvEntityRelationshipDiagram").prop('checked', 'checked');
-    Page.setDiagramTypeIconState('entityRelationshipDiagram');
+    Page.setDiagramTypeIconState('none');
     jQuery(".view_opt_class").show();
     Page.initExamples();
 
@@ -7186,8 +7190,6 @@ Action.reindent = function(lines, cursorPos)
   Page.codeMirrorEditor6.focus();
 }
 
-// TEST DEBUG
-
 Action.setLiveView = function(viewNameToSet)
 {
   //Page.catFeedbackMessage("DEBUG:"+viewNameToSet);
@@ -7207,3 +7209,52 @@ Action.syncLiveViewSelector = function(viewCode) {
   }
 };
 
+// --- Live View visibility helpers ---
+// Requirement: if Diagram (D) is off, Live View control disappears;
+// it reappears when D is on again.
+Action.setLiveViewMenuVisible = function(isVisible) {
+  try {
+    var $selector = jQuery("#liveViewSelector");
+    if ($selector.length === 0) return;
+
+    //Prefer an explicit wrapper if present.
+    var $wrapper = jQuery("#liveViewWrapper, #liveViewContainer, .liveViewContainer").filter(function() {
+      return jQuery(this).find("#liveViewSelector").length > 0;
+    }).first();
+
+    //Otherwise, use the smallest nearby container that looks like the Live View control.
+    if ($wrapper.length === 0) {
+      $wrapper = $selector.parents("span,div").filter(function() {
+        var txt = (jQuery(this).text() || "").toLowerCase();
+        return txt.indexOf("live view") !== -1 && jQuery(this).find("#liveViewSelector").length > 0;
+      }).first();
+    }
+
+    // If we found a safe wrapper, hide/show it (label + select together).
+    if ($wrapper.length > 0) {
+      $wrapper.toggle(!!isVisible);
+      return;
+    }
+
+    // Fallback: hide/show the selector + any associated label.
+    $selector.toggle(!!isVisible);
+    var $label = jQuery("label[for='liveViewSelector'], #liveViewLabel");
+    if ($label.length) $label.toggle(!!isVisible);
+  } catch (e) {
+    // Fail silently; do not break the UI if DOM differs.
+  }
+};
+
+Action.updateLiveViewVisibility = function() {
+  // Diagram visibility is tracked by Page.showCanvas in UmpleOnline.
+  // When D is toggled, Page.showCanvas flips true/false.
+  var diagramVisible = !!Page.showCanvas;
+  Action.setLiveViewMenuVisible(diagramVisible);
+};
+
+// Ensure Live View visibility is correct on initial page load.
+jQuery(function() {
+  if (typeof Action.updateLiveViewVisibility === "function") {
+    Action.updateLiveViewVisibility();
+  }
+});

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -145,14 +145,12 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
     Page.setDiagramTypeIconState('structureDiagram');
     Page.useGvFeatureDiagram = false;
   }
-  else if(diagramType.toLowerCase() == "gventityrelationshipdiagram"
-  || diagramType.toLowerCase() == "gventity"
-  || diagramType.toLowerCase() == "erd")
+  else if(diagramType.toLowerCase() == "gventityrelationshipdiagram")
   {
     Page.useGvEntityRelationshipDiagram = true;
     Page.useStructureDiagram = false;
     Page.useEditableClassDiagram = false;  
-    Page.setDiagramTypeIconState('entityRelationshipDiagram');
+    Page.setDiagramTypeIconState('none');
     Page.useGvFeatureDiagram = false;
   }
   else
@@ -665,8 +663,6 @@ Page.setDiagramTypeIconState = function(diagramType){
     document.getElementById('ECD_button').className = "button2 active";
     break;
     case 'GvClass':
-    case 'entityRelationshipDiagram': // Map ERD to the 'G' button
-    case 'GvEntity': 
     document.getElementById('GCD_button').className = "button2 active";
     break;
     case 'GvState':

--- a/umpleonline/scripts/umple_tooltips.js
+++ b/umpleonline/scripts/umple_tooltips.js
@@ -101,6 +101,9 @@ ToolTips.tooltipEntries = {
   ttShowStructureDiagram: ["li", "Display a graphically editable composite structure diagram </br><b>Shortcut: [ctrl+l]</b>"],
   ttShowGvFeatureDiagram: ["li", "Display a feature diagram rendered using GraphViz </br>"],
 
+    // Live View tooltip
+  liveViewSelector: ["Select", "Select the diagram type to display (Class Diagram, ERD, State Diagram, Feature Diagram, or Structure Diagram)</br><br>"],
+
   ECD_button: ['a', "Class diagram where the user can Edit the layout - <b>ctrl-E</b>"],
   GCD_button: ['a', "Graphviz Class diagram (the default as of 2026), automatically laid out - editable using a contextual menu (double-click or right-click to display it) when pointing to a class, association or attribute - <b>ctrl-G</b>"],
   SD_button: ['a', "State diagram - editable using a contextual menu (double-click or right-click to display it) when pointing to  a state or transition  - <b>ctrl-S</b>"],
@@ -204,6 +207,7 @@ ToolTips.initTooltips = function()
         ||id=="ttSaveNCollab"
         ||id=="collabDisconnect"
         ||id=="topBookmarkable"
+        ||id=="liveViewSelector"
     )
     {
       // Tooltips selected above should appear below (which is all in the top buttons


### PR DESCRIPTION
**Summary**
This PR improves Live View behaviour and UI consistency in UmpleOnline by ensuring proper synchronization with the diagram pane, correcting toggle highlighting, and adding tooltip support.

**Changes**

- Live View dropdown now hides when the Diagram pane (D) is disabled and reappears when enabled.

- Fixed ERD incorrectly highlighting the GraphViz Class Diagram (G) toggle.

- Added tooltip support for the Live View selector using the existing ToolTips system.

**Testing**
Verified correct behaviour when toggling Diagram pane and switching between Live View modes. No regressions observed.