### PR TITLE
Issue #2378: Extend Requirement metamodel to support structured use cases

### DIFF
--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1327,13 +1327,19 @@ class Requirement{
   * -> * Token reqToken;
 
   // Ordered structured use case steps such as userStep/systemResponse
-  * -- * UseCaseStep useCaseStep;
+  1 -- * UseCaseStep;
 }
 
 class UseCaseStep
 {
+  enum UseCaseStepType
+  {
+    userStep,
+    systemResponse
+  }
+
   id;
-  stepType;
+  UseCaseStepType stepType;
   content;
 }
 

--- a/cruise.umple/src/Umple.ump
+++ b/cruise.umple/src/Umple.ump
@@ -1325,6 +1325,16 @@ class Requirement{
   // Used when reporting errors regarding missing implementations
   // and when reporting where a requirement is located in the code
   * -> * Token reqToken;
+
+  // Ordered structured use case steps such as userStep/systemResponse
+  * -- * UseCaseStep useCaseStep;
+}
+
+class UseCaseStep
+{
+  id;
+  stepType;
+  content;
 }
 
 /*

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -933,6 +933,13 @@ class Requirement{
     what = aReq.getWhat();
     why = aReq.getWhy();
     language = aReq.getLanguage();
+
+    useCaseStep = new ArrayList<UseCaseStep>();
+    for (int i = 0; i < aReq.numberOfUseCaseStep(); i++)
+    {
+      UseCaseStep originalStep = aReq.getUseCaseStep(i);
+      addUseCaseStep(new UseCaseStep(originalStep.getId(), originalStep.getStepType(), originalStep.getContent()));
+    }
   }
   public static List<Comment> convertToComment(List<ReqImplementation> reqSelected,UmpleModel aModel){
     List<Comment> reqTextOnly = new ArrayList<Comment>();

--- a/cruise.umple/src/Umple_Code.ump
+++ b/cruise.umple/src/Umple_Code.ump
@@ -934,11 +934,16 @@ class Requirement{
     why = aReq.getWhy();
     language = aReq.getLanguage();
 
-    useCaseStep = new ArrayList<UseCaseStep>();
-    for (int i = 0; i < aReq.numberOfUseCaseStep(); i++)
+    useCaseSteps = new ArrayList<UseCaseStep>();
+    for (int i = 0; i < aReq.numberOfUseCaseSteps(); i++)
     {
       UseCaseStep originalStep = aReq.getUseCaseStep(i);
-      addUseCaseStep(new UseCaseStep(originalStep.getId(), originalStep.getStepType(), originalStep.getContent()));
+      new UseCaseStep(
+        originalStep.getId(),
+        originalStep.getStepType(),
+        originalStep.getContent(),
+        this
+      );
     }
   }
   public static List<Comment> convertToComment(List<ReqImplementation> reqSelected,UmpleModel aModel){

--- a/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
@@ -98,4 +98,46 @@ public class RequirementTest
     Assert.assertEquals(original.getLanguage(), copy.getLanguage());
   }
 
+  @Test
+  public void useCaseStepsStoredInOrder()
+  {
+    Requirement req = new Requirement("UC1", "checkout flow", null, null, null, null, "useCase");
+
+    req.addUseCaseStep(new UseCaseStep("1", "userStep", "select product"));
+    req.addUseCaseStep(new UseCaseStep("1", "systemResponse", "display price"));
+    req.addUseCaseStep(new UseCaseStep("2", "userStep", "enter quantity"));
+
+    Assert.assertEquals(3, req.numberOfUseCaseStep());
+
+    Assert.assertEquals("1", req.getUseCaseStep(0).getId());
+    Assert.assertEquals("userStep", req.getUseCaseStep(0).getStepType());
+    Assert.assertEquals("select product", req.getUseCaseStep(0).getContent());
+
+    Assert.assertEquals("1", req.getUseCaseStep(1).getId());
+    Assert.assertEquals("systemResponse", req.getUseCaseStep(1).getStepType());
+    Assert.assertEquals("display price", req.getUseCaseStep(1).getContent());
+
+    Assert.assertEquals("2", req.getUseCaseStep(2).getId());
+    Assert.assertEquals("userStep", req.getUseCaseStep(2).getStepType());
+    Assert.assertEquals("enter quantity", req.getUseCaseStep(2).getContent());
+  }
+  @Test
+  public void deepCopyConstructorCopiesUseCaseSteps()
+  {
+    Requirement original = new Requirement("UC2", "checkout flow", null, null, null, null, "useCase");
+    original.addUseCaseStep(new UseCaseStep("1", "userStep", "select product"));
+    original.addUseCaseStep(new UseCaseStep("1", "systemResponse", "display price"));
+
+    Requirement copy = new Requirement(original);
+
+    Assert.assertEquals(2, copy.numberOfUseCaseStep());
+
+    Assert.assertEquals("1", copy.getUseCaseStep(0).getId());
+    Assert.assertEquals("userStep", copy.getUseCaseStep(0).getStepType());
+    Assert.assertEquals("select product", copy.getUseCaseStep(0).getContent());
+
+    Assert.assertEquals("1", copy.getUseCaseStep(1).getId());
+    Assert.assertEquals("systemResponse", copy.getUseCaseStep(1).getStepType());
+    Assert.assertEquals("display price", copy.getUseCaseStep(1).getContent());
+  }
 }

--- a/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
+++ b/cruise.umple/test/cruise/umple/compiler/RequirementTest.java
@@ -103,41 +103,41 @@ public class RequirementTest
   {
     Requirement req = new Requirement("UC1", "checkout flow", null, null, null, null, "useCase");
 
-    req.addUseCaseStep(new UseCaseStep("1", "userStep", "select product"));
-    req.addUseCaseStep(new UseCaseStep("1", "systemResponse", "display price"));
-    req.addUseCaseStep(new UseCaseStep("2", "userStep", "enter quantity"));
+    new UseCaseStep("1", UseCaseStep.UseCaseStepType.UserStep, "select product", req);
+    new UseCaseStep("1", UseCaseStep.UseCaseStepType.SystemResponse, "display price", req);
+    new UseCaseStep("2", UseCaseStep.UseCaseStepType.UserStep, "enter quantity", req);
 
-    Assert.assertEquals(3, req.numberOfUseCaseStep());
+    Assert.assertEquals(3, req.numberOfUseCaseSteps());
 
     Assert.assertEquals("1", req.getUseCaseStep(0).getId());
-    Assert.assertEquals("userStep", req.getUseCaseStep(0).getStepType());
+    Assert.assertEquals(UseCaseStep.UseCaseStepType.UserStep, req.getUseCaseStep(0).getStepType());
     Assert.assertEquals("select product", req.getUseCaseStep(0).getContent());
 
     Assert.assertEquals("1", req.getUseCaseStep(1).getId());
-    Assert.assertEquals("systemResponse", req.getUseCaseStep(1).getStepType());
+    Assert.assertEquals(UseCaseStep.UseCaseStepType.SystemResponse, req.getUseCaseStep(1).getStepType());
     Assert.assertEquals("display price", req.getUseCaseStep(1).getContent());
 
     Assert.assertEquals("2", req.getUseCaseStep(2).getId());
-    Assert.assertEquals("userStep", req.getUseCaseStep(2).getStepType());
+    Assert.assertEquals(UseCaseStep.UseCaseStepType.UserStep, req.getUseCaseStep(2).getStepType());
     Assert.assertEquals("enter quantity", req.getUseCaseStep(2).getContent());
   }
   @Test
   public void deepCopyConstructorCopiesUseCaseSteps()
   {
     Requirement original = new Requirement("UC2", "checkout flow", null, null, null, null, "useCase");
-    original.addUseCaseStep(new UseCaseStep("1", "userStep", "select product"));
-    original.addUseCaseStep(new UseCaseStep("1", "systemResponse", "display price"));
+    new UseCaseStep("1", UseCaseStep.UseCaseStepType.UserStep, "select product", original);
+    new UseCaseStep("1", UseCaseStep.UseCaseStepType.SystemResponse, "display price", original);
 
     Requirement copy = new Requirement(original);
 
-    Assert.assertEquals(2, copy.numberOfUseCaseStep());
+    Assert.assertEquals(2, copy.numberOfUseCaseSteps());
 
     Assert.assertEquals("1", copy.getUseCaseStep(0).getId());
-    Assert.assertEquals("userStep", copy.getUseCaseStep(0).getStepType());
+    Assert.assertEquals(UseCaseStep.UseCaseStepType.UserStep, copy.getUseCaseStep(0).getStepType());
     Assert.assertEquals("select product", copy.getUseCaseStep(0).getContent());
 
     Assert.assertEquals("1", copy.getUseCaseStep(1).getId());
-    Assert.assertEquals("systemResponse", copy.getUseCaseStep(1).getStepType());
+    Assert.assertEquals(UseCaseStep.UseCaseStepType.SystemResponse, copy.getUseCaseStep(1).getStepType());
     Assert.assertEquals("display price", copy.getUseCaseStep(1).getContent());
   }
 }


### PR DESCRIPTION
This PR implements the metamodel step of Issue #2378.

## Scope

Extend the `Requirement` class to support structured use case elements.

This PR introduces a `UseCaseStep` model element and associates it with `Requirement` so ordered use case steps can be stored internally.

Supported structured step storage:

* `userStep`
* `systemResponse`
* step identifiers
* step ordering

Additional changes:

* Update the deep-copy constructor to preserve associated use case steps
* Preserve backward compatibility with existing `Requirement` construction and formatting flows
* Reuse existing structured requirement fields already introduced for `userStory`:

  * `who`
  * `when`
  * `what`
  * `why`

## Tests

Add unit tests to verify:

* structured use case steps are stored correctly
* step order is preserved
* deep copies preserve structured use case step data

## Rationale

The grammar now supports `useCase` requirements with structured step syntax. This PR introduces the necessary metamodel changes so these elements can be stored internally before parser extraction and output generation are added.

## Notes

* This PR does not yet populate these fields during parsing
* This PR does not yet modify output generation
* These will be handled in subsequent PRs
