### PR TITLE
Change case of BBedit link in manual

### DIFF
--- a/build/reference/0102umpleTools.txt
+++ b/build/reference/0102umpleTools.txt
@@ -36,7 +36,7 @@ can be run locally on your machine by using a Docker image. <a href="https://hub
 
 <br />&nbsp;<br />
 
-<li><a href="BBedit.html"><b style="background-color: #A7593D; padding: 2px; color: white">BBEdit tool support</b>. See the BBEdit page in this user manual.</a>. It includes Language Server Protocol support.</li>
+<li><a href="BBEdit.html"><b style="background-color: #A7593D; padding: 2px; color: white">BBEdit tool support</b>. See the BBEdit page in this user manual.</a>. It includes Language Server Protocol support.</li>
 
 <br />&nbsp;<br />
 

--- a/build/reference/0102umpleTools.txt
+++ b/build/reference/0102umpleTools.txt
@@ -27,7 +27,7 @@ allows you to instantly experiment with Umple on the web. You can explore
 examples or create your own and save them in the "cloud". You can generate 
 diagrams, code in several languages and several other outputs. <a href="UsingUmpleOnline.html">The UmpleOnline
 section of this User manual describes how to use UmpleOnline</a>. Note that UmpleOnline
-can be run locally on your machine by using a Docker image. <a href="https://hub.docker.com/r/umple/umpleonline/">See the DockerHub page for information.</a></li>
+can be run locally on your machine by using a Docker image. <a href="https://hub.docker.com/r/umple/umpleonline/">See the DockerHub page for information.</a>  Note that a <a href="https://github.com/umple/umpleonline/" target="newulgh">completely rewritten experimental version of UmpleOnline</a> is avalable for early exploration.</li>
 
 
 <br />&nbsp;<br />


### PR DESCRIPTION
Fixes a bad link in the tools manual page ... just changing lowercase b to uppercase B !!