### PR TITLE
Fix local state popup menu in state diagrams

### DIFF
--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -1653,27 +1653,16 @@ Action.drawStateMenu = function(){
     targ = targ.parentNode;
   }
   //grabs state name
-  var match = targ.outerHTML.match(/stateClicked\("([^"]+)"\)/);
-
+  var match = targ.outerHTML.match(/stateClicked\((?:&quot;|"|')([^"']+)(?:&quot;|"|')\)/);
+  
   if (!match) {
     return;
   }
-
-  var elemText = match[1].split("^*^").map(function(part) {
-    return part.trim();
-  }); 
-
-  var titleMatch = targ.outerHTML.match(/xlink:title="Class ([^,]+), SM ([^,]+), State ([^"]+)"/);
-
-  if (titleMatch) {
-    elemText[0] = titleMatch[1].trim(); // proper class name casing
-    elemText[1] = titleMatch[2].trim(); // state machine name
-  }
-
+  
+  var elemText = match[1].split("^*^");
   if (!elemText[2]) {
     return;
   }
-  
   elemText[2]=elemText[2].split(".");
   var orig = Page.codeMirrorEditor6.state.doc.toString();
   var chosenStateIndices=Action.selectStateInClassCM6(elemText[0],elemText[1],elemText[2][0]);

--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -1649,12 +1649,31 @@ Action.drawStateMenu = function(){
   Action.removeContextMenu();
   var targ=event.target;
   //iterate up to top of graph elements
-  while(targ.parentElement.id!="graph0"){
-    targ=targ.parentNode;
+  while (targ && targ.parentElement && targ.parentElement.id != "graph0") {
+    targ = targ.parentNode;
   }
   //grabs state name
-  var elemText=targ.outerHTML.substr(targ.outerHTML.indexOf("stateClicked(&quot;")+"stateClicked(&quot;".length,targ.outerHTML.indexOf("&quot;)\"")-(targ.outerHTML.indexOf("stateClicked(&quot;")+"stateClicked(&quot;".length));
-  elemText=elemText.split("^*^"); //index 0: class, index 1: base state, index 2: remaining states
+  var match = targ.outerHTML.match(/stateClicked\("([^"]+)"\)/);
+
+  if (!match) {
+    return;
+  }
+
+  var elemText = match[1].split("^*^").map(function(part) {
+    return part.trim();
+  }); 
+
+  var titleMatch = targ.outerHTML.match(/xlink:title="Class ([^,]+), SM ([^,]+), State ([^"]+)"/);
+
+  if (titleMatch) {
+    elemText[0] = titleMatch[1].trim(); // proper class name casing
+    elemText[1] = titleMatch[2].trim(); // state machine name
+  }
+
+  if (!elemText[2]) {
+    return;
+  }
+  
   elemText[2]=elemText[2].split(".");
   var orig = Page.codeMirrorEditor6.state.doc.toString();
   var chosenStateIndices=Action.selectStateInClassCM6(elemText[0],elemText[1],elemText[2][0]);


### PR DESCRIPTION
## Summary
This PR fixes the state popup menu parsing in UmpleOnline for local setups.

The issue was that `Action.drawStateMenu()` assumed a specific `stateClicked(...)` encoding in the SVG/outerHTML, which caused the popup menu code to fail locally with:

`Uncaught TypeError: can't access property "split", t[2] is undefined`

## Changes
- Made state popup menu parsing more robust in `Action.drawStateMenu`
- Added safe ancestor traversal before reading the graph node
- Added a guard when the expected state identifier cannot be extracted
- Preserved the existing state menu behavior once the identifier is found

## Testing
- Rebuilt UmpleOnline locally
- Opened the local site
- Right-clicked or Double-Click states in state diagrams
- Confirmed the popup menu no longer crashes locally
- Confirmed the official web behavior was preserved