### PR TITLE
Fixes Issue #831 - Intermittent build failures on DoActivityTest

### DIFF
--- a/testbed/test/cruise/statemachine/test/DoActivityTest.java
+++ b/testbed/test/cruise/statemachine/test/DoActivityTest.java
@@ -1,19 +1,33 @@
 package cruise.statemachine.test;
 
 import org.junit.*;
-import org.junit.Ignore;
 
 public class DoActivityTest
 {
-    
+  // For longest possible waiting time (ms) do NUM_CHECKS * CHECK_INTERVAL_MS
+  private static final int NUM_CHECKS = 800;
+  private static final int CHECK_INTERVAL_MS = 25;
+
   @Test
   public void doActivity() throws InterruptedException
   {
     CourseC course = new CourseC();
     course.flip();
-   
-    Thread.sleep(5000);
-    Assert.assertEquals("Expected 3, but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == 3);
+
+    int numChecks = NUM_CHECKS;
+    final int expectedLogs = 3;
+    
+    while(numChecks > 0)
+    {
+      boolean testsCompleted = false;
+      if (course.numberOfLogs() == expectedLogs) {
+        break;
+      } 
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+    
+    Assert.assertEquals("Expected " + expectedLogs + ", but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == expectedLogs);
     Assert.assertEquals("Open Entry", course.getLog(0));
     Assert.assertEquals("Closed Entry", course.getLog(1));
     Assert.assertEquals("Do Activity On Closed",course.getLog(2));
@@ -26,8 +40,19 @@ public class DoActivityTest
     course.flip();
     course.flip();
    
-    Thread.sleep(5000);
-    Assert.assertEquals("Expected 3, but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == 3);
+    int numChecks = NUM_CHECKS;
+    final int expectedLogs = 3;
+
+    while(numChecks > 0)
+    { 
+      if (course.numberOfLogs() == expectedLogs) {
+        break;
+      } 
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+    
+    Assert.assertEquals("Expected " + expectedLogs + ", but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == expectedLogs);
     Assert.assertEquals("Open Entry", course.getLog(0));
     Assert.assertEquals("Closed Entry", course.getLog(1));
     Assert.assertEquals("Open Entry",course.getLog(2));
@@ -37,17 +62,39 @@ public class DoActivityTest
   public void transitionAfterDoActivity() throws InterruptedException
   {
     CourseV course = new CourseV();
-    Thread.sleep(5000);
+    int numChecks = NUM_CHECKS;
+    final CourseV.Status expectedStatus = CourseV.Status.On;
+    
+    while(numChecks > 0)
+    {
+
+      if (course.getStatus() == expectedStatus) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+
     Assert.assertEquals(1, course.getCount());
     Assert.assertEquals(CourseV.Status.On, course.getStatus());
   }
 
   @Test
-  
   public void autoTransitionSyncAfterMultipleDo() throws InterruptedException
   {
     TransitionActivitySync sync = new TransitionActivitySync();
-    Thread.sleep(1000);
+    int numChecks = NUM_CHECKS;
+    final String expectedList = "[1, 2, 3]";
+
+    while(numChecks > 0)
+    {
+      if (expectedList.equals(sync.getList())) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+
     Assert.assertEquals("[1, 2, 3]", sync.getList());
     Assert.assertEquals(TransitionActivitySync.Status.On, sync.getStatus());
   }
@@ -56,8 +103,18 @@ public class DoActivityTest
   public void doActivityInNestedStateMachine() throws InterruptedException
   {
     CourseW course = new CourseW();
-    Thread.sleep(5000);
-    
+    int numChecks = NUM_CHECKS;
+    final int expectedLogs = 1;
+    while(numChecks > 0)
+    {
+      if(course.numberOfLogs() == expectedLogs) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+
+    Assert.assertEquals("Expected " + expectedLogs + ", but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == expectedLogs);
     Assert.assertEquals("DoActivity in nested state", course.getLog(0));
   }
 
@@ -67,8 +124,19 @@ public class DoActivityTest
     MultiLogCourse course = new MultiLogCourse();
     course.flip();
    
-    Thread.sleep(5000);
-    Assert.assertEquals("Expected 4, but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == 4);
+    int numChecks = NUM_CHECKS;
+    final int expectedLogs = 4;
+    
+    while(numChecks > 0)
+    {
+      if(course.numberOfLogs() == expectedLogs) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+
+    Assert.assertEquals("Expected " + expectedLogs + ", but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == expectedLogs);
     Assert.assertEquals("Open Entry", course.getLog(0));
     Assert.assertEquals("Closed Entry", course.getLog(1));
 
@@ -91,9 +159,19 @@ public class DoActivityTest
     course.flip();
     course.flip();
    
-    Thread.sleep(5000);
+    int numChecks = NUM_CHECKS;
+    final int expectedLogs = 3;
+    
+    while(numChecks > 0)
+    {
+      if(course.numberOfLogs() == expectedLogs) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
 
-    Assert.assertEquals("Expected 3, but produced " + course.numberOfLogs(), true,course.numberOfLogs() == 3);
+    Assert.assertEquals("Expected " + expectedLogs + ", but produced " + course.numberOfLogs(), true,course.numberOfLogs() == expectedLogs);
     Assert.assertEquals("Open Entry", course.getLog(0));
     Assert.assertEquals("Closed Entry", course.getLog(1));
     Assert.assertEquals("Open Entry",course.getLog(2));
@@ -104,7 +182,18 @@ public class DoActivityTest
   public void transitionAfterMultipleDoActivities() throws InterruptedException
   {
     CourseVMultiDo course = new CourseVMultiDo();
-    Thread.sleep(5000);
+    int numChecks = NUM_CHECKS;
+    final CourseVMultiDo.Status expectedStatus = CourseVMultiDo.Status.On;
+
+    while(numChecks > 0)
+    {
+      if(course.getStatus() == expectedStatus) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+    
     Assert.assertEquals(2, course.getCount());
     Assert.assertEquals(CourseVMultiDo.Status.On, course.getStatus());
   }
@@ -113,8 +202,19 @@ public class DoActivityTest
   public void multipleDoActivitiesInNestedStateMachine() throws InterruptedException
   {
     CourseWMultiDo course = new CourseWMultiDo();
-    Thread.sleep(5000);
-    
+    int numChecks = NUM_CHECKS;
+    final int expectedLogs = 2;
+    while(numChecks > 0)
+    {
+      if(course.numberOfLogs() == expectedLogs) {
+        break;
+      }
+      Thread.sleep(CHECK_INTERVAL_MS);
+      numChecks--;
+    }
+
+
+    Assert.assertEquals("Expected " + expectedLogs + ", but only produced " + course.numberOfLogs(), true,course.numberOfLogs() == expectedLogs);
     Assert.assertTrue(course.getLog(0).equals("DoActivity in nested state Thread1") || course.getLog(0).equals("DoActivity in nested state Thread2"));
   
     if (course.getLog(0).equals("DoActivity in nested state Thread1"))


### PR DESCRIPTION
## Fixes Issue #831 - Intermittent build failures on DoActivityTest

### Files Changed
`testbed/test/cruise/statemachine/test/DoActivityTest.java`
- Increased maximum wait time for tests
- Added mechanism to exit waiting early if test completes before maximum wait time
- Added additional assertions to prevent other assertions from failing unexpectedly if the maximum wait time is exceeded