### PR TITLE
Issue #2377: Update simple requirements output for userStory

### DIFF
--- a/cruise.umple/src/generators/Generator_CodePlainRequirementsDoc.ump
+++ b/cruise.umple/src/generators/Generator_CodePlainRequirementsDoc.ump
@@ -53,7 +53,43 @@ class PlainRequirementsDocGenerator
     for (Requirement req : ReqTreeSet){
     	if (req.hasReqImplementations() || !hasreqHideNotImpl) {
     	  // Below string stores the requirement statement and language and translates to html
-				String mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());
+				String mainReqText = "";
+				if ("userStory".equals(req.getLanguage())) {
+					StringBuilder userStoryText = new StringBuilder();
+
+					if (req.getWho() != null && !req.getWho().equals("")) {
+						userStoryText.append("As ").append(req.getWho());
+					}
+					if (req.getWhen() != null && !req.getWhen().equals("")) {
+						if (userStoryText.length() > 0) {
+							userStoryText.append("<br/>");
+						}
+						userStoryText.append("When ").append(req.getWhen());
+					}
+					if (req.getWhat() != null && !req.getWhat().equals("")) {
+						if (userStoryText.length() > 0) {
+							userStoryText.append("<br/>");
+						}
+						userStoryText.append("I want ").append(req.getWhat());
+					}
+					if (req.getWhy() != null && !req.getWhy().equals("")) {
+						if (userStoryText.length() > 0) {
+							userStoryText.append("<br/>");
+						}
+						userStoryText.append("So that ").append(req.getWhy());
+					}
+
+					if (userStoryText.length() > 0) {
+						mainReqText = Requirement.translateToHTML(userStoryText.toString(), req.getLanguage());
+					}
+					else {
+						mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());
+					}
+				}
+				else {
+					mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());
+				}
+
 				mainReqText = linkifyHttpUrls(mainReqText);
 				doc.createParagraphElement("<b>" + req.getIdentifier() + ": " + mainReqText + "</b>", false);
     	  // Check if the requirement is implemented

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryPlain.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryPlain.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUserStoryPlain.ump
+</p><p><b>US1: As a customer, I want to reset my password so that I can regain access to my account.</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryPlain.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryPlain.ump
@@ -1,0 +1,3 @@
+req US1 userStory {
+  As a customer, I want to reset my password so that I can regain access to my account.
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructured.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructured.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUserStoryStructured.ump
+</p><p><b>US2: As customer<br/>When password is forgotten<br/>I want reset my password<br/>So that regain access to my account</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructured.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructured.ump
@@ -1,0 +1,6 @@
+req US2 userStory {
+  who { customer }
+  when { password is forgotten }
+  what { reset my password }
+  why { regain access to my account }
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructuredPartial.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructuredPartial.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUserStoryStructuredPartial.ump
+</p><p><b>US3: As administrator<br/>I want manage users</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructuredPartial.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryStructuredPartial.ump
@@ -1,0 +1,4 @@
+req US3 userStory {
+  who { administrator }
+  what { manage users }
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryWhoOnly.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryWhoOnly.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUserStoryWhoOnly.ump
+</p><p><b>US4: As customer</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryWhoOnly.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUserStoryWhoOnly.ump
@@ -1,0 +1,3 @@
+req US4 userStory {
+  who { customer }
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/RequirementsPlainTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/RequirementsPlainTest.java
@@ -36,6 +36,10 @@ public class RequirementsPlainTest extends TemplateTest
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqHideNotImpl.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqNotImpl.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqMultipleItems.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryPlain.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryStructured.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryStructuredPartial.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryWhoOnly.html");
   }
 
   @Test
@@ -95,5 +99,26 @@ public class RequirementsPlainTest extends TemplateTest
   public void ReqMultipleItems()
   {
     assertUmpleTemplateFor("requirements/ReqMultipleItems.ump","requirements/ReqMultipleItems.html.txt");
+  }
+
+  @Test
+  public void userStoryStructured()
+  {
+    assertUmpleTemplateFor("requirements/ReqUserStoryStructured.ump", "requirements/ReqUserStoryStructured.html.txt");
+  }
+  @Test
+  public void userStoryStructuredPartial()
+  {
+    assertUmpleTemplateFor("requirements/ReqUserStoryStructuredPartial.ump","requirements/ReqUserStoryStructuredPartial.html.txt");
+  }
+  @Test
+  public void userStoryPlain()
+  {
+    assertUmpleTemplateFor("requirements/ReqUserStoryPlain.ump","requirements/ReqUserStoryPlain.html.txt");
+  }
+  @Test
+  public void userStoryWhoOnly()
+  {
+    assertUmpleTemplateFor("requirements/ReqUserStoryWhoOnly.ump","requirements/ReqUserStoryWhoOnly.html.txt");
   }
 }


### PR DESCRIPTION
Fixes part of #2377

## Summary
This PR updates the `PlainRequirementsDoc` generator so structured `userStory` requirements are rendered in a readable user-story format instead of exposing the raw internal syntax.

Previously, structured user stories appeared as:
`who { ... } when { ... } what { ... } why { ... }`

They now render as:
- As ...
- When ...
- I want ...
- So that ...

This makes generated requirement documentation significantly easier to read while preserving existing behavior for all other requirement types.

## Changes
- Updated `PlainRequirementsDocGenerator` to detect `userStory`
- Render structured fields using readable story prose:
  - `who` → `As ...`
  - `when` → `When ...`
  - `what` → `I want ...`
  - `why` → `So that ...`
- Preserved fallback to `getStatement()` for plain-text `userStory`
- Preserved existing output formatting for non-`userStory` requirements

## Tests
Added template tests covering:
- plain-text `userStory`
- fully structured `userStory`
- partially structured `userStory`
- single-field structured `userStory`

These tests validate both standard behavior and edge cases involving missing optional fields.