### PR TITLE
Issue2421 Make jopt-simple use the cached version on the Umple site to reduce CI failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,10 +173,13 @@ task downloadUmpleJar(type: Download) {
     src rootProject.ext.umpleJarRemoteSource
     dest rootProject.ext.umpleJarRemoteFile
 }
+// The following used to download from
+// "https://codeload.github.com/pholser/jopt-simple/zip/jopt-simple-4.4"
+// but was giving CI failures periodically, so using our cached version
 task downloadJOptSimpleVendorZip(type: Download) {
     onlyIfNewer true
     overwrite true
-    src "https://codeload.github.com/pholser/jopt-simple/zip/jopt-simple-4.4"
+    src "https://umple.org/joptsimpledl/jopt-simple-4.4.zip"
     dest "${rootProject.projectDir.toString()}/dist/gradle/libs/vendors/jopt-simple-4.4.zip"
 }
 

--- a/build/build.deps.xml
+++ b/build/build.deps.xml
@@ -131,7 +131,11 @@
     <echo>Installing Vendors...</echo>
     <delete dir="${vendors.path}" failonerror="false" />
     <mkdir dir="${vendors.path}"/>
-    <get src="https://codeload.github.com/pholser/jopt-simple/zip/jopt-simple-${jopt-simple.install.version}" verbose="true" dest="${vendors.path}/jopt-simple-${jopt-simple.install.version}.zip"/>
+    <!-- The following used to download from 
+"https://codeload.github.com/pholser/jopt-simple/zip/jopt-simple-${jopt-simple.install.version}" verbose="true" dest="${vendors.path}/jopt-simple-${jopt-simple.install.version}.zip"
+        but was giving CI failures periodically, so using our cached version
+    -->
+    <get src="https://umple.org/joptsimpledl/jopt-simple-4.4.zip" verbose="true" dest="${vendors.path}/jopt-simple-${jopt-simple.install.version}.zip"/>
     <unzip src="${vendors.path}/jopt-simple-${jopt-simple.install.version}.zip" dest="${vendors.path}/"/>
     <delete dir="${vendors.path}/jopt-simple-jopt-simple-${jopt-simple.install.version}/src/test" failonerror="false" />
     <move file="${vendors.path}/jopt-simple-jopt-simple-${jopt-simple.install.version}" tofile="${vendors.path}/jopt-simple"/>


### PR DESCRIPTION
CI is failing periodically due to occasional problems getting 

https://codeload.github.com/pholser/jopt-simple/zip/jopt-simple-4.4

This instead gets the version we have cached at

https://umple.org/joptsimpledl/jopt-simple-4.4.zip

This dependency is used in umple.jar