### PR TITLE
Leftover json test file should be removed

### DIFF
--- a/cruise.umple/test/cruise/umple/implementation/gv/GvInstanceDiagramGeneratorTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/gv/GvInstanceDiagramGeneratorTest.java
@@ -25,6 +25,8 @@ public class GvInstanceDiagramGeneratorTest extends TemplateTest
     super.tearDown();
     SampleFileWriter.destroy(pathToInput + "/gv/TooManyAssociationscid.gv");
     SampleFileWriter.destroy(pathToInput + "/gv/InheritanceErrorOnecid.gv");
+    SampleFileWriter.destroy(pathToInput + "/gv/InheritanceErrorOnecid.instance.json");
+    SampleFileWriter.destroy(pathToInput + "/gv/TooManyAssociationscid.instance.json");
   }
 
 


### PR DESCRIPTION
After the last few merges two test files were not being deleted.

This deletes

TooManyAssociationscid.instance.json
InheritanceErrorOnecid.instance.json

