### PR TITLE
Fix LSP config parsing for multi-instance support

### DIFF
--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -1243,11 +1243,17 @@ $output = $dataHandle->readData('model.ump');
   // Docker sets this to "/lsp" (nginx proxy). For local php -S dev,
   // fall back to the default lsp-proxy port on loopback.
   // Read LSP port from UmpleLsp/config.cfg if available (supports multiple instances)
+  // Uses line-by-line parsing to match shell-style config format (same as compiler_config.php)
   $lspPort = '9999';
   $lspCfgPath = rootDir() . '/../UmpleLsp/config.cfg';
-  if (file_exists($lspCfgPath)) {
-    $lspCfg = parse_ini_file($lspCfgPath);
-    if (!empty($lspCfg['portToUse'])) $lspPort = $lspCfg['portToUse'];
+  $lspCfgHandle = @fopen($lspCfgPath, "r");
+  if ($lspCfgHandle) {
+    while (($line = fgets($lspCfgHandle)) !== false) {
+      if (substr($line, 0, 10) === "portToUse=") {
+        $lspPort = trim(substr($line, 10));
+      }
+    }
+    fclose($lspCfgHandle);
   }
   $lspWsUrl = getenv('UMPLE_LSP_WS_URL') ?: 'ws://127.0.0.1:' . $lspPort;
   $lspAuthSecret = getenv('LSP_AUTH_SECRET') ?: '';


### PR DESCRIPTION
## Summary

Replaces `parse_ini_file()` with line-by-line parsing when reading `portToUse` from `UmpleLsp/config.cfg` in `umple.php`.

`parse_ini_file()` fails silently on shell-style comments containing `<` and `>` characters (e.g., `# Requires: cd <lsp-repo>/packages/server && npm link`), returning `false`. This causes PHP to fall back to the default port 9999, making the browser connect to the wrong LSP container in multi-instance setups — producing `4002 Model directory not found`.

Uses the same line-by-line parsing approach that `compiler_config.php` already uses for `UmpleCodeExecution/config.cfg`.

## Test plan

- [ ] Run two UmpleOnline clones with different `portToUse` in their `UmpleLsp/config.cfg`
- [ ] Verify each clone's browser connects to its own LSP container (check `window.UMPLE_LSP_WS_URL` in browser console)
- [ ] Verify LSP features work in both instances independently
- [ ] Single-instance setup still works with default port 9999