### PR TITLE
CRUD UI - Live View

### DIFF
--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -2636,7 +2636,6 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
           return false;
         });
       }
-
       if (targetClass && typeof Page.openCrudDialogForClass === "function") {
         Page.crudClassSelected = targetClass;
         Page.openCrudDialogForClass(targetClass);

--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -771,8 +771,11 @@ Page.showCrudAbstractMessage = function(className) {
 };
 
 // Sets up clickable class headers and hides underlying forms
-Page.initCrudUi = function(tabnumber) {
-  var container = jQuery("#innerGeneratedCodeRow" + tabnumber);
+// If containerSelector is provided, CRUD UI will be initialized inside
+// that container (used for Live View); otherwise it defaults to the
+// bottom generated-code area for the given tabnumber.
+Page.initCrudUi = function(tabnumber, containerSelector) {
+  var container = containerSelector ? jQuery(containerSelector) : jQuery("#innerGeneratedCodeRow" + tabnumber);
 
   // Remember current container for inline CRUD panel rendering
   Page.currentCrudContainer = container;
@@ -2196,8 +2199,10 @@ Page.renderCrudClassArrayItems = function($container, attrName, items) {
   $list.html(html);
 };
 
-// Entry point used by Page.showGeneratedCode when language === "crudJson"
-Page.showCrudFromJson = function(jsonText, tabnumber) {
+// Entry point used by Page.showGeneratedCode when language === "crudJson".
+// Optional containerSelector allows rendering into an arbitrary container
+// (e.g., Live View's htmlCanvas) instead of the default bottom panel.
+Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
   var formHtml = "<div class='crud-ui-forms'>";
   try {
     var data = JSON.parse(jsonText);
@@ -2603,10 +2608,11 @@ Page.showCrudFromJson = function(jsonText, tabnumber) {
     formHtml = "<pre>Failed to parse JSON for CRUD UI:\n" + e + "</pre>";
   }
 
-  jQuery("#innerGeneratedCodeRow" + tabnumber).html(formHtml);
+  var targetSelector = containerSelector || ("#innerGeneratedCodeRow" + tabnumber);
+  jQuery(targetSelector).html(formHtml);
 
   // Enhance forms with clickable class headers and popup dialog per class
-  Page.initCrudUi(tabnumber);
+  Page.initCrudUi(tabnumber, containerSelector);
 
   // If instance-data JSON has been prepared via the backend, import it
   // now that the CRUD metadata and forms have been initialized.

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -334,11 +334,11 @@ Action.clicked = function(event)
     Action.changeDiagramType({type:"instanceDiagram"});
     Action.syncLiveViewSelector("instanceDiagram");
   }
-  // else if (action == "ShowCRUDUI")
-  // {
-  //   Action.changeDiagramType({type:"crudUI"});
-  //   Action.syncLiveViewSelector("crudUI");
-  // }
+  else if (action == "ShowCRUDUI")
+  {
+    Action.changeDiagramType({type:"crudUI"});
+    Action.syncLiveViewSelector("crudUI");
+  }
   else if (action == "ShowStateTables")
   {
     Action.changeDiagramType({type:"stateTables"});
@@ -969,7 +969,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useStructureDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -989,7 +989,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useStructureDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -1008,7 +1008,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useStructureDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -1028,7 +1028,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useStructureDiagram = false;
     Page.useGvEntityRelationshipDiagram = true;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -1049,7 +1049,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvFeatureDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -1068,7 +1068,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvFeatureDiagram = true;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -1088,7 +1088,7 @@ Action.changeDiagramType = function(newDiagramType)
     Page.useGvFeatureDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     changedType = true;
@@ -1106,7 +1106,7 @@ Action.changeDiagramType = function(newDiagramType)
      Page.useGvFeatureDiagram = false;
      Page.useGvEntityRelationshipDiagram = false;
      Page.useInstanceDiagram = true;
-    //  Page.useCRUDUI = false;
+     Page.useCRUDUI = false;
      Page.useStateTables = false;
      Page.useEventSequence = false;
      changedType = true;
@@ -1117,24 +1117,24 @@ Action.changeDiagramType = function(newDiagramType)
  
    }
 
-//    else if(newDiagramType.type == "crudUI"){
-//     if(Page.useCRUDUI) return;
-//      Page.useEditableClassDiagram = false;
-//      Page.useJointJSClassDiagram = false;
-//      Page.useGvClassDiagram = false;
-//      Page.useGvStateDiagram = false;
-//      Page.useStructureDiagram = false;
-//      Page.useGvFeatureDiagram = false;
-//      Page.useGvEntityRelationshipDiagram = false;
-//      Page.useInstanceDiagram = false;
-//     //  Page.useCRUDUI = true;
-//      Page.useStateTables = false;
-//      Page.useEventSequence = false;
-//      changedType = true;
-//      jQuery("#buttonShowCRUDUI").prop('checked', 'checked');
-//      Page.setDiagramTypeIconState('none');
-//      jQuery(".view_opt_feature").show();
-// }
+  else if(newDiagramType.type == "crudUI"){
+   if(Page.useCRUDUI) return;
+    Page.useEditableClassDiagram = false;
+    Page.useJointJSClassDiagram = false;
+    Page.useGvClassDiagram = false;
+    Page.useGvStateDiagram = false;
+    Page.useStructureDiagram = false;
+    Page.useGvFeatureDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
+    Page.useInstanceDiagram = false;
+    Page.useCRUDUI = true;
+    Page.useStateTables = false;
+    Page.useEventSequence = false;
+    changedType = true;
+    jQuery("#buttonShowCRUDUI").prop('checked', 'checked');
+    Page.setDiagramTypeIconState('none');
+    jQuery(".view_opt_feature").show();
+}
 
    else if(newDiagramType.type == "stateTables"){
     if(Page.useStateTables) return;
@@ -1146,7 +1146,7 @@ Action.changeDiagramType = function(newDiagramType)
      Page.useGvFeatureDiagram = false;
      Page.useGvEntityRelationshipDiagram = false;
      Page.useInstanceDiagram = false;
-    //  Page.useCRUDUI = false;
+     Page.useCRUDUI = false;
      Page.useStateTables = true;
      Page.useEventSequence = false;
      changedType = true;
@@ -1165,7 +1165,7 @@ Action.changeDiagramType = function(newDiagramType)
      Page.useGvFeatureDiagram = false;
      Page.useGvEntityRelationshipDiagram = false;
      Page.useInstanceDiagram = false;
-     //  Page.useCRUDUI = false;
+     Page.useCRUDUI = false;
      Page.useStateTables = false;
      Page.useEventSequence = true;
      changedType = true;
@@ -4661,9 +4661,6 @@ Action.loadExample = function loadExample()
     diagramType="&diagramtype=instanceDiagram";
   }
 
-  // else if(Page.useCRUDUI) {
-  //   diagramType="&diagramtype=crudJson";
-  // }
 
   else if(Page.useStateTables) {
     diagramType="&diagramtype=StateTables";
@@ -6211,11 +6208,11 @@ Action.updateUmpleDiagramCallback = function(response)
   }
 }
 
-// else if(Page.useCRUDUI)
-// {
-//   theCanvas.html("<div id='htmlCanvas' class='generatedDiagram'></div>");
-//   Page.showCrudFromJson(diagramCode, "", "#htmlCanvas");
-// }
+    else if(Page.useCRUDUI)
+    {
+      theCanvas.html("<div id='htmlCanvas' class='generatedDiagram'></div>");
+      Page.showCrudFromJson(diagramCode, "", "#htmlCanvas");
+    }
     //Display structure diagram
     else if(Page.useStructureDiagram)
     {
@@ -6378,9 +6375,9 @@ Action.getDiagramCode = function(responseText)
       output = output.replace(/<\/svg>$/, "");
     }
   }
-  else if(/*Page.useCRUDUI ||*/ Page.useEventSequence || Page.useStateTables)
+  else if(Page.useCRUDUI || Page.useEventSequence || Page.useStateTables)
   {
-    var language = /*Page.useCRUDUI ? "crudJson" :*/
+    var language = Page.useCRUDUI ? "crudJson" :
                    Page.useEventSequence ? "eventSequence" :
                    "stateTables";
 
@@ -6415,12 +6412,11 @@ Action.getErrorCode = function(responseText)
       output = miscStuffAndErrorMessages.split("</script>&nbsp;")[0];
     }
   }
-  else if(/*Page.useCRUDUI ||*/ Page.useEventSequence || Page.useStateTables)
+  else if(Page.useCRUDUI || Page.useEventSequence || Page.useStateTables)
   {
-    var language = /*Page.useCRUDUI ? "crudJson" :*/
+    var language = Page.useCRUDUI ? "crudJson" :
                    Page.useEventSequence ? "eventSequence" :
                    "stateTables";
-
     output = Page.getErrorMarkup(responseText, language);
   }
   return output;
@@ -7041,7 +7037,7 @@ Action.getLanguage = function()
   else if(Page.useGvEntityRelationshipDiagram) {language="language=entityRelationshipDiagram"}
   else if(Page.useStructureDiagram) {language="language=StructureDiagram"}
   else if(Page.useInstanceDiagram) {language="language=instanceDiagram"}
-  // else if(Page.useCRUDUI) {language="language=crudJson"}
+  else if(Page.useCRUDUI) {language="language=Json&languageStyle=crudJson"}
   else if(Page.useStateTables) {language="language=StateTables"}
   else if(Page.useEventSequence) {language="language=eventSequence"}
  
@@ -7395,7 +7391,7 @@ Action.setLiveView = function(viewNameToSet)
   else if (viewNameToSet=="erd") { Page.clickShowGvEntityRelationshipDiagram();}
   else if (viewNameToSet=="gfd") { Page.clickShowGvFeatureDiagram();}
   else if (viewNameToSet=="instanceDiagram") {Page.clickShowInstanceDiagram();}
-  // else if (viewNameToSet == "crudUI") { Page.clickShowCRUDUI();}
+  else if (viewNameToSet == "crudUI") { Page.clickShowCRUDUI();}
   else if (viewNameToSet == "stateTables") { Page.clickShowStateTables();}
   else if (viewNameToSet == "eventSequence") { Page.clickShowEventSequence();}
   else Page.catFeedbackMessage("DEBUG bad selection!!!");

--- a/umpleonline/scripts/umple_page.js
+++ b/umpleonline/scripts/umple_page.js
@@ -45,7 +45,7 @@ Page.useStructureDiagram = false;
 Page.useFeatureDiagram = false;
 Page.useGvEntityRelationshipDiagram = false;
 Page.useInstanceDiagram = false;
-// Page.useCRUDUI = false;
+Page.useCRUDUI = false;
 Page.useStateTables = false;
 Page.useEventSequence = false;
 Page.showAttributes = true;
@@ -175,7 +175,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   {
     Page.useGvEntityRelationshipDiagram = true;
     Page.useInstanceDiagram = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     Page.useStructureDiagram = false;
@@ -186,7 +186,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   else if(diagramType.toLowerCase() == "instancediagram")
   {
     Page.useInstanceDiagram = true;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useEventSequence = false;
     Page.useGvEntityRelationshipDiagram = false;
@@ -195,22 +195,22 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
     Page.setDiagramTypeIconState('none');
     Page.useGvFeatureDiagram = false;
   }
-  // else if(diagramType.toLowerCase() == "crudui" || diagramType.toLowerCase() == "crudjson")
-  // {
-  //   Page.useCRUDUI = true;
-  //   Page.useStateTables = false;
-  //   Page.useEventSequence = false;
-  //   Page.useInstanceDiagram = false;
-  //   Page.useGvEntityRelationshipDiagram = false;
-  //   Page.useStructureDiagram = false;
-  //   Page.useEditableClassDiagram = false;  
-  //   Page.setDiagramTypeIconState('none');
-  //   Page.useGvFeatureDiagram = false;
-  // }
+  else if(diagramType.toLowerCase() == "crudui" || diagramType.toLowerCase() == "crudjson")
+  {
+    Page.useCRUDUI = true;
+    Page.useStateTables = false;
+    Page.useEventSequence = false;
+    Page.useInstanceDiagram = false;
+    Page.useGvEntityRelationshipDiagram = false;
+    Page.useStructureDiagram = false;
+    Page.useEditableClassDiagram = false;  
+    Page.setDiagramTypeIconState('none');
+    Page.useGvFeatureDiagram = false;
+  }
   else if(diagramType.toLowerCase() == "eventsequence")
   {
     Page.useEventSequence = true;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useStateTables = false;
     Page.useInstanceDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
@@ -223,7 +223,7 @@ Page.init = function(doShowDiagram, doShowText, doShowMenu, doReadOnly, doShowLa
   {
     Page.useStateTables = true;
     Page.useEventSequence = false;
-    // Page.useCRUDUI = false;
+    Page.useCRUDUI = false;
     Page.useInstanceDiagram = false;
     Page.useGvEntityRelationshipDiagram = false;
     Page.useStructureDiagram = false;
@@ -383,7 +383,7 @@ Page.initPaletteArea = function()
   Page.initAction("buttonShowStructureDiagram");
   Page.initAction("buttonShowGvEntityRelationshipDiagram");
   Page.initAction("buttonShowInstanceDiagram");
-  // Page.initAction("buttonShowCRUDUI");
+  Page.initAction("buttonShowCRUDUI");
   Page.initAction("buttonShowStateTables");
   Page.initAction("buttonShowEventSequence");
   Page.initAction("buttonShowHideLayoutEditor");
@@ -517,8 +517,8 @@ Page.initOptions = function()
   if(Page.useInstanceDiagram)
     jQuery("#buttonShowInstanceDiagram").prop('checked', true);
 
-  // if(Page.useCRUDUI)
-  //   jQuery("#buttonShowCRUDUI").prop('checked', true);
+  if(Page.useCRUDUI)
+    jQuery("#buttonShowCRUDUI").prop('checked', true);
  
   if(Page.useStateTables)
     jQuery("#buttonShowStateTables").prop('checked', true);
@@ -822,9 +822,9 @@ Page.clickShowGvEntityRelationshipDiagram = function() {
 Page.clickShowInstanceDiagram = function() {
   jQuery('#buttonShowInstanceDiagram').trigger('click');
 }
-// Page.clickShowCRUDUI = function() {
-//   jQuery('#buttonShowCRUDUI').trigger('click');
-// }
+Page.clickShowCRUDUI = function() {
+  jQuery('#buttonShowCRUDUI').trigger('click');
+}
 Page.clickShowStateTables = function() {
   jQuery('#buttonShowStateTables').trigger('click');
 }
@@ -1697,16 +1697,16 @@ Page.getSelectedExample = function()
     
     } 
 
-    // else if (theExampleType == "crudModels")
-    // {
-    //    inputExample = jQuery("#inputExample4 option:selected").val(); 
-    //    if( !Page.useCRUDUI) {
-    //      jQuery("#buttonShowCRUDUI").prop('checked', true); 
-    //      Action.changeDiagramType({type: "crudUI"});
+    else if (theExampleType == "crudModels")
+    {
+       inputExample = jQuery("#inputExample4 option:selected").val(); 
+       if( !Page.useCRUDUI) {
+         jQuery("#buttonShowCRUDUI").prop('checked', true); 
+         Action.changeDiagramType({type: "crudUI"});
          
-    //   }
+      }
     
-    // } 
+    } 
 
     else if (theExampleType == "stateModels")
     {
@@ -1905,7 +1905,7 @@ Page.getErrorMarkup = function(code, language)
   { // Covers simple right-hand side canvas updates
     output = code.replace(/<p>[\s\S]*/, "");
   }
-  else if(/*language == "crudJson" ||*/ language == "eventSequence" || language == "stateTables")
+  else if(language == "eventSequence" || language == "stateTables")
   {
     // These use URL_SPLIT output, not SVG parsing
     var split = code.split("URL_SPLIT");
@@ -1955,18 +1955,13 @@ Page.getGeneratedMarkup = function(code, language)
     output = jQuery("<div/>").html(output).text();
   }
   else if(language == "eventSequence" || language == "stateTables")
-{
+  {
   var split = code.split("URL_SPLIT");
   output = (split.length > 1) ? split[1] : code;
 
   // Decode escaped HTML so it renders in the right pane
   output = jQuery("<div/>").html(output).text();
-}
-// else if(language == "crudJson")
-// {
-//   var split = code.split("URL_SPLIT");
-//   output = (split.length > 1) ? split[1] : code;
-// }
+  }
   else
   {
     // Covers the rest of the generated languages

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -581,7 +581,7 @@ $output = $dataHandle->readData('model.ump');
     <option value="gfd" id="menu-set-gfd">Feature Diagram</option>
     <option value="erd" id="buttonShowGvEntityRelationshipDiagram">ERD</option>
     <option value="instanceDiagram" id="buttonShowInstanceDiagram">Instance Diagram</option>
-    <!-- <option value="crudUI" id="buttonShowCRUDUI">CRUD UI</option> -->
+    <option value="crudUI" id="buttonShowCRUDUI">CRUD UI</option>
     <option value="eventSequence" id="buttonShowEventSequence">Event Sequence</option>
     <option value="stateTables" id="buttonShowStateTables">State Tables</option>
   </select>


### PR DESCRIPTION
This change enables CRUD UI as a Live View option and wires it through the existing diagram-type and view-selection logic. When the CRUD UI view is chosen, the frontend calls the same backend CRUD JSON generator and uses the existing logic inside umple_crudui.js file to display the form. CRUD now behaves consistently between the bottom panel and Live View.