### PR TITLE
Add /healthcheck endpoint to LSP proxy

### DIFF
--- a/umpleonline/scripts/lsp-proxy/server.js
+++ b/umpleonline/scripts/lsp-proxy/server.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { WebSocketServer } = require("ws");
+const http = require("http");
 const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
@@ -178,13 +179,33 @@ function killSession(modelId, reason) {
 // WebSocket server
 // ---------------------------------------------------------------------------
 
-const wss = new WebSocketServer({
-  port: LSP_PORT,
-  host: LSP_HOST,
+const server = http.createServer((req, res) => {
+  if (req.url === "/healthcheck") {
+    const uptime = process.uptime();
+    const sessions = [];
+    for (const [key, entry] of activeSessions) {
+      sessions.push({ key, pid: entry.process.pid, cleanedUp: entry.cleanedUp });
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      status: "ok",
+      uptime: Math.floor(uptime),
+      activeSessions: sessions.length,
+      sessions,
+      umpBaseDir: UMP_BASE_DIR,
+      lspCommand: LSP_COMMAND,
+    }));
+    return;
+  }
+  res.writeHead(404);
+  res.end();
 });
 
-wss.on("listening", () => {
+const wss = new WebSocketServer({ server });
+
+server.listen(LSP_PORT, LSP_HOST, () => {
   log(`WebSocket server listening on ${LSP_HOST}:${LSP_PORT}`);
+  log(`Health check at http://${LSP_HOST}:${LSP_PORT}/healthcheck`);
 });
 
 wss.on("connection", (ws, req) => {


### PR DESCRIPTION
## Summary

- Add HTTP GET `/healthcheck` endpoint to the LSP WebSocket proxy (`server.js`)
- Returns JSON with server status, active sessions, `UMP_BASE_DIR`, LSP command, and uptime
- Helps debug multi-instance deployment issues without checking container logs

## Test plan

- [ ] Start LSP container via `pumple`
- [ ] `curl http://localhost:9999/healthcheck` returns JSON status
- [ ] WebSocket LSP connections still work alongside the HTTP endpoint
- [ ] Production Docker (`bdock`) healthcheck accessible at `/lsp/healthcheck` via nginx