### PR TITLE
Fix gradle build issue #2358 and remove the plugin unnecessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-  id 'org.ajoberstar.grgit' version '3.0.0'
+  id 'org.ajoberstar.grgit' version '5.3.3'
   id 'nebula.ospackage' version '9.1.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,21 @@ buildscript {
 }
 
 plugins {
-  id 'org.ajoberstar.grgit' version '5.3.3'
   id 'nebula.ospackage' version '9.1.1'
+}
+
+String runGit(List<String> args, String fallback) {
+    // The Ant script uses the git command to get version info data. Use the same behavior here.
+    def output = new ByteArrayOutputStream()
+    def result = project.exec {
+        commandLine = ['git'] + args
+        standardOutput = output
+        ignoreExitValue = true
+    }
+
+    def value = output.toString().trim()
+    // The Ant has a fallback. Follow the same one.
+    return result.exitValue == 0 && value ? value : fallback
 }
 
 ext {
@@ -19,7 +32,7 @@ ext {
     umpleMajorVersionFile = new File("${rootProject.projectDir.toString()}/build/umpleversion.txt")
     umpleLastVersion = new org.yaml.snakeyaml.Yaml().load(rootProject.ext.umpleLastVersionFile.newInputStream()).version
     umpleMajorVersion = new org.yaml.snakeyaml.Yaml().load(rootProject.ext.umpleMajorVersionFile.newInputStream()).version
-    umpleCurrentVersion = "${rootProject.ext.umpleMajorVersion}.${grgit.log().size()}.${grgit.head().getAbbreviatedId(9)}"
+    umpleCurrentVersion = "${rootProject.ext.umpleMajorVersion}.${runGit(['rev-list', '--count', 'master'], 'x')}.${runGit(['rev-parse', '--short', 'master'], 'dev')}"
     umpleCurrentJarBase = "umple-${rootProject.ext.umpleCurrentVersion}"
     umpleCurrentJar = "${rootProject.projectDir.toString()}/dist/gradle/libs/${rootProject.ext.umpleCurrentJarBase}.jar"
     umpleJarRemoteSource = "https://cruise.umple.org/umpleonline/scripts/umple.jar"


### PR DESCRIPTION
This PR fixes #2358.

I tested both `grgit:4.1.1` and `grgit:5.3.3`, and neither introduced breaking changes. However, after reviewing how `grgit` is used here and comparing it with the Ant build, I concluded that removing `grgit` is the better long-term solution.

`grgit` is only used to generate the Umple version number, while the Ant build already does this via the `git` command. More importantly, `grgit` and Ant produce different version numbers for the same codebase. Since version numbers are part of the build artifact names, this inconsistency could lead to conflicts between Gradle and Ant outputs.

In addition, `grgit` is no longer actively supported by its author and may become unmaintained in the future:
`https://git.sr.ht/~ajoberstar/grgit`

The version string does not require any special semantics; it only needs to be consistent for everyone building from the same commit. Based on that, this PR removes `grgit` and replaces it with a small Gradle function that generates the version number in the same way as Ant, using the `git` command directly and without any plugin dependency.

After multiple tests and builds, the new approach works as expected and remains consistent with Ant. The only remaining failure is the `umpleOnline` build (like `pumple` did), which appears unrelated to version generation and is more likely caused by missing build artifacts during the build process.