### PR TITLE
Issue #2377: Add userStory examples to requirements documentation

### DIFF
--- a/build/reference/0215requirementsExamples.txt
+++ b/build/reference/0215requirementsExamples.txt
@@ -5,8 +5,7 @@ noreferences
 
 @@description Examples of requirements documents in Umple that can be used to generate code
 
-<p>This page provides some examples of Umple requirements specified using plain text. They show possible styles for specifying requirements. They can be used to guide you to specify requirements in Umple before manually creating a model, or to use UmpleOnline AI capabilities to generate actual Umple code.</p>
-
+<p>This page provides examples of Umple requirements using both plain-text and structured userStory styles. They show possible ways of specifying requirements. They can be used to guide you before manually creating a model, or to use UmpleOnline AI capabilities to generate actual Umple code.</p>
 <br />
 
 @@example  @@caption Hotel booking requirements for creating class diagrams or state machines @@endcaption
@@ -27,4 +26,16 @@ noreferences
 
 @@example @@caption Agent loop system requirements for state machine generation @@endcaption
 @@source manualexamples/ReqAgentLoop.ump
+@@endexample
+
+@@example @@caption Plain-text userStory requirement example @@endcaption
+@@source manualexamples/ReqUserStoryPlain.ump
+@@endexample
+
+@@example @@caption Structured userStory requirement example using who, when, what, and why @@endcaption
+@@source manualexamples/ReqUserStoryStructured.ump
+@@endexample
+
+@@example @@caption Partial structured userStory requirement example @@endcaption
+@@source manualexamples/ReqUserStoryStructuredPartial.ump
 @@endexample

--- a/umpleonline/umplibrary/manualexamples/ReqUserStoryPlain.ump
+++ b/umpleonline/umplibrary/manualexamples/ReqUserStoryPlain.ump
@@ -1,0 +1,3 @@
+req US1 userStory {
+  As a customer, I want to reset my password so that I can regain access to my account.
+}

--- a/umpleonline/umplibrary/manualexamples/ReqUserStoryStructured.ump
+++ b/umpleonline/umplibrary/manualexamples/ReqUserStoryStructured.ump
@@ -1,0 +1,6 @@
+req US2 userStory {
+  who { customer }
+  when { password is forgotten }
+  what { reset my password }
+  why { regain access to my account }
+}

--- a/umpleonline/umplibrary/manualexamples/ReqUserStoryStructuredPartial.ump
+++ b/umpleonline/umplibrary/manualexamples/ReqUserStoryStructuredPartial.ump
@@ -1,0 +1,4 @@
+req US3 userStory {
+  who { administrator }
+  what { manage users }
+}


### PR DESCRIPTION
Fixes part of https://github.com/umple/umple/issues/2377

## Summary
Adds realistic `userStory` requirement examples to the **Requirements Examples** user manual page.

## Changes
- Added a plain-text `userStory` example
- Added a structured `userStory` example using:
  - `who { ... }`
  - `when { ... }`
  - `what { ... }`
  - `why { ... }`
- Added a partial structured `userStory` example
- Added the corresponding manual example `.ump` files in UmpleOnline library examples