### PR TITLE
Loading Instance Diagram into CRUD

### DIFF
--- a/cruise.umple/src/generators/instanceDiagramGenerator/Generator_CodeInstanceDiagram.ump
+++ b/cruise.umple/src/generators/instanceDiagramGenerator/Generator_CodeInstanceDiagram.ump
@@ -78,8 +78,16 @@ class InstanceDiagramGenerator
   // off of what's contained in here.
   UmpleModel model = null;
   String outputCode = "";
-  Random attributeRandomGen = new Random(67); // Set the seed used for the generation of random attributes
+  Random attributeRandomGen = new Random();
   Map<String, String> instanceIdtoInstanceName = new HashMap<String, String>();
+  // When running in CRUD-driven mode, this map holds concrete
+  // attribute values for specific instances so that the instance
+  // diagram can reflect exactly what the user entered in the CRUD UI.
+  // Key: class name -> (instance index -> (attribute name -> value))
+  Map<String, Map<Integer, Map<String, String>>> crudAttributeValues = null;
+  // And this list holds explicit association links between concrete
+  // instances captured from the CRUD UI.
+  java.util.List<CrudAssociationLink> crudAssociationLinks = null;
   
   // Meta variables - These should only be updated by suboptions
   int suboptionLinkingFlag = 2; // 2 is Random
@@ -106,25 +114,71 @@ class InstanceDiagramGenerator
     // Update meta variables based on suboptions
     useSuboptions();
     
-    InstanceDiagramResult instanceData = ClassInstanceCountSet.computeInstanceDiagram(
-      model,
-      suboptionLinkingFlag,
-      suboptionInitialClassCountFlag,
-      suboptionMaxIterations,
-      suboptionMaxClassCount
-    );
+    InstanceDiagramResult instanceData;
 
     // Special mode: when invoked from the CRUD UI with suboption
-    // "crudRandomJson", emit a compact JSON payload describing the
-    // randomly generated instances and associations instead of GraphViz.
+    // "crudUseJson", build the instance data directly from the CRUD
+    // instance counts embedded in the Umple source as a comment. This
+    // bypasses the random instance generation and simply reflects the
+    // counts currently present in the CRUD UI.
+    if (hasSuboption("crudUseJson")) {
+      instanceData = buildInstanceDiagramFromCrudInstanceCounts();
+    }
+    else {
+      instanceData = ClassInstanceCountSet.computeInstanceDiagram(
+        model,
+        suboptionLinkingFlag,
+        suboptionInitialClassCountFlag,
+        suboptionMaxIterations,
+        suboptionMaxClassCount
+      );
+    }
+
+    // When asked for CRUD-style JSON, emit a compact JSON payload
+    // instead of GraphViz. This is used both by the random-data
+    // generator endpoint (crudRandomJson alone) and by flows that
+    // reuse CRUD-sourced instance data (crudUseJson + crudRandomJson).
     if (hasSuboption("crudRandomJson")) {
       String json = buildCrudRandomDataJson(instanceData);
       model.setCode(json);
       return;
     }
 
-    // Default behaviour: render the GraphViz instance diagram
+    // For normal instance-diagram generation, first build the JSON
+    // sidecar. In the purely random case (no CRUD-driven data), this
+    // call also captures the concrete random attribute values into
+    // crudAttributeValues so that the subsequent GraphViz rendering
+    // can display exactly the same values as those exported to JSON.
+    writeCrudJsonSidecar(instanceData);
+
+    // Default behaviour: render the GraphViz instance diagram using
+    // any captured CRUD or random attribute values.
     renderInstanceDiagram(instanceData);
+  }
+
+  // Write a JSON sidecar file for the given instance data next to the
+  // generated GraphViz file. This uses the same JSON structure as
+  // crudRandomJson but writes to disk instead of stdout.
+  private void writeCrudJsonSidecar(InstanceDiagramResult data) {
+    try {
+      String outputDir = getModel().getUmpleFile().getPath();
+      String path = StringFormatter.addPathOrAbsolute(outputDir, "");
+      File dir = new File(path);
+      dir.mkdirs();
+      String baseName = getModel().getUmpleFile().getSimpleFileName() + generatorType();
+      String jsonFilename = path + File.separator + baseName + ".instance.json";
+
+      String json = buildCrudRandomDataJson(data);
+
+      BufferedWriter bw = new BufferedWriter(new FileWriter(jsonFilename));
+      bw.write(json);
+      bw.flush();
+      bw.close();
+    }
+    catch (Exception e) {
+      // Sidecar JSON is an optional convenience; if it fails, fall
+      // back silently so that GraphViz generation is not impacted.
+    }
   }
 
   // Build JSON representation of the generated instance data in the
@@ -192,6 +246,16 @@ class InstanceDiagramGenerator
     // Map from className#iteration to umpleObjectID (as string)
     Map<String, String> umpleIdByKey = new HashMap<String, String>();
 
+    // When running in purely random mode (no CRUD-sourced attribute
+    // values present), we want the GraphViz instance diagram to show
+    // exactly the same randomly generated attribute values as the
+    // JSON sidecar that is produced in the same run. We achieve this
+    // by capturing the generated attributes here and, once complete,
+    // storing them into crudAttributeValues so that renderInstanceDiagram
+    // can reuse them instead of regenerating new random values.
+    boolean captureRandomAttributes = (crudAttributeValues == null);
+    Map<String, Map<Integer, Map<String, String>>> capturedAttrs = null;
+
     int nextId = 1;
 
     // First pass: create instances for each concrete class with random
@@ -223,9 +287,32 @@ class InstanceDiagramGenerator
 
           // Generate random attribute values consistent with instance
           // diagram attribute generation.
-          Map<String, String> attrs = generateRandomAttributesForInstance(uClass, iter);
+          // Prefer CRUD-sourced attribute values when available for
+          // this specific instance; otherwise, fall back to random
+          // attribute generation consistent with the instance diagram.
+          Map<String, String> attrs = generateAttributesForInstance(uClass, iter);
           for (Map.Entry<String, String> e : attrs.entrySet()) {
             instData.put(e.getKey(), e.getValue());
+          }
+
+          // In the non-CRUD case, remember these generated values so
+          // that the GraphViz generator can render the same ones.
+          if (captureRandomAttributes && !attrs.isEmpty()) {
+            if (capturedAttrs == null) {
+              capturedAttrs = new LinkedHashMap<String, Map<Integer, Map<String, String>>>();
+            }
+            Map<Integer, Map<String, String>> byIndex = capturedAttrs.get(className);
+            if (byIndex == null) {
+              byIndex = new LinkedHashMap<Integer, Map<String, String>>();
+              capturedAttrs.put(className, byIndex);
+            }
+            // Store a shallow copy so later mutations to attrs don't
+            // accidentally affect the captured snapshot.
+            Map<String, String> copy = new LinkedHashMap<String, String>();
+            for (Map.Entry<String, String> ae : attrs.entrySet()) {
+              copy.put(ae.getKey(), ae.getValue());
+            }
+            byIndex.put(Integer.valueOf(iter), copy);
           }
 
           list.add(instData);
@@ -340,6 +427,14 @@ class InstanceDiagramGenerator
       }
     }
 
+    // If we captured random attributes for this run (i.e., there were
+    // no CRUD-sourced attribute values), expose them via
+    // crudAttributeValues so that renderInstanceDiagram can reuse the
+    // exact same values when printing node attributes.
+    if (captureRandomAttributes && capturedAttrs != null && !capturedAttrs.isEmpty()) {
+      crudAttributeValues = capturedAttrs;
+    }
+
     // Final pass: emit JSON array of instance wrappers
     StringBuilder sb = new StringBuilder();
     sb.append("[");
@@ -441,6 +536,43 @@ class InstanceDiagramGenerator
     }
 
     return result;
+  }
+
+  // Helper to generate attribute values for a class instance, preferring
+  // CRUD-sourced values (when available) and falling back to the standard
+  // random attribute generation used by instance diagrams.
+  private Map<String, String> generateAttributesForInstance(UmpleClass uClass, int iteration) {
+    // Start with the default/random attribute values so ID/name
+    // heuristics remain consistent with the instance diagram.
+    Map<String, String> base = generateRandomAttributesForInstance(uClass, iteration);
+
+    if (crudAttributeValues == null) {
+      return base;
+    }
+
+    Map<Integer, Map<String, String>> byIndex = crudAttributeValues.get(uClass.getName());
+    if (byIndex == null) {
+      return base;
+    }
+
+    Map<String, String> perInstance = byIndex.get(Integer.valueOf(iteration));
+    if (perInstance == null || perInstance.isEmpty()) {
+      return base;
+    }
+
+    // Overlay CRUD-sourced values on top of the base map so that any
+    // attributes explicitly set in the CRUD UI win, while still
+    // preserving reasonable defaults for others.
+    for (Map.Entry<String, String> entry : perInstance.entrySet()) {
+      String attrName = entry.getKey();
+      String val = entry.getValue();
+      if (attrName == null || attrName.length() == 0) {
+        continue;
+      }
+      base.put(attrName, val == null ? "" : val);
+    }
+
+    return base;
   }
 
   // Derive a CRUD-style property name for an association end, matching
@@ -620,8 +752,9 @@ class InstanceDiagramGenerator
 
       } else if (instanceData.diagramIsEmpty) {
         outputCode += "Generated InstanceDiagram is empty. For random diagrams, consider trying again or setting the initial class counts to a constant";
-      
-      } 
+      } else if (instanceData.statusCode == 5) {
+        outputCode += "Unable to build instance diagram from CRUD data. Ensure the @crudInstanceCounts marker JSON is present and well-formed.";
+      }
       outputCode += "\"];";
 
       code.append(outputCode);
@@ -651,13 +784,28 @@ class InstanceDiagramGenerator
           continue;
       }
       String currentInstanceName = umpClass.getName();
-      Integer numberOfInstaces = minInstance.get(currentInstanceName);    // minInstance may change at a later date
-      for (int i = 0; i < numberOfInstaces; i++) {
+      Integer numberOfInstaces = null;
+      if (minInstance != null) {
+        numberOfInstaces = minInstance.get(currentInstanceName);    // minInstance may change at a later date
+      }
+      // If there is no entry or the count is non-positive, just skip.
+      if (numberOfInstaces == null || numberOfInstaces.intValue() <= 0) {
+        continue;
+      }
+      int instanceCount = numberOfInstaces.intValue();
+      for (int i = 0; i < instanceCount; i++) {
         createInstance(umpClass, code, i + 1);
       }
     }
 
     Map<String, ClassInstanceCount> classInstanceCountMap = instanceData.rawClassInstanceCounts;
+
+    if (actualLinks == null) {
+      // No association information available; finalize the diagram with
+      // just the instances.
+      terminateCode(code, associations);
+      return;
+    }
 
     for (int k = 0; k < actualLinks.size(); k++) {
       AssociationLinkSet assocLinkSet = actualLinks.get(k);
@@ -674,8 +822,39 @@ class InstanceDiagramGenerator
       ArrayList<String> leftInstanceList = new ArrayList<String>();
       ArrayList<String> rightInstanceList = new ArrayList<String>();
 
-      PopulateInstanceList(leftClass , classInstanceCountMap , leftInstanceList);
-      PopulateInstanceList(rightClass, classInstanceCountMap , rightInstanceList);
+      // Prefer using the full ClassInstanceCount map when available so
+      // inheritance and subclassing are respected. For simplified
+      // inputs (such as CRUD-driven instance counts) where the raw
+      // map may not contain entries for all classes, fall back to
+      // generating instance identifiers directly from the per-class
+      // instanceCounts map used above for node creation.
+      if (classInstanceCountMap != null &&
+          classInstanceCountMap.containsKey(leftClass) &&
+          classInstanceCountMap.containsKey(rightClass)) {
+
+        PopulateInstanceList(leftClass , classInstanceCountMap , leftInstanceList);
+        PopulateInstanceList(rightClass, classInstanceCountMap , rightInstanceList);
+
+      } else if (minInstance != null) {
+        Integer leftCountObj = minInstance.get(leftClass);
+        Integer rightCountObj = minInstance.get(rightClass);
+        int leftCount = (leftCountObj != null) ? leftCountObj.intValue() : 0;
+        int rightCount = (rightCountObj != null) ? rightCountObj.intValue() : 0;
+
+        if (leftCount <= 0 || rightCount <= 0) {
+          continue;
+        }
+
+        for (int i = 1; i <= leftCount; i++) {
+          leftInstanceList.add(leftClass + i);
+        }
+        for (int j = 1; j <= rightCount; j++) {
+          rightInstanceList.add(rightClass + j);
+        }
+      } else {
+        // No way to derive instance identifiers; skip this association.
+        continue;
+      }
 
       for (int i = 0; i < assocLinkSet.links.length; i++) {
         for (int j = 0; j < assocLinkSet.links[0].length; j++) {
@@ -810,7 +989,22 @@ class InstanceDiagramGenerator
         { 
           String instanceAttribute;
 
-          if (isFirst && (hasId)){
+          // If CRUD-sourced attribute values are available for this
+          // specific instance, prefer them over generated random
+          // values so that the diagram reflects exactly what the user
+          // entered in the CRUD UI.
+          Map<String, String> crudAttrsForInstance = null;
+          if (crudAttributeValues != null) {
+            Map<Integer, Map<String, String>> byIndex = crudAttributeValues.get(uClass.getName());
+            if (byIndex != null) {
+              crudAttrsForInstance = byIndex.get(Integer.valueOf(idValue));
+            }
+          }
+
+          if (crudAttrsForInstance != null && crudAttrsForInstance.containsKey(uAttribute.getName())) {
+            Object rawVal = crudAttrsForInstance.get(uAttribute.getName());
+            instanceAttribute = (rawVal == null) ? "" : rawVal.toString();
+          } else if (isFirst && (hasId)){
             instanceAttribute = Integer.toString(idValue);
           } else if (isFirst && instanceName.length() != 0){
             instanceAttribute = instanceName;
@@ -961,6 +1155,318 @@ public String randomStringGen(){
         "There was a problem generating the Instance Diagram." + e, e);
     }
   }
+  
+  // Build an InstanceDiagramResult based on instance data supplied by
+  // the CRUD UI. The UI embeds two markers into the Umple source:
+  //   // @crudInstanceCounts {"ClassA":2,"ClassB":3}
+  //   // @crudInstanceData {"instances":[{"class":"ClassA","index":1,"attrs":{...}},...]}
+  // The counts marker controls how many instances of each class are
+  // drawn, while the data marker (if present and valid) provides
+  // concrete attribute values per instance so the diagram reflects the
+  // exact CRUD state instead of regenerating random attributes.
+  private InstanceDiagramResult buildInstanceDiagramFromCrudInstanceCounts() {
+    InstanceDiagramResult result = new InstanceDiagramResult();
+    result.statusCode = 0;
+    result.diagramIsEmpty = true;
+    result.instanceCounts = new LinkedHashMap<String, Integer>();
+    result.loopScores = new LinkedHashMap<String, Integer>();
+    result.noPossibleInheritance = new LinkedHashSet<String>();
+    result.associationLinks = new ArrayList<AssociationLinkSet>();
+    result.rawClassInstanceCounts = new LinkedHashMap<String, ClassInstanceCount>();
+
+    try {
+      if (model == null || model.getUmpleFile() == null) {
+        // Nothing to work with; mark as an error so the user sees a
+        // meaningful message in the diagram.
+        result.statusCode = 5;
+        result.diagramIsEmpty = false;
+        return result;
+      }
+
+      // Prefer the working copy of the model in the output directory,
+      // since that is what the compiler actually compiled (it includes
+      // any changes the user just made in the UmpleOnline editor).
+      String basePath = model.getUmpleFile().getPath();
+      String simpleName = model.getUmpleFile().getSimpleFileName();
+      File sourceFile = new File(basePath + File.separator + simpleName + ".ump");
+      if (!sourceFile.exists() || !sourceFile.isFile()) {
+        // Fall back to the raw filename if the constructed path is not
+        // available in this environment.
+        sourceFile = new File(model.getUmpleFile().getFileName());
+      }
+      if (!sourceFile.exists() || !sourceFile.isFile()) {
+        result.statusCode = 5;
+        result.diagramIsEmpty = false;
+        return result;
+      }
+
+      String markerCounts = "// @crudInstanceCounts ";
+      String markerData = "// @crudInstanceData ";
+      String encodedCounts = null;
+      String encodedData = null;
+
+      BufferedReader br = new BufferedReader(new FileReader(sourceFile));
+      try {
+        String line;
+        while ((line = br.readLine()) != null) {
+          String trimmed = line.trim();
+          if (encodedCounts == null && trimmed.startsWith(markerCounts)) {
+            encodedCounts = trimmed.substring(markerCounts.length()).trim();
+          } else if (encodedData == null && trimmed.startsWith(markerData)) {
+            encodedData = trimmed.substring(markerData.length()).trim();
+          }
+        }
+      } finally {
+        br.close();
+      }
+
+      if (encodedCounts == null || encodedCounts.length() == 0) {
+        // No CRUD counts were found; treat this as an error specific to
+        // CRUD-driven instance diagrams.
+        result.statusCode = 5;
+        result.diagramIsEmpty = false;
+        return result;
+      }
+
+      // Parse the JSON text into a simple map of className -> count.
+      // We intentionally support only a very small subset of JSON
+      // (a single flat object with string keys and numeric values),
+      // which is exactly what the CRUD UI emits.
+      String body = encodedCounts.trim();
+      if (body.startsWith("{")) {
+        body = body.substring(1);
+      }
+      if (body.endsWith("}")) {
+        body = body.substring(0, body.length() - 1);
+      }
+
+      boolean anyInstances = false;
+
+      String[] entries = body.split(",");
+      for (String entry : entries) {
+        String part = entry.trim();
+        if (part.length() == 0) {
+          continue;
+        }
+        int colon = part.indexOf(":");
+        if (colon <= 0) {
+          continue;
+        }
+        String rawKey = part.substring(0, colon).trim();
+        String rawVal = part.substring(colon + 1).trim();
+
+        // Strip surrounding quotes from the key if present.
+        if (rawKey.startsWith("\"") && rawKey.endsWith("\"") && rawKey.length() >= 2) {
+          rawKey = rawKey.substring(1, rawKey.length() - 1);
+        }
+
+        String className = rawKey;
+        if (className == null || className.length() == 0) {
+          continue;
+        }
+
+        // Interpret non-numeric or negative values as zero and skip.
+        int count = 0;
+        try {
+          // Remove any trailing comma or quote artifacts.
+          if (rawVal.startsWith("\"") && rawVal.endsWith("\"") && rawVal.length() >= 2) {
+            rawVal = rawVal.substring(1, rawVal.length() - 1);
+          }
+          count = Integer.parseInt(rawVal);
+        } catch (Exception e) {
+          count = 0;
+        }
+        if (count <= 0) {
+          continue;
+        }
+
+        anyInstances = true;
+        result.instanceCounts.put(className, Integer.valueOf(count));
+
+        ClassInstanceCount cic = new ClassInstanceCount();
+        cic.requiredInstances = Integer.valueOf(count);
+        cic.trueInstances = Integer.valueOf(count);
+        cic.directSubclasses = new LinkedHashSet<String>();
+        cic.directSuperclasses = new LinkedHashSet<String>();
+        cic.maximumInstanceCount = Integer.valueOf(-1);
+        result.rawClassInstanceCounts.put(className, cic);
+      }
+
+      result.diagramIsEmpty = !anyInstances;
+
+      // If a full CRUD instance-data marker is present, attempt to parse
+      // it and capture attribute values for each instance. Failure to
+      // parse this marker does not abort diagram generation; we simply
+      // fall back to randomized attribute values.
+      crudAttributeValues = null;
+      crudAssociationLinks = null;
+      if (encodedData != null && encodedData.length() > 0) {
+        try {
+          cruise.umple.util.JsonParser jsonParser = new cruise.umple.util.JsonParser("json");
+          cruise.umple.parser.ParseResult pr = jsonParser.parse("json", encodedData);
+          if (pr != null && pr.getWasSuccess()) {
+            cruise.umple.util.Json root = jsonParser.analyze();
+            cruise.umple.util.Json[] instArray = root.getArray("instances");
+            if (instArray != null) {
+              Map<String, Map<Integer, Map<String, String>>> attrMap = new LinkedHashMap<String, Map<Integer, Map<String, String>>>();
+              for (cruise.umple.util.Json j : instArray) {
+                if (j == null) {
+                  continue;
+                }
+                String className = j.getValue("class");
+                int index = j.getIntValue("index");
+                if (className == null || className.length() == 0 || index <= 0) {
+                  continue;
+                }
+                cruise.umple.util.Json attrsHolder = j.getAttribute("attrs");
+                if (attrsHolder == null) {
+                  continue;
+                }
+                cruise.umple.util.Json[] comps = attrsHolder.getComposites();
+                if (comps == null) {
+                  continue;
+                }
+                Map<String, String> perInstance = new LinkedHashMap<String, String>();
+                for (cruise.umple.util.Json comp : comps) {
+                  if (comp == null) {
+                    continue;
+                  }
+                  String attrName = comp.getName();
+                  String val = comp.getValue();
+                  if (attrName != null && attrName.length() > 0) {
+                    perInstance.put(attrName, val == null ? "" : val);
+                  }
+                }
+                if (!perInstance.isEmpty()) {
+                  Map<Integer, Map<String, String>> byIndex = attrMap.get(className);
+                  if (byIndex == null) {
+                    byIndex = new LinkedHashMap<Integer, Map<String, String>>();
+                    attrMap.put(className, byIndex);
+                  }
+                  byIndex.put(Integer.valueOf(index), perInstance);
+                }
+              }
+              if (!attrMap.isEmpty()) {
+                crudAttributeValues = attrMap;
+              }
+            }
+
+            // Parse explicit association links if provided
+            cruise.umple.util.Json[] assocArray = root.getArray("associations");
+            if (assocArray != null) {
+              java.util.List<CrudAssociationLink> links = new ArrayList<CrudAssociationLink>();
+              for (cruise.umple.util.Json jLink : assocArray) {
+                if (jLink == null) {
+                  continue;
+                }
+                String fromClass = jLink.getValue("fromClass");
+                String toClass = jLink.getValue("toClass");
+                int fromIndex = jLink.getIntValue("fromIndex");
+                int toIndex = jLink.getIntValue("toIndex");
+                if (fromClass == null || fromClass.length() == 0 ||
+                    toClass == null || toClass.length() == 0 ||
+                    fromIndex <= 0 || toIndex <= 0) {
+                  continue;
+                }
+                CrudAssociationLink link = new CrudAssociationLink();
+                link.fromClass = fromClass;
+                link.toClass = toClass;
+                link.fromIndex = Integer.valueOf(fromIndex);
+                link.toIndex = Integer.valueOf(toIndex);
+                links.add(link);
+              }
+              if (!links.isEmpty()) {
+                crudAssociationLinks = links;
+              }
+            }
+          }
+        } catch (Exception e) {
+          // Ignore JSON parsing errors for the data marker; we still have
+          // valid instance counts and can proceed with randomized
+          // attributes.
+          crudAttributeValues = null;
+          crudAssociationLinks = null;
+        }
+      }
+
+      // If we have at least some instances, synthesize association link
+      // matrices so that the instance diagram includes links. We do not
+      // attempt to mirror any specific CRUD linkage pattern here (the
+      // marker only stores counts), but we generate links that respect
+      // multiplicity constraints using the same AssociationLinkSet logic
+      // as the random instance generator.
+      if (anyInstances) {
+        ArrayList<AssociationLinkSet> links = new ArrayList<AssociationLinkSet>();
+        for (Association assoc : model.getAssociations()) {
+          AssociationEnd leftEnd = assoc.getEnd(0);
+          AssociationEnd rightEnd = assoc.getEnd(1);
+          String leftClass = leftEnd.getClassName();
+          String rightClass = rightEnd.getClassName();
+
+          Integer leftCountObj = result.instanceCounts.get(leftClass);
+          Integer rightCountObj = result.instanceCounts.get(rightClass);
+          int leftCount = (leftCountObj != null) ? leftCountObj.intValue() : 0;
+          int rightCount = (rightCountObj != null) ? rightCountObj.intValue() : 0;
+
+          if (leftCount <= 0 || rightCount <= 0) {
+            continue;
+          }
+
+          AssociationLinkSet linkSet = new AssociationLinkSet(assoc, leftCount, rightCount);
+
+          // If explicit CRUD association links are available, use them
+          // to populate the link matrix so the instance diagram matches
+          // the CRUD UI exactly. Otherwise, synthesize links based on
+          // multiplicities.
+          if (crudAssociationLinks != null && !crudAssociationLinks.isEmpty()) {
+            boolean[][] matrix = new boolean[leftCount][rightCount];
+            boolean anyLink = false;
+            for (CrudAssociationLink rec : crudAssociationLinks) {
+              if (rec == null) {
+                continue;
+              }
+              int i = -1;
+              int j = -1;
+              if (leftClass.equals(rec.fromClass) && rightClass.equals(rec.toClass)) {
+                i = rec.fromIndex.intValue() - 1;
+                j = rec.toIndex.intValue() - 1;
+              } else if (leftClass.equals(rec.toClass) && rightClass.equals(rec.fromClass)) {
+                // Reverse orientation
+                i = rec.toIndex.intValue() - 1;
+                j = rec.fromIndex.intValue() - 1;
+              } else {
+                continue;
+              }
+              if (i < 0 || i >= leftCount || j < 0 || j >= rightCount) {
+                continue;
+              }
+              matrix[i][j] = true;
+              anyLink = true;
+            }
+            if (!anyLink) {
+              // No explicit links for this association; skip it.
+              continue;
+            }
+            linkSet.links = matrix;
+          } else {
+            linkSet.getLinksFromAssociation(suboptionLinkingFlag);
+          }
+
+          links.add(linkSet);
+        }
+        result.associationLinks = links;
+      }
+
+      return result;
+    }
+    catch (Exception e) {
+      // On any unexpected error (I/O, parsing, etc.), fall back to a
+      // generic CRUD-specific error so the generator never throws.
+      result.statusCode = 5;
+      result.diagramIsEmpty = false;
+      return result;
+    }
+  }
 
 }
 
@@ -985,6 +1491,18 @@ class InstanceDiagramResult {
   public ArrayList<AssociationLinkSet> associationLinks;
   // Full underlying instance data (required/true counts, inheritance trees, etc.)
   public Map<String, ClassInstanceCount> rawClassInstanceCounts;
+}
+
+/*
+ Helper data class capturing a single association link between two
+ concrete instances as recorded by the CRUD UI. This is used only
+ when building instance diagrams from CRUD data.
+*/
+class CrudAssociationLink {
+  public String fromClass;
+  public Integer fromIndex; // 1-based index of source instance
+  public String toClass;
+  public Integer toIndex;   // 1-based index of target instance
 }
 
 /*
@@ -1722,7 +2240,6 @@ class ClassInstanceCountSet {
   public void initializeClassCountsRandom(Map<Integer, Double> minimumInstanceProbabilities) {    
     this.instances = new HashMap<>();
     
-    // Seed Random
     Random randomNumGen = new Random();
     // For each class
     for (UmpleClass umpClass : umpleModel.getUmpleClasses()) {

--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -728,8 +728,20 @@ else if (isset($_REQUEST["umpleCode"]))
       $svgcode = readTemporaryFile("{$thedir}/instanceDiagram.svg");
       $gvlink = $workDir->makePermalink('model'.$generatorType.'.gv');
       $svglink = $workDir->makePermalink('instanceDiagram.svg');
-      $html = "<a href=\"$gvlink\">Download the GraphViz file for the following</a>&nbsp;<a target=\"_GraphVizOutput\" href=\"$svglink\">Download the SVG file for the following</a>&nbsp;<br/>{$errhtml}&nbsp;
-      <svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" height=\"2000\" width=\"2000\">";
+      // Read the CRUD-style JSON sidecar written by the InstanceDiagram
+      // generator in the same pass that produced the GraphViz file.
+      $jsonSidecarPath = $thedir . "/model" . $generatorType . ".instance.json";
+      $instanceJson = '';
+      if (file_exists($jsonSidecarPath)) {
+        $instanceJson = readTemporaryFile($jsonSidecarPath);
+      }
+
+      $html = "<button type=\"button\" id=\"instance-load-into-crud\" class=\"jQuery-palette-button ui-button ui-corner-all ui-widget\" style=\"margin-right:6px;\">Load data into CRUD</button>&nbsp;" .
+        // Embed the JSON as a hidden script tag so the client can
+        // reuse it when \"Load data into CRUD\" is clicked.
+        "<script id=\"instance-diagram-crud-json\" type=\"application/json\">" . $instanceJson . "</script>" .
+        "<a href=\"$gvlink\">Download the GraphViz file for the following</a>&nbsp;<a target=\"_GraphVizOutput\" href=\"$svglink\">Download the SVG file for the following</a>&nbsp;<br/>{$errhtml}&nbsp;
+                <svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" height=\"2000\" width=\"2000\">";
       echo $html;
       $changesToMake = 1;
       $shrunksvgcode = preg_replace($svg_regex,$svg_scale,$svgcode,$changesToMake);

--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -777,12 +777,13 @@ Page.initCrudUi = function(tabnumber) {
   // Remember current container for inline CRUD panel rendering
   Page.currentCrudContainer = container;
 
-   // Add JSON persistence controls once per container
+  // Add JSON persistence controls once per container
   if (container.find(".crud-json-actions").length === 0) {
     var jsonHtml = "<div class='crud-json-actions' style='margin:6px 0 10px 0;'>" +
       "<button type='button' id='crud-generate-json' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:6px;'>Generate JSON</button>" +
       "<button type='button' id='crud-generate-random-data' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:6px;'>Generate Random Data</button>" +
-      "<button type='button' id='crud-load-json' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button'>Load JSON</button>" +
+    "<button type='button' id='crud-load-json' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:6px;'>Load JSON</button>" +
+    "<button type='button' id='crud-load-instance-diagram' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button'>Load as Instance Diagram</button>" +
       "<input type='file' id='crud-load-json-file' accept='application/json,.json' style='display:none;' />" +
       "</div>";
     container.prepend(jsonHtml);
@@ -852,6 +853,155 @@ Page.initCrudUi = function(tabnumber) {
       reader.readAsText(file);
       // Reset the input so the same file can be chosen again later
       jQuery(this).val("");
+    });
+
+    // Use the current CRUD instances as input to the Instance Diagram
+    // generator. This works by embedding a small JSON blob of per-class
+    // instance counts into the Umple source as a special comment, then
+    // invoking the InstanceDiagram generator with a custom suboption.
+    container.find("#crud-load-instance-diagram").off("click").on("click", function() {
+      if (typeof Page.getUmpleCode !== "function" || typeof Page.setUmpleCode !== "function") {
+        console.warn("Umple code accessors are unavailable; cannot load instance diagram from CRUD.");
+        return;
+      }
+
+      if (!Page.crudData || !Page.crudData.classes) {
+        Page.setFeedbackMessage && Page.setFeedbackMessage("No CRUD data available to build an instance diagram.");
+        return;
+      }
+
+      var counts = {};
+      var hasAny = false;
+      // Also build a lightweight snapshot of attribute values and
+      // association links per instance so the backend instance diagram
+      // can render exactly what the user sees in the CRUD UI instead
+      // of regenerating random attributes or links.
+      var instanceSnapshot = { instances: [], associations: [] };
+
+      var assocByClass = Page.crudAssociationsByClass || {};
+
+      Object.keys(Page.crudData.classes).forEach(function(className) {
+        var info = Page.crudData.classes[className] || {};
+        var instances = info.instances || [];
+        var count = instances.length || 0;
+        if (count > 0) {
+          counts[className] = count;
+          hasAny = true;
+        }
+
+        if (count > 0) {
+          var attrsMeta = info.attributes || [];
+          // Precompute attribute names for this class so we only
+          // capture real attributes, not internal association fields.
+          var attrNames = [];
+          attrsMeta.forEach(function(a) {
+            if (a && a.name) {
+              attrNames.push(a.name);
+            }
+          });
+
+          var assocEnds = assocByClass[className] || [];
+
+          instances.forEach(function(inst, idx) {
+            if (!inst) { return; }
+            var attrs = {};
+            attrNames.forEach(function(an) {
+              if (Object.prototype.hasOwnProperty.call(inst, an)) {
+                attrs[an] = inst[an];
+              }
+            });
+            instanceSnapshot.instances.push({
+              "class": className,
+              index: idx + 1, // 1-based to match instance diagram numbering
+              attrs: attrs
+            });
+
+            // Capture association links for this instance using the
+            // same index space (1-based) so the backend can build
+            // precise link matrices instead of random ones.
+            assocEnds.forEach(function(end) {
+              if (!end || end.fromClass !== className) { return; }
+              var fieldName = end.storageKey;
+              if (!fieldName) { return; }
+              var rawVal = inst[fieldName];
+              if (rawVal === undefined || rawVal === null || rawVal === "") {
+                return;
+              }
+
+              var multiple = true;
+              if (typeof end.toMax === "number" && end.toMax <= 1) {
+                multiple = false;
+              }
+
+              var targetIndices = [];
+              if (multiple) {
+                if (!Array.isArray(rawVal)) { return; }
+                rawVal.forEach(function(tIdx) {
+                  if (typeof tIdx === "number" && tIdx >= 0) {
+                    targetIndices.push(tIdx);
+                  }
+                });
+              } else {
+                if (typeof rawVal === "number" && rawVal >= 0) {
+                  targetIndices.push(rawVal);
+                }
+              }
+
+              if (targetIndices.length === 0) { return; }
+
+              targetIndices.forEach(function(tIdx) {
+                instanceSnapshot.associations.push({
+                  fromClass: className,
+                  fromIndex: idx + 1,
+                  toClass: end.toClass,
+                  toIndex: tIdx + 1
+                });
+              });
+            });
+          });
+        }
+      });
+
+      if (!hasAny) {
+        Page.setFeedbackMessage && Page.setFeedbackMessage("No instances exist in CRUD to build an instance diagram.");
+        return;
+      }
+
+      var originalCode = Page.getUmpleCode() || "";
+      // Remove any previous CRUD markers to avoid stale data.
+      var cleanedCode = originalCode
+        .replace(/^\/\/ @crudInstanceCounts .*$/gm, "")
+        .replace(/^\/\/ @crudInstanceData .*$/gm, "");
+
+      var jsonCountsText;
+      var jsonDataText;
+      try {
+        jsonCountsText = JSON.stringify(counts);
+        jsonDataText = JSON.stringify(instanceSnapshot);
+      } catch (e) {
+        console.error("Failed to serialize CRUD instance data:", e);
+        Page.setFeedbackMessage && Page.setFeedbackMessage("Unable to serialize CRUD data for instance diagram.");
+        return;
+      }
+
+      // Append markers as single-line comments. The backend will scan
+      // for these and interpret the JSON payloads.
+      var markerLineCounts = "// @crudInstanceCounts " + jsonCountsText;
+      var markerLineData = "// @crudInstanceData " + jsonDataText;
+      var sep = cleanedCode.length && !/\n$/.test(cleanedCode) ? "\n" : "";
+      var newCode = cleanedCode + sep + markerLineCounts + "\n" + markerLineData + "\n";
+
+      Page.setUmpleCode(newCode);
+
+      if (typeof Action !== "undefined" && typeof Action.generateCode === "function") {
+        // Ask the backend to generate an instance diagram using the
+        // CRUD-supplied counts. The compiler will translate
+        // "instanceDiagram.crudUseJson" into an InstanceDiagram
+        // generation with the -s crudUseJson suboption.
+        Action.generateCode("instanceDiagram", "instanceDiagram.crudUseJson");
+      } else {
+        console.warn("Action.generateCode is unavailable; cannot trigger instance diagram generation.");
+      }
     });
   }
 
@@ -2457,4 +2607,38 @@ Page.showCrudFromJson = function(jsonText, tabnumber) {
 
   // Enhance forms with clickable class headers and popup dialog per class
   Page.initCrudUi(tabnumber);
+
+  // If instance-data JSON has been prepared via the backend, import it
+  // now that the CRUD metadata and forms have been initialized.
+  if (Page._pendingCrudInstanceJson && typeof Page.crudJsonImportFromText === "function") {
+    try {
+      Page.crudJsonImportFromText(Page._pendingCrudInstanceJson);
+
+      // After import, automatically open a dialog for a class that
+      // actually has instances, preferring the current selection if
+      // one exists.
+      var targetClass = Page.crudClassSelected || null;
+      if (!targetClass && Page.crudData && Page.crudData.classes) {
+        Object.keys(Page.crudData.classes).some(function(cn) {
+          var info = Page.crudData.classes[cn] || {};
+          if (info.isAbstract) { return false; }
+          var inst = info.instances || [];
+          if (inst.length > 0) {
+            targetClass = cn;
+            return true;
+          }
+          return false;
+        });
+      }
+
+      if (targetClass && typeof Page.openCrudDialogForClass === "function") {
+        Page.crudClassSelected = targetClass;
+        Page.openCrudDialogForClass(targetClass);
+      }
+    } catch (e) {
+      console.error("Failed to import CRUD instances from pending instance-diagram JSON:", e);
+    } finally {
+      Page._pendingCrudInstanceJson = null;
+    }
+  }
 };

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -2038,6 +2038,65 @@ Page.getModel = function()
   return jQuery("#model").val();
 }
 
+// Load instance diagram data back into the CRUD UI.
+//
+// This relies on the backend InstanceDiagram generator to produce
+// CRUD-compatible JSON for the current model/diagram, and then uses
+// the existing CRUD JSON import logic to materialize instances.
+Page.loadCrudFromInstanceDiagram = function() {
+  if (typeof Page.getUmpleCode !== "function") {
+    console.warn("Umple code accessor is unavailable; cannot load CRUD from instance diagram.");
+    return;
+  }
+
+  var code = Page.getUmpleCode() || "";
+  if (!code) {
+    Page.setFeedbackMessage && Page.setFeedbackMessage("No Umple code available to load into CRUD.");
+    return;
+  }
+
+  // Preferred path: if the current instance diagram response already
+  // embedded CRUD-style JSON (via a hidden script tag), reuse that so
+  // we don't need to re-run the generator.
+  var $embedded = jQuery("#instance-diagram-crud-json");
+  if ($embedded.length) {
+    var jsonText = $embedded.text() || "";
+    jsonText = ("" + jsonText).trim();
+    if (jsonText) {
+      Page._pendingCrudInstanceJson = jsonText;
+
+      if (typeof Action !== "undefined" && typeof Action.generateCode === "function") {
+        Action.generateCode("crudJson", "Json");
+      } else {
+        console.warn("Action.generateCode is unavailable; attempting direct CRUD import using embedded JSON.");
+        if (Page.crudData && Page.crudData.classes && typeof Page.crudJsonImportFromText === "function") {
+          try {
+            Page.crudJsonImportFromText(jsonText);
+          } catch (e) {
+            console.error("Failed to import embedded CRUD JSON from instance diagram:", e);
+            Page.setFeedbackMessage && Page.setFeedbackMessage("Unable to load instance diagram data into CRUD.");
+          }
+        }
+      }
+      return;
+    }
+  }
+
+  // If we reach here, no embedded instance JSON is available. Older
+  // diagrams that were generated before JSON embedding was added
+  // cannot be loaded into CRUD.
+  Page.setFeedbackMessage && Page.setFeedbackMessage("This instance diagram does not contain embedded instance data for CRUD.");
+};
+
+// Delegate clicks on the Instance Diagram toolbar button so it works
+// even though the button is injected dynamically by the backend.
+jQuery(document).on("click", "#instance-load-into-crud", function(evt) {
+  evt.preventDefault();
+  if (typeof Page.loadCrudFromInstanceDiagram === "function") {
+    Page.loadCrudFromInstanceDiagram();
+  }
+});
+
 jQuery.fn.selectRange = function(start, end) {
   return this.each(function() 
   {


### PR DESCRIPTION
This PR enables loading instance diagram data into the CRUD UI by capturing the JSON data generated alongside instance diagrams and providing a "Load Data into CRUD" button. When users generate an instance diagram, the frontend receives both the visual diagram and a JSON representation of all instances with their attribute values and associations; clicking the new button parses this JSON and populates the CRUD interface with the complete instance data, allowing users to seamlessly transition from viewing auto-generated instances in diagram form to interactively editing and managing them in the CRUD UI.