### PR TITLE
Fix LSP multi-instance and Alpine compatibility

### DIFF
--- a/UmpleLsp/Dockerfile
+++ b/UmpleLsp/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for UmpleLsp — standalone LSP container for local development
-FROM --platform=linux/amd64 alpine
+FROM alpine:latest
 
-RUN apk add --no-cache nodejs-current npm openjdk21-jre-headless
+RUN apk add --no-cache nodejs npm openjdk21-jre-headless
 
 WORKDIR /usr/src/app
 

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -1242,7 +1242,14 @@ $output = $dataHandle->readData('model.ump');
   // LSP configuration — generate signed token for WebSocket proxy auth
   // Docker sets this to "/lsp" (nginx proxy). For local php -S dev,
   // fall back to the default lsp-proxy port on loopback.
-  $lspWsUrl = getenv('UMPLE_LSP_WS_URL') ?: 'ws://127.0.0.1:9999';
+  // Read LSP port from UmpleLsp/config.cfg if available (supports multiple instances)
+  $lspPort = '9999';
+  $lspCfgPath = rootDir() . '/../UmpleLsp/config.cfg';
+  if (file_exists($lspCfgPath)) {
+    $lspCfg = parse_ini_file($lspCfgPath);
+    if (!empty($lspCfg['portToUse'])) $lspPort = $lspCfg['portToUse'];
+  }
+  $lspWsUrl = getenv('UMPLE_LSP_WS_URL') ?: 'ws://127.0.0.1:' . $lspPort;
   $lspAuthSecret = getenv('LSP_AUTH_SECRET') ?: '';
   $lspToken = '';
   $lspModelId = $dataHandle->getName();


### PR DESCRIPTION
## Summary

- Read LSP port from `UmpleLsp/config.cfg` instead of hardcoding 9999, so multiple UmpleOnline instances on the same machine each connect to their own LSP container
- Fix Dockerfile Alpine compatibility: use `alpine:latest` without platform pin, `nodejs` instead of `nodejs-current`

## Test plan

- [ ] Run two UmpleOnline instances with different `portToUse` and `containerName` in their `UmpleLsp/config.cfg`
- [ ] Both instances should have working LSP independently
- [ ] Production Docker (`bdock`) still works (uses `UMPLE_LSP_WS_URL=/lsp`, ignores config.cfg)