### PR TITLE
Progress on #2369: Add Gradle 8 support (V2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.netflix.nebula.ospackage' version '12.3.0'
+  id 'com.netflix.nebula.ospackage' version '11.5.0'
 }
 
 String runGit(List<String> args, String fallback) {

--- a/build.gradle
+++ b/build.gradle
@@ -426,7 +426,7 @@ tasks.named("compileTestJava") {
 }
 
 // ===============
-//  Jar packaging
+//  Jar packaging 
 // ===============
 
 // Grammar and error files also need to be included in the Umple jar

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.ospackage' version '9.1.1'
+  id 'com.netflix.nebula.ospackage' version '12.3.0'
 }
 
 String runGit(List<String> args, String fallback) {
@@ -397,7 +397,6 @@ sourceSets {
             ]
             exclude '**/*.ump', '**/.git*'
         }
-        java.outputDir = file(rootProject.ext.classfileOutputDir)
     }
     test {
         compileClasspath = files(
@@ -415,10 +414,16 @@ sourceSets {
             ]
             exclude '**/*.ump', '**/.git*'
         }
-        java.outputDir = file(rootProject.ext.testClassfileOutputDir)
     }
 }
 
+tasks.named("compileJava") {
+    destinationDirectory.set(file(rootProject.ext.classfileOutputDir))
+}
+
+tasks.named("compileTestJava") {
+    destinationDirectory.set(file(rootProject.ext.testClassfileOutputDir))
+}
 
 // ===============
 //  Jar packaging
@@ -2069,7 +2074,7 @@ task executeDocJar (type: JavaExec){
     def drop = fileTree ("${rootProject.ext.umpleoscripts}/dropbox") {
       include '*.js'
     }
-   files = files (
+   files = project.files (
      'umpleonline/scripts/prototype.js',
      'umpleonline/scripts/dom.js',
      'umpleonline/scripts/ajax.js', 


### PR DESCRIPTION
Clone of PR #2429 from @MysteryBlokHed since he did not have write access

Related issue: #2369
(Doesn't close the issue)

Adds support for building Umple with Gradle 8. Gradle 8 support can be achieved using a very small diff, whereas Gradle 9 support requires a bit more work. I figured it would still be valuable for Umple to be buildable using a non-EOL version of Gradle until Gradle 9 support is added, especially since the changes are so minimal.

The project also still builds properly with Gradle 7.