### PR TITLE
Fixes Issue #2331 - ConcurrentModificationException occuring in random parses

### DIFF
--- a/UmpleParser/src/GrammarParsing_Code.ump
+++ b/UmpleParser/src/GrammarParsing_Code.ump
@@ -121,9 +121,10 @@ class RuleBasedParser
       if(token.is("value") && token.getValue().contains("\\u003B"))
         token.setValue(token.getValue().replace("\\u003B",";")); 
     } 
-    for(Token subToken : token.getSubTokens())
+    List<Token> subTokens = token.getSubTokens();
+    for(int i = 0; i < subTokens.size(); i++)
     {
-      cleanEscapeChars(subToken);
+      cleanEscapeChars(subTokens.get(i));
     }
 
 }
@@ -142,7 +143,7 @@ class RuleBasedParser
     int parseResult = root.parse(token, 0,data.getInput().length(),data.getInput(),data);
     if(parseResult==data.getInput().length())
     {
-      cleanEscapeChars(token);cleanEscapeChars(token);
+      cleanEscapeChars(token);
       setRootToken(token);
     }
     else

--- a/UmpleParser/src/ParseUtilities_Code.ump
+++ b/UmpleParser/src/ParseUtilities_Code.ump
@@ -411,8 +411,8 @@ class ParseResult
   public String toString()
   {
     String ret = "";
-    for(ErrorMessage em : errorMessages)
-      ret += em.toString() + "\n";
+    for(int i = 0; i < errorMessages.size(); i++)
+     ret += errorMessages.get(i).toString() + "\n";
     return ret;
   }
 
@@ -440,8 +440,10 @@ class ParseResult
   {
     String ret = "{ \"results\" : [ ";
     boolean hasOne = false;
-    for(ErrorMessage em : errorMessages)
+    for(int i = 0; i < errorMessages.size(); i++)
     {
+      ErrorMessage em = errorMessages.get(i);
+
       ErrorType et = em.getErrorType();
 
       String line     = String.valueOf(em.getPosition().getLineNumber());

--- a/UmpleParser/src/ParsingRules_Code.ump
+++ b/UmpleParser/src/ParsingRules_Code.ump
@@ -898,7 +898,8 @@ class BalancedRule
   public static void initialize(String input, ParserDataPackage data)
   {
     data.setCouples(new HashMap<String,ParsingCouple>());
-    for(String[] key:data.getKeys().values())
+    List<String[]> keysCopy = new ArrayList<String[]>(data.getKeys().values());
+    for(String[] key : keysCopy)
     {
       data.getCouples().put(key[0]+key[1],new ParsingCouple(key[0],key[1]).init(input));
     }


### PR DESCRIPTION
## Fixes Issue #2331 - ConcurrentModificationException occuring in random parses

### Files Changed
`UmpleParser/src/GrammarParsing_Code.ump`
- Change a for each loop to a simple for loop
- Remove duplicate function call

`UmpleParser/src/ParseUtilities_Code.ump`
- Change 2 for each loops to simple for loops

`UmpleParser/src/ParsingRules_Code.ump`
- Make the list that is iterated over a copy 

### Results
The command used to test: `./gradlew test --tests cruise.umple.compiler.ConcurrentParsingTest --rerun-tasks` 

Without changes - 12/200 errors
<img width="500" height="161" alt="image" src="https://github.com/user-attachments/assets/c7ec6657-c424-4ba8-9610-a3712a6af909" />
_Note: The build does fail when a ConcurrentModificationException (CME) occurs, the `Build failures` is counting other failures not specifically listed_

With changes - 0/200 errors
<img width="500" height="161" alt="image" src="https://github.com/user-attachments/assets/53236537-43f6-49c5-9306-24b884ebecd8" />

_Note: Issues #591 and #831 are not being tested when running the command, disregard their output_