### PR TITLE
Enable zooming of svg

### DIFF
--- a/umpleonline/scripts/pinch.js
+++ b/umpleonline/scripts/pinch.js
@@ -10,8 +10,16 @@
 Action.svgChangeCount=0;
 
 Action.removePinch = function() {
-  // Functionality needs to be added to remove
-  // the event listeners when allowPinch is switched off.
+  // Remove the event listeners when allowPinch is switched off.
+  var parentNode = document.querySelector("#umpleCanvas"); 
+  parentNode.removeEventListener('wheel',
+    Action.wheelPinchFunction);
+  parentNode.removeEventListener("gesturestart",
+    Action.gesturestartPinchFunction);
+  parentNode.removeEventListener("gesturechange",
+    Action.gesturechangePinchFunction);
+  parentNode.removeEventListener("gestureend",
+    Action.gestureendPinchFunction);
 }
 
 Action.setupPinch = function()
@@ -34,7 +42,8 @@ Action.setupPinch = function()
   
   var svgPosX=0;
   var posY=0;
-  var scale=1;
+  // Default zoom is 0.4 set in umple_page; default scale is 1
+  var scale = Page.currentZoom * 2.5;
 
   // The area currently dedicated to the canvas
   var fullArea = document.querySelector("#umpleCanvasColumn");
@@ -136,42 +145,48 @@ Action.setupPinch = function()
   
   }
 
-  parentNode.addEventListener('wheel', (e) => {
-    e.preventDefault();
+//  parentNode.addEventListener('wheel', (e) => {
+//    e.preventDefault();
 
+  Action.wheelPinchFunction = function (e) {
     if (e.ctrlKey) {
       scale -= e.deltaY * 0.01;
+      Page.currentZoom = scale * 0.4;
     } else {
       svgPosX -= e.deltaX * 2;
       posY -= e.deltaY * 2;
     }
 
     render();
-  });
+  };
+  parentNode.addEventListener('wheel',Action.wheelPinchFunction);
 
-  parentNode.addEventListener("gesturestart", function (e) {
+  Action.gesturestartPinchFunction = function (e) {
     e.preventDefault();
     startX = e.pageX - svgPosX;
     startY = e.pageY - posY;
     gestureStartRotation = rotation;
     gestureStartScale = scale;
-  });
+  };
+  parentNode.addEventListener('gesturestart',Action.gesturestartPinchFunction);
 
-  parentNode.addEventListener("gesturechange", function (e) {
+  Action.gesturechangePinchFunction = function (e) {
     e.preventDefault();
   
     rotation = gestureStartRotation + e.rotation;
     scale = gestureStartScale * e.scale;
+    Page.currentZoom = scale * 0.4;    
 
     svgPosX = e.pageX - startX;
     posY = e.pageY - startY; 
 
     render();
 
-  })
+  };
+  parentNode.addEventListener('gesturechange',Action.gesturechangePinchFunction);
 
-  parentNode.addEventListener("gestureend", function (e) {
+  Action.gesturechangePinchFunction = function (e) {
     e.preventDefault();
-  });
-
+  };
+  parentNode.addEventListener('gestureend',Action.gestureendPinchFunction);
 }

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -5753,6 +5753,7 @@ Action.updateUmpleDiagramCallback = function(response)
     {
       theCanvas.html(format('{0}', diagramCode));
       theCanvas.children().first().attr("id", "svgCanvas");
+      Page.zoomToCurrentZoom();
 
       // If gv class mode is gvmanual then we need to update all the umple 
       // positioning information given the diagram locations
@@ -6341,6 +6342,10 @@ Action.toggleGuardLabels = function()
 Action.allowPinch = function()
 {
   Page.allowPinch = !Page.allowPinch;
+  if (Page.allowPinch == false) {
+     // has been turned off
+     Action.removePinch();
+  }
   Action.redrawDiagram();
 }
 Action.toggleFeatureDependency = function()

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -769,6 +769,30 @@ Page.clickAllowPinch = function() {
   jQuery('#buttonAllowPinch').trigger('click');
 }
 
+Page.currentZoom = 0.4; // default start zoom see also pinchtozoom
+
+Page.zoomToCurrentZoom = function() {
+  zoomDiv=document.getElementById('svgCanvas');
+  theBBox=zoomDiv.getBBox();
+  newWidth=theBBox.width*(1+Page.currentZoom);
+  newHeight=theBBox.height*(1+Page.currentZoom);
+  zoomDiv.setAttribute('viewBox', `0 0 ${newWidth} ${newHeight}`);
+}
+
+Page.zoomIn = function() {
+  // If further zooming was allowed, then cropping would occur
+  // If the default start zoom and this was to be changed, then the
+  // generators would need to be adjusted
+  if(Page.currentZoom > 0.01) {
+    Page.currentZoom -= 0.1;
+    Page.zoomToCurrentZoom();
+  }
+}
+
+Page.zoomOut = function() {
+  Page.currentZoom += 0.1;
+  Page.zoomToCurrentZoom();
+}
 
 Page.isPhotoReady = function()
 {

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -1044,6 +1044,9 @@ $output = $dataHandle->readData('model.ump');
             <li id="ttToggleFeatureDependencyLabels" class="layoutListItem view_opt_feature"> 
               <input id="buttonToggleFeatureDependency" class="checkbox" type="checkbox"/> 
               <a id="labelToggleFeatureDependencyLabels" class="buttonExtend">Feature Dependency</a> 
+            <li id="ttZoomInOut" class="copyMix" >
+            &nbsp;Zoom <button onclick="Page.zoomIn()">In</button>
+<button onclick="Page.zoomOut()">Out</button>
             </li>
             <li id="ttAllowPinch">
               <input id="buttonAllowPinch" class="checkbox" type="checkbox" name="allowPinch" value="allowPinch"/> 


### PR DESCRIPTION
This fixes a bug in the pinch to zoom function (event listeners were not turned off), and also adds buttons to zoom in and out for svg diagrams.