### PR TITLE
Progress on #2369: Add Gradle 8 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.ospackage' version '9.1.1'
+  id 'com.netflix.nebula.ospackage' version '12.3.0'
 }
 
 String runGit(List<String> args, String fallback) {
@@ -397,7 +397,6 @@ sourceSets {
             ]
             exclude '**/*.ump', '**/.git*'
         }
-        java.outputDir = file(rootProject.ext.classfileOutputDir)
     }
     test {
         compileClasspath = files(
@@ -415,10 +414,16 @@ sourceSets {
             ]
             exclude '**/*.ump', '**/.git*'
         }
-        java.outputDir = file(rootProject.ext.testClassfileOutputDir)
     }
 }
 
+tasks.named("compileJava") {
+    destinationDirectory.set(file(rootProject.ext.classfileOutputDir))
+}
+
+tasks.named("compileTestJava") {
+    destinationDirectory.set(file(rootProject.ext.testClassfileOutputDir))
+}
 
 // ===============
 //  Jar packaging
@@ -2069,7 +2074,7 @@ task executeDocJar (type: JavaExec){
     def drop = fileTree ("${rootProject.ext.umpleoscripts}/dropbox") {
       include '*.js'
     }
-   files = files (
+   files = project.files (
      'umpleonline/scripts/prototype.js',
      'umpleonline/scripts/dom.js',
      'umpleonline/scripts/ajax.js', 


### PR DESCRIPTION
Related issue: #2369
(Doesn't close the issue)

Adds support for building Umple with Gradle 8. Gradle 8 support can be achieved using a very small diff, whereas Gradle 9 support requires a bit more work. I figured it would still be valuable for Umple to be buildable using a non-EOL version of Gradle until Gradle 9 support is added, especially since the changes are so minimal.

The project also still builds properly with Gradle 7.

---

> PRs should always be made from a branch you have created on umple/umple, not from a fork: This ensures that a Docker image of your PR can be automatically generated for manual testing.

I don't have write access to the repository, so I had to use a fork. If this is a problem, the branch could be copied to the upstream repo and then used as the head of this PR instead.