### PR TITLE
Issue #2377: Add userstory alias support for userStory requirements

### DIFF
--- a/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
+++ b/cruise.umple/src/class/UmpleInternalParser_CodeClass.ump
@@ -218,6 +218,9 @@ class UmpleInternalParser
     if (!(t.getSubToken("reqLanguage") == null || t.getSubToken("reqLanguage").getValue() == null)) {
       newLanguage = t.getSubToken("reqLanguage").getValue();
     }
+    if ("userstory".equals(newLanguage)) {
+      newLanguage = "userStory";
+    }
 
     String whoContent = null;
     String whenContent = null;

--- a/cruise.umple/src/trait/UmpleInternalParser_CodeTrait.ump
+++ b/cruise.umple/src/trait/UmpleInternalParser_CodeTrait.ump
@@ -340,7 +340,9 @@ class UmpleInternalParser
     if (!(t.getSubToken("reqLanguage") == null || t.getSubToken("reqLanguage").getValue() == null)) {
       newLanguage = t.getSubToken("reqLanguage").getValue();
     }
-
+    if ("userstory".equals(newLanguage)) {
+      newLanguage = "userStory";
+    }
     String whoContent = null;
     String whenContent = null;
     String whatContent = null;

--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -57,7 +57,7 @@ multilineComment- : /* [**multilineComment] */
 
 requirement : req [reqIdentifier] ( ( [[userStory]] ) | ( [[plainReq]] ) )
 plainReq- : [reqLanguage]? { [**reqContent] }
-userStory- : [=reqLanguage:userStory] { ( [[userStoryTags]] | [**reqContent] ) }
+userStory- : [=reqLanguage:userStory|userstory] { ( [[userStoryTags]] | [**reqContent] ) }
 userStoryTags- : ( who { [*whoContent] } )? ( when { [*whenContent] } )? ( what { [*whatContent] } )? ( why { [*whyContent] } )?
 reqImplementation : implementsReq [reqIdentifier] (, [reqIdentifier])* ;
 

--- a/cruise.umple/test/cruise/umple/compiler/454_ReqUserStoryCamelCase.ump
+++ b/cruise.umple/test/cruise/umple/compiler/454_ReqUserStoryCamelCase.ump
@@ -1,0 +1,4 @@
+req US6 userStory {
+  who { customer }
+  what { reset password }
+}

--- a/cruise.umple/test/cruise/umple/compiler/454_ReqUserstoryAlias.ump
+++ b/cruise.umple/test/cruise/umple/compiler/454_ReqUserstoryAlias.ump
@@ -1,0 +1,4 @@
+req US5 userstory {
+  who { customer }
+  what { reset password }
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -1637,19 +1637,19 @@ public class UmpleParserTest
   {
           assertNoWarningsParse("451_ReqMixsetOutputGenerated.ump");
   }
-  //Issue 2377
+  //Issue 2377 (User Story)
   @Test
   public void ReqUserStoryBasic()
   {
     assertNoWarningsParse("452_ReqUserStoryBasic.ump");
   }
-  //Issue 2377
+  //Issue 2377 (User Story)
   @Test
   public void ReqNormalStillWorksAfterUserStoryGrammar()
   {
     assertNoWarningsParse("452_ReqNormalStillWorks.ump");
   }
-  //Issue 2377
+  //Issue 2377 (User Story)
   @Test
   public void ReqUserStoryStructuredAll()
   {
@@ -1664,7 +1664,7 @@ public class UmpleParserTest
     Assert.assertEquals("reset my password", req.getWhat());
     Assert.assertEquals("regain access to my account", req.getWhy());
   }
-  //Issue 2377
+  //Issue 2377 (User Story)
   @Test
   public void ReqUserStoryStructuredPartial()
   {
@@ -1678,6 +1678,30 @@ public class UmpleParserTest
     Assert.assertNull(req.getWhen());
     Assert.assertEquals("manage users", req.getWhat());
     Assert.assertNull(req.getWhy());
+  }
+  //Issue 2377 (User Story)
+  @Test
+  public void ReqUserstoryAliasLowercase()
+  {
+    assertNoWarningsParse("454_ReqUserstoryAlias.ump");
+
+    Requirement req = model.getAllRequirements().get("US5");
+    Assert.assertNotNull(req);
+    Assert.assertEquals("userStory", req.getLanguage());
+    Assert.assertEquals("customer", req.getWho());
+    Assert.assertEquals("reset password", req.getWhat());
+  }
+  //Issue 2377 (User Story)
+  @Test
+  public void ReqUserstoryAliasCamelCase()
+  {
+    assertNoWarningsParse("454_ReqUserStoryCamelCase.ump");
+
+    Requirement req = model.getAllRequirements().get("US6");
+    Assert.assertNotNull(req);
+    Assert.assertEquals("userStory", req.getLanguage());
+    Assert.assertEquals("customer", req.getWho());
+    Assert.assertEquals("reset password", req.getWhat());
   }
   @Test
   public void associationName()


### PR DESCRIPTION
Fixes part of https://github.com/umple/umple/issues/2377

## Summary

Added support for the lowercase `userstory` alias so it is parsed consistently as the canonical `userStory` requirement language.

## Changes

* Updated `umple_core.grammar` to recognize the lowercase alias
* Normalized parsed `userstory` values to `userStory`
* Applied the normalization in both:

  * `UmpleInternalParser_CodeClass`
  * `UmpleInternalParser_CodeTrait`
* Added parser fixture tests for:

  * lowercase `userstory`
  * camelCase `userStory`

## Validation

* Ran `./dev-tools/bumple`
* Full build completed successfully
* Verified both alias test cases pass
* Confirmed no parser regressions in requirements flow
