### PR TITLE
Issue #2378: Add grammar support for useCase requirements

### DIFF
--- a/cruise.umple/src/umple_core.grammar
+++ b/cruise.umple/src/umple_core.grammar
@@ -55,10 +55,13 @@ comment- : [[inlineComment]] | [[multilineComment]] | [[annotationComment]]
 inlineComment- : // [*inlineComment]
 multilineComment- : /* [**multilineComment] */
 
-requirement : req [reqIdentifier] ( ( [[userStory]] ) | ( [[plainReq]] ) )
+requirement : req [reqIdentifier] ( ( [[userStory]] ) | ( [[useCase]] ) | ( [[plainReq]] ) )
 plainReq- : [reqLanguage]? { [**reqContent] }
 userStory- : [=reqLanguage:userStory|userstory] { ( [[userStoryTags]] | [**reqContent] ) }
 userStoryTags- : ( who { [*whoContent] } )? ( when { [*whenContent] } )? ( what { [*whatContent] } )? ( why { [*whyContent] } )?
+useCase- : [=reqLanguage:useCase|usecase] { ( [[useCaseTags]] | [**reqContent] ) }
+useCaseTags- : ( [[userStoryTags]] | [[useCaseStep]] )*
+useCaseStep- : ( userStep [useCaseId] { [*useCaseStepContent] } ) | ( systemResponse [useCaseId] { [*useCaseStepContent] } )
 reqImplementation : implementsReq [reqIdentifier] (, [reqIdentifier])* ;
 
 //Matches all forms of Java annotations including those with parentheses and values in quotes

--- a/cruise.umple/test/cruise/umple/compiler/454_ReqNormalStillWorksAfterUseCase.ump
+++ b/cruise.umple/test/cruise/umple/compiler/454_ReqNormalStillWorksAfterUseCase.ump
@@ -1,0 +1,3 @@
+req A text {
+  This is a normal requirement.
+}

--- a/cruise.umple/test/cruise/umple/compiler/454_ReqUseCaseBasic.ump
+++ b/cruise.umple/test/cruise/umple/compiler/454_ReqUseCaseBasic.ump
@@ -1,0 +1,3 @@
+req UC1 useCase {
+  Customer checks out items and the system calculates the total.
+}

--- a/cruise.umple/test/cruise/umple/compiler/454_ReqUsecaseAlias.ump
+++ b/cruise.umple/test/cruise/umple/compiler/454_ReqUsecaseAlias.ump
@@ -1,0 +1,3 @@
+req UC1A usecase {
+  Customer checks out items and the system calculates the total.
+}

--- a/cruise.umple/test/cruise/umple/compiler/455_ReqUseCaseMultipleSteps.ump
+++ b/cruise.umple/test/cruise/umple/compiler/455_ReqUseCaseMultipleSteps.ump
@@ -1,0 +1,6 @@
+req UC4 useCase {
+  userStep 1 { select product }
+  systemResponse 1 { display price }
+  userStep 2 { enter quantity }
+  systemResponse 2 { update total }
+}

--- a/cruise.umple/test/cruise/umple/compiler/455_ReqUseCaseStructuredAll.ump
+++ b/cruise.umple/test/cruise/umple/compiler/455_ReqUseCaseStructuredAll.ump
@@ -1,0 +1,8 @@
+req UC2 useCase {
+  who { customer }
+  when { cart is ready }
+  what { complete checkout }
+  why { purchase selected items }
+  userStep 1 { confirm order }
+  systemResponse 1 { display total price }
+}

--- a/cruise.umple/test/cruise/umple/compiler/455_ReqUseCaseStructuredPartial.ump
+++ b/cruise.umple/test/cruise/umple/compiler/455_ReqUseCaseStructuredPartial.ump
@@ -1,0 +1,5 @@
+req UC3 useCase {
+  who { salesPerson }
+  userStep 1 { select product }
+  systemResponse 1 { display price }
+}

--- a/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/UmpleParserTest.java
@@ -1703,6 +1703,42 @@ public class UmpleParserTest
     Assert.assertEquals("customer", req.getWho());
     Assert.assertEquals("reset password", req.getWhat());
   }
+  //Issue 2378 (Use Case)
+  @Test
+  public void ReqUseCaseBasic()
+  {
+    assertNoWarningsParse("454_ReqUseCaseBasic.ump");
+  }
+  //Issue 2378 (Use Case)
+  @Test
+  public void ReqUsecaseAliasLowercase()
+  {
+    assertNoWarningsParse("454_ReqUsecaseAlias.ump");
+  }
+  //Issue 2378 (Use Case)
+  @Test
+  public void ReqNormalStillWorksAfterUseCaseGrammar()
+  {
+    assertNoWarningsParse("454_ReqNormalStillWorksAfterUseCase.ump");
+  }
+  //Issue 2378 (Use Case)
+  @Test
+  public void ReqUseCaseStructuredAll()
+  {
+    assertNoWarningsParse("455_ReqUseCaseStructuredAll.ump");
+  }
+  //Issue 2378 (Use Case)
+  @Test
+  public void ReqUseCaseStructuredPartial()
+  {
+    assertNoWarningsParse("455_ReqUseCaseStructuredPartial.ump");
+  }
+  //Issue 2378 (Use Case)
+  @Test
+  public void ReqUseCaseMultipleSteps()
+  {
+    assertNoWarningsParse("455_ReqUseCaseMultipleSteps.ump");
+  }
   @Test
   public void associationName()
   {


### PR DESCRIPTION
Implements `useCase` requirement grammar support as part of Issue #2378.

## Summary

This PR extends the requirements grammar to support a new requirement type: `useCase`.

The grammar now follows the same structured approach introduced for `userStory`, using three alternatives:

* `plainReq` for existing requirements
* `userStory` for user story requirements
* `useCase` for use case requirements

It supports either:

* plain free-text use cases
* structured use case sections:

  * `who { ... }`
  * `when { ... }`
  * `what { ... }`
  * `why { ... }`
  * `userStep <id> { ... }`
  * `systemResponse <id> { ... }`

This PR also adds lowercase alias support for:

* `usecase`

## Key Changes

* Added `useCase` as a recognized requirement type
* Added lowercase alias support for `usecase`
* Updated the `requirement` rule to support plain requirements, `userStory`, and `useCase`
* Reused existing structured story tags (`who/when/what/why`) inside use cases
* Added grammar support for:

  * `userStep`
  * `systemResponse`
* Preserved backward compatibility with existing requirement syntax
* Added parser tests for:

  * normal requirements
  * plain free-text use cases
  * lowercase alias `usecase`
  * fully structured use cases
  * partially structured use cases
  * multiple step sequences

## Tested Examples

Normal requirement:

```umple
req A text {
  This is a normal requirement.
}
```

Plain use case:

```umple
req UC1 useCase {
  Customer checks out items and the system calculates the total.
}
```

Use case alias:

```umple
req UC1A usecase {
  Customer checks out items and the system calculates the total.
}
```

Fully structured use case:

```umple
req UC2 useCase {
  who { customer }
  when { cart is ready }
  what { complete checkout }
  why { purchase selected items }
  userStep 1 { confirm order }
  systemResponse 1 { display total price }
}
```

Partially structured use case:

```umple
req UC3 useCase {
  who { salesPerson }
  userStep 1 { select product }
  systemResponse 1 { display price }
}
```

Multiple steps:

```umple
req UC4 useCase {
  userStep 1 { select product }
  systemResponse 1 { display price }
  userStep 2 { enter quantity }
  systemResponse 2 { update total }
}
```
