### PR TITLE
Validate association role names as identifiers

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -4537,7 +4537,9 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     AssociationEnd firstEnd = createPreliminaryAssociationEnd(myEndToken, defaultMyType);
     AssociationEnd secondEnd = createPreliminaryAssociationEnd(yourEndToken, defaultMyType);
     if(firstEnd == null || secondEnd == null){
-        setFailedPosition(associationToken.getPosition(), 8, name);
+        if(isAssociationClass){
+          setFailedPosition(associationToken.getPosition(), 8, name);
+        }
         return null;
     }
     
@@ -4650,6 +4652,10 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       if (!mult.isValid()){
         String invalidBound = bound == null ? lowerBound + ".." + upperBound : bound;
         setFailedPosition(associationEndToken.getPosition(), 4, invalidBound);
+        return null;
+      }
+      if(roleName != null && !"".equals(roleName) && !Token.isValidIdentifier(roleName)){
+        setFailedPosition(associationEndToken.getPosition("roleName"), 120, roleName);
         return null;
       }
       if(type == null){

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -4536,6 +4536,16 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
     }
     AssociationEnd firstEnd = createPreliminaryAssociationEnd(myEndToken, defaultMyType);
     AssociationEnd secondEnd = createPreliminaryAssociationEnd(yourEndToken, defaultMyType);
+    // If createPreliminaryAssociationEnd() fails validation (e.g., an invalid role name),
+    // it reports the error and returns null for that association end.
+    //
+    // Without the guard below, analyzeAssociation() would also report error 8
+    // ("Association class is missing an end") whenever one end is null.
+    // This would create a misleading cascading error, since the real issue
+    // (such as error 120 for an invalid identifier) has already been reported.
+    //
+    // Error 8 should only apply to AssociationClasses that actually lack an end,
+    // so we restrict it to those cases using the isAssociationClass check.
     if(firstEnd == null || secondEnd == null){
         if(isAssociationClass){
           setFailedPosition(associationToken.getPosition(), 8, name);
@@ -4657,6 +4667,11 @@ private Boolean checkIsDistributed(UmpleInterface uInterface)
       if(roleName != null && !"".equals(roleName) && !Token.isValidIdentifier(roleName)){
         setFailedPosition(associationEndToken.getPosition("roleName"), 120, roleName);
         return null;
+      }
+      if(roleName != null && roleName.length() > 0 && Character.isUpperCase(roleName.charAt(0))){
+          getParseResult().addErrorMessage(
+              new ErrorMessage(121, associationEndToken.getPosition("roleName"), roleName)
+          );
       }
       if(type == null){
           type = defaultType;

--- a/cruise.umple/src/en.error
+++ b/cruise.umple/src/en.error
@@ -118,8 +118,8 @@
 111: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Interface name '{0}' should start with a capital letter ;
 112: 2, "https://manual.umple.org/?E112DuplicateConstantsinInterface.html", Interface '{0}' has duplicate constant name {1} ;
 
-# [TODO - issue 337] 120: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' must be alphanumeric and start with a letter ;
-# [TODO - issue 337] 121: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' should start with a lower-case letter ;
+120: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' must be alphanumeric and start with a letter ;
+121: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Association role name '{0}' should start with a lower-case letter ;
 
 130: 2, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' must {1} ;
 131: 4, "https://manual.umple.org/?WE1xxIdentifierInvalid.html", Attribute name '{0}' should start with a lower-case letter ;

--- a/cruise.umple/test/cruise/umple/compiler/024_multiAssocToAnotherClassCapitalizationRoleName.ump
+++ b/cruise.umple/test/cruise/umple/compiler/024_multiAssocToAnotherClassCapitalizationRoleName.ump
@@ -1,5 +1,5 @@
 class A{
   0..1  -- * B assoc;
-  0..1  -- * B Assoc;
+  0..1  -- * B assoC;
 }
 class B{}

--- a/cruise.umple/test/cruise/umple/compiler/2341_invalidAssociationRoleName.ump
+++ b/cruise.umple/test/cruise/umple/compiler/2341_invalidAssociationRoleName.ump
@@ -1,0 +1,13 @@
+class X {
+  implementsReq R1%R3;
+  agt;
+}
+
+req R1%R3 {test}
+
+class Y {
+  1 -- * X Df-dfd;
+  public static void main() {
+    System.out.println ("Aha!")
+  }
+}

--- a/cruise.umple/test/cruise/umple/compiler/2341_roleNameUppercaseWarning.ump
+++ b/cruise.umple/test/cruise/umple/compiler/2341_roleNameUppercaseWarning.ump
@@ -1,5 +1,5 @@
 class X {}
 
 class Y {
-  1 -- * X Df-dfd;
+  1 -- * X Role;
 }

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -1863,6 +1863,11 @@ public class UmpleParserTest
   }
 
   @Test
+  public void TestInvalidAssociationRoleNameError120() {
+          assertFailedParse("2341_invalidAssociationRoleName.ump",120);
+  }
+
+  @Test
   public void associationClass2()
   {
     String input = SampleFileWriter.readContent(new File(pathToInput, "010_associationClass2.ump"));

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -1864,7 +1864,12 @@ public class UmpleParserTest
 
   @Test
   public void TestInvalidAssociationRoleNameError120() {
-          assertFailedParse("2341_invalidAssociationRoleName.ump",120);
+    assertFailedParse("2341_invalidAssociationRoleName.ump",120);
+  }
+
+  @Test
+  public void TestAssociationRoleNameWarning121() {
+      assertHasWarningsParse("2341_roleNameUppercaseWarning.ump",121);
   }
 
   @Test


### PR DESCRIPTION
Fixes #2341

Summary
This change validates association role names so they must be valid identifiers.

Changes
- Added identifier validation for association role names using Token.isValidIdentifier in createPreliminaryAssociationEnd(...)
- Enabled error messages 120 and 121 in en.error
- Prevented misleading cascade error E008 when an association end already fails validation and the association is not an association class
- Added parser regression test:
  cruise.umple/test/cruise/umple/compiler/2341_invalidAssociationRoleName.ump
  TestInvalidAssociationRoleNameError120()

Testing
- Tested using the issue example in UmpleOnline
- Invalid role name "Df-dfd" now correctly reports error 120 only
- Added parser regression test verifying the parser fails with error 120

Result
Association role names containing invalid characters are now correctly rejected by the parser.