### PR TITLE
Issue #2377: Extend Requirement metamodel to support structured user stories

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1307,6 +1307,12 @@ class Requirement{
   
   // The content of the requirement, expressed in the language
   statement;
+
+  // Structured user story elements
+  who;
+  when;
+  what;
+  why;
   
   // The requirements language used to express this requirement
   // can be blank, then 'text' is assumed

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -923,12 +923,20 @@ class Comment
 /*
  */
 class Requirement{
+  public Requirement(String aIdentifier, String aStatement, String aLanguage)
+  {
+    this(aIdentifier, aStatement, null, null, null, null, aLanguage);
+  }
 
   // deep copy constructor
   public Requirement(Requirement aReq)
   {
     identifier = aReq.getIdentifier();
     statement = aReq.getStatement();
+    who = aReq.getWho();
+    when = aReq.getWhen();
+    what = aReq.getWhat();
+    why = aReq.getWhy();
     language = aReq.getLanguage();
   }
   public static List<Comment> convertToComment(List<ReqImplementation> reqSelected,UmpleModel aModel){

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -923,11 +923,6 @@ class Comment
 /*
  */
 class Requirement{
-  public Requirement(String aIdentifier, String aStatement, String aLanguage)
-  {
-    this(aIdentifier, aStatement, null, null, null, null, aLanguage);
-  }
-
   // deep copy constructor
   public Requirement(Requirement aReq)
   {

--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -244,7 +244,7 @@ class UmpleInternalParser
     {
     // If existing requirement is null
     // create new requirement
-      Requirement req = new Requirement(reqID, newContent, newLanguage);// Create new requirement 
+      Requirement req = new Requirement(reqID, newContent, null, null, null, null, newLanguage);// Create new requirement
     // Add the new requirement
       req.addReqToken(t);// new addition
       model.getAllRequirements().put(reqID, req);

--- a/cruise.umple/src/trait/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/trait/UmpleInternalParser_CodeTrait.ump
@@ -366,7 +366,7 @@ class UmpleInternalParser
     {
     // If existing requirement is null
     // create new requirement
-      Requirement req = new Requirement(reqID, newContent, newLanguage);// Create new requirement 
+      Requirement req = new Requirement(reqID, newContent, null, null, null, null, newLanguage);// Create new requirement
     // Add the new requirement
       req.addReqToken(t);// new addition
       model.getAllRequirements().put(reqID, req);

--- a/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
@@ -64,4 +64,38 @@ public class RequirementTest
     Assert.assertEquals("// R01: a\n// R02: a2",output);
   }
 
+  @Test
+  public void structuredFieldsStored()
+  {
+    Requirement req = new Requirement("US1", "As a customer...", "userStory");
+    req.setWho("customer");
+    req.setWhen("password is forgotten");
+    req.setWhat("reset my password");
+    req.setWhy("regain access to my account");
+
+    Assert.assertEquals("customer", req.getWho());
+    Assert.assertEquals("password is forgotten", req.getWhen());
+    Assert.assertEquals("reset my password", req.getWhat());
+    Assert.assertEquals("regain access to my account", req.getWhy());
+  }
+
+  @Test
+  public void deepCopyConstructorCopiesStructuredFields()
+  {
+    Requirement original = new Requirement("US2", "As an administrator...", "userStory");
+    original.setWho("administrator");
+    original.setWhen("account review");
+    original.setWhat("manage users");
+    original.setWhy("maintain the system");
+
+    Requirement copy = new Requirement(original);
+
+    Assert.assertEquals("administrator", copy.getWho());
+    Assert.assertEquals("account review", copy.getWhen());
+    Assert.assertEquals("manage users", copy.getWhat());
+    Assert.assertEquals("maintain the system", copy.getWhy());
+    Assert.assertEquals(original.getStatement(), copy.getStatement());
+    Assert.assertEquals(original.getLanguage(), copy.getLanguage());
+  }
+
 }

--- a/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
@@ -29,7 +29,7 @@ public class RequirementTest
   @Test
   public void constructor()
   {
-    Requirement c = new Requirement("R01","blah2","");
+    Requirement c = new Requirement("R01","blah2", null, null, null, null, "");
     Assert.assertEquals("blah2",c.getStatement());
   }
   
@@ -43,7 +43,7 @@ public class RequirementTest
   @Test
   public void format_oneRequirement()
   {
-    Requirement newReq = new Requirement("R01", "a", "");
+    Requirement newReq = new Requirement("R01", "a", null, null, null, null, "");
     model.getAllRequirements().put("R01",newReq);
     allTestRequirementsImpl.add(new ReqImplementation("R01",reqTok));
     String output = Requirement.format("Slashes",allTestRequirementsImpl,model);
@@ -54,8 +54,8 @@ public class RequirementTest
   @Test
   public void format_multipleRequirements()
   {
-    Requirement newReq1 = new Requirement("R01", "a", "");
-    Requirement newReq2 = new Requirement("R02", "a2", "");
+    Requirement newReq1 = new Requirement("R01", "a", null, null, null, null, "");
+    Requirement newReq2 = new Requirement("R02", "a2", null, null, null, null, "");
     model.getAllRequirements().put("R01",newReq1);
     model.getAllRequirements().put("R02",newReq2);
     allTestRequirementsImpl.add(new ReqImplementation("R01",reqTok));
@@ -67,7 +67,7 @@ public class RequirementTest
   @Test
   public void structuredFieldsStored()
   {
-    Requirement req = new Requirement("US1", "As a customer...", "userStory");
+    Requirement req = new Requirement("US1", "As a customer...", null, null, null, null, "userStory");
     req.setWho("customer");
     req.setWhen("password is forgotten");
     req.setWhat("reset my password");
@@ -82,7 +82,7 @@ public class RequirementTest
   @Test
   public void deepCopyConstructorCopiesStructuredFields()
   {
-    Requirement original = new Requirement("US2", "As an administrator...", "userStory");
+    Requirement original = new Requirement("US2", "As an administrator...", null, null, null, null, "userStory");
     original.setWho("administrator");
     original.setWhen("account review");
     original.setWhat("manage users");


### PR DESCRIPTION
This PR implements the metamodel step of Issue #2377.

### Scope
- Extend the `Requirement` class to support structured user story elements:
  - `who`
  - `when`
  - `what`
  - `why`
- Update the deep-copy constructor to include the new fields
- Preserve backward compatibility by adding a 3-argument constructor used by existing code
- Add unit tests to verify:
  - structured fields are stored correctly
  - deep copies preserve structured data

### Rationale
The grammar now supports `userStory` requirements with optional structured sections. This PR introduces the necessary data model changes so these elements can be stored internally.

### Notes
- This PR does not yet populate these fields during parsing
- This PR does not modify output generation

These will be handled in subsequent PRs.