### PR TITLE
Fixes #1867 Add natural language descriptions to GV state diagram tooltips

### DIFF
--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -27,6 +27,7 @@ class GvStateDiagramGenerator
 {
   Boolean hideActions = false;
   Boolean hideGuards = false;
+  Boolean hideNaturalLanguage = false;
   Boolean showTransitionLabels = false;
   Boolean showGuardLabels = false;
   internal String display_language = "";
@@ -71,6 +72,7 @@ digraph "<<=filename>>" {
     
     hideActions = hasSuboption("hideactions");
     hideGuards = hasSuboption("hideguards");
+    hideNaturalLanguage = hasSuboption("hidenaturallanguage");
     showTransitionLabels = hasSuboption("showtransitionlabels");
     showGuardLabels = hasSuboption("showguardlabels");
     display_language = getDisplayLanguage();
@@ -458,26 +460,9 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
            transitionLabel = "   t"+getObjectIdentity( root, t )+": ";
         }       
         
-        if(event.isAutoTransition()) 
+        if(!event.isAutoTransition())
         {
-          transitionLabel += "";
-        } 
-        else {
-          if (event.getIsTimer()) 
-          {
-            transitionLabel += "after("+event.getTimerInSeconds()+")";
-          }
-          else 
-          {
-            if(event.getArgs() == null || event.getArgs() == "") 
-            {
-              transitionLabel += event.getName();
-            }
-            else 
-            {
-              transitionLabel += event.getName()+"("+event.getArgs()+")";
-            }
-          }
+          transitionLabel += getTriggerDescription(event);
         }
         
         if (action == null || getAvailableActionCode(action) == "" || hideActions) 
@@ -508,7 +493,7 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
           else guardString = " [";
 
           //guardString += guard.getCondition(gen).replaceAll("\"","&quot;") + "]";
-	      guardString += guard.getExpression().replaceAll("\"","&quot;") + "]"+guardLabel;
+	      guardString += getEscapedGuardExpression(guard) + "]"+guardLabel;
         }
         
         String orig = getTransitionNameForState(t.getFromState(),uClass,true);
@@ -632,19 +617,18 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
 	
     // Set transition event information
     String tooltip = "From "+tooltipFromState+" to "+tooltipToState;
-    if (!event.isAutoTransition()) 
+    if (event.isAutoTransition())
     {
-      if (event.getIsTimer()) // Timed transition
-        tooltip = tooltip+" after("+event.getTimerInSeconds()+")";
-      else if(event.getArgs() == null || event.getArgs() == "") 
-        tooltip = tooltip+" on "+event.getName();
-      else 
-        tooltip = tooltip+" on "+event.getName()+"("+event.getArgs()+")";
+      tooltip = tooltip+" automatically";
+    }
+    else if (event.getIsTimer())
+    {
+      tooltip = tooltip+" "+getTriggerDescription(event);
     }
     else
     {
-      tooltip = tooltip+" automatically";
-	}
+      tooltip = tooltip+" on "+getTriggerDescription(event);
+    }
 	
     // Get guard code for transition
     if (guardString != "" && !hideGuards)
@@ -652,7 +636,7 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
       tooltip = tooltip+"&#13;"+"Guard: "+guardString;
     }
 	
-    // Get action code for transition	
+    // Get action code for transition
     Action action = t.getAction();
     String transitionAction = "";
     if (action != null)
@@ -660,11 +644,62 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
       transitionAction = getAvailableActionCode(action);
     }
     if (transitionAction != "" && !hideActions)
-    {	
+    {
       transitionAction = transitionAction.replaceAll("\"","&quot;");
       tooltip = tooltip+"&#13;"+"Transition Action:\n"+retFiveLines(transitionAction);
     }
-	
+
+    // Add natural language description
+    if (!hideNaturalLanguage)
+    {
+      boolean isSelfTransition = t.getFromState() == t.getNextState();
+      String nlTransition;
+      if (event.isAutoTransition())
+      {
+        if (isSelfTransition)
+        {
+          nlTransition = "Automatically loops back to " + tooltipFromState;
+        }
+        else
+        {
+          nlTransition = "Automatically transitions from " + tooltipFromState + " to " + tooltipToState;
+        }
+      }
+      else if (event.getIsTimer())
+      {
+        nlTransition = "After " + event.getTimerInSeconds() + " second(s) in state " + tooltipFromState;
+        if (isSelfTransition)
+        {
+          nlTransition += ", loops back to self";
+        }
+        else
+        {
+          nlTransition += ", transitions to " + tooltipToState;
+        }
+      }
+      else
+      {
+        nlTransition = "When " + getTriggerDescription(event) + " occurs in state " + tooltipFromState;
+        if (isSelfTransition)
+        {
+          nlTransition += ", loops back to self";
+        }
+        else
+        {
+          nlTransition += ", transitions to " + tooltipToState;
+        }
+      }
+
+      Guard guard = t.getGuard();
+      if (guard != null && !hideGuards)
+      {
+        nlTransition += " if guard [" + getEscapedGuardExpression(guard) + "]";
+      }
+      nlTransition += ".";
+
+      tooltip = tooltip + "&#13;&#13;" + nlTransition;
+    }
+
     return tooltip;
   }
 
@@ -703,10 +738,205 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
       String activityCode = activity.getCodeblock().toString().replaceAll("\"","&quot;");
       tooltip = tooltip+"&#13;"+"Activity:\n"+retFiveLines(activityCode);
     }
-	
+
+    // Add natural language description
+    if (!hideNaturalLanguage)
+    {
+      tooltip = tooltip + buildNaturalLanguageStateDescription(sm, st);
+    }
+
     return tooltip;
   }
   
+  // Get the natural language trigger description for an event
+  private String getTriggerDescription(Event event)
+  {
+    if (event.getIsTimer())
+    {
+      return "after(" + event.getTimerInSeconds() + ")";
+    }
+    if (event.getArgs() == null || event.getArgs().equals(""))
+    {
+      return event.getName();
+    }
+    return event.getName() + "(" + event.getArgs() + ")";
+  }
+
+  // Get the guard expression with quotes escaped for HTML tooltip display
+  private String getEscapedGuardExpression(Guard guard)
+  {
+    return guard.getExpression().replaceAll("\"","&quot;");
+  }
+
+  // Build a natural language description of a state's behavior
+  private String buildNaturalLanguageStateDescription(StateMachine sm, State st)
+  {
+    StringBuilder nl = new StringBuilder();
+
+    // 1. Initial state detection
+    if (st == sm.getState(0))
+    {
+      if (sm.getParentState() == null)
+      {
+        nl.append("&#13;This is the default initial state and is entered when the object is created.");
+      }
+      else
+      {
+        State parentState = sm.getParentState();
+        String[] parentInfo = getStatePath(parentState.getStateMachine(), parentState.getName());
+        nl.append("&#13;This is the default initial state when entering state ").append(parentInfo[1]);
+        if (isEnteredOnCreation(st))
+        {
+          nl.append(" and is entered when the object is created");
+        }
+        nl.append(".");
+      }
+    }
+
+    // 2. Incoming transitions (direct and via parent for initial substates)
+    for (Transition t : st.getNextTransition())
+    {
+      appendIncomingTransitionNL(nl, t);
+    }
+    // For initial substates, also include transitions entering parent states
+    if (st == sm.getState(0) && sm.getParentState() != null)
+    {
+      addParentIncomingTransitionsNL(nl, sm.getParentState());
+    }
+
+    // 3. Entry actions
+    boolean hasEntry = false;
+    boolean hasExit = false;
+    for (Action action : st.getActions())
+    {
+      if ("entry".equals(action.getActionType())) hasEntry = true;
+      if ("exit".equals(action.getActionType())) hasExit = true;
+      if (hasEntry && hasExit) break;
+    }
+
+    if (hasEntry)
+    {
+      nl.append("&#13;On entry into this state an entry action is executed.");
+    }
+
+    // 4. Do activities
+    if (st.numberOfActivities() > 0)
+    {
+      nl.append("&#13;A do activity runs in a separate thread until completion or state exit.");
+    }
+
+    // 5. Outgoing transitions
+    for (Transition t : st.getTransitions())
+    {
+      String[] toInfo = getStatePath(t.getNextState().getStateMachine(), t.getNextState().getName());
+      String toPath = toInfo[1];
+      Event event = t.getEvent();
+      Guard guard = t.getGuard();
+      boolean isSelfTransition = t.getFromState() == t.getNextState();
+
+      if (event.isAutoTransition())
+      {
+        nl.append("&#13;Exits automatically");
+      }
+      else if (event.getIsTimer())
+      {
+        nl.append("&#13;After ").append(event.getTimerInSeconds()).append(" second(s)");
+      }
+      else
+      {
+        nl.append("&#13;On ").append(getTriggerDescription(event));
+      }
+
+      if (guard != null && !hideGuards)
+      {
+        nl.append(" if guard [").append(getEscapedGuardExpression(guard)).append("]");
+      }
+
+      if (isSelfTransition)
+      {
+        nl.append(", loops back to self.");
+      }
+      else
+      {
+        nl.append(", transitions to ").append(toPath).append(".");
+      }
+    }
+
+    // 6. Exit actions
+    if (hasExit)
+    {
+      nl.append("&#13;On exit from this state an exit action is executed.");
+    }
+
+    if (nl.length() > 0)
+    {
+      return "&#13;" + nl.toString();
+    }
+    return "";
+  }
+
+  // Append a natural language description of an incoming transition to a state
+  private void appendIncomingTransitionNL(StringBuilder nl, Transition t)
+  {
+    String[] fromInfo = getStatePath(t.getFromState().getStateMachine(), t.getFromState().getName());
+    String fromPath = fromInfo[1];
+    Event event = t.getEvent();
+    Guard guard = t.getGuard();
+
+    if (event.isAutoTransition())
+    {
+      nl.append("&#13;This state is entered automatically from ").append(fromPath);
+      if (guard != null && !hideGuards)
+      {
+        nl.append(" when guard [").append(getEscapedGuardExpression(guard)).append("] is true");
+      }
+    }
+    else if (event.getIsTimer())
+    {
+      nl.append("&#13;This state is entered after ").append(event.getTimerInSeconds()).append(" second(s)");
+      nl.append(" while in state ").append(fromPath);
+      if (guard != null && !hideGuards)
+      {
+        nl.append(" when guard [").append(getEscapedGuardExpression(guard)).append("] is true");
+      }
+    }
+    else
+    {
+      nl.append("&#13;This state is entered when event ").append(getTriggerDescription(event)).append(" occurs");
+      nl.append(" while in state ").append(fromPath);
+      if (guard != null && !hideGuards)
+      {
+        nl.append(" when guard [").append(getEscapedGuardExpression(guard)).append("] is true");
+      }
+    }
+    nl.append(".");
+  }
+
+  // Recursively add incoming transitions from parent states for initial substates
+  // If the parent state is itself the initial state of its SM, recurse further up
+  private void addParentIncomingTransitionsNL(StringBuilder nl, State parentState)
+  {
+    for (Transition t : parentState.getNextTransition())
+    {
+      appendIncomingTransitionNL(nl, t);
+    }
+    StateMachine parentSm = parentState.getStateMachine();
+    if (parentState == parentSm.getState(0) && parentSm.getParentState() != null)
+    {
+      addParentIncomingTransitionsNL(nl, parentSm.getParentState());
+    }
+  }
+
+  // Check if a state is entered when the object is created
+  // (i.e., it is the initial state in a chain from the root state machine)
+  private boolean isEnteredOnCreation(State st)
+  {
+    StateMachine sm = st.getStateMachine();
+    if (st != sm.getState(0)) return false;
+    if (sm.getParentState() == null) return true;
+    return isEnteredOnCreation(sm.getParentState());
+  }
+
   // Get the smallest space indent in the code
   private int getMinSpace(String[] parts)
   {

--- a/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
+++ b/cruise.umple/src/generators/statemachineDiagramGenerator/Generator_CodeGvStateDiagram.ump
@@ -667,7 +667,7 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
       }
       else if (event.getIsTimer())
       {
-        nlTransition = "After " + event.getTimerInSeconds() + " second(s) in state " + tooltipFromState;
+        nlTransition = "After " + (int)(Double.parseDouble(event.getTimerInSeconds()) * 1000) + " millisecond(s) in state " + tooltipFromState;
         if (isSelfTransition)
         {
           nlTransition += ", loops back to self";
@@ -840,7 +840,7 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
       }
       else if (event.getIsTimer())
       {
-        nl.append("&#13;After ").append(event.getTimerInSeconds()).append(" second(s)");
+        nl.append("&#13;After ").append((int)(Double.parseDouble(event.getTimerInSeconds()) * 1000)).append(" millisecond(s)");
       }
       else
       {
@@ -893,7 +893,7 @@ node [ratio="auto" shape = circle, fixedsize = true, width=.3];
     }
     else if (event.getIsTimer())
     {
-      nl.append("&#13;This state is entered after ").append(event.getTimerInSeconds()).append(" second(s)");
+      nl.append("&#13;This state is entered after ").append((int)(Double.parseDouble(event.getTimerInSeconds()) * 1000)).append(" millisecond(s)");
       nl.append(" while in state ").append(fromPath);
       if (guard != null && !hideGuards)
       {

--- a/cruise.umple/test/cruise/umple/implementation/gv/Act5Transition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/Act5Transition.gv.txt
@@ -15,12 +15,12 @@ digraph "Act5Transition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
@@ -31,7 +31,7 @@ digraph "Act5Transition" {
    doTransition2();
    doTransition3();
    doTransition4();
-   doTransition5();", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+   doTransition5();&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/ActLess5Transition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ActLess5Transition.gv.txt
@@ -15,19 +15,19 @@ digraph "ActLess5Transition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
     A_sm_s1 -> A_sm_s2 [  label = "e1 / doTransition();", tooltip = "From s1 to s2 on e1&#13;Transition Action:
-   doTransition();", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+   doTransition();&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/ActMore5Transition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ActMore5Transition.gv.txt
@@ -15,12 +15,12 @@ digraph "ActMore5Transition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
@@ -32,7 +32,7 @@ digraph "ActMore5Transition" {
    doTransition3();
    doTransition4();
    doTransition5();
-   ...", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+   ...&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/Activity5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/Activity5State.gv.txt
@@ -20,7 +20,7 @@ digraph "Activity5State" {
    doThisContinuouslyWhileOn2();
    doThisContinuouslyWhileOn3();
    doThisContinuouslyWhileOn4();
-   doThisContinuouslyWhileOn5();", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   doThisContinuouslyWhileOn5();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;A do activity runs in a separate thread until completion or state exit.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/ActivityLess5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ActivityLess5State.gv.txt
@@ -16,7 +16,7 @@ digraph "ActivityLess5State" {
       // State: s2
 
       A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;Activity:
-   doThisContinuouslyWhileOn();", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   doThisContinuouslyWhileOn();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;A do activity runs in a separate thread until completion or state exit.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/ActivityMore5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ActivityMore5State.gv.txt
@@ -21,7 +21,7 @@ digraph "ActivityMore5State" {
    doThisContinuouslyWhileOn3();
    doThisContinuouslyWhileOn4();
    doThisContinuouslyWhileOn5();
-   ...", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   ...&#13;&#13;This is the default initial state and is entered when the object is created.&#13;A do activity runs in a separate thread until completion or state exit.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/AutoTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/AutoTransition.gv.txt
@@ -18,7 +18,7 @@ digraph "AutoTransition" {
       X_sm_s1 [label = s1, tooltip = "Class X, SM sm, State s1&#13;Entry:
    System.out.println(&quot;Starting first sleep&quot;);&#13;Activity:
    Thread.sleep(2000);
-   System.out.println(&quot;Ending first sleep&quot;);", URL="javascript:Action.stateClicked(\"X^*^sm^*^s1\")"];
+   System.out.println(&quot;Ending first sleep&quot;);&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;A do activity runs in a separate thread until completion or state exit.&#13;Exits automatically, transitions to s2.", URL="javascript:Action.stateClicked(\"X^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
@@ -26,13 +26,13 @@ digraph "AutoTransition" {
       X_sm_s2 [label = s2, tooltip = "Class X, SM sm, State s2&#13;Entry:
    System.out.println(&quot;Starting second sleep&quot;);&#13;Activity:
    Thread.sleep(2000);
-   System.out.println(&quot;Ending second sleep&quot;);", URL="javascript:Action.stateClicked(\"X^*^sm^*^s2\")"];
+   System.out.println(&quot;Ending second sleep&quot;);&#13;&#13;This state is entered automatically from s1.&#13;On entry into this state an entry action is executed.&#13;A do activity runs in a separate thread until completion or state exit.", URL="javascript:Action.stateClicked(\"X^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_X_sm -> X_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    X_sm_s1 -> X_sm_s2 [  tooltip = "From s1 to s2 automatically", URL="javascript:Action.transitionClicked(\"X*^*sm*^**^*s1*^*s2*^*\")" ] ;
+    X_sm_s1 -> X_sm_s2 [  tooltip = "From s1 to s2 automatically&#13;&#13;Automatically transitions from s1 to s2.", URL="javascript:Action.transitionClicked(\"X*^*sm*^**^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/ColouredDerivedNestedState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ColouredDerivedNestedState.gv.txt
@@ -15,7 +15,7 @@ digraph "ColouredDerivedNestedState" {
     
       // State: Off
 
-      Car_state_Off [label = Off, tooltip = "Class Car, SM state, State Off", URL="javascript:Action.stateClicked(\"Car^*^state^*^Off\")"];
+      Car_state_Off [label = Off, tooltip = "Class Car, SM state, State Off&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event turnOff occurs while in state Running.state.Stopped.&#13;On turnOn, transitions to Running.", URL="javascript:Action.stateClicked(\"Car^*^state^*^Off\")"];
       // End State: Off
 
       // State: Running
@@ -54,17 +54,17 @@ digraph "ColouredDerivedNestedState" {
         
           // State: Idle
 
-          Car_stateRunningState_Idle [label = Idle,style = "filled, rounded", fillcolor ="yellow", tooltip = "Class Car, SM state, State Running.state.Idle", URL="javascript:Action.stateClicked(\"Car^*^state^*^Running.state.Idle\")"];
+          Car_stateRunningState_Idle [label = Idle,style = "filled, rounded", fillcolor ="yellow", tooltip = "Class Car, SM state, State Running.state.Idle&#13;&#13;This is the default initial state when entering state Running.state.&#13;This state is entered when event decelerate occurs while in state Running.state.Moving.&#13;This state is entered when event turnOn occurs while in state Off.&#13;On accelerate, transitions to Running.state.Moving.", URL="javascript:Action.stateClicked(\"Car^*^state^*^Running.state.Idle\")"];
           // End State: Idle
 
           // State: Moving
 
-          Car_stateRunningState_Moving [label = Moving,style = "filled, rounded", fillcolor ="green", tooltip = "Class Car, SM state, State Running.state.Moving", URL="javascript:Action.stateClicked(\"Car^*^state^*^Running.state.Moving\")"];
+          Car_stateRunningState_Moving [label = Moving,style = "filled, rounded", fillcolor ="green", tooltip = "Class Car, SM state, State Running.state.Moving&#13;&#13;This state is entered when event accelerate occurs while in state Running.state.Idle.&#13;This state is entered when event accelerate occurs while in state Running.state.Stopped.&#13;On decelerate, transitions to Running.state.Idle.&#13;On stop, transitions to Running.state.Stopped.", URL="javascript:Action.stateClicked(\"Car^*^state^*^Running.state.Moving\")"];
           // End State: Moving
 
           // State: Stopped
 
-          Car_stateRunningState_Stopped [label = Stopped,style = "filled, rounded", fillcolor ="red", tooltip = "Class Car, SM state, State Running.state.Stopped", URL="javascript:Action.stateClicked(\"Car^*^state^*^Running.state.Stopped\")"];
+          Car_stateRunningState_Stopped [label = Stopped,style = "filled, rounded", fillcolor ="red", tooltip = "Class Car, SM state, State Running.state.Stopped&#13;&#13;This state is entered when event stop occurs while in state Running.state.Moving.&#13;On accelerate, transitions to Running.state.Moving.&#13;On turnOff, transitions to Off.", URL="javascript:Action.stateClicked(\"Car^*^state^*^Running.state.Stopped\")"];
           // End State: Stopped
         // End Bottom Level StateMachine: state
        }
@@ -76,19 +76,19 @@ digraph "ColouredDerivedNestedState" {
 
   // All transitions
     start_Car_state -> Car_state_Off [  tooltip = "start to Off", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    Car_stateRunningState_Stopped -> Car_state_Off [  label = "turnOff", tooltip = "From Running.state.Stopped to Off on turnOff", URL="javascript:Action.transitionClicked(\"Car*^*state*^*turnOff*^*Running.state.Stopped*^*Off*^*\")" ] ;
+    Car_stateRunningState_Stopped -> Car_state_Off [  label = "turnOff", tooltip = "From Running.state.Stopped to Off on turnOff&#13;&#13;When turnOff occurs in state Running.state.Stopped, transitions to Off.", URL="javascript:Action.transitionClicked(\"Car*^*state*^*turnOff*^*Running.state.Stopped*^*Off*^*\")" ] ;
   
-  Car_state_Off -> Car_stateRunningState_Idle [  lhead=clusterCar_state_Running,  label = "turnOn", tooltip = "From Off to Running on turnOn", URL="javascript:Action.transitionClicked(\"Car*^*state*^*turnOn*^*Off*^*Running*^*\")" ] ;
+  Car_state_Off -> Car_stateRunningState_Idle [  lhead=clusterCar_state_Running,  label = "turnOn", tooltip = "From Off to Running on turnOn&#13;&#13;When turnOn occurs in state Off, transitions to Running.", URL="javascript:Action.transitionClicked(\"Car*^*state*^*turnOn*^*Off*^*Running*^*\")" ] ;
   
   start_Car_stateRunning -> Car_stateRunningState_Idle [  lhead=clusterCar_stateRunning_state,  tooltip = "start to Running.state", URL="javascript:Action.transitionClicked(\"null\")" ] ;
     start_Car_stateRunningState -> Car_stateRunningState_Idle [  tooltip = "start to Running.state.Idle", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    Car_stateRunningState_Moving -> Car_stateRunningState_Idle [  label = "decelerate", tooltip = "From Running.state.Moving to Running.state.Idle on decelerate", URL="javascript:Action.transitionClicked(\"Car*^*state*^*decelerate*^*Running.state.Moving*^*Running.state.Idle*^*\")" ] ;
+    Car_stateRunningState_Moving -> Car_stateRunningState_Idle [  label = "decelerate", tooltip = "From Running.state.Moving to Running.state.Idle on decelerate&#13;&#13;When decelerate occurs in state Running.state.Moving, transitions to Running.state.Idle.", URL="javascript:Action.transitionClicked(\"Car*^*state*^*decelerate*^*Running.state.Moving*^*Running.state.Idle*^*\")" ] ;
   
-  Car_stateRunningState_Idle -> Car_stateRunningState_Moving [  label = "accelerate", tooltip = "From Running.state.Idle to Running.state.Moving on accelerate", URL="javascript:Action.transitionClicked(\"Car*^*state*^*accelerate*^*Running.state.Idle*^*Running.state.Moving*^*\")" ] ;
+  Car_stateRunningState_Idle -> Car_stateRunningState_Moving [  label = "accelerate", tooltip = "From Running.state.Idle to Running.state.Moving on accelerate&#13;&#13;When accelerate occurs in state Running.state.Idle, transitions to Running.state.Moving.", URL="javascript:Action.transitionClicked(\"Car*^*state*^*accelerate*^*Running.state.Idle*^*Running.state.Moving*^*\")" ] ;
   
-  Car_stateRunningState_Stopped -> Car_stateRunningState_Moving [  label = "accelerate", tooltip = "From Running.state.Stopped to Running.state.Moving on accelerate", URL="javascript:Action.transitionClicked(\"Car*^*state*^*accelerate*^*Running.state.Stopped*^*Running.state.Moving*^*\")" ] ;
+  Car_stateRunningState_Stopped -> Car_stateRunningState_Moving [  label = "accelerate", tooltip = "From Running.state.Stopped to Running.state.Moving on accelerate&#13;&#13;When accelerate occurs in state Running.state.Stopped, transitions to Running.state.Moving.", URL="javascript:Action.transitionClicked(\"Car*^*state*^*accelerate*^*Running.state.Stopped*^*Running.state.Moving*^*\")" ] ;
   
-  Car_stateRunningState_Moving -> Car_stateRunningState_Stopped [  label = "stop", tooltip = "From Running.state.Moving to Running.state.Stopped on stop", URL="javascript:Action.transitionClicked(\"Car*^*state*^*stop*^*Running.state.Moving*^*Running.state.Stopped*^*\")" ] ;
+  Car_stateRunningState_Moving -> Car_stateRunningState_Stopped [  label = "stop", tooltip = "From Running.state.Moving to Running.state.Stopped on stop&#13;&#13;When stop occurs in state Running.state.Moving, transitions to Running.state.Stopped.", URL="javascript:Action.transitionClicked(\"Car*^*state*^*stop*^*Running.state.Moving*^*Running.state.Stopped*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/ColouredDerivedState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ColouredDerivedState.gv.txt
@@ -15,20 +15,20 @@ digraph "ColouredDerivedState" {
     
       // State: Off
 
-      LightBulb_state_Off [label = Off,style = "filled, rounded", fillcolor ="red", tooltip = "Class LightBulb, SM state, State Off", URL="javascript:Action.stateClicked(\"LightBulb^*^state^*^Off\")"];
+      LightBulb_state_Off [label = Off,style = "filled, rounded", fillcolor ="red", tooltip = "Class LightBulb, SM state, State Off&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event turnOff occurs while in state On.&#13;On turnOn, transitions to On.", URL="javascript:Action.stateClicked(\"LightBulb^*^state^*^Off\")"];
       // End State: Off
 
       // State: On
 
-      LightBulb_state_On [label = On,style = "filled, rounded", fillcolor ="yellow", tooltip = "Class LightBulb, SM state, State On", URL="javascript:Action.stateClicked(\"LightBulb^*^state^*^On\")"];
+      LightBulb_state_On [label = On,style = "filled, rounded", fillcolor ="yellow", tooltip = "Class LightBulb, SM state, State On&#13;&#13;This state is entered when event turnOn occurs while in state Off.&#13;On turnOff, transitions to Off.", URL="javascript:Action.stateClicked(\"LightBulb^*^state^*^On\")"];
       // End State: On
     // End Top and Bottom Level StateMachine: state
 
   // All transitions
     start_LightBulb_state -> LightBulb_state_Off [  tooltip = "start to Off", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    LightBulb_state_On -> LightBulb_state_Off [  label = "turnOff", tooltip = "From On to Off on turnOff", URL="javascript:Action.transitionClicked(\"LightBulb*^*state*^*turnOff*^*On*^*Off*^*\")" ] ;
+    LightBulb_state_On -> LightBulb_state_Off [  label = "turnOff", tooltip = "From On to Off on turnOff&#13;&#13;When turnOff occurs in state On, transitions to Off.", URL="javascript:Action.transitionClicked(\"LightBulb*^*state*^*turnOff*^*On*^*Off*^*\")" ] ;
   
-  LightBulb_state_Off -> LightBulb_state_On [  label = "turnOn", tooltip = "From Off to On on turnOn", URL="javascript:Action.transitionClicked(\"LightBulb*^*state*^*turnOn*^*Off*^*On*^*\")" ] ;
+  LightBulb_state_Off -> LightBulb_state_On [  label = "turnOn", tooltip = "From Off to On on turnOn&#13;&#13;When turnOn occurs in state Off, transitions to On.", URL="javascript:Action.transitionClicked(\"LightBulb*^*state*^*turnOn*^*Off*^*On*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/Entry5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/Entry5State.gv.txt
@@ -20,7 +20,7 @@ digraph "Entry5State" {
    doEntry2();
    doEntry3();
    doEntry4();
-   doEntry5();", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   doEntry5();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/EntryLess5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/EntryLess5State.gv.txt
@@ -16,7 +16,7 @@ digraph "EntryLess5State" {
       // State: s2
 
       A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;Entry:
-   doEntry();", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   doEntry();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/EntryMore5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/EntryMore5State.gv.txt
@@ -21,7 +21,7 @@ digraph "EntryMore5State" {
    doEntry3();
    doEntry4();
    doEntry5();
-   ...", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   ...&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/Exit5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/Exit5State.gv.txt
@@ -20,7 +20,7 @@ digraph "Exit5State" {
    doEntry2();
    doEntry3();
    doEntry4();
-   doEntry5();", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   doEntry5();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On exit from this state an exit action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/ExitLess5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ExitLess5State.gv.txt
@@ -16,7 +16,7 @@ digraph "ExitLess5State" {
       // State: s2
 
       A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;Exit:
-   doEntry();", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   doEntry();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On exit from this state an exit action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/ExitMore5State.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ExitMore5State.gv.txt
@@ -21,7 +21,7 @@ digraph "ExitMore5State" {
    doEntry3();
    doEntry4();
    doEntry5();
-   ...", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+   ...&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On exit from this state an exit action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/GuardTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GuardTransition.gv.txt
@@ -15,18 +15,18 @@ digraph "GuardTransition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1 if guard [guard()], transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1 when guard [guard()] is true.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_sm_s1 -> A_sm_s2 [  label = "e1 [guard()]", tooltip = "From s1 to s2 on e1&#13;Guard:  [guard()]", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^* [guard()]\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "e1 [guard()]", tooltip = "From s1 to s2 on e1&#13;Guard:  [guard()]&#13;&#13;When e1 occurs in state s1, transitions to s2 if guard [guard()].", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^* [guard()]\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/GuardedAutoTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GuardedAutoTransition.gv.txt
@@ -18,7 +18,7 @@ digraph "GuardedAutoTransition" {
       X_sm_s1 [label = s1, tooltip = "Class X, SM sm, State s1&#13;Entry:
    System.out.println(&quot;Starting first sleep&quot;);&#13;Activity:
    Thread.sleep(2000);
-   System.out.println(&quot;Ending first sleep&quot;);", URL="javascript:Action.stateClicked(\"X^*^sm^*^s1\")"];
+   System.out.println(&quot;Ending first sleep&quot;);&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;A do activity runs in a separate thread until completion or state exit.&#13;Exits automatically if guard [guard], transitions to s2.", URL="javascript:Action.stateClicked(\"X^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
@@ -26,13 +26,13 @@ digraph "GuardedAutoTransition" {
       X_sm_s2 [label = s2, tooltip = "Class X, SM sm, State s2&#13;Entry:
    System.out.println(&quot;Starting second sleep&quot;);&#13;Activity:
    Thread.sleep(2000);
-   System.out.println(&quot;Ending second sleep&quot;);", URL="javascript:Action.stateClicked(\"X^*^sm^*^s2\")"];
+   System.out.println(&quot;Ending second sleep&quot;);&#13;&#13;This state is entered automatically from s1 when guard [guard] is true.&#13;On entry into this state an entry action is executed.&#13;A do activity runs in a separate thread until completion or state exit.", URL="javascript:Action.stateClicked(\"X^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_X_sm -> X_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    X_sm_s1 -> X_sm_s2 [  label = "[guard]", tooltip = "From s1 to s2 automatically&#13;Guard: [guard]", URL="javascript:Action.transitionClicked(\"X*^*sm*^**^*s1*^*s2*^*[guard]\")" ] ;
+    X_sm_s1 -> X_sm_s2 [  label = "[guard]", tooltip = "From s1 to s2 automatically&#13;Guard: [guard]&#13;&#13;Automatically transitions from s1 to s2 if guard [guard].", URL="javascript:Action.transitionClicked(\"X*^*sm*^**^*s1*^*s2*^*[guard]\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/GvSdGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvSdGeneratorTest.java
@@ -52,7 +52,14 @@ public class GvSdGeneratorTest extends TemplateTest {
     SampleFileWriter.destroy(pathToInput + "/gv/ParameterTransition.gv");
     
     SampleFileWriter.destroy(pathToInput + "/gv/IncreaseStateSep.gv");
-    
+
+    // Natural language tests
+    SampleFileWriter.destroy(pathToInput + "/gv/NLInitialState.gv");
+    SampleFileWriter.destroy(pathToInput + "/gv/NLMultipleTransitions.gv");
+    SampleFileWriter.destroy(pathToInput + "/gv/NLTimerGuardEntry.gv");
+    SampleFileWriter.destroy(pathToInput + "/gv/NLHideNaturalLanguage.gv");
+    SampleFileWriter.destroy(pathToInput + "/gv/NLDeeplyNestedState.gv");
+
   }
 
   /********* STATE TESTS **********/
@@ -256,6 +263,42 @@ public class GvSdGeneratorTest extends TemplateTest {
   {
     language = null;
     assertUmplePartialTemplateFor("gv/IncreaseStateSep.ump","gv/IncreaseStateSep.gv.txt");
+  }
+
+  /********* NATURAL LANGUAGE TESTS **********/
+  @Test
+  public void nl_initial_state()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/NLInitialState.ump","gv/NLInitialState.gv.txt");
+  }
+
+  @Test
+  public void nl_multiple_transitions()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/NLMultipleTransitions.ump","gv/NLMultipleTransitions.gv.txt");
+  }
+
+  @Test
+  public void nl_timer_guard_entry()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/NLTimerGuardEntry.ump","gv/NLTimerGuardEntry.gv.txt");
+  }
+
+  @Test
+  public void nl_hide_natural_language()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/NLHideNaturalLanguage.ump","gv/NLHideNaturalLanguage.gv.txt");
+  }
+
+  @Test
+  public void nl_deeply_nested_state()
+  {
+    language = null;
+    assertUmplePartialTemplateFor("gv/NLDeeplyNestedState.ump","gv/NLDeeplyNestedState.gv.txt");
   }
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/HexColouredState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/HexColouredState.gv.txt
@@ -15,45 +15,45 @@ digraph "HexColouredState" {
     
       // State: Open
 
-      GarageDoor_status_Open [label = Open,style = "filled, rounded", fillcolor ="#FFFF00", tooltip = "Class GarageDoor, SM status, State Open", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Open\")"];
+      GarageDoor_status_Open [label = Open,style = "filled, rounded", fillcolor ="#FFFF00", tooltip = "Class GarageDoor, SM status, State Open&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event reachTop occurs while in state Opening.&#13;On buttonOrObstacle, transitions to Closing.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Open\")"];
       // End State: Open
 
       // State: Closing
 
-      GarageDoor_status_Closing [label = Closing,style = "filled, rounded", fillcolor ="#008000", tooltip = "Class GarageDoor, SM status, State Closing", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closing\")"];
+      GarageDoor_status_Closing [label = Closing,style = "filled, rounded", fillcolor ="#008000", tooltip = "Class GarageDoor, SM status, State Closing&#13;&#13;This state is entered when event buttonOrObstacle occurs while in state Open.&#13;On buttonOrObstacle, transitions to Opening.&#13;On reachBottom, transitions to Closed.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closing\")"];
       // End State: Closing
 
       // State: Closed
 
-      GarageDoor_status_Closed [label = Closed,style = "filled, rounded", fillcolor ="#FF0000", tooltip = "Class GarageDoor, SM status, State Closed", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closed\")"];
+      GarageDoor_status_Closed [label = Closed,style = "filled, rounded", fillcolor ="#FF0000", tooltip = "Class GarageDoor, SM status, State Closed&#13;&#13;This state is entered when event reachBottom occurs while in state Closing.&#13;On buttonOrObstacle, transitions to Opening.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closed\")"];
       // End State: Closed
 
       // State: Opening
 
-      GarageDoor_status_Opening [label = Opening,style = "filled, rounded", fillcolor ="#FFA500", tooltip = "Class GarageDoor, SM status, State Opening", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Opening\")"];
+      GarageDoor_status_Opening [label = Opening,style = "filled, rounded", fillcolor ="#FFA500", tooltip = "Class GarageDoor, SM status, State Opening&#13;&#13;This state is entered when event buttonOrObstacle occurs while in state Closing.&#13;This state is entered when event buttonOrObstacle occurs while in state Closed.&#13;This state is entered when event buttonOrObstacle occurs while in state HalfOpen.&#13;On buttonOrObstacle, transitions to HalfOpen.&#13;On reachTop, transitions to Open.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Opening\")"];
       // End State: Opening
 
       // State: HalfOpen
 
-      GarageDoor_status_HalfOpen [label = HalfOpen,style = "filled, rounded", fillcolor ="#FFC0CB", tooltip = "Class GarageDoor, SM status, State HalfOpen", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^HalfOpen\")"];
+      GarageDoor_status_HalfOpen [label = HalfOpen,style = "filled, rounded", fillcolor ="#FFC0CB", tooltip = "Class GarageDoor, SM status, State HalfOpen&#13;&#13;This state is entered when event buttonOrObstacle occurs while in state Opening.&#13;On buttonOrObstacle, transitions to Opening.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^HalfOpen\")"];
       // End State: HalfOpen
     // End Top and Bottom Level StateMachine: status
 
   // All transitions
     start_GarageDoor_status -> GarageDoor_status_Open [  tooltip = "start to Open", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    GarageDoor_status_Opening -> GarageDoor_status_Open [  label = "reachTop", tooltip = "From Opening to Open on reachTop", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachTop*^*Opening*^*Open*^*\")" ] ;
+    GarageDoor_status_Opening -> GarageDoor_status_Open [  label = "reachTop", tooltip = "From Opening to Open on reachTop&#13;&#13;When reachTop occurs in state Opening, transitions to Open.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachTop*^*Opening*^*Open*^*\")" ] ;
   
-  GarageDoor_status_Open -> GarageDoor_status_Closing [  label = "buttonOrObstacle", tooltip = "From Open to Closing on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Open*^*Closing*^*\")" ] ;
+  GarageDoor_status_Open -> GarageDoor_status_Closing [  label = "buttonOrObstacle", tooltip = "From Open to Closing on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Open, transitions to Closing.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Open*^*Closing*^*\")" ] ;
   
-  GarageDoor_status_Closing -> GarageDoor_status_Closed [  label = "reachBottom", tooltip = "From Closing to Closed on reachBottom", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachBottom*^*Closing*^*Closed*^*\")" ] ;
+  GarageDoor_status_Closing -> GarageDoor_status_Closed [  label = "reachBottom", tooltip = "From Closing to Closed on reachBottom&#13;&#13;When reachBottom occurs in state Closing, transitions to Closed.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachBottom*^*Closing*^*Closed*^*\")" ] ;
   
-  GarageDoor_status_Closing -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closing to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closing*^*Opening*^*\")" ] ;
+  GarageDoor_status_Closing -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closing to Opening on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Closing, transitions to Opening.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closing*^*Opening*^*\")" ] ;
   
-  GarageDoor_status_Closed -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closed to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closed*^*Opening*^*\")" ] ;
+  GarageDoor_status_Closed -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closed to Opening on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Closed, transitions to Opening.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closed*^*Opening*^*\")" ] ;
   
-  GarageDoor_status_HalfOpen -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From HalfOpen to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*HalfOpen*^*Opening*^*\")" ] ;
+  GarageDoor_status_HalfOpen -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From HalfOpen to Opening on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state HalfOpen, transitions to Opening.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*HalfOpen*^*Opening*^*\")" ] ;
   
-  GarageDoor_status_Opening -> GarageDoor_status_HalfOpen [  label = "buttonOrObstacle", tooltip = "From Opening to HalfOpen on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Opening*^*HalfOpen*^*\")" ] ;
+  GarageDoor_status_Opening -> GarageDoor_status_HalfOpen [  label = "buttonOrObstacle", tooltip = "From Opening to HalfOpen on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Opening, transitions to HalfOpen.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Opening*^*HalfOpen*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/HideActionState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/HideActionState.gv.txt
@@ -15,7 +15,7 @@ digraph "HideActionState" {
     
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;On exit from this state an exit action is executed.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 

--- a/cruise.umple/test/cruise/umple/implementation/gv/HideActionTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/HideActionTransition.gv.txt
@@ -15,18 +15,18 @@ digraph "HideActionTransition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/HideGuardTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/HideGuardTransition.gv.txt
@@ -15,18 +15,18 @@ digraph "HideGuardTransition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/IncreaseStateSep.gv.txt
@@ -15,45 +15,45 @@ nodesep =2.0;ranksep =2.0;
     
       // State: Open
 
-      GarageDoor_status_Open [label = Open, tooltip = "Class GarageDoor, SM status, State Open", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Open\")"];
+      GarageDoor_status_Open [label = Open, tooltip = "Class GarageDoor, SM status, State Open&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event reachTop occurs while in state Opening.&#13;On buttonOrObstacle, transitions to Closing.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Open\")"];
       // End State: Open
 
       // State: Closing
 
-      GarageDoor_status_Closing [label = Closing, tooltip = "Class GarageDoor, SM status, State Closing", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closing\")"];
+      GarageDoor_status_Closing [label = Closing, tooltip = "Class GarageDoor, SM status, State Closing&#13;&#13;This state is entered when event buttonOrObstacle occurs while in state Open.&#13;On buttonOrObstacle, transitions to Opening.&#13;On reachBottom, transitions to Closed.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closing\")"];
       // End State: Closing
 
       // State: Closed
 
-      GarageDoor_status_Closed [label = Closed, tooltip = "Class GarageDoor, SM status, State Closed", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closed\")"];
+      GarageDoor_status_Closed [label = Closed, tooltip = "Class GarageDoor, SM status, State Closed&#13;&#13;This state is entered when event reachBottom occurs while in state Closing.&#13;On buttonOrObstacle, transitions to Opening.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Closed\")"];
       // End State: Closed
 
       // State: Opening
 
-      GarageDoor_status_Opening [label = Opening, tooltip = "Class GarageDoor, SM status, State Opening", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Opening\")"];
+      GarageDoor_status_Opening [label = Opening, tooltip = "Class GarageDoor, SM status, State Opening&#13;&#13;This state is entered when event buttonOrObstacle occurs while in state Closing.&#13;This state is entered when event buttonOrObstacle occurs while in state Closed.&#13;This state is entered when event buttonOrObstacle occurs while in state HalfOpen.&#13;On buttonOrObstacle, transitions to HalfOpen.&#13;On reachTop, transitions to Open.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^Opening\")"];
       // End State: Opening
 
       // State: HalfOpen
 
-      GarageDoor_status_HalfOpen [label = HalfOpen, tooltip = "Class GarageDoor, SM status, State HalfOpen", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^HalfOpen\")"];
+      GarageDoor_status_HalfOpen [label = HalfOpen, tooltip = "Class GarageDoor, SM status, State HalfOpen&#13;&#13;This state is entered when event buttonOrObstacle occurs while in state Opening.&#13;On buttonOrObstacle, transitions to Opening.", URL="javascript:Action.stateClicked(\"GarageDoor^*^status^*^HalfOpen\")"];
       // End State: HalfOpen
     // End Top and Bottom Level StateMachine: status
 
   // All transitions
     start_GarageDoor_status -> GarageDoor_status_Open [  tooltip = "start to Open", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    GarageDoor_status_Opening -> GarageDoor_status_Open [  label = "reachTop", tooltip = "From Opening to Open on reachTop", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachTop*^*Opening*^*Open*^*\")" ] ;
+    GarageDoor_status_Opening -> GarageDoor_status_Open [  label = "reachTop", tooltip = "From Opening to Open on reachTop&#13;&#13;When reachTop occurs in state Opening, transitions to Open.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachTop*^*Opening*^*Open*^*\")" ] ;
   
-  GarageDoor_status_Open -> GarageDoor_status_Closing [  label = "buttonOrObstacle", tooltip = "From Open to Closing on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Open*^*Closing*^*\")" ] ;
+  GarageDoor_status_Open -> GarageDoor_status_Closing [  label = "buttonOrObstacle", tooltip = "From Open to Closing on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Open, transitions to Closing.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Open*^*Closing*^*\")" ] ;
   
-  GarageDoor_status_Closing -> GarageDoor_status_Closed [  label = "reachBottom", tooltip = "From Closing to Closed on reachBottom", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachBottom*^*Closing*^*Closed*^*\")" ] ;
+  GarageDoor_status_Closing -> GarageDoor_status_Closed [  label = "reachBottom", tooltip = "From Closing to Closed on reachBottom&#13;&#13;When reachBottom occurs in state Closing, transitions to Closed.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*reachBottom*^*Closing*^*Closed*^*\")" ] ;
   
-  GarageDoor_status_Closing -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closing to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closing*^*Opening*^*\")" ] ;
+  GarageDoor_status_Closing -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closing to Opening on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Closing, transitions to Opening.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closing*^*Opening*^*\")" ] ;
   
-  GarageDoor_status_Closed -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closed to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closed*^*Opening*^*\")" ] ;
+  GarageDoor_status_Closed -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From Closed to Opening on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Closed, transitions to Opening.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Closed*^*Opening*^*\")" ] ;
   
-  GarageDoor_status_HalfOpen -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From HalfOpen to Opening on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*HalfOpen*^*Opening*^*\")" ] ;
+  GarageDoor_status_HalfOpen -> GarageDoor_status_Opening [  label = "buttonOrObstacle", tooltip = "From HalfOpen to Opening on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state HalfOpen, transitions to Opening.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*HalfOpen*^*Opening*^*\")" ] ;
   
-  GarageDoor_status_Opening -> GarageDoor_status_HalfOpen [  label = "buttonOrObstacle", tooltip = "From Opening to HalfOpen on buttonOrObstacle", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Opening*^*HalfOpen*^*\")" ] ;
+  GarageDoor_status_Opening -> GarageDoor_status_HalfOpen [  label = "buttonOrObstacle", tooltip = "From Opening to HalfOpen on buttonOrObstacle&#13;&#13;When buttonOrObstacle occurs in state Opening, transitions to HalfOpen.", URL="javascript:Action.transitionClicked(\"GarageDoor*^*status*^*buttonOrObstacle*^*Opening*^*HalfOpen*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLDeeplyNestedState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLDeeplyNestedState.gv.txt
@@ -1,0 +1,83 @@
+digraph "NLDeeplyNestedState" {
+  compound = true;
+
+  // Class: A
+
+    // Top Level StateMachine: sm
+    
+    // Start states are shown as a black circle
+    node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+    start_A_sm [ tooltip = "Class A, SM sm, State start" ];
+    
+        
+    // Format for normal states
+    node [ratio="auto" shape = rectangle, width=1,style=rounded];
+    
+      // State: s1
+
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event e3 occurs while in state s2.s2a.s2a2.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      // End State: s1
+
+      // State: s2
+
+     subgraph clusterA_sm_s2 {
+      label = "s2";
+      style = rounded; 
+      URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")";
+
+      // StateMachine: s2
+      
+      // Start states are shown as a black circle
+      node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+      start_A_smS2 [ tooltip = "Class A, SM sm, State s2.start" ];
+      
+            
+      // Format for normal states
+      node [ratio="auto" shape = rectangle, width=1,style=rounded];
+      
+        // State: s2a
+
+       subgraph clusterA_smS2_s2a {
+        label = "s2a";
+        style = rounded; 
+        URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a\")";
+
+        // Bottom Level StateMachine: s2a
+        
+        // Start states are shown as a black circle
+        node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+        start_A_smS2S2a [ tooltip = "Class A, SM sm, State s2.s2a.start" ];
+        
+                
+        // Format for normal states
+        node [ratio="auto" shape = rectangle, width=1,style=rounded];
+        
+          // State: s2a1
+
+          A_smS2S2a_s2a1 [label = s2a1, tooltip = "Class A, SM sm, State s2.s2a.s2a1&#13;&#13;This is the default initial state when entering state s2.s2a.&#13;This state is entered when event e1 occurs while in state s1.&#13;On e2, transitions to s2.s2a.s2a2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a.s2a1\")"];
+          // End State: s2a1
+
+          // State: s2a2
+
+          A_smS2S2a_s2a2 [label = s2a2, tooltip = "Class A, SM sm, State s2.s2a.s2a2&#13;&#13;This state is entered when event e2 occurs while in state s2.s2a.s2a1.&#13;On e3, transitions to s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a.s2a2\")"];
+          // End State: s2a2
+        // End Bottom Level StateMachine: s2a
+       }
+        // End State: s2a
+      // End StateMachine: s2
+     }
+      // End State: s2
+    // End Top Level StateMachine: sm
+
+  // All transitions
+    start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    A_smS2S2a_s2a2 -> A_sm_s1 [  label = "e3", tooltip = "From s2.s2a.s2a2 to s1 on e3&#13;&#13;When e3 occurs in state s2.s2a.s2a2, transitions to s1.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e3*^*s2.s2a.s2a2*^*s1*^*\")" ] ;
+  
+  A_sm_s1 -> A_smS2S2a_s2a1 [  lhead=clusterA_sm_s2,  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+  
+  start_A_smS2 -> A_smS2S2a_s2a1 [  lhead=clusterA_smS2_s2a,  tooltip = "start to s2.s2a", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    start_A_smS2S2a -> A_smS2S2a_s2a1 [  tooltip = "start to s2.s2a.s2a1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    A_smS2S2a_s2a1 -> A_smS2S2a_s2a2 [  label = "e2", tooltip = "From s2.s2a.s2a1 to s2.s2a.s2a2 on e2&#13;&#13;When e2 occurs in state s2.s2a.s2a1, transitions to s2.s2a.s2a2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e2*^*s2.s2a.s2a1*^*s2.s2a.s2a2*^*\")" ] ;
+  
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLDeeplyNestedState.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLDeeplyNestedState.ump
@@ -1,0 +1,20 @@
+generate GvStateDiagram;
+namespace example;
+
+class A {
+  sm {
+    s1 {
+      e1 -> s2;
+    }
+    s2 {
+      s2a {
+        s2a1 {
+          e2 -> s2a2;
+        }
+        s2a2 {
+          e3 -> s1;
+        }
+      }
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLHideNaturalLanguage.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLHideNaturalLanguage.gv.txt
@@ -1,4 +1,4 @@
-digraph "NormalState" {
+digraph "NLHideNaturalLanguage" {
   compound = true;
 
   // Class: A
@@ -15,11 +15,18 @@ digraph "NormalState" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
+
+      // State: s2
+
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
+
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLHideNaturalLanguage.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLHideNaturalLanguage.ump
@@ -1,0 +1,12 @@
+generate GvStateDiagram -s "hidenaturallanguage";
+namespace example;
+
+class A {
+  sm {
+    s1 {
+      e1 -> s2;
+    }
+    s2 {
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLInitialState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLInitialState.gv.txt
@@ -1,0 +1,34 @@
+digraph "NLInitialState" {
+  compound = true;
+
+  // Class: A
+
+    // Top and Bottom Level StateMachine: sm
+    
+    // Start states are shown as a black circle
+    node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+    start_A_sm [ tooltip = "Class A, SM sm, State start" ];
+    
+        
+    // Format for normal states
+    node [ratio="auto" shape = rectangle, width=1,style=rounded];
+    
+      // State: s1
+
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event e2 occurs while in state s2.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      // End State: s1
+
+      // State: s2
+
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.&#13;On e2, transitions to s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      // End State: s2
+    // End Top and Bottom Level StateMachine: sm
+
+  // All transitions
+    start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    A_sm_s2 -> A_sm_s1 [  label = "e2", tooltip = "From s2 to s1 on e2&#13;&#13;When e2 occurs in state s2, transitions to s1.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e2*^*s2*^*s1*^*\")" ] ;
+  
+  A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+  
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLInitialState.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLInitialState.ump
@@ -1,0 +1,13 @@
+generate GvStateDiagram;
+namespace example;
+
+class A {
+  sm {
+    s1 {
+      e1 -> s2;
+    }
+    s2 {
+      e2 -> s1;
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLMultipleTransitions.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLMultipleTransitions.gv.txt
@@ -1,0 +1,45 @@
+digraph "NLMultipleTransitions" {
+  compound = true;
+
+  // Class: A
+
+    // Top and Bottom Level StateMachine: sm
+    
+    // Start states are shown as a black circle
+    node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+    start_A_sm [ tooltip = "Class A, SM sm, State start" ];
+    
+        
+    // Format for normal states
+    node [ratio="auto" shape = rectangle, width=1,style=rounded];
+    
+      // State: s1
+
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event e3 occurs while in state s2.&#13;This state is entered when event e1 occurs while in state s3.&#13;On e1, transitions to s2.&#13;On e2, transitions to s3.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      // End State: s1
+
+      // State: s2
+
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.&#13;This state is entered when event e2 occurs while in state s3.&#13;On e3, transitions to s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      // End State: s2
+
+      // State: s3
+
+      A_sm_s3 [label = s3, tooltip = "Class A, SM sm, State s3&#13;&#13;This state is entered when event e2 occurs while in state s1.&#13;On e1, transitions to s1.&#13;On e2, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s3\")"];
+      // End State: s3
+    // End Top and Bottom Level StateMachine: sm
+
+  // All transitions
+    start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    A_sm_s2 -> A_sm_s1 [  label = "e3", tooltip = "From s2 to s1 on e3&#13;&#13;When e3 occurs in state s2, transitions to s1.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e3*^*s2*^*s1*^*\")" ] ;
+  
+  A_sm_s3 -> A_sm_s1 [  label = "e1", tooltip = "From s3 to s1 on e1&#13;&#13;When e1 occurs in state s3, transitions to s1.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s3*^*s1*^*\")" ] ;
+  
+  A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+  
+  A_sm_s3 -> A_sm_s2 [  label = "e2", tooltip = "From s3 to s2 on e2&#13;&#13;When e2 occurs in state s3, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e2*^*s3*^*s2*^*\")" ] ;
+  
+  A_sm_s1 -> A_sm_s3 [  label = "e2", tooltip = "From s1 to s3 on e2&#13;&#13;When e2 occurs in state s1, transitions to s3.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e2*^*s1*^*s3*^*\")" ] ;
+  
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLMultipleTransitions.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLMultipleTransitions.ump
@@ -1,0 +1,18 @@
+generate GvStateDiagram;
+namespace example;
+
+class A {
+  sm {
+    s1 {
+      e1 -> s2;
+      e2 -> s3;
+    }
+    s2 {
+      e3 -> s1;
+    }
+    s3 {
+      e1 -> s1;
+      e2 -> s2;
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLTimerGuardEntry.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLTimerGuardEntry.gv.txt
@@ -1,0 +1,33 @@
+digraph "NLTimerGuardEntry" {
+  compound = true;
+
+  // Class: A
+
+    // Top and Bottom Level StateMachine: sm
+    
+    // Start states are shown as a black circle
+    node [ratio="auto" shape = point, fillcolor="black", width=0.2 ];
+    start_A_sm [ tooltip = "Class A, SM sm, State start" ];
+    
+        
+    // Format for normal states
+    node [ratio="auto" shape = rectangle, width=1,style=rounded];
+    
+      // State: s1
+
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;Entry:
+   doEntry();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;After 5 second(s) if guard [isReady()], transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      // End State: s1
+
+      // State: s2
+
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered after 5 second(s) while in state s1 when guard [isReady()] is true.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      // End State: s2
+    // End Top and Bottom Level StateMachine: sm
+
+  // All transitions
+    start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "after(5) [isReady()]", tooltip = "From s1 to s2 after(5)&#13;Guard:  [isReady()]&#13;&#13;After 5 second(s) in state s1, transitions to s2 if guard [isReady()].", URL="javascript:Action.transitionClicked(\"A*^*sm*^*after(5)*^*s1*^*s2*^* [isReady()]\")" ] ;
+  
+
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLTimerGuardEntry.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLTimerGuardEntry.gv.txt
@@ -16,18 +16,18 @@ digraph "NLTimerGuardEntry" {
       // State: s1
 
       A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;Entry:
-   doEntry();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;After 5 second(s) if guard [isReady()], transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+   doEntry();&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;After 5000 millisecond(s) if guard [isReady()], transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered after 5 second(s) while in state s1 when guard [isReady()] is true.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered after 5000 millisecond(s) while in state s1 when guard [isReady()] is true.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_sm_s1 -> A_sm_s2 [  label = "after(5) [isReady()]", tooltip = "From s1 to s2 after(5)&#13;Guard:  [isReady()]&#13;&#13;After 5 second(s) in state s1, transitions to s2 if guard [isReady()].", URL="javascript:Action.transitionClicked(\"A*^*sm*^*after(5)*^*s1*^*s2*^* [isReady()]\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "after(5) [isReady()]", tooltip = "From s1 to s2 after(5)&#13;Guard:  [isReady()]&#13;&#13;After 5000 millisecond(s) in state s1, transitions to s2 if guard [isReady()].", URL="javascript:Action.transitionClicked(\"A*^*sm*^*after(5)*^*s1*^*s2*^* [isReady()]\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/NLTimerGuardEntry.ump
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NLTimerGuardEntry.ump
@@ -1,0 +1,13 @@
+generate GvStateDiagram;
+namespace example;
+
+class A {
+  sm {
+    s1 {
+      entry / {doEntry();}
+      after(5) [isReady()] -> s2;
+    }
+    s2 {
+    }
+  }
+}

--- a/cruise.umple/test/cruise/umple/implementation/gv/NestedState.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NestedState.gv.txt
@@ -32,7 +32,7 @@ digraph "NestedState" {
       
         // State: s2a
 
-        A_smS2_s2a [label = s2a, tooltip = "Class A, SM sm, State s2.s2a", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a\")"];
+        A_smS2_s2a [label = s2a, tooltip = "Class A, SM sm, State s2.s2a&#13;&#13;This is the default initial state when entering state s2 and is entered when the object is created.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a\")"];
         // End State: s2a
       // End Bottom Level StateMachine: s2
      }

--- a/cruise.umple/test/cruise/umple/implementation/gv/NestedTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/NestedTransition.gv.txt
@@ -15,7 +15,7 @@ digraph "NestedTransition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event e1 occurs while in state s2.&#13;On e1, transitions to s2.&#13;On e2, transitions to s2.s2b.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
@@ -37,12 +37,12 @@ digraph "NestedTransition" {
       
         // State: s2a
 
-        A_smS2_s2a [label = s2a, tooltip = "Class A, SM sm, State s2.s2a", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a\")"];
+        A_smS2_s2a [label = s2a, tooltip = "Class A, SM sm, State s2.s2a&#13;&#13;This is the default initial state when entering state s2.&#13;This state is entered when event e3 occurs while in state s2.s2b.&#13;This state is entered when event e1 occurs while in state s1.&#13;On e3, transitions to s2.s2b.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2a\")"];
         // End State: s2a
 
         // State: s2b
 
-        A_smS2_s2b [label = s2b, tooltip = "Class A, SM sm, State s2.s2b", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2b\")"];
+        A_smS2_s2b [label = s2b, tooltip = "Class A, SM sm, State s2.s2b&#13;&#13;This state is entered when event e2 occurs while in state s1.&#13;This state is entered when event e3 occurs while in state s2.s2a.&#13;On e3, transitions to s2.s2a.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2.s2b\")"];
         // End State: s2b
       // End Bottom Level StateMachine: s2
      }
@@ -51,16 +51,16 @@ digraph "NestedTransition" {
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_smS2_s2a -> A_sm_s1 [  ltail=clusterA_sm_s2,  label = "e1", tooltip = "From s2 to s1 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s2*^*s1*^*\")" ] ;
+    A_smS2_s2a -> A_sm_s1 [  ltail=clusterA_sm_s2,  label = "e1", tooltip = "From s2 to s1 on e1&#13;&#13;When e1 occurs in state s2, transitions to s1.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s2*^*s1*^*\")" ] ;
   
-  A_sm_s1 -> A_smS2_s2a [  lhead=clusterA_sm_s2,  label = "e1", tooltip = "From s1 to s2 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+  A_sm_s1 -> A_smS2_s2a [  lhead=clusterA_sm_s2,  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
   start_A_smS2 -> A_smS2_s2a [  tooltip = "start to s2.s2a", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_smS2_s2b -> A_smS2_s2a [  label = "e3", tooltip = "From s2.s2b to s2.s2a on e3", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e3*^*s2.s2b*^*s2.s2a*^*\")" ] ;
+    A_smS2_s2b -> A_smS2_s2a [  label = "e3", tooltip = "From s2.s2b to s2.s2a on e3&#13;&#13;When e3 occurs in state s2.s2b, transitions to s2.s2a.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e3*^*s2.s2b*^*s2.s2a*^*\")" ] ;
   
-  A_sm_s1 -> A_smS2_s2b [  label = "e2", tooltip = "From s1 to s2.s2b on e2", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e2*^*s1*^*s2.s2b*^*\")" ] ;
+  A_sm_s1 -> A_smS2_s2b [  label = "e2", tooltip = "From s1 to s2.s2b on e2&#13;&#13;When e2 occurs in state s1, transitions to s2.s2b.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e2*^*s1*^*s2.s2b*^*\")" ] ;
   
-  A_smS2_s2a -> A_smS2_s2b [  label = "e3", tooltip = "From s2.s2a to s2.s2b on e3", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e3*^*s2.s2a*^*s2.s2b*^*\")" ] ;
+  A_smS2_s2a -> A_smS2_s2b [  label = "e3", tooltip = "From s2.s2a to s2.s2b on e3&#13;&#13;When e3 occurs in state s2.s2a, transitions to s2.s2b.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e3*^*s2.s2a*^*s2.s2b*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/ParameterTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/ParameterTransition.gv.txt
@@ -25,12 +25,12 @@ digraph "ParameterTransition" {
    Thread.sleep(1000);
    e(6);
    Thread.sleep(1000);
-   ...", URL="javascript:Action.stateClicked(\"X^*^stateMachine1^*^s1a\")"];
+   ...&#13;&#13;This is the default initial state and is entered when the object is created.&#13;A do activity runs in a separate thread until completion or state exit.&#13;Exits automatically, transitions to s1b.", URL="javascript:Action.stateClicked(\"X^*^stateMachine1^*^s1a\")"];
       // End State: s1a
 
       // State: s1b
 
-      X_stateMachine1_s1b [label = s1b, tooltip = "Class X, SM stateMachine1, State s1b", URL="javascript:Action.stateClicked(\"X^*^stateMachine1^*^s1b\")"];
+      X_stateMachine1_s1b [label = s1b, tooltip = "Class X, SM stateMachine1, State s1b&#13;&#13;This state is entered automatically from s1a.", URL="javascript:Action.stateClicked(\"X^*^stateMachine1^*^s1b\")"];
       // End State: s1b
     // End Top and Bottom Level StateMachine: stateMachine1
   }
@@ -52,27 +52,27 @@ digraph "ParameterTransition" {
       // State: s2a
 
       X_stateMachine2_s2a [label = s2a, tooltip = "Class X, SM stateMachine2, State s2a&#13;Entry:
-   System.out.println(&quot;s2a&quot;);", URL="javascript:Action.stateClicked(\"X^*^stateMachine2^*^s2a\")"];
+   System.out.println(&quot;s2a&quot;);&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event e(int a) occurs while in state s2b.&#13;On entry into this state an entry action is executed.&#13;On e(int a) if guard [a > 6], transitions to s2b.", URL="javascript:Action.stateClicked(\"X^*^stateMachine2^*^s2a\")"];
       // End State: s2a
 
       // State: s2b
 
       X_stateMachine2_s2b [label = s2b, tooltip = "Class X, SM stateMachine2, State s2b&#13;Entry:
-   System.out.println(&quot;s2b&quot;);", URL="javascript:Action.stateClicked(\"X^*^stateMachine2^*^s2b\")"];
+   System.out.println(&quot;s2b&quot;);&#13;&#13;This state is entered when event e(int a) occurs while in state s2a when guard [a > 6] is true.&#13;On entry into this state an entry action is executed.&#13;On e(int a), transitions to s2a.", URL="javascript:Action.stateClicked(\"X^*^stateMachine2^*^s2b\")"];
       // End State: s2b
     // End Top and Bottom Level StateMachine: stateMachine2
   }
 
   // All transitions
     start_X_stateMachine1 -> X_stateMachine1_s1a [  tooltip = "start to s1a", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    X_stateMachine1_s1a -> X_stateMachine1_s1b [  tooltip = "From s1a to s1b automatically", URL="javascript:Action.transitionClicked(\"X*^*stateMachine1*^**^*s1a*^*s1b*^*\")" ] ;
+    X_stateMachine1_s1a -> X_stateMachine1_s1b [  tooltip = "From s1a to s1b automatically&#13;&#13;Automatically transitions from s1a to s1b.", URL="javascript:Action.transitionClicked(\"X*^*stateMachine1*^**^*s1a*^*s1b*^*\")" ] ;
   
   start_X_stateMachine2 -> X_stateMachine2_s2a [  tooltip = "start to s2a", URL="javascript:Action.transitionClicked(\"null\")" ] ;
     X_stateMachine2_s2b -> X_stateMachine2_s2a [  label = "e(int a) / {...}", tooltip = "From s2b to s2a on e(int a)&#13;Transition Action:
-   System.out.println(&quot;e&quot;+a);", URL="javascript:Action.transitionClicked(\"X*^*stateMachine2*^*e(int a)*^*s2b*^*s2a*^*\")" ] ;
+   System.out.println(&quot;e&quot;+a);&#13;&#13;When e(int a) occurs in state s2b, transitions to s2a.", URL="javascript:Action.transitionClicked(\"X*^*stateMachine2*^*e(int a)*^*s2b*^*s2a*^*\")" ] ;
   
   X_stateMachine2_s2a -> X_stateMachine2_s2b [  label = "e(int a) [a > 6] / {...}", tooltip = "From s2a to s2b on e(int a)&#13;Guard:  [a > 6]&#13;Transition Action:
-   System.out.println(&quot;e&quot;+a);", URL="javascript:Action.transitionClicked(\"X*^*stateMachine2*^*e(int a)*^*s2a*^*s2b*^* [a > 6]\")" ] ;
+   System.out.println(&quot;e&quot;+a);&#13;&#13;When e(int a) occurs in state s2a, transitions to s2b if guard [a > 6].", URL="javascript:Action.transitionClicked(\"X*^*stateMachine2*^*e(int a)*^*s2a*^*s2b*^* [a > 6]\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/TimedTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/TimedTransition.gv.txt
@@ -16,19 +16,19 @@ digraph "TimedTransition" {
       // State: a
 
       X_sm_a [label = a, tooltip = "Class X, SM sm, State a&#13;Entry:
-   System.out.println(&quot;entering a&quot;);&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;After 1 second(s), transitions to b.", URL="javascript:Action.stateClicked(\"X^*^sm^*^a\")"];
+   System.out.println(&quot;entering a&quot;);&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;After 1000 millisecond(s), transitions to b.", URL="javascript:Action.stateClicked(\"X^*^sm^*^a\")"];
       // End State: a
 
       // State: b
 
       X_sm_b [label = b, tooltip = "Class X, SM sm, State b&#13;Entry:
-   System.out.println(&quot;entering b&quot;);&#13;&#13;This state is entered after 1 second(s) while in state a.&#13;On entry into this state an entry action is executed.", URL="javascript:Action.stateClicked(\"X^*^sm^*^b\")"];
+   System.out.println(&quot;entering b&quot;);&#13;&#13;This state is entered after 1000 millisecond(s) while in state a.&#13;On entry into this state an entry action is executed.", URL="javascript:Action.stateClicked(\"X^*^sm^*^b\")"];
       // End State: b
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_X_sm -> X_sm_a [  tooltip = "start to a", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    X_sm_a -> X_sm_b [  label = "after(1)", tooltip = "From a to b after(1)&#13;&#13;After 1 second(s) in state a, transitions to b.", URL="javascript:Action.transitionClicked(\"X*^*sm*^*after(1)*^*a*^*b*^*\")" ] ;
+    X_sm_a -> X_sm_b [  label = "after(1)", tooltip = "From a to b after(1)&#13;&#13;After 1000 millisecond(s) in state a, transitions to b.", URL="javascript:Action.transitionClicked(\"X*^*sm*^*after(1)*^*a*^*b*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/TimedTransition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/TimedTransition.gv.txt
@@ -16,19 +16,19 @@ digraph "TimedTransition" {
       // State: a
 
       X_sm_a [label = a, tooltip = "Class X, SM sm, State a&#13;Entry:
-   System.out.println(&quot;entering a&quot;);", URL="javascript:Action.stateClicked(\"X^*^sm^*^a\")"];
+   System.out.println(&quot;entering a&quot;);&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On entry into this state an entry action is executed.&#13;After 1 second(s), transitions to b.", URL="javascript:Action.stateClicked(\"X^*^sm^*^a\")"];
       // End State: a
 
       // State: b
 
       X_sm_b [label = b, tooltip = "Class X, SM sm, State b&#13;Entry:
-   System.out.println(&quot;entering b&quot;);", URL="javascript:Action.stateClicked(\"X^*^sm^*^b\")"];
+   System.out.println(&quot;entering b&quot;);&#13;&#13;This state is entered after 1 second(s) while in state a.&#13;On entry into this state an entry action is executed.", URL="javascript:Action.stateClicked(\"X^*^sm^*^b\")"];
       // End State: b
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_X_sm -> X_sm_a [  tooltip = "start to a", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    X_sm_a -> X_sm_b [  label = "after(1)", tooltip = "From a to b after(1)", URL="javascript:Action.transitionClicked(\"X*^*sm*^*after(1)*^*a*^*b*^*\")" ] ;
+    X_sm_a -> X_sm_b [  label = "after(1)", tooltip = "From a to b after(1)&#13;&#13;After 1 second(s) in state a, transitions to b.", URL="javascript:Action.transitionClicked(\"X*^*sm*^*after(1)*^*a*^*b*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/Transition.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/Transition.gv.txt
@@ -15,18 +15,18 @@ digraph "Transition" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;On e1, transitions to s2.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
 
       // State: s2
 
-      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
+      A_sm_s2 [label = s2, tooltip = "Class A, SM sm, State s2&#13;&#13;This state is entered when event e1 occurs while in state s1.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s2\")"];
       // End State: s2
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
+    A_sm_s1 -> A_sm_s2 [  label = "e1", tooltip = "From s1 to s2 on e1&#13;&#13;When e1 occurs in state s1, transitions to s2.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s2*^*\")" ] ;
   
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/gv/TransitionSelf.gv.txt
+++ b/cruise.umple/test/cruise/umple/implementation/gv/TransitionSelf.gv.txt
@@ -15,13 +15,13 @@ digraph "TransitionSelf" {
     
       // State: s1
 
-      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
+      A_sm_s1 [label = s1, tooltip = "Class A, SM sm, State s1&#13;&#13;This is the default initial state and is entered when the object is created.&#13;This state is entered when event e1 occurs while in state s1.&#13;On e1, loops back to self.", URL="javascript:Action.stateClicked(\"A^*^sm^*^s1\")"];
       // End State: s1
     // End Top and Bottom Level StateMachine: sm
 
   // All transitions
     start_A_sm -> A_sm_s1 [  tooltip = "start to s1", URL="javascript:Action.transitionClicked(\"null\")" ] ;
-    A_sm_s1 -> A_sm_s1 [  label = "e1", tooltip = "From s1 to s1 on e1", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s1*^*\")" ] ;
+    A_sm_s1 -> A_sm_s1 [  label = "e1", tooltip = "From s1 to s1 on e1&#13;&#13;When e1 occurs in state s1, loops back to self.", URL="javascript:Action.transitionClicked(\"A*^*sm*^*e1*^*s1*^*s1*^*\")" ] ;
   
 
 }

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -376,6 +376,10 @@ Action.clicked = function(event)
   {
     Action.toggleGuardLabels();
   }
+  else if (action == "ToggleNaturalLanguage")
+  {
+    Action.toggleNaturalLanguage();
+  }
   else if (action == "AllowPinch")
   {
     Action.allowPinch();
@@ -6338,6 +6342,11 @@ Action.toggleGuardLabels = function()
   Page.showGuardLabels = !Page.showGuardLabels;
   Action.redrawDiagram();
 }
+Action.toggleNaturalLanguage = function()
+{
+  Page.showNaturalLanguage = !Page.showNaturalLanguage;
+  Action.redrawDiagram();
+}
 Action.allowPinch = function()
 {
   Page.allowPinch = !Page.allowPinch;
@@ -6827,6 +6836,7 @@ Action.getLanguage = function()
     if(Page.showTransitionLabels) language=language+".showtransitionlabels";
     if(!Page.showGuards) language=language+".hideguards";    
     if(Page.showGuardLabels) language=language+".showguardlabels";
+    if(!Page.showNaturalLanguage) language=language+".hidenaturallanguage";
     language=language+"."+$("inputGenerateCode").value.split(":")[1];
   }
   // append any suboptions needed for GvClassDiagram

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -58,6 +58,7 @@ Page.showTraits = false;
 Page.showTransitionLabels = false;
 Page.showGuardLabels = false;
 Page.showGuards = true;
+Page.showNaturalLanguage = true;
 Page.modifiedDiagrams = false;
 Page.allowPinch = false;
 
@@ -268,6 +269,7 @@ Page.initPaletteArea = function()
   Page.initHighlighter("buttonToggleTransitionLabels");
   Page.initHighlighter("buttonToggleGuards");
   Page.initHighlighter("buttonToggleGuardLabels");
+  Page.initHighlighter("buttonToggleNaturalLanguage");
   Page.initHighlighter("buttonToggleTraits");
   Page.initHighlighter("buttonToggleFeatureDependency");
   Page.initHighlighter("buttonAllowPinch");
@@ -349,6 +351,7 @@ Page.initPaletteArea = function()
   Page.initAction("buttonToggleTransitionLabels");
   Page.initAction("buttonToggleGuards");
   Page.initAction("buttonToggleGuardLabels");
+  Page.initAction("buttonToggleNaturalLanguage");
   Page.initAction("buttonAllowPinch");
     
   Page.initLabels();
@@ -410,6 +413,7 @@ Page.initOptions = function()
   jQuery("#buttonToggleTransitionLabels").prop('checked',false);
   jQuery("#buttonToggleGuards").prop('checked',true);  
   jQuery("#buttonToggleGuardLabels").prop('checked',false);
+  jQuery("#buttonToggleNaturalLanguage").prop('checked',true);
   jQuery("#buttonToggleTraits").prop('checked',Page.showTraits);
   jQuery("#buttonToggleFeatureDependency").prop('checked',false);
   jQuery("#buttonAllowPinch").prop('checked',false);

--- a/umpleonline/scripts/umple_tooltips.js
+++ b/umpleonline/scripts/umple_tooltips.js
@@ -83,6 +83,7 @@ ToolTips.tooltipEntries = {
   ttToggleGuards: ['li', "Show/Hide guards in state diagrams (hide to simplify)"],
   ttToggleTransitionLabels: ['li', "Show/Hide transition labels in state diagrams (t1, t2 etc.) to allow reference"],
   ttToggleGuardLabels: ['li', "Show/Hide guard labels on the state diagrams (g1, g2 etc.) to allow reference"],
+  ttToggleNaturalLanguage: ['li', "Show/Hide natural language descriptions in state diagram tooltips (hover text explaining states and transitions in plain English)"],
   SHT_button: ['a', "Show/Hide the text editor - <b>" + toggleTextEditor +"</b>" ],
   SHD_button: ['a', "Show/hide diagram pane on right - <b> ctrl-D</b>"],
   SHA_button: ['a', "Show/hide attributes in class diagrams - <b>shift-ctrl-A</b>"],

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -1037,9 +1037,13 @@ $output = $dataHandle->readData('model.ump');
               <input id="buttonToggleGuards" class="checkbox" type="checkbox"/> 
               <a id="labelToggleGuards" class="buttonExtend">Guards</a> 
             </li>
-            <li id="ttToggleGuardLabels" class="layoutListItem view_opt_state"> 
-              <input id="buttonToggleGuardLabels" class="checkbox" type="checkbox"/> 
-              <a id="labelToggleGuardLabels" class="buttonExtend">Guard Labels</a> 
+            <li id="ttToggleGuardLabels" class="layoutListItem view_opt_state">
+              <input id="buttonToggleGuardLabels" class="checkbox" type="checkbox"/>
+              <a id="labelToggleGuardLabels" class="buttonExtend">Guard Labels</a>
+            </li>
+            <li id="ttToggleNaturalLanguage" class="layoutListItem view_opt_state">
+              <input id="buttonToggleNaturalLanguage" class="checkbox" type="checkbox"/>
+              <a id="labelToggleNaturalLanguage" class="buttonExtend">Natural Language</a>
             </li>
             <li id="ttToggleFeatureDependencyLabels" class="layoutListItem view_opt_feature"> 
               <input id="buttonToggleFeatureDependency" class="checkbox" type="checkbox"/> 


### PR DESCRIPTION
## Summary

This PR adds automatically generated **natural language (plain-English) descriptions** to the tooltips of states and transitions in Graphviz state machine diagrams. When users hover over a state or transition in UmpleOnline, they now see descriptions in natural language.

A new **"Natural Language" toggle checkbox** is added to UmpleOnline's state diagram view options. It is **enabled by default**

<img width="197" height="324" alt="image" src="https://github.com/user-attachments/assets/9c204242-edfa-4a1f-bf12-4e472192f3dc" />

This is a **scoped, non-breaking change** — it only adds new content to tooltips and a new UI toggle. All existing functionality remains intact.

## Natural language patterns by situation

### State tooltips

| Situation | Example tooltip text |
|---|---|
| **Initial state** | `This is the default initial state and is entered when the object is created.` |
| **Initial substate (nested)** | `This is the default initial state when entering state s2.s2a.` |
| **Incoming event transition** | `This state is entered when event e1 occurs while in state s1.` |
| **Incoming timer transition** | `This state is entered after 5 second(s) while in state s1 when guard [isReady()] is true.` |
| **Entry action present** | `On entry into this state an entry action is executed.` |
| **Do activity present** | `A do activity runs in a separate thread until completion or state exit.` |
| **Outgoing event transition** | `On e1, transitions to s2.` |
| **Outgoing timer transition** | `After 5 second(s) if guard [isReady()], transitions to s2.` |
| **Self-transition** | `On e1, loops back to self.` |
| **Exit action present** | `On exit from this state an exit action is executed.` |

### Transition tooltips

| Situation | Example tooltip text |
|---|---|
| **Event transition** | `When e1 occurs in state s1, transitions to s2.` |
| **Timer transition** | `After 5 second(s) in state s1, transitions to s2 if guard [isReady()].` |
| **Auto-transition** | `Automatically transitions from s1 to s2.` |
| **Self-transition** | `When e1 occurs in state s1, loops back to self.` |
| **Guarded transition** | `When e1 occurs in state s1, transitions to s2 if guard [x > 0].` |

### Deeply nested states

For deeply nested sm, the natural language uses full state paths.
<img width="317" height="194" alt="image" src="https://github.com/user-attachments/assets/dc944285-8960-4f99-a6e9-79e952e75488" />


### Toggle (show/hide)

- **Default**: Natural language descriptions are **shown** (`Page.showNaturalLanguage = true`)
- Users can **uncheck** the "Natural Language" checkbox
- Only applies to the **state machine diagram** 

## Test plan

- [x] Run `GvSdGeneratorTest` — all 5 new NL tests and all 27 existing tests should pass
- [x] Open UmpleOnline, create a state machine, and verify tooltips show natural language descriptions on hover
- [x] Uncheck the "Natural Language" checkbox and verify tooltips revert to technical-only content
- [x] Verify nested state machines display correct full state paths in NL text
- [x] Verify no regressions in other diagram types (class diagrams, etc.)

Fixes #1867