### PR TITLE
Adding Symboleo example to UmpleOnline referencing the live GitHub page

### DIFF
--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -826,6 +826,9 @@ $output = $dataHandle->readData('model.ump');
                 <option name = "optionExample" value="realestate.ump">Real Estate</option>
                 <option name = "optionExample" value="RoutesAndLocations.ump">Routes And Locations</option>
                 <option name = "optionExample" value="School.ump">School</option>
+                
+                <option name = "optionExample" value="https://raw.githubusercontent.com/Smart-Contract-Modelling-uOttawa/Symboleo-JS-Core/refs/heads/main/ontology/ontology.ump">Symboleo Smart Contracts</option>
+                
                 <option name = "optionExample" value="TelephoneSystem.ump">Telephone System</option>
                 <option name = "optionExample" value="UniversitySystem.ump">University System</option>
                 <option name = "optionExample" value="VendingMachineClassDiagram.ump">Vending Machine</option>


### PR DESCRIPTION
Fixes #2289 

Adds Symboleo example as published on Github at
https://github.com/Smart-Contract-Modelling-uOttawa/Symboleo-JS-Core/blob/main/ontology/ontology.ump

This is a formal language for specifying smart contracts, i.e. on BlockChains.

It is referenced in this paper 
https://www.site.uottawa.ca/~luigi/papers/22_SoSym.pdf

This has good examples of both state machines and class diagrams.