### PR TITLE
Generate Random Data in CRUD, Store and Load JSON

### DIFF
--- a/build/build.umple.xml
+++ b/build/build.umple.xml
@@ -385,7 +385,8 @@
       <fileset file="${scriptPath}/umple_tooltips.js"/>
       <fileset file="${scriptPath}/umple_tab_control.js"/>
       <!-- CRUD UI -->
-      <fileset file="${scriptPath}/umple_crudui.js"/>      
+      <fileset file="${scriptPath}/crud/umple_crudui.js"/>
+      <fileset file="${scriptPath}/crud/umple_crud_json_persistence.js"/>        
       <!-- Core AI modules - must be in dependency order -->
       <fileset dir="${scriptPath}/ai/utils" includes="**/*.js"/>
       <fileset file="${scriptPath}/ai/config/umple_ai_config.js"/>

--- a/cruise.umple/src/generators/instanceDiagramGenerator/Generator_CodeInstanceDiagram.ump
+++ b/cruise.umple/src/generators/instanceDiagramGenerator/Generator_CodeInstanceDiagram.ump
@@ -105,55 +105,520 @@ class InstanceDiagramGenerator
   {
     // Update meta variables based on suboptions
     useSuboptions();
-
-    // Create class instance object
-    ClassInstanceCountSet classInstanceResult = new ClassInstanceCountSet(model);
-
-    // Initialize class counts
-    if (suboptionInitialClassCountFlag == -1) {
-      Map<Integer, Double> minimumInstanceProbabilities = new HashMap<>();
-      minimumInstanceProbabilities.put(0, 0.25);
-      minimumInstanceProbabilities.put(1, 0.50);
-      minimumInstanceProbabilities.put(2, 0.25);
-      classInstanceResult.initializeClassCountsRandom(minimumInstanceProbabilities);
-    } else {
-      classInstanceResult.initializeClassCountsConstant(suboptionInitialClassCountFlag);
-    }
     
-    // Run the instance count algorithm
-    classInstanceResult.getInstanceCounts(suboptionMaxIterations, suboptionMaxClassCount);
+    InstanceDiagramResult instanceData = ClassInstanceCountSet.computeInstanceDiagram(
+      model,
+      suboptionLinkingFlag,
+      suboptionInitialClassCountFlag,
+      suboptionMaxIterations,
+      suboptionMaxClassCount
+    );
 
+    // Special mode: when invoked from the CRUD UI with suboption
+    // "crudRandomJson", emit a compact JSON payload describing the
+    // randomly generated instances and associations instead of GraphViz.
+    if (hasSuboption("crudRandomJson")) {
+      String json = buildCrudRandomDataJson(instanceData);
+      model.setCode(json);
+      return;
+    }
+
+    // Default behaviour: render the GraphViz instance diagram
+    renderInstanceDiagram(instanceData);
+  }
+
+  // Build JSON representation of the generated instance data in the
+  // same general shape as CRUD's JSON export:
+  private String buildCrudRandomDataJson(InstanceDiagramResult data) {
+    if (data.statusCode != 0 || data.diagramIsEmpty) {
+      StringBuilder err = new StringBuilder();
+      err.append("{");
+      err.append("\"statusCode\":").append(data.statusCode).append(",");
+      err.append("\"diagramIsEmpty\":").append(data.diagramIsEmpty ? "true" : "false");
+      err.append(",\"error\":{");
+      err.append("\"message\":\"");
+      if (data.statusCode == 1) {
+        err.append("Reached maximum iterations. Ensure that the system is instantiable and non-infinite");
+      } else if (data.statusCode == 2) {
+        err.append("Reached maximum class count. Ensure that the system is instantiable and non-infinite");
+      } else if (data.statusCode == 3) {
+        err.append("Inheritance unresolvable. Ensure that abstract/interface classes with associations have concrete implementations that can be instantiated without creating an infinite loop");
+      } else if (data.statusCode == 4) {
+        err.append("Infinite loop detected. Instantiating some classes will lead to an infinite number of instances.");
+      } else if (data.diagramIsEmpty) {
+        err.append("Generated InstanceDiagram is empty. For random diagrams, consider trying again or setting the initial class counts to a constant");
+      }
+      err.append("\"");
+
+      // Include any classes with no possible inheritance
+      err.append(",\"noPossibleInheritance\":[");
+      if (data.noPossibleInheritance != null) {
+        boolean first = true;
+        for (String cname : data.noPossibleInheritance) {
+          if (!first) { err.append(","); }
+          first = false;
+          err.append("\"").append(escapeJson(cname)).append("\"");
+        }
+      }
+      err.append("]");
+
+      // Include loop scores for diagnostics
+      err.append(",\"loopScores\":{");
+      if (data.loopScores != null) {
+        boolean firstLoop = true;
+        for (Map.Entry<String, Integer> entry : data.loopScores.entrySet()) {
+          if (!firstLoop) { err.append(","); }
+          firstLoop = false;
+          err.append("\"").append(escapeJson(entry.getKey())).append("\":").append(entry.getValue());
+        }
+      }
+      err.append("}");
+
+      err.append("}}");
+      return err.toString();
+    }
+
+    // Successful, non-empty diagram: build per-instance objects with
+    // attributes and association references, then emit a top-level array
+    // of { "FQN": { ... } } wrappers.
+
+    // Determine namespace for fully-qualified names
+    String ns = model.getDefaultNamespace();
+
+    // Per-class list of instance data maps (attribute + association data)
+    Map<String, java.util.List<Map<String, Object>>> instancesByClass = new LinkedHashMap<String, java.util.List<Map<String, Object>>>();
+    // Map from className#iteration to instance data map
+    Map<String, Map<String, Object>> instanceByKey = new HashMap<String, Map<String, Object>>();
+    // Map from className#iteration to umpleObjectID (as string)
+    Map<String, String> umpleIdByKey = new HashMap<String, String>();
+
+    int nextId = 1;
+
+    // First pass: create instances for each concrete class with random
+    // attribute values, but no associations yet.
+    if (data.instanceCounts != null) {
+      for (UmpleClass uClass : model.getUmpleClasses()) {
+        if (uClass.getIsAbstract()) {
+          continue;
+        }
+        String className = uClass.getName();
+        Integer countObj = data.instanceCounts.get(className);
+        int count = (countObj != null) ? countObj.intValue() : 0;
+        if (count <= 0) {
+          continue;
+        }
+
+        java.util.List<Map<String, Object>> list = instancesByClass.get(className);
+        if (list == null) {
+          list = new ArrayList<Map<String, Object>>();
+          instancesByClass.put(className, list);
+        }
+
+        for (int iter = 1; iter <= count; iter++) {
+          Map<String, Object> instData = new LinkedHashMap<String, Object>();
+
+          // Assign a unique umpleObjectID (as string)
+          String objId = Integer.toString(nextId++);
+          instData.put("umpleObjectID", objId);
+
+          // Generate random attribute values consistent with instance
+          // diagram attribute generation.
+          Map<String, String> attrs = generateRandomAttributesForInstance(uClass, iter);
+          for (Map.Entry<String, String> e : attrs.entrySet()) {
+            instData.put(e.getKey(), e.getValue());
+          }
+
+          list.add(instData);
+          String key = className + "#" + iter;
+          instanceByKey.put(key, instData);
+          umpleIdByKey.put(key, objId);
+        }
+      }
+    }
+
+    // Second pass: map association links to per-instance association
+    // properties using umpleObjectID references.
+    Map<String, ClassInstanceCount> classInstanceCountMap = data.rawClassInstanceCounts;
+    if (data.associationLinks != null && classInstanceCountMap != null) {
+      for (AssociationLinkSet linkSet : data.associationLinks) {
+        Association assoc = linkSet.getAssociation();
+        AssociationEnd leftEnd = assoc.getEnd(0);
+        AssociationEnd rightEnd = assoc.getEnd(1);
+        String leftClass = leftEnd.getClassName();
+        String rightClass = rightEnd.getClassName();
+
+        ArrayList<String> leftInstanceList = new ArrayList<String>();
+        ArrayList<String> rightInstanceList = new ArrayList<String>();
+        PopulateInstanceList(leftClass, classInstanceCountMap, leftInstanceList);
+        PopulateInstanceList(rightClass, classInstanceCountMap, rightInstanceList);
+
+        String propFromLeft = getCrudAssocPropertyName(rightEnd);
+        String propFromRight = getCrudAssocPropertyName(leftEnd);
+        boolean leftMultiple = isCrudAssocMultiple(rightEnd);
+        boolean rightMultiple = isCrudAssocMultiple(leftEnd);
+
+        if (linkSet.links == null) {
+          continue;
+        }
+
+        for (int i = 0; i < linkSet.links.length; i++) {
+          for (int j = 0; j < linkSet.links[i].length; j++) {
+            if (!linkSet.links[i][j]) {
+              continue;
+            }
+
+            // Map matrix indices to concrete instances using the
+            // same naming convention as PopulateInstanceList.
+            if (i >= leftInstanceList.size() || j >= rightInstanceList.size()) {
+              continue;
+            }
+
+            String leftInstName = leftInstanceList.get(i);
+            String rightInstName = rightInstanceList.get(j);
+
+            String leftSimpleClass = getClassNameFromInstanceId(leftInstName);
+            int leftIter = getIndexFromInstanceId(leftInstName);
+            String rightSimpleClass = getClassNameFromInstanceId(rightInstName);
+            int rightIter = getIndexFromInstanceId(rightInstName);
+
+            if (leftIter <= 0 || rightIter <= 0) {
+              continue;
+            }
+
+            String leftKey = leftSimpleClass + "#" + leftIter;
+            String rightKey = rightSimpleClass + "#" + rightIter;
+
+            Map<String, Object> leftData = instanceByKey.get(leftKey);
+            Map<String, Object> rightData = instanceByKey.get(rightKey);
+            String rightId = umpleIdByKey.get(rightKey);
+            String leftId = umpleIdByKey.get(leftKey);
+
+            if (leftData != null && rightId != null && propFromLeft != null && propFromLeft.length() > 0) {
+              // Create wrapper { "FQN": { "umpleObjectID": "..." } }
+              Map<String, Object> inner = new LinkedHashMap<String, Object>();
+              inner.put("umpleObjectID", rightId);
+              Map<String, Object> wrapper = new LinkedHashMap<String, Object>();
+              wrapper.put(getFqn(rightSimpleClass, ns), inner);
+
+              Object existing = leftData.get(propFromLeft);
+              if (leftMultiple) {
+                java.util.List<Object> listVal;
+                if (existing instanceof java.util.List) {
+                  listVal = (java.util.List<Object>) existing;
+                } else {
+                  listVal = new ArrayList<Object>();
+                  leftData.put(propFromLeft, listVal);
+                }
+                listVal.add(wrapper);
+              } else {
+                leftData.put(propFromLeft, wrapper);
+              }
+            }
+
+            if (rightData != null && leftId != null && propFromRight != null && propFromRight.length() > 0) {
+              Map<String, Object> innerR = new LinkedHashMap<String, Object>();
+              innerR.put("umpleObjectID", leftId);
+              Map<String, Object> wrapperR = new LinkedHashMap<String, Object>();
+              wrapperR.put(getFqn(leftSimpleClass, ns), innerR);
+
+              Object existingR = rightData.get(propFromRight);
+              if (rightMultiple) {
+                java.util.List<Object> listValR;
+                if (existingR instanceof java.util.List) {
+                  listValR = (java.util.List<Object>) existingR;
+                } else {
+                  listValR = new ArrayList<Object>();
+                  rightData.put(propFromRight, listValR);
+                }
+                listValR.add(wrapperR);
+              } else {
+                rightData.put(propFromRight, wrapperR);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Final pass: emit JSON array of instance wrappers
+    StringBuilder sb = new StringBuilder();
+    sb.append("[");
+
+    boolean firstTop = true;
+    // Use model class order so that output is predictable
+    for (UmpleClass uClass : model.getUmpleClasses()) {
+      String className = uClass.getName();
+      java.util.List<Map<String, Object>> list = instancesByClass.get(className);
+      if (list == null || list.isEmpty()) {
+        continue;
+      }
+
+      String fqn = getFqn(className, ns);
+      for (Map<String, Object> instData : list) {
+        if (!firstTop) {
+          sb.append(",");
+        }
+        firstTop = false;
+        sb.append("{");
+        sb.append("\"").append(escapeJson(fqn)).append("\":");
+        appendInstanceObjectJson(sb, instData);
+        sb.append("}");
+      }
+    }
+
+    sb.append("]");
+    return sb.toString();
+  }
+
+  // Minimal JSON string escaper for keys and values we emit.
+  private String escapeJson(String input) {
+    if (input == null) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      if (c == '\\' || c == '\"') {
+        sb.append('\\').append(c);
+      } else if (c == '\n') {
+        sb.append("\\n");
+      } else if (c == '\r') {
+        sb.append("\\r");
+      } else if (c == '\t') {
+        sb.append("\\t");
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+
+  // Helper to generate random attribute values for a class instance,
+  // following the same conventions as the GraphViz instance generator
+  // (special handling for id/name as the first attribute).
+  private Map<String, String> generateRandomAttributesForInstance(UmpleClass uClass, int iteration) {
+    Map<String, String> result = new LinkedHashMap<String, String>();
+
+    java.util.List<Attribute> attrs = uClass.getAttributes();
+    if (attrs == null || attrs.size() == 0) {
+      return result;
+    }
+
+    Attribute firstAttribute = attrs.get(0);
+    String firstAttributeName = firstAttribute.getName();
+    boolean firstAttributeIsId = false;
+    String firstAttributeInstanceName = "";
+
+    if (firstAttributeName != null) {
+      String lower = firstAttributeName.toLowerCase();
+      String type = firstAttribute.getType();
+      boolean typeOk = "String".equals(type) || "Integer".equals(type);
+      if (typeOk && (lower.equals("id") || (firstAttributeName.length() > 1 &&
+          (firstAttributeName.substring(firstAttributeName.length() - 2).equals("Id") ||
+           firstAttributeName.substring(firstAttributeName.length() - 2).equals("ID"))))) {
+        firstAttributeIsId = true;
+      } else if (lower.equals("name") && "String".equals(type)) {
+        firstAttributeInstanceName = createRandomAttributeValue(firstAttribute);
+      }
+    }
+
+    boolean isFirst = true;
+    for (Attribute uAttribute : attrs) {
+      if (uAttribute.isConstant()) {
+        // Constants are ignored in the instance diagram; skip them here too.
+        continue;
+      }
+      String value;
+      if (isFirst && firstAttributeIsId) {
+        value = Integer.toString(iteration);
+      } else if (isFirst && firstAttributeInstanceName.length() != 0) {
+        value = firstAttributeInstanceName;
+      } else {
+        value = createRandomAttributeValue(uAttribute);
+      }
+      result.put(uAttribute.getName(), value);
+      isFirst = false;
+    }
+
+    return result;
+  }
+
+  // Derive a CRUD-style property name for an association end, matching
+  // the client-side getAssocPropertyName helper.
+  private String getCrudAssocPropertyName(AssociationEnd end) {
+    if (end == null) {
+      return "";
+    }
+    String roleName = end.getDisplayRoleName();
+    if (roleName != null && !roleName.equals("")) {
+      return roleName;
+    }
+    String base = end.getClassName();
+    if (base == null || base.equals("")) {
+      return "";
+    }
+    // decapitalize first letter
+    if (base.length() > 0) {
+      base = base.substring(0, 1).toLowerCase() + base.substring(1);
+    }
+    boolean multiple = isCrudAssocMultiple(end);
+    if (multiple && !base.endsWith("s")) {
+      base = base + "s";
+    }
+    return base;
+  }
+
+  private boolean isCrudAssocMultiple(AssociationEnd end) {
+    if (end == null || end.getMultiplicity() == null) {
+      return true;
+    }
+    int upper = end.getMultiplicity().getUpperBound();
+    // 0..1 or 1 (or any <=1 finite) is single-valued; * (-1) is treated as multiple
+    if (upper != -1 && upper <= 1) {
+      return false;
+    }
+    return true;
+  }
+
+  // Build a fully-qualified name using the model's default namespace
+  // (if any) and a simple class name.
+  private String getFqn(String className, String namespace) {
+    if (className == null) {
+      return "";
+    }
+    if (namespace != null && namespace.length() > 0) {
+      return namespace + "." + className;
+    }
+    return className;
+  }
+
+  // Given an instance identifier like "Employee3" or "OrderItem12",
+  // return the simple class name portion.
+  private String getClassNameFromInstanceId(String instanceId) {
+    if (instanceId == null || instanceId.length() == 0) {
+      return "";
+    }
+    int idx = instanceId.length() - 1;
+    while (idx >= 0 && Character.isDigit(instanceId.charAt(idx))) {
+      idx--;
+    }
+    if (idx < 0) {
+      return instanceId;
+    }
+    return instanceId.substring(0, idx + 1);
+  }
+
+  // Given an instance identifier like "Employee3", return the
+  // 1-based index portion (e.g., 3). Returns -1 if none.
+  private int getIndexFromInstanceId(String instanceId) {
+    if (instanceId == null || instanceId.length() == 0) {
+      return -1;
+    }
+    int idx = instanceId.length() - 1;
+    while (idx >= 0 && Character.isDigit(instanceId.charAt(idx))) {
+      idx--;
+    }
+    if (idx == instanceId.length() - 1) {
+      return -1;
+    }
+    String num = instanceId.substring(idx + 1);
+    try {
+      return Integer.parseInt(num);
+    } catch (Exception e) {
+      return -1;
+    }
+  }
+
+  // Append a JSON object representing one instance's data.
+  private void appendInstanceObjectJson(StringBuilder sb, Map<String, Object> data) {
+    sb.append("{");
+    boolean first = true;
+    for (Map.Entry<String, Object> entry : data.entrySet()) {
+      if (!first) {
+        sb.append(",");
+      }
+      first = false;
+      sb.append("\"").append(escapeJson(entry.getKey())).append("\":");
+      appendJsonValue(sb, entry.getValue());
+    }
+    sb.append("}");
+  }
+
+  // Append a JSON value that may be a primitive, string, object or array.
+  private void appendJsonValue(StringBuilder sb, Object value) {
+    if (value == null) {
+      sb.append("null");
+    } else if (value instanceof String) {
+      sb.append("\"").append(escapeJson((String)value)).append("\"");
+    } else if (value instanceof Number || value instanceof Boolean) {
+      sb.append(value.toString());
+    } else if (value instanceof java.util.List) {
+      java.util.List list = (java.util.List)value;
+      sb.append("[");
+      boolean first = true;
+      for (Object elem : list) {
+        if (!first) {
+          sb.append(",");
+        }
+        first = false;
+        appendJsonValue(sb, elem);
+      }
+      sb.append("]");
+    } else if (value instanceof Map) {
+      Map map = (Map)value;
+      sb.append("{");
+      boolean first = true;
+      java.util.Iterator it = map.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry entry = (Map.Entry)it.next();
+        if (!first) {
+          sb.append(",");
+        }
+        first = false;
+        String key = entry.getKey().toString();
+        sb.append("\"").append(escapeJson(key)).append("\":");
+        appendJsonValue(sb, entry.getValue());
+      }
+      sb.append("}");
+    } else {
+      // Fallback: quote string representation
+      sb.append("\"").append(escapeJson(value.toString())).append("\"");
+    }
+  }
+
+  // Render a GraphViz instance diagram from pre-computed instance data
+  private void renderInstanceDiagram(InstanceDiagramResult instanceData) {
     StringBuilder code = new StringBuilder();           // part of the gv file with the node/classes
     StringBuilder associations = new StringBuilder();   // part of the gv file with all the associations
 
     // Output basic gv file header
     _graphStart(0,code);
 
-    if (classInstanceResult.statusCode != 0 || classInstanceResult.diagramIsEmpty()) {
+    if (instanceData.statusCode != 0 || instanceData.diagramIsEmpty) {
       // Error code outputs
 
       outputCode += "message [label =\"";
-      if (classInstanceResult.statusCode == 1) {
+      if (instanceData.statusCode == 1) {
         outputCode += "Reached maximum iterations. Ensure that the system is instantiable and non-infinite";
 
-      } else if (classInstanceResult.statusCode == 2) {
+      } else if (instanceData.statusCode == 2) {
         outputCode += "Reached maximum class count. Ensure that the system is instantiable and non-infinite";
 
-      } else if (classInstanceResult.statusCode == 3) {
+      } else if (instanceData.statusCode == 3) {
         outputCode += "Inheritance unresolvable. ";
         outputCode += "Ensure that abstract/interface classes with associations have concrete implementations that can be instantiated without creating an infinite loop";
         outputCode += "\n The following classes have no valid inheritors and could be the source of this error:";
-        for (String classname : classInstanceResult.getNoPossibleInheritance()) {
+        for (String classname : instanceData.noPossibleInheritance) {
           outputCode += "\n" + classname;
         }
         
-      } else if (classInstanceResult.statusCode == 4) {
+      } else if (instanceData.statusCode == 4) {
         outputCode += "Infinite loop detected. Instantiating the following classes will lead to an infinite number of instances: ";
-        for (String classname : classInstanceResult.loopScores.keySet()) {
+        for (String classname : instanceData.loopScores.keySet()) {
           outputCode += "\n" + classname;
         }
 
-      } else if (classInstanceResult.diagramIsEmpty()) {
+      } else if (instanceData.diagramIsEmpty) {
         outputCode += "Generated InstanceDiagram is empty. For random diagrams, consider trying again or setting the initial class counts to a constant";
       
       } 
@@ -166,9 +631,9 @@ class InstanceDiagramGenerator
 
 
     // Get class count result
-    Map<String, Integer> minInstance = classInstanceResult.getInstanceCountMap();
+    Map<String, Integer> minInstance = instanceData.instanceCounts;
     // Get associations from the class count
-    ArrayList<AssociationLinkSet> actualLinks = classInstanceResult.distributeAssociations(suboptionLinkingFlag);
+    ArrayList<AssociationLinkSet> actualLinks = instanceData.associationLinks;
 
 
     //gets the desired separator value. Graphviz default is 0.5 but for Umple we use 1.0 for 'normal'
@@ -192,7 +657,7 @@ class InstanceDiagramGenerator
       }
     }
 
-    Map<String, ClassInstanceCount> classInstanceCountMap = classInstanceResult.instances;
+    Map<String, ClassInstanceCount> classInstanceCountMap = instanceData.rawClassInstanceCounts;
 
     for (int k = 0; k < actualLinks.size(); k++) {
       AssociationLinkSet assocLinkSet = actualLinks.get(k);
@@ -500,6 +965,29 @@ public String randomStringGen(){
 }
 
 /*
+ Data class to hold the computed instance diagram information so it can be reused
+ without generating GraphViz output.
+*/
+class InstanceDiagramResult {
+  depend java.util.*;
+
+  // Status of the computation (mirrors ClassInstanceCountSet.statusCode)
+  public int statusCode;
+  // True if there are no concrete instances in the diagram
+  public boolean diagramIsEmpty;
+  // Map from class name to number of concrete instances
+  public Map<String, Integer> instanceCounts;
+  // Loop scores for each class (used for diagnostics and infinite-loop reporting)
+  public Map<String, Integer> loopScores;
+  // Classes with no possible concrete inheritors (used for inheritance error reporting)
+  public Set<String> noPossibleInheritance;
+  // Association links between instances for each association
+  public ArrayList<AssociationLinkSet> associationLinks;
+  // Full underlying instance data (required/true counts, inheritance trees, etc.)
+  public Map<String, ClassInstanceCount> rawClassInstanceCounts;
+}
+
+/*
  Data class to hold the number of class instances
 */
 class ClassInstanceCount {
@@ -547,6 +1035,58 @@ class ClassInstanceCountSet {
 
   // Map of any potential infinite loops in the model
   public Map<String, Integer> loopScores;
+
+
+  public static InstanceDiagramResult computeInstanceDiagram(
+    UmpleModel model,
+    int linkingFlag,
+    int initialClassCountFlag,
+    int maxIterations,
+    int maxClassCount
+  ) {
+    // Create class instance object
+    ClassInstanceCountSet classInstanceResult = new ClassInstanceCountSet(model);
+
+    // Initialize class counts (random or constant)
+    if (initialClassCountFlag == -1) {
+      Map<Integer, Double> minimumInstanceProbabilities = new HashMap<Integer, Double>();
+      minimumInstanceProbabilities.put(0, 0.25);
+      minimumInstanceProbabilities.put(1, 0.50);
+      minimumInstanceProbabilities.put(2, 0.25);
+      classInstanceResult.initializeClassCountsRandom(minimumInstanceProbabilities);
+    } else {
+      classInstanceResult.initializeClassCountsConstant(initialClassCountFlag);
+    }
+
+    // Run the instance count algorithm
+    classInstanceResult.getInstanceCounts(maxIterations, maxClassCount);
+
+    // Build result object
+    InstanceDiagramResult result = new InstanceDiagramResult();
+    result.statusCode = classInstanceResult.statusCode;
+    result.diagramIsEmpty = classInstanceResult.diagramIsEmpty();
+
+    // Always compute loop scores and inheritance diagnostics for error reporting
+    if (classInstanceResult.loopScores == null) {
+      classInstanceResult.loopScores = classInstanceResult.getClassLoopScores();
+    }
+    result.loopScores = classInstanceResult.loopScores;
+    result.noPossibleInheritance = classInstanceResult.getNoPossibleInheritance();
+
+    // Only compute instance counts and association links when the system is valid
+    if (result.statusCode == 0 && !result.diagramIsEmpty) {
+      result.instanceCounts = classInstanceResult.getInstanceCountMap();
+      result.associationLinks = classInstanceResult.distributeAssociations(linkingFlag);
+    } else {
+      result.instanceCounts = new HashMap<String, Integer>();
+      result.associationLinks = new ArrayList<AssociationLinkSet>();
+    }
+
+    // Expose the raw instance objects for callers that need full detail
+    result.rawClassInstanceCounts = classInstanceResult.instances;
+
+    return result;
+  }
 
   // Get the number of instances for each class, interface, etc...
   public Map<String, Integer> getInstanceCountMap() {

--- a/cruise.umple/src/generators/instanceDiagramGenerator/Generator_CodeInstanceDiagram.ump
+++ b/cruise.umple/src/generators/instanceDiagramGenerator/Generator_CodeInstanceDiagram.ump
@@ -1064,7 +1064,14 @@ class ClassInstanceCountSet {
     // Build result object
     InstanceDiagramResult result = new InstanceDiagramResult();
     result.statusCode = classInstanceResult.statusCode;
-    result.diagramIsEmpty = classInstanceResult.diagramIsEmpty();
+    // Only probe diagram emptiness when the computation succeeded.
+    // For error states, some trueInstances values may be null, so
+    // calling diagramIsEmpty() would throw a NullPointerException.
+    if (result.statusCode == 0) {
+      result.diagramIsEmpty = classInstanceResult.diagramIsEmpty();
+    } else {
+      result.diagramIsEmpty = false;
+    }
 
     // Always compute loop scores and inheritance diagnostics for error reporting
     if (classInstanceResult.loopScores == null) {

--- a/umpleonline/scripts/_load.js
+++ b/umpleonline/scripts/_load.js
@@ -149,7 +149,8 @@ document.write('<script type="text/javascript" src="scripts/umple_action_diagram
 document.write('<script type="text/javascript" src="scripts/umple_tooltips.js"></script>');
 document.write('<script type="text/javascript" src="scripts/umple_tab_control.js"></script>');
 //CRUD UI
-document.write('<script type="text/javascript" src="scripts/umple_crudui.js"></script>');
+document.write('<script type="text/javascript" src="scripts/crud/umple_crudui.js"></script>');
+document.write('<script type="text/javascript" src="scripts/crud/umple_crud_json_persistence.js"></script>');
 // The following script includes configuration file for collab_server
 // where serverURL and path have to be set to connect specific instance of a collaboration server
 document.write('<script type="text/javascript" src="scripts/collab-server-config.js"></script>')

--- a/umpleonline/scripts/allumple-minifyscript
+++ b/umpleonline/scripts/allumple-minifyscript
@@ -29,7 +29,8 @@ cat \
  umple_action_diagram.js \
  umple_tooltips.js \
  umple_tab_control.js \
- umple_crudui.js \
+ crud/umple_crudui.js \
+ crud/umple_crud_json_persistence.js \
  ai/utils/umple_ai_constants.js \
  ai/utils/umple_ai_provider_utils.js \
  ai/utils/umple_ai_prompt_utils.js \

--- a/umpleonline/scripts/crud/umple_crud_json_persistence.js
+++ b/umpleonline/scripts/crud/umple_crud_json_persistence.js
@@ -1,0 +1,491 @@
+// JSON persistence helper for CRUD UI instances and associations
+
+(function(global, jQuery) {
+  "use strict";
+
+  var Page = global.Page = global.Page || {};
+
+  // Internal storage for generated IDs so associations can refer to objects
+  Page._crudJsonIds = Page._crudJsonIds || {};
+  Page._crudJsonIdCounter = Page._crudJsonIdCounter || 1;
+
+  function getNamespaceFromModel() {
+    if (typeof Page.getUmpleCode !== "function") {
+      return "";
+    }
+    try {
+      var code = Page.getUmpleCode() || "";
+      var match = code.match(/\bnamespace\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/);
+      return match ? match[1] : "";
+    } catch (e) {
+      return "";
+    }
+  }
+
+  function getQualifiedClassName(className, ns) {
+    if (!className) { return className; }
+    ns = (typeof ns === "string") ? ns : getNamespaceFromModel();
+    return ns ? (ns + "." + className) : className;
+  }
+
+  function ensureUmpleId(className, index) {
+    var key = className + "#" + index;
+    if (!Page._crudJsonIds[key]) {
+      Page._crudJsonIds[key] = String(Page._crudJsonIdCounter++);
+    }
+    return Page._crudJsonIds[key];
+  }
+
+  function getAssocPropertyName(end) {
+    if (end && end.roleName) {
+      return end.roleName;
+    }
+    var base = (end && end.toClass) ? String(end.toClass) : "";
+    if (!base) { return ""; }
+    var prop = base.charAt(0).toLowerCase() + base.slice(1);
+    var multiple = true;
+    if (typeof end.toMax === "number" && end.toMax <= 1) {
+      multiple = false;
+    }
+    if (multiple) {
+      // Very simple pluralization: append "s" if not already ending in s
+      if (prop.charAt(prop.length - 1) !== "s") {
+        prop += "s";
+      }
+    }
+    return prop;
+  }
+
+  function makeAssociationRef(namespace, targetClass, targetIndex) {
+    if (targetIndex === null || typeof targetIndex === "undefined") {
+      return null;
+    }
+    var fqn = getQualifiedClassName(targetClass, namespace);
+    var id = ensureUmpleId(targetClass, targetIndex);
+    var inner = { umpleObjectID: id };
+    var wrapper = {};
+    wrapper[fqn] = inner;
+    return wrapper;
+  }
+
+  // Recursively build a nested object (including composed children) for a
+  // single instance. 
+  function buildNestedInstance(ns, className, index, visited) {
+    if (!Page.crudData || !Page.crudData.classes || !Page.crudData.classes[className]) {
+      return null;
+    }
+
+    var info = Page.crudData.classes[className] || {};
+    var attrs = info.attributes || [];
+    var instances = info.instances || [];
+    if (index < 0 || index >= instances.length) {
+      return null;
+    }
+
+    visited = visited || {};
+    var visitKey = className + "#" + index;
+    if (visited[visitKey]) {
+      // Cycle guard: fall back to an ID-only reference.
+      return makeAssociationRef(ns, className, index);
+    }
+
+    // If this instance was already fully expanded earlier in this export
+    // run (for another root tree), emit only an ID-based reference to avoid
+    // repeating the same nested object multiple times in the final JSON.
+    if (Page._crudJsonExported && Page._crudJsonExported[visitKey]) {
+      return makeAssociationRef(ns, className, index);
+    }
+
+    visited[visitKey] = true;
+
+    var inst = instances[index] || {};
+    var data = {};
+    data.umpleObjectID = ensureUmpleId(className, index);
+
+    // Copy attribute values
+    attrs.forEach(function(attr) {
+      var name = attr && attr.name;
+      if (!name) { return; }
+      if (Object.prototype.hasOwnProperty.call(inst, name)) {
+        data[name] = inst[name];
+      }
+    });
+
+    var assocEnds = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+
+    assocEnds.forEach(function(end) {
+      if (!end || end.fromClass !== className) { return; }
+      var fieldName = end.storageKey;
+      if (!fieldName) { return; }
+
+      var propName = getAssocPropertyName(end);
+      if (!propName) { return; }
+
+      var val = inst[fieldName];
+      var multiple = true;
+      if (typeof end.toMax === "number" && end.toMax <= 1) {
+        multiple = false;
+      }
+
+      if (multiple) {
+        var arr = [];
+        if (Array.isArray(val)) {
+          val.forEach(function(targetIdx) {
+            if (typeof targetIdx !== "number") {
+              targetIdx = parseInt(targetIdx, 10);
+            }
+            if (isNaN(targetIdx) || targetIdx < 0) { return; }
+            // Always expand forward links; the cycle guard above will turn
+            // back-references into ID-only stubs.
+            var child = buildNestedInstance(ns, end.toClass, targetIdx, visited);
+            if (child) {
+              arr.push(child);
+            }
+          });
+        }
+        data[propName] = arr;
+      } else {
+        if (val === undefined || val === null || val === "") {
+          // Single-valued ends are omitted when there is no link.
+          return;
+        }
+        var idxSingle = val;
+        if (typeof idxSingle !== "number") {
+          idxSingle = parseInt(idxSingle, 10);
+        }
+        if (isNaN(idxSingle) || idxSingle < 0) { return; }
+        var linked = buildNestedInstance(ns, end.toClass, idxSingle, visited);
+        if (linked) {
+          data[propName] = linked;
+        }
+      }
+    });
+
+    var fqn = getQualifiedClassName(className, ns);
+    var wrapper = {};
+    wrapper[fqn] = data;
+
+    // Mark this instance as fully exported so subsequent references from
+    // other roots can collapse to ID-only stubs.
+    if (!Page._crudJsonExported) {
+      Page._crudJsonExported = {};
+    }
+    Page._crudJsonExported[visitKey] = true;
+
+    return wrapper;
+  }
+
+  Page.crudJsonBuildExport = function() {
+    if (!Page.crudData || !Page.crudData.classes) {
+      return {};
+    }
+
+    var ns = getNamespaceFromModel();
+
+    // Reset per-export tracking of which instances have been fully
+    // materialized in the JSON so we can collapse repeats to ID-only stubs.
+    Page._crudJsonExported = {};
+
+    var objects = [];
+
+    var composedClasses = {};
+    if (Page.crudAssociationsByClass) {
+      Object.keys(Page.crudAssociationsByClass).forEach(function(srcClass) {
+        var ends = Page.crudAssociationsByClass[srcClass] || [];
+        ends.forEach(function(end) {
+          if (end && end.cascadeDeleteTargets && end.toClass) {
+            composedClasses[end.toClass] = true;
+          }
+        });
+      });
+    }
+
+    // Collect candidate root classes: non-composed classes that actually
+    // have instances. These are the only reasonable roots.
+    var rootCandidates = [];
+    Object.keys(Page.crudData.classes).forEach(function(className) {
+      if (composedClasses[className]) {
+        return;
+      }
+      var info = Page.crudData.classes[className] || {};
+      var instances = info.instances || [];
+      if (!instances.length) { return; }
+      rootCandidates.push(className);
+    });
+
+    // Prefer classes that are marked as main (have a main() method in the
+    // Umple model) as roots. If none exist, fall back to all candidates.
+    var mainRoots = [];
+    rootCandidates.forEach(function(className) {
+      var info = Page.crudData.classes[className] || {};
+      if (info.isMain) {
+        mainRoots.push(className);
+      }
+    });
+    var rootClasses = mainRoots.length ? mainRoots : rootCandidates;
+
+    rootClasses.forEach(function(className) {
+      var info = Page.crudData.classes[className] || {};
+      var instances = info.instances || [];
+      instances.forEach(function(_, idx) {
+        // Ensure IDs are stable
+        ensureUmpleId(className, idx);
+        var nested = buildNestedInstance(ns, className, idx, {});
+        if (nested) {
+          objects.push(nested);
+        }
+      });
+    });
+
+    if (objects.length === 1) {
+      return objects[0];
+    }
+
+    // Otherwise, fall back to an array of roots.
+    return objects;
+  };
+
+  // Trigger a JSON download of the current CRUD state
+  Page.crudJsonDownload = function() {
+    var payload = Page.crudJsonBuildExport();
+    var jsonText = JSON.stringify(payload, null, 2);
+
+    try {
+      var blob = new Blob([jsonText], { type: "application/json" });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement("a");
+      a.href = url;
+      a.download = "umple-crud-data.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      // Fallback: open in a new window/tab
+      var w = window.open("", "_blank");
+      if (w) {
+        w.document.write("<pre>" + jsonText.replace(/</g, "&lt;") + "</pre>");
+      }
+    }
+  };
+
+  // Import a previously exported JSON payload and rebuild CRUD instances
+  Page.crudJsonImport = function(payload) {
+    if (!payload) { return; }
+    var objects = [];
+
+    if (Array.isArray(payload)) {
+      objects = payload;
+    } else if (Array.isArray(payload.objects)) {
+      objects = payload.objects;
+    } else {
+      // Single object case: wrap it
+      objects = [payload];
+    }
+
+    if (!Page.crudData || !Page.crudData.classes) {
+      return;
+    }
+
+    var idMap = {}; // key: fqn#id -> { className, index, data }
+    var instancesByClass = {};
+
+    // Helper to recursively walk a wrapper (and its nested association
+    // wrappers) so that composed children and other linked objects are also
+    // allocated, not just the top-level roots.
+    function collectEntitiesFromWrapper(wrapper) {
+      if (!wrapper || typeof wrapper !== "object") { return; }
+      var keys = Object.keys(wrapper);
+      if (!keys.length) { return; }
+      var fqn = keys[0];
+      var data = wrapper[fqn] || {};
+      if (!data || typeof data !== "object") { return; }
+      var id = data.umpleObjectID;
+      if (!id) { return; }
+
+      var parts = fqn.split(".");
+      var className = parts[parts.length - 1];
+      if (!className || !Page.crudData.classes[className]) {
+        return; // Unknown class in this model
+      }
+
+      var mapKey = fqn + "#" + id;
+      var entry = idMap[mapKey];
+      if (!entry) {
+        if (!instancesByClass[className]) {
+          instancesByClass[className] = [];
+        }
+        var index = instancesByClass[className].length;
+        instancesByClass[className].push({});
+        entry = {
+          className: className,
+          index: index,
+          data: data
+        };
+        idMap[mapKey] = entry;
+      } else {
+        // Prefer the richest copy of the data we see (a fully expanded
+        // object rather than an ID-only stub), based on number of keys.
+        var existingData = entry.data || {};
+        if (Object.keys(data).length > Object.keys(existingData).length) {
+          entry.data = data;
+        }
+      }
+
+      // Recurse into association-valued properties so that children and
+      // other linked objects are discovered.
+      var assocEnds = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+      assocEnds.forEach(function(end) {
+        if (!end || end.fromClass !== className) { return; }
+        var propName = getAssocPropertyName(end);
+        if (!propName) { return; }
+        var rawVal = data[propName];
+        if (rawVal === undefined || rawVal === null || rawVal === "") {
+          return;
+        }
+
+        var multiple = true;
+        if (typeof end.toMax === "number" && end.toMax <= 1) {
+          multiple = false;
+        }
+
+        if (multiple) {
+          if (!Array.isArray(rawVal)) { return; }
+          rawVal.forEach(function(childWrapper) {
+            collectEntitiesFromWrapper(childWrapper);
+          });
+        } else {
+          collectEntitiesFromWrapper(rawVal);
+        }
+      });
+    }
+
+    // First pass: walk all root objects and any nested association wrappers
+    // so that we allocate slots for Airline, RegularFlight, SpecificFlight,
+    // etc., not only the roots.
+    objects.forEach(function(wrapper) {
+      collectEntitiesFromWrapper(wrapper);
+    });
+
+    // Second pass: populate attributes and forward association indices
+    Object.keys(instancesByClass).forEach(function(className) {
+      var info = Page.crudData.classes[className] || {};
+      var attrs = info.attributes || [];
+      var assocEnds = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+      var arr = instancesByClass[className];
+
+      arr.forEach(function(inst, localIndex) {
+        // Locate corresponding payload
+        var ns = payload && payload.namespace ? payload.namespace : getNamespaceFromModel();
+        var fqn = getQualifiedClassName(className, ns);
+        var keyPrefix = fqn + "#";
+        var matchedEntry = null;
+        Object.keys(idMap).some(function(k) {
+          var entry = idMap[k];
+          if (entry.className === className && entry.index === localIndex) {
+            matchedEntry = entry;
+            return true;
+          }
+          return false;
+        });
+        if (!matchedEntry) { return; }
+        var data = matchedEntry.data || {};
+
+        // Attributes
+        attrs.forEach(function(attr) {
+          var name = attr && attr.name;
+          if (!name) { return; }
+          if (Object.prototype.hasOwnProperty.call(data, name)) {
+            inst[name] = data[name];
+          }
+        });
+
+        // Associations (forward ends only; reverse ends will be synced later)
+        assocEnds.forEach(function(end) {
+          if (!end || end.fromClass !== className) { return; }
+          var fieldName = end.storageKey;
+          if (!fieldName) { return; }
+
+          var propName = getAssocPropertyName(end);
+          if (!propName) { return; }
+          var rawVal = data[propName];
+          if (rawVal === undefined || rawVal === null || rawVal === "") {
+            return;
+          }
+
+          var multiple = true;
+          if (typeof end.toMax === "number" && end.toMax <= 1) {
+            multiple = false;
+          }
+
+          if (multiple) {
+            if (!Array.isArray(rawVal)) { return; }
+            var indices = [];
+            rawVal.forEach(function(refWrapper) {
+              if (!refWrapper || typeof refWrapper !== "object") { return; }
+              var keys = Object.keys(refWrapper);
+              if (!keys.length) { return; }
+              var rfqn = keys[0];
+              var inner = refWrapper[rfqn] || {};
+              var rid = inner.umpleObjectID;
+              if (!rid) { return; }
+              var entry = idMap[rfqn + "#" + rid];
+              if (!entry) { return; }
+              indices.push(entry.index);
+            });
+            inst[fieldName] = indices;
+          } else {
+            if (!rawVal || typeof rawVal !== "object") { return; }
+            var keysSingle = Object.keys(rawVal);
+            if (!keysSingle.length) { return; }
+            var sfqn = keysSingle[0];
+            var sinner = rawVal[sfqn] || {};
+            var sid = sinner.umpleObjectID;
+            if (!sid) { return; }
+            var sentry = idMap[sfqn + "#" + sid];
+            if (!sentry) { return; }
+            inst[fieldName] = sentry.index;
+          }
+        });
+      });
+    });
+
+    // Apply rebuilt instances to Page.crudData
+    Object.keys(Page.crudData.classes).forEach(function(className) {
+      var arr = instancesByClass[className] || [];
+      Page.crudData.classes[className].instances = arr;
+      if (typeof Page.updateCrudClassCount === "function") {
+        Page.updateCrudClassCount(className);
+      }
+    });
+
+    // Sync reverse association ends to keep bidirectional links consistent
+    if (Page.crudAssociationsByClass && typeof Page.syncCrudReverseAssociationsForEnd === "function") {
+      Object.keys(Page.crudAssociationsByClass).forEach(function(className) {
+        var assocEnds = Page.crudAssociationsByClass[className] || [];
+        var info = Page.crudData.classes[className] || {};
+        var instArr = info.instances || [];
+        assocEnds.forEach(function(end) {
+          if (!end || end.fromClass !== className) { return; }
+          var fieldName = end.storageKey;
+          instArr.forEach(function(inst, idx) {
+            var newVal = inst[fieldName];
+            Page.syncCrudReverseAssociationsForEnd(className, idx, end, newVal);
+          });
+        });
+      });
+    }
+  };
+
+  // Helper to import from a JSON string (used by UI layer)
+  Page.crudJsonImportFromText = function(text) {
+    if (!text) { return; }
+    try {
+      var payload = JSON.parse(text);
+      Page.crudJsonImport(payload);
+    } catch (e) {
+      alert("Failed to parse JSON for CRUD import: " + e);
+    }
+  };
+
+})(window, jQuery);

--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -777,6 +777,84 @@ Page.initCrudUi = function(tabnumber) {
   // Remember current container for inline CRUD panel rendering
   Page.currentCrudContainer = container;
 
+   // Add JSON persistence controls once per container
+  if (container.find(".crud-json-actions").length === 0) {
+    var jsonHtml = "<div class='crud-json-actions' style='margin:6px 0 10px 0;'>" +
+      "<button type='button' id='crud-generate-json' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:6px;'>Generate JSON</button>" +
+      "<button type='button' id='crud-generate-random-data' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:6px;'>Generate Random Data</button>" +
+      "<button type='button' id='crud-load-json' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button'>Load JSON</button>" +
+      "<input type='file' id='crud-load-json-file' accept='application/json,.json' style='display:none;' />" +
+      "</div>";
+    container.prepend(jsonHtml);
+
+    // Wire up JSON buttons
+    container.find("#crud-generate-json").off("click").on("click", function() {
+      if (typeof Page.crudJsonDownload === "function") {
+        Page.crudJsonDownload();
+      }
+    });
+
+    // Ask the backend Instance Diagram generator for random data and
+    // import the returned JSON using the same path as "Load JSON".
+    container.find("#crud-generate-random-data").off("click").on("click", function() {
+      if (typeof Page.getUmpleCode !== "function") {
+        console.warn("No Umple code available for random data generation.");
+        return;
+      }
+      var code = Page.getUmpleCode() || "";
+      if (!code) {
+        console.warn("Umple code is empty; cannot generate random data.");
+        return;
+      }
+
+      jQuery.ajax({
+        url: "scripts/crud_random_data.php",
+        method: "POST",
+        data: {
+          code: code
+          // Additional tuning parameters for random generation could be
+          // threaded through via a 'suboptions' field in future.
+        },
+        dataType: "text",
+        success: function(resp) {
+          if (typeof Page.crudJsonImportFromText === "function") {
+            Page.crudJsonImportFromText(resp);
+            // After import, refresh the currently open CRUD dialog, if any
+            if (Page.crudClassSelected) {
+              Page.openCrudDialogForClass(Page.crudClassSelected);
+            }
+            
+          } 
+        },
+        error: function(xhr, status, err) {
+          console.error("Failed to generate random instance data:", status, err, xhr && xhr.responseText);
+        }
+      });
+    });
+
+    container.find("#crud-load-json").off("click").on("click", function() {
+      container.find("#crud-load-json-file").trigger("click");
+    });
+
+    container.find("#crud-load-json-file").off("change").on("change", function(evt) {
+      var file = evt.target.files && evt.target.files[0];
+      if (!file) { return; }
+      var reader = new FileReader();
+      reader.onload = function(e) {
+        if (typeof Page.crudJsonImportFromText === "function") {
+          Page.crudJsonImportFromText(e.target.result);
+          // After import, refresh the currently open CRUD dialog, if any
+          if (Page.crudClassSelected) {
+            Page.openCrudDialogForClass(Page.crudClassSelected);
+          }
+        }
+      };
+      reader.readAsText(file);
+      // Reset the input so the same file can be chosen again later
+      jQuery(this).val("");
+    });
+  }
+
   container.find(".crud-form").each(function() {
     var $form = jQuery(this);
     var className = $form.data("class");
@@ -1985,11 +2063,24 @@ Page.showCrudFromJson = function(jsonText, tabnumber) {
     classes.forEach(function(cls) {
       var className = cls.name || cls.id;
       if (!className) { return; }
+
+      var methods = cls.methods || [];
+      var hasMain = false;
+      methods.forEach(function(m) {
+        if (!m) { return; }
+        // Treat any concrete method named "main" as an indicator that
+        // this class is a main/root class for JSON export purposes.
+        if (m.name === "main" && (m.isAbstract === false || m.isAbstract === "false" || typeof m.isAbstract === "undefined")) {
+          hasMain = true;
+        }
+      });
+
       crudMetaByClass[className] = {
         name: className,
         rawAttributes: cls.attributes || [],
         extendsClass: cls.extendsClass || null,
-        isAbstract: cls.isAbstract === true || cls.isAbstract === "true"
+        isAbstract: cls.isAbstract === true || cls.isAbstract === "true",
+        hasMain: hasMain
       };
       Page.crudExtendsByClass[className] = cls.extendsClass || null;
 
@@ -2348,7 +2439,10 @@ Page.showCrudFromJson = function(jsonText, tabnumber) {
       Page.crudData.classes[className] = {
         attributes: attrs,
         instances: [],
-        isAbstract: isAbstract
+        isAbstract: isAbstract,
+        // Mark whether this class declares a main() method so that the
+        // CRUD JSON exporter can treat it as a root/main class.
+        isMain: !!meta.hasMain
       };
 
       formHtml += "</form>";

--- a/umpleonline/scripts/crud_random_data.php
+++ b/umpleonline/scripts/crud_random_data.php
@@ -1,0 +1,49 @@
+<?php
+// Lightweight endpoint used by the CRUD UI to request
+// randomly generated instance data from the Instance Diagram
+// generator and return it as JSON for inspection in the
+// browser dev tools.
+
+require_once __DIR__ . '/compiler_config.php';
+
+header('Content-Type: application/json');
+
+// Raw Umple code for the current model
+$code = isset($_POST['code']) ? $_POST['code'] : '';
+// Optional extra suboptions (e.g., to tweak linking behaviour)
+$suboptions = isset($_POST['suboptions']) ? $_POST['suboptions'] : '';
+
+if ($code === '') {
+  echo json_encode(array(
+    'status' => 'error',
+    'message' => 'No Umple code supplied for random data generation.'
+  ));
+  exit;
+}
+
+list($dataname, $dataHandle) = getOrCreateDataHandle();
+$dataHandle->writeData($dataname, $code);
+$workDir = $dataHandle->getWorkDir();
+$filename = $workDir->getPath() . '/' . $dataname;
+$errorFilename = $filename . '.erroroutput';
+
+// Always ask the InstanceDiagram generator to emit JSON-only
+// random data suitable for CRUD via the custom suboption.
+$language = 'InstanceDiagram';
+$fullSuboptions = trim($suboptions . ' -s crudRandomJson');
+
+$command = "java -jar umplesync.jar -generate {$language} {$filename} {$fullSuboptions} 2> {$errorFilename}";
+$json = executeCommand($command);
+
+// If the generator failed silently, surface a generic error.
+if ($json === '') {
+  $errors = @file_get_contents($errorFilename);
+  echo json_encode(array(
+    'status' => 'error',
+    'message' => 'No data returned from InstanceDiagram generator.',
+    'generatorErrors' => $errors !== false ? $errors : ''
+  ));
+  exit;
+}
+
+echo $json;

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -4464,7 +4464,8 @@ Action.loadExample = function loadExample()
     shortExampleName=exampleName;
     newURL="?example="+shortExampleName+diagramType;
   }
-    Page.setSelectExample(shortExampleName + ".ump");
+    // COMMENTED OUT SUBJECT TO INVESTIGATION
+    // Page.setSelectExample(shortExampleName + ".ump");
     window.history.pushState({}, "", newURL);
 
     setTimeout(function () { // Delay so it doesn't get erased


### PR DESCRIPTION
This PR fixes issue #2334 . It adds end‑to‑end JSON support for the CRUD UI and plugs it into the Instance Diagram generator. The generator now has a crudRandomJson suboption that produces CRUD‑compatible JSON, exposed via a new crud_random_data.php, and the CRUD UI gets “Generate JSON”, “Generate Random Data”, and “Load JSON” buttons that all use the same import/export code so the code can save, reload, or auto‑generate instance data.