### PR TITLE
CRUD UI bug fixes and improvements

### DIFF
--- a/cruise.umple/src/generators/Generator_CodeJson.ump
+++ b/cruise.umple/src/generators/Generator_CodeJson.ump
@@ -228,10 +228,20 @@ class JsonGenerator
         }
       }
 
+      // Only emit a keys property when at least one valid key attribute
+      // exists for the class. This keeps the JSON identical to legacy
+      // output for models without keys while still exposing key metadata
+      // for CRUD when it is present.
+      String keysJsonSuffix = "";
+      if (jsonForKeys.length() > 0)
+      {
+        keysJsonSuffix = StringFormatter.format("\n {0}keys{0}: [{1}]", "\"", jsonForKeys);
+      }
+
       boolean isInterface = false;
       jsonForClasses += StringFormatter.format(
         "{\n{0}position{0}: {\n{0}x{0}: {1},\n {0}y{0}: {2},\n {0}width{0}: {3},\n " +
-        "{0}height{0}: {4}},\n {0}attributes{0}: [{7}],\n{0}methods{0}: [{8}],\n {0}enums{0}: [{14}],\n {0}keys{0}: [{15}],\n " +
+        "{0}height{0}: {4}},\n {0}attributes{0}: [{7}],\n{0}methods{0}: [{8}],\n {0}enums{0}: [{14}]{15},\n " +
         "{0}id{0}: {0}{5}{0},\n {0}name{0}: {0}{6}{0},\n {0}isAbstract{0}: {0}{13}{0},\n {0}displayColor{0}: {0}{10}{0} {9},\n " +
         "{0}isInterface{0}: {0}{11}{0}{12}}", 
         "\"", 
@@ -249,7 +259,7 @@ class JsonGenerator
         implementedInterfaces,
         isAbstract,
         jsonForEnums,
-        jsonForKeys);
+        keysJsonSuffix);
 
       isFirst = false;
     }

--- a/cruise.umple/src/generators/Generator_CodeJson.ump
+++ b/cruise.umple/src/generators/Generator_CodeJson.ump
@@ -46,6 +46,7 @@ class JsonGenerator
       String jsonForAttributes = "";
       String jsonForMethods = "";
       String jsonForEnums = "";
+      String jsonForKeys = "";
  
       for (Attribute attribute : aClass.getAttributes())
       {
@@ -193,12 +194,44 @@ class JsonGenerator
           }
           implementedInterfaces += " ]";
       }
-       
+
+      // Include key attribute information, if any. Keys may reference
+      // attributes or association/role names; for the CRUD JSON we only
+      // include keys that correspond to actual attributes of this class.
+      Key key = aClass.getKey();
+      if (key != null && key.isProvided())
+      {
+        String[] members = key.getMembers();
+        boolean firstKeyMember = true;
+
+        for (int i = 0; i < members.length; i++)
+        {
+          String memberName = members[i];
+          if (memberName == null || memberName.length() == 0)
+          {
+            continue;
+          }
+
+          // Only include key members that are attributes of the class.
+          if (aClass.getAttribute(memberName) == null)
+          {
+            continue;
+          }
+
+          if (!firstKeyMember)
+          {
+            jsonForKeys += ", ";
+          }
+
+          jsonForKeys += StringFormatter.format("{0}{1}{0}", "\"", memberName);
+          firstKeyMember = false;
+        }
+      }
 
       boolean isInterface = false;
       jsonForClasses += StringFormatter.format(
         "{\n{0}position{0}: {\n{0}x{0}: {1},\n {0}y{0}: {2},\n {0}width{0}: {3},\n " +
-        "{0}height{0}: {4}},\n {0}attributes{0}: [{7}],\n{0}methods{0}: [{8}],\n {0}enums{0}: [{14}],\n " +
+        "{0}height{0}: {4}},\n {0}attributes{0}: [{7}],\n{0}methods{0}: [{8}],\n {0}enums{0}: [{14}],\n {0}keys{0}: [{15}],\n " +
         "{0}id{0}: {0}{5}{0},\n {0}name{0}: {0}{6}{0},\n {0}isAbstract{0}: {0}{13}{0},\n {0}displayColor{0}: {0}{10}{0} {9},\n " +
         "{0}isInterface{0}: {0}{11}{0}{12}}", 
         "\"", 
@@ -215,7 +248,8 @@ class JsonGenerator
         isInterface,
         implementedInterfaces,
         isAbstract,
-        jsonForEnums);
+        jsonForEnums,
+        jsonForKeys);
 
       isFirst = false;
     }

--- a/cruise.umple/src/generators/Generator_CodeJson.ump
+++ b/cruise.umple/src/generators/Generator_CodeJson.ump
@@ -232,17 +232,21 @@ class JsonGenerator
       // exists for the class. This keeps the JSON identical to legacy
       // output for models without keys while still exposing key metadata
       // for CRUD when it is present.
+      // The keys line is emitted as its own JSON property between
+      // "enums" and "id" to avoid introducing syntax issues.
       String keysJsonSuffix = "";
       if (jsonForKeys.length() > 0)
       {
-        keysJsonSuffix = StringFormatter.format("\n {0}keys{0}: [{1}]", "\"", jsonForKeys);
+        // Example emitted fragment (including trailing comma and newline):
+        //   "keys": ["id", "code"],
+        keysJsonSuffix = StringFormatter.format("{0}keys{0}: [{1}],\n ", "\"", jsonForKeys);
       }
 
       boolean isInterface = false;
       jsonForClasses += StringFormatter.format(
         "{\n{0}position{0}: {\n{0}x{0}: {1},\n {0}y{0}: {2},\n {0}width{0}: {3},\n " +
-        "{0}height{0}: {4}},\n {0}attributes{0}: [{7}],\n{0}methods{0}: [{8}],\n {0}enums{0}: [{14}]{15},\n " +
-        "{0}id{0}: {0}{5}{0},\n {0}name{0}: {0}{6}{0},\n {0}isAbstract{0}: {0}{13}{0},\n {0}displayColor{0}: {0}{10}{0} {9},\n " +
+        "{0}height{0}: {4}},\n {0}attributes{0}: [{7}],\n{0}methods{0}: [{8}],\n {0}enums{0}: [{14}],\n {15}{0}id{0}: {0}{5}{0},\n " +
+        "{0}name{0}: {0}{6}{0},\n {0}isAbstract{0}: {0}{13}{0},\n {0}displayColor{0}: {0}{10}{0} {9},\n " +
         "{0}isInterface{0}: {0}{11}{0}{12}}", 
         "\"", 
         x, 

--- a/cruise.umple/test/cruise/umple/implementation/json/JsonTemplateTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/json/JsonTemplateTest.java
@@ -163,5 +163,11 @@ public class JsonTemplateTest extends TemplateTest
     assertUmpleTemplateFor("json/EnumGeneration.ump", "json/EnumGeneration.json.txt");
   }
 
+  @Test
+  public void KeyAttributeClassTest()
+  {
+    assertUmpleTemplateFor("json/KeyAttributeClass.ump", "json/KeyAttributeClass.json.txt");
+  }
+
 
 }

--- a/cruise.umple/test/cruise/umple/implementation/json/KeyAttributeClass.json.txt
+++ b/cruise.umple/test/cruise/umple/implementation/json/KeyAttributeClass.json.txt
@@ -1,0 +1,25 @@
+{"umpleClasses":[{
+"position": {
+"x": 50,
+ "y": 30,
+ "width": 109,
+ "height": 45},
+ "attributes": [{
+ "type" : "Integer",
+ "name" : "id",
+ "modifier" : "",
+ "traceColor" : "black" }, {
+ "type" : "String",
+ "name" : "name",
+ "modifier" : "",
+ "traceColor" : "black" }],
+"methods": [],
+ "enums": [],
+ "keys": ["id"],
+ "id": "KeyAttributeClass",
+ "name": "KeyAttributeClass",
+ "isAbstract": "false",
+ "displayColor": "" ,
+ "isInterface": "false"}],
+ "umpleAssociations":[],
+ "globalEnums":[] }

--- a/cruise.umple/test/cruise/umple/implementation/json/KeyAttributeClass.ump
+++ b/cruise.umple/test/cruise/umple/implementation/json/KeyAttributeClass.ump
@@ -1,0 +1,9 @@
+generate Json;
+namespace example;
+
+class KeyAttributeClass
+{
+  Integer id;
+  String name;
+  key {id}
+}

--- a/umpleonline/scripts/crud/umple_crud_json_persistence.js
+++ b/umpleonline/scripts/crud/umple_crud_json_persistence.js
@@ -111,10 +111,37 @@
       }
     });
 
-    var assocEnds = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+    // Resolve association ends that are applicable to this runtime class,
+    // including those declared on superclasses. We treat ends whose
+    // fromClass is a superclass of className as inherited. For hierarchical
+    // self-reflexive associations (e.g., mentee->mentor), only the
+    // single-valued storing side is exported; the multi-valued reverse side
+    // is derived at runtime and should not appear in the JSON.
+    var assocEndsRaw = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+    var assocEnds = [];
+    assocEndsRaw.forEach(function(end) {
+      if (!end) { return; }
+      // Only consider ends whose fromClass is this class or one of its
+      // superclasses.
+      if (Page.isCrudSubclass && !Page.isCrudSubclass(className, end.fromClass)) {
+        return;
+      }
+
+      // Skip derived multi-valued side of hierarchical self-reflexive
+      // associations; only the single-valued side actually stores data.
+      if (end.reflexiveHierarchy && end.fromClass === end.toClass) {
+        var toMax = (typeof end.toMax === "number") ? end.toMax : null;
+        var multipleSide = (toMax === null || toMax > 1);
+        if (multipleSide) {
+          return;
+        }
+      }
+
+      assocEnds.push(end);
+    });
 
     assocEnds.forEach(function(end) {
-      if (!end || end.fromClass !== className) { return; }
+      if (!end) { return; }
       var fieldName = end.storageKey;
       if (!fieldName) { return; }
 
@@ -399,7 +426,25 @@
     Object.keys(instancesByClass).forEach(function(className) {
       var info = Page.crudData.classes[className] || {};
       var attrs = info.attributes || [];
-      var assocEnds = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+      // Resolve association ends applicable to this class, including those
+      // declared on superclasses, and skip the derived multi-valued side of
+      // hierarchical self-reflexive associations.
+      var assocEndsRaw = (Page.crudAssociationsByClass && Page.crudAssociationsByClass[className]) || [];
+      var assocEnds = [];
+      assocEndsRaw.forEach(function(end) {
+        if (!end) { return; }
+        if (Page.isCrudSubclass && !Page.isCrudSubclass(className, end.fromClass)) {
+          return;
+        }
+        if (end.reflexiveHierarchy && end.fromClass === end.toClass) {
+          var toMax = (typeof end.toMax === "number") ? end.toMax : null;
+          var multipleSide = (toMax === null || toMax > 1);
+          if (multipleSide) {
+            return;
+          }
+        }
+        assocEnds.push(end);
+      });
       var arr = instancesByClass[className];
 
       arr.forEach(function(inst, localIndex) {
@@ -430,7 +475,7 @@
 
         // Associations (forward ends only; reverse ends will be synced later)
         assocEnds.forEach(function(end) {
-          if (!end || end.fromClass !== className) { return; }
+          if (!end) { return; }
           var fieldName = end.storageKey;
           if (!fieldName) { return; }
 

--- a/umpleonline/scripts/crud/umple_crud_json_persistence.js
+++ b/umpleonline/scripts/crud/umple_crud_json_persistence.js
@@ -498,6 +498,18 @@
         });
       });
     }
+
+    // Successful import: clear any prior adjustment messages related to
+    // previous incompatible loads and refresh the global CRUD banner so
+    // stale errors (including the compatibility message) are not shown.
+    if (!Array.isArray(Page.crudAdjustmentMessages)) {
+      Page.crudAdjustmentMessages = [];
+    } else if (Page.crudAdjustmentMessages.length) {
+      Page.crudAdjustmentMessages = [];
+    }
+    if (typeof Page.renderCrudGlobalErrors === "function") {
+      Page.renderCrudGlobalErrors(null);
+    }
   };
 
   // Helper to import from a JSON string (used by UI layer)

--- a/umpleonline/scripts/crud/umple_crud_json_persistence.js
+++ b/umpleonline/scripts/crud/umple_crud_json_persistence.js
@@ -127,17 +127,23 @@
         multiple = false;
       }
 
+      // Normalize association values to typed refs so that we support
+      // both legacy numeric indices and the newer {className,index}
+      // representation (including polymorphic subclasses).
+      var refs = (Page.normalizeCrudAssociationRefs && typeof Page.normalizeCrudAssociationRefs === "function")
+        ? Page.normalizeCrudAssociationRefs(end, val)
+        : [];
+
       if (multiple) {
         var arr = [];
-        if (Array.isArray(val)) {
-          val.forEach(function(targetIdx) {
-            if (typeof targetIdx !== "number") {
-              targetIdx = parseInt(targetIdx, 10);
-            }
-            if (isNaN(targetIdx) || targetIdx < 0) { return; }
+        if (refs && refs.length) {
+          refs.forEach(function(ref) {
+            if (!ref || typeof ref.index !== "number" || ref.index < 0) { return; }
+            var targetClass = ref.className || end.toClass;
+            if (!targetClass) { return; }
             // Always expand forward links; the cycle guard above will turn
             // back-references into ID-only stubs.
-            var child = buildNestedInstance(ns, end.toClass, targetIdx, visited);
+            var child = buildNestedInstance(ns, targetClass, ref.index, visited);
             if (child) {
               arr.push(child);
             }
@@ -145,16 +151,15 @@
         }
         data[propName] = arr;
       } else {
-        if (val === undefined || val === null || val === "") {
+        if (!refs || !refs.length) {
           // Single-valued ends are omitted when there is no link.
           return;
         }
-        var idxSingle = val;
-        if (typeof idxSingle !== "number") {
-          idxSingle = parseInt(idxSingle, 10);
-        }
-        if (isNaN(idxSingle) || idxSingle < 0) { return; }
-        var linked = buildNestedInstance(ns, end.toClass, idxSingle, visited);
+        var refSingle = refs[0];
+        if (!refSingle || typeof refSingle.index !== "number" || refSingle.index < 0) { return; }
+        var targetClassSingle = refSingle.className || end.toClass;
+        if (!targetClassSingle) { return; }
+        var linked = buildNestedInstance(ns, targetClassSingle, refSingle.index, visited);
         if (linked) {
           data[propName] = linked;
         }
@@ -443,7 +448,7 @@
 
           if (multiple) {
             if (!Array.isArray(rawVal)) { return; }
-            var indices = [];
+            var refsForField = [];
             rawVal.forEach(function(refWrapper) {
               if (!refWrapper || typeof refWrapper !== "object") { return; }
               var keys = Object.keys(refWrapper);
@@ -454,9 +459,12 @@
               if (!rid) { return; }
               var entry = idMap[rfqn + "#" + rid];
               if (!entry) { return; }
-              indices.push(entry.index);
+              refsForField.push({
+                className: entry.className,
+                index: entry.index
+              });
             });
-            inst[fieldName] = indices;
+            inst[fieldName] = refsForField;
           } else {
             if (!rawVal || typeof rawVal !== "object") { return; }
             var keysSingle = Object.keys(rawVal);
@@ -467,7 +475,10 @@
             if (!sid) { return; }
             var sentry = idMap[sfqn + "#" + sid];
             if (!sentry) { return; }
-            inst[fieldName] = sentry.index;
+            inst[fieldName] = {
+              className: sentry.className,
+              index: sentry.index
+            };
           }
         });
       });

--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -33,6 +33,148 @@ Page.resetCrudData = function() {
   Page.crudAssociationLabelPreference = {};
 };
 
+// Return the inheritance chain (superclasses) for a given class name
+// using the extends map built from the JSON. The array is ordered from
+// immediate parent up to the root. Cycles are guarded against.
+Page.getCrudSuperclasses = function(className) {
+  var result = [];
+  if (!className || !Page.crudExtendsByClass) {
+    return result;
+  }
+  var seen = {};
+  var current = className;
+  while (current) {
+    var parent = Page.crudExtendsByClass[current];
+    if (!parent || seen[parent]) {
+      break;
+    }
+    seen[parent] = true;
+    result.push(parent);
+    current = parent;
+  }
+  return result;
+};
+// Return true if candidateClass is the same as or a (direct or
+// indirect) subclass of rootType according to the extends map
+// built from the JSON.
+Page.isCrudSubclass = function(candidateClass, rootType) {
+  if (!candidateClass || !rootType) {
+    return false;
+  }
+  if (candidateClass === rootType) {
+    return true;
+  }
+  var supers = Page.getCrudSuperclasses(candidateClass);
+  return supers.indexOf(rootType) !== -1;
+};
+
+// Polymorphic target resolution for associations. Given a root type
+// name, return an array of { className, index, instance } for every
+// instance whose runtime type is that class or any of its subclasses.
+// This preserves the existing per-class storage model; it is a
+// read-only aggregation used by the CRUD UI.
+Page.getCrudPolymorphicTargets = function(rootType) {
+  var results = [];
+  if (!rootType || !Page.crudData || !Page.crudData.classes) {
+    return results;
+  }
+  var classesData = Page.crudData.classes;
+  Object.keys(classesData).forEach(function(className) {
+    if (!Page.isCrudSubclass(className, rootType)) {
+      return;
+    }
+    var info = classesData[className] || {};
+    var instances = info.instances || [];
+    for (var i = 0; i < instances.length; i++) {
+      var inst = instances[i];
+      if (!inst) { continue; }
+      results.push({ className: className, index: i, instance: inst });
+    }
+  });
+  return results;
+};
+
+// Association reference helpers
+// -----------------------------
+// A canonical association reference is an object of the form
+//   { className: string, index: number }
+// referring to an instance in Page.crudData.classes[className].instances[index].
+// New CRUD writes always use this shape; legacy numeric values are
+// still supported on read by treating them as indices into end.toClass.
+
+Page.encodeCrudAssocRef = function(ref) {
+  if (!ref || typeof ref.index !== "number" || ref.index < 0 || !ref.className) {
+    return "";
+  }
+  return ref.className + ":" + String(ref.index);
+};
+
+Page.decodeCrudAssocRef = function(value, defaultClassName) {
+  if (value === null || typeof value === "undefined") {
+    return null;
+  }
+  if (typeof value === "object") {
+    var cls = value.className || defaultClassName || null;
+    var idx = value.index;
+    if (typeof idx !== "number") {
+      idx = parseInt(idx, 10);
+    }
+    if (!cls || isNaN(idx) || idx < 0) {
+      return null;
+    }
+    return { className: cls, index: idx };
+  }
+
+  var s = String(value);
+  if (s.indexOf(":") !== -1) {
+    var parts = s.split(":");
+    var clsName = parts[0] || defaultClassName || null;
+    var idxStr = parts[1];
+    var idxNum = parseInt(idxStr, 10);
+    if (!clsName || isNaN(idxNum) || idxNum < 0) {
+      return null;
+    }
+    return { className: clsName, index: idxNum };
+  }
+
+  var idxLegacy = parseInt(s, 10);
+  if (isNaN(idxLegacy) || idxLegacy < 0) {
+    return null;
+  }
+  return {
+    className: defaultClassName || null,
+    index: idxLegacy
+  };
+};
+
+// Normalize any stored association value (number, object, array of
+// either) into a canonical array of {className, index} references for
+// the given association end. Legacy numeric values are interpreted as
+// indices into end.toClass.
+Page.normalizeCrudAssociationRefs = function(end, raw) {
+  var refs = [];
+  if (!end || raw === undefined || raw === null || raw === "") {
+    return refs;
+  }
+  var defClass = end.toClass || null;
+
+  var addRef = function(v) {
+    var r = Page.decodeCrudAssocRef(v, defClass);
+    if (!r || !r.className || typeof r.index !== "number" || r.index < 0) {
+      return;
+    }
+    refs.push(r);
+  };
+
+  if (Array.isArray(raw)) {
+    raw.forEach(function(v) { addRef(v); });
+  } else {
+    addRef(raw);
+  }
+
+  return refs;
+};
+
 // Validate that key attributes for a single instance (within a class)
 // are not left blank. This is used for per-form validation when saving
 // an instance so that key fields are always populated.
@@ -289,23 +431,15 @@ Page.normalizeCrudMultiValuedAssociations = function() {
           continue;
         }
 
-        var indices = [];
-        if (Array.isArray(raw)) {
-          raw.forEach(function(v) {
-            var idx = (typeof v === "number") ? v : parseInt(v, 10);
-            if (!isNaN(idx) && idx >= 0) {
-              indices.push(idx);
-            }
-          });
-        } else {
-          var idxSingle = (typeof raw === "number") ? raw : parseInt(raw, 10);
-          if (!isNaN(idxSingle) && idxSingle >= 0) {
-            indices.push(idxSingle);
-          }
-        }
+        // Normalize to canonical polymorphic refs. This preserves
+        // existing object-based references while upgrading legacy
+        // numeric values into an array form for multi-valued ends.
+        var refs = Page.normalizeCrudAssociationRefs
+          ? Page.normalizeCrudAssociationRefs(end, raw)
+          : [];
 
-        if (indices.length > 0) {
-          inst[fieldName] = indices;
+        if (refs.length > 0) {
+          inst[fieldName] = refs;
         } else {
           inst[fieldName] = [];
         }
@@ -359,31 +493,25 @@ Page.adjustCrudAssociationsForTightenedMax = function() {
           continue;
         }
 
-        var indices = [];
-        if (Array.isArray(raw)) {
-          raw.forEach(function(v) {
-            var idx = (typeof v === "number") ? v : parseInt(v, 10);
-            if (!isNaN(idx) && idx >= 0) {
-              indices.push(idx);
-            }
-          });
-        } else {
-          var idxSingle = (typeof raw === "number") ? raw : parseInt(raw, 10);
-          if (!isNaN(idxSingle) && idxSingle >= 0) {
-            indices.push(idxSingle);
-          }
-        }
+        // Work with canonical polymorphic refs so that both legacy
+        // numeric indices and new {className,index} objects are
+        // handled uniformly.
+        var refs = Page.normalizeCrudAssociationRefs
+          ? Page.normalizeCrudAssociationRefs(end, raw)
+          : [];
 
-        if (!indices.length) {
+        if (!refs.length) {
           // Normalize empty links according to max: scalar null for single,
           // empty array for multi-valued.
           inst[fieldName] = (maxAllowed === 1 ? null : []);
+          // With no forward links, there is nothing to keep in sync on the
+          // reverse side for this instance.
           continue;
         }
 
-        if (indices.length > maxAllowed) {
-          var kept = indices.slice(0, maxAllowed);
-          var removed = indices.slice(maxAllowed);
+        if (refs.length > maxAllowed) {
+          var kept = refs.slice(0, maxAllowed);
+          var removed = refs.slice(maxAllowed);
 
           if (maxAllowed === 1) {
             inst[fieldName] = kept[0];
@@ -395,10 +523,17 @@ Page.adjustCrudAssociationsForTightenedMax = function() {
         } else {
           // Keep representation consistent with the new max bound
           if (maxAllowed === 1) {
-            inst[fieldName] = indices[0];
+            inst[fieldName] = refs[0];
           } else {
-            inst[fieldName] = indices;
+            inst[fieldName] = refs;
           }
+        }
+
+        // Ensure reverse association ends are also updated to reflect any
+        // trimming so that Show Associations never displays links that no
+        // longer exist from this side.
+        if (typeof Page.syncCrudReverseAssociationsForEnd === "function") {
+          Page.syncCrudReverseAssociationsForEnd(fromClass, i, end, inst[fieldName]);
         }
       }
 
@@ -1080,10 +1215,6 @@ Page.checkCrudReflexiveHierarchyCycle = function(className, instances, end, chil
     return;
   }
 
-  if (typeof parentIndex !== "number" || parentIndex < 0 || parentIndex >= instances.length) {
-    return;
-  }
-
   var fieldName = end.storageKey;
   var visited = {};
   var current = parentIndex;
@@ -1099,13 +1230,16 @@ Page.checkCrudReflexiveHierarchyCycle = function(className, instances, end, chil
     visited[current] = true;
 
     var inst = instances[current] || {};
-    var next = inst[fieldName];
-    if (Array.isArray(next)) {
-      next = next.length ? next[0] : null;
-    }
-    if (typeof next !== "number") {
-      var n = parseInt(next, 10);
-      next = isNaN(n) ? null : n;
+    var nextRaw = inst[fieldName];
+    var nextRefs = Page.normalizeCrudAssociationRefs
+      ? Page.normalizeCrudAssociationRefs(end, nextRaw)
+      : [];
+    var next = null;
+    if (nextRefs.length > 0) {
+      var r0 = nextRefs[0];
+      if (r0 && r0.className === className && typeof r0.index === "number") {
+        next = r0.index;
+      }
     }
     current = next;
   }
@@ -1194,18 +1328,10 @@ Page.validateCrudGlobalModel = function(pendingUpdate) {
         if (!inst) { continue; }
 
         var rawVal = inst[fieldName];
-        var linkCount = 0;
-
-        if (Array.isArray(rawVal)) {
-          linkCount = rawVal.length;
-        } else if (typeof rawVal === "number") {
-          linkCount = rawVal >= 0 ? 1 : 0;
-        } else if (rawVal !== undefined && rawVal !== null && rawVal !== "") {
-          var parsed = parseInt(rawVal, 10);
-          if (!isNaN(parsed) && parsed >= 0) {
-            linkCount = 1;
-          }
-        }
+        var refsForCount = Page.normalizeCrudAssociationRefs
+          ? Page.normalizeCrudAssociationRefs(end, rawVal)
+          : [];
+        var linkCount = refsForCount.length;
 
         if (linkCount < minRequired) {
           missingCount++;
@@ -1495,7 +1621,11 @@ Page.syncCrudReverseAssociationsForEnd = function(className, index, end, newValu
 
   var fromClass = end.fromClass;
   var toClass = end.toClass;
-  if (fromClass !== className) {
+  // Only handle updates when the edited instance's runtime class is
+  // the same as or a subclass of the association's fromClass. This
+  // allows subclass-specific forms (e.g., Student isA Person) to keep
+  // reverse links in sync for associations declared on the base type.
+  if (!Page.isCrudSubclass || !Page.isCrudSubclass(className, fromClass)) {
     return;
   }
 
@@ -1510,14 +1640,8 @@ Page.syncCrudReverseAssociationsForEnd = function(className, index, end, newValu
     return;
   }
 
-  var targetInfo = Page.crudData.classes[toClass];
-  if (!targetInfo) {
-    return;
-  }
-  var targetInstances = targetInfo.instances || [];
-
-  // Find reverse end: same association id, from the target class back to
-  // this class.
+  // Find reverse end definition: same association id, from the target
+  // root class back to this class's root type.
   var reverseEnd = null;
   var candidates = Page.crudAssociationsByClass[toClass] || [];
   for (var i = 0; i < candidates.length; i++) {
@@ -1534,45 +1658,125 @@ Page.syncCrudReverseAssociationsForEnd = function(className, index, end, newValu
   var revKey = reverseEnd.storageKey;
   var revMultiple = reverseEnd.toMultiplicity && reverseEnd.toMultiplicity.indexOf("*") !== -1;
 
-  // Helper to know whether the edited instance should be linked to a given
-  // target index according to newValue.
-  var isLinked;
-  if (Array.isArray(newValue)) {
-    var set = {};
-    for (var s = 0; s < newValue.length; s++) {
-      var v = newValue[s];
-      if (typeof v === "number" && v >= 0) {
-        set[v] = true;
+  // Normalize the forward value into canonical refs for this end.
+  var forwardRefs = Page.normalizeCrudAssociationRefs(end, newValue);
+  var sourceRef = { className: className, index: index };
+
+  // For each concrete target class that can play the role of toClass
+  // (i.e., toClass and its subclasses), update the reverse end to
+  // reflect the new forwardRefs.
+  var classesData = Page.crudData.classes;
+  // Track replacements for single-valued reverse ends so that we can
+  // remove stale forward links from any previous source instance.
+  var replacedSingleLinks = [];
+
+  Object.keys(classesData).forEach(function(targetRuntimeClass) {
+    if (!Page.isCrudSubclass(targetRuntimeClass, toClass)) {
+      return;
+    }
+    var targetInfo = classesData[targetRuntimeClass] || {};
+    var targetInstances = targetInfo.instances || [];
+    for (var tIdx = 0; tIdx < targetInstances.length; tIdx++) {
+      var tInst = targetInstances[tIdx] || {};
+
+      var shouldLink = false;
+      for (var r = 0; r < forwardRefs.length; r++) {
+        var fr = forwardRefs[r];
+        if (fr.className === targetRuntimeClass && fr.index === tIdx) {
+          shouldLink = true;
+          break;
+        }
+      }
+
+      var currentRaw = tInst[revKey];
+      var currentRefs = Page.normalizeCrudAssociationRefs(reverseEnd, currentRaw);
+
+      if (revMultiple) {
+        var hasRef = false;
+        var filtered = [];
+        for (var k = 0; k < currentRefs.length; k++) {
+          var cr = currentRefs[k];
+          if (cr.className === sourceRef.className && cr.index === sourceRef.index) {
+            hasRef = true;
+            if (!shouldLink) { continue; }
+          }
+          filtered.push(cr);
+        }
+        if (shouldLink && !hasRef) {
+          filtered.push(sourceRef);
+        }
+        tInst[revKey] = filtered;
+      } else {
+        if (shouldLink) {
+          if (currentRefs.length > 0) {
+            var oldRef = currentRefs[0];
+            if (!(oldRef.className === sourceRef.className && oldRef.index === sourceRef.index)) {
+              // Remember that this target instance is now owned by a
+              // different source so we can strip the target from the
+              // old source's forward association field.
+              replacedSingleLinks.push({
+                oldSource: { className: oldRef.className, index: oldRef.index },
+                targetClassName: targetRuntimeClass,
+                targetIndex: tIdx
+              });
+            }
+          }
+          tInst[revKey] = sourceRef;
+        } else {
+          if (currentRefs.length > 0) {
+            var cr0 = currentRefs[0];
+            if (cr0.className === sourceRef.className && cr0.index === sourceRef.index) {
+              tInst[revKey] = null;
+            }
+          }
+        }
       }
     }
-    isLinked = function(tIdx) { return !!set[tIdx]; };
-  } else if (typeof newValue === "number" && newValue >= 0) {
-    isLinked = function(tIdx) { return newValue === tIdx; };
-  } else {
-    isLinked = function() { return false; };
-  }
+  });
 
-  for (var tIdx = 0; tIdx < targetInstances.length; tIdx++) {
-    var tInst = targetInstances[tIdx] || {};
-    var linked = isLinked(tIdx);
+  // For associations where the reverse end is single-valued, a target
+  // instance can only be linked to one source at a time. When a target
+  // is re-assigned to a new source, also remove that target from the
+  // old source's forward association field so that stale references do
+  // not accumulate.
+  if (!revMultiple && replacedSingleLinks.length > 0) {
+    var forwardKey = end.storageKey;
+    replacedSingleLinks.forEach(function(entry) {
+      var old = entry.oldSource;
+      var targetClassName = entry.targetClassName;
+      var targetIndex = entry.targetIndex;
+      var srcData = classesData[old.className] || {};
+      var srcInstances = srcData.instances || [];
+      if (old.index < 0 || old.index >= srcInstances.length) {
+        return;
+      }
+      var srcInst = srcInstances[old.index] || {};
+      var rawForward = srcInst[forwardKey];
+      var fwdRefs = Page.normalizeCrudAssociationRefs(end, rawForward);
+      if (!fwdRefs.length) {
+        return;
+      }
 
-    if (revMultiple) {
-      var arr = Array.isArray(tInst[revKey]) ? tInst[revKey].slice() : [];
-      var pos = arr.indexOf(index);
-      if (linked && pos === -1) {
-        arr.push(index);
+      var updated;
+      if (Array.isArray(rawForward)) {
+        // Multi-valued forward end: filter out the stolen target.
+        updated = [];
+        for (var i = 0; i < fwdRefs.length; i++) {
+          var fr2 = fwdRefs[i];
+          if (fr2.className === targetClassName && fr2.index === targetIndex) {
+            continue;
+          }
+          updated.push(fr2);
+        }
+        srcInst[forwardKey] = updated;
+      } else {
+        // Single-valued forward end: clear it if it points at this target.
+        var fr0 = fwdRefs[0];
+        if (fr0.className === targetClassName && fr0.index === targetIndex) {
+          srcInst[forwardKey] = null;
+        }
       }
-      if (!linked && pos !== -1) {
-        arr.splice(pos, 1);
-      }
-      tInst[revKey] = arr;
-    } else {
-      if (linked) {
-        tInst[revKey] = index;
-      } else if (tInst[revKey] === index) {
-        tInst[revKey] = null;
-      }
-    }
+    });
   }
 };
 
@@ -1597,39 +1801,41 @@ Page.removeCrudInstance = function(className, index) {
   endsFromThis.forEach(function(end) {
     if (!end || !end.cascadeDeleteTargets) { return; }
     var key = end.storageKey;
-    var val = inst[key];
-    if (val === undefined || val === null) { return; }
+    var rawVal = inst[key];
+    if (rawVal === undefined || rawVal === null) { return; }
 
-    var targetIndices = [];
-    if (Array.isArray(val)) {
-      val.forEach(function(v) {
-        if (typeof v !== "number") { v = parseInt(v, 10); }
-        if (!isNaN(v) && v >= 0) {
-          targetIndices.push(v);
-        }
-      });
-    } else {
-      var v2 = val;
-      if (typeof v2 !== "number") { v2 = parseInt(v2, 10); }
-      if (!isNaN(v2) && v2 >= 0) {
-        targetIndices.push(v2);
+    var refs = Page.normalizeCrudAssociationRefs(end, rawVal);
+    if (!refs.length) { return; }
+
+    // Delete targets in descending index order per concrete runtime
+    // class so that earlier indices remain valid as we remove later
+    // ones.
+    var byClass = {};
+    refs.forEach(function(ref) {
+      if (!ref || typeof ref.index !== "number" || ref.index < 0 || !ref.className) {
+        return;
       }
-    }
+      if (!byClass[ref.className]) {
+        byClass[ref.className] = [];
+      }
+      byClass[ref.className].push(ref.index);
+    });
 
-    if (!targetIndices.length) { return; }
-
-    // Delete targets in descending order so that earlier indices remain
-    // valid as we remove later ones.
-    targetIndices.sort(function(a, b) { return b - a; });
-    targetIndices.forEach(function(tIdx) {
-      Page.removeCrudInstance(end.toClass, tIdx);
+    Object.keys(byClass).forEach(function(targetClass) {
+      var idxs = byClass[targetClass];
+      if (!idxs || !idxs.length) { return; }
+      idxs.sort(function(a, b) { return b - a; });
+      idxs.forEach(function(tIdx) {
+        Page.removeCrudInstance(targetClass, tIdx);
+      });
     });
   });
 
   // Remove the instance itself
   instances.splice(index, 1);
 
-  // Reindex any association links that point to this class
+  // Reindex any association links that may point to this concrete class
+  // through ends whose target type can include this class.
   for (var sourceClass in assocByClass) {
     if (!assocByClass.hasOwnProperty(sourceClass)) { continue; }
     var ends = assocByClass[sourceClass] || [];
@@ -1639,38 +1845,53 @@ Page.removeCrudInstance = function(className, index) {
     var sourceInstances = sourceInfo.instances || [];
 
     ends.forEach(function(end) {
-      if (!end || end.toClass !== className) { return; }
+      if (!end) { return; }
+      if (!Page.isCrudSubclass(className, end.toClass)) { return; }
       var key = end.storageKey;
 
       sourceInstances.forEach(function(inst) {
-        var val = inst[key];
-        if (Array.isArray(val)) {
-          var arr = val.slice();
-          var changed = false;
-          var newArr = [];
-          arr.forEach(function(v) {
-            if (typeof v !== "number") { return; }
-            if (v === index) { changed = true; return; }
-            if (v > index) {
-              newArr.push(v - 1);
-              changed = true;
-            } else {
-              newArr.push(v);
+        var raw = inst[key];
+        var refs = Page.normalizeCrudAssociationRefs(end, raw);
+        if (!refs.length && (raw === null || typeof raw === "undefined")) {
+          return;
+        }
+
+        var multiple = end.toMultiplicity && end.toMultiplicity.indexOf("*") !== -1;
+        var changed = false;
+
+        if (multiple) {
+          var newRefs = [];
+          for (var r = 0; r < refs.length; r++) {
+            var ref = refs[r];
+            if (ref.className === className) {
+              if (ref.index === index) {
+                // Drop refs to the removed instance.
+                changed = true;
+                continue;
+              }
+              if (ref.index > index) {
+                ref = { className: ref.className, index: ref.index - 1 };
+                changed = true;
+              }
             }
-          });
+            newRefs.push(ref);
+          }
           if (changed) {
-            inst[key] = newArr;
+            inst[key] = newRefs;
           }
         } else {
-          var v2 = val;
-          if (typeof v2 !== "number") {
-            v2 = parseInt(v2, 10);
-            if (isNaN(v2)) { return; }
+          if (!refs.length) {
+            return;
           }
-          if (v2 === index) {
-            inst[key] = null;
-          } else if (v2 > index) {
-            inst[key] = v2 - 1;
+          var refSingle = refs[0];
+          if (refSingle.className === className) {
+            if (refSingle.index === index) {
+              inst[key] = null;
+              changed = true;
+            } else if (refSingle.index > index) {
+              inst[key] = { className: refSingle.className, index: refSingle.index - 1 };
+              changed = true;
+            }
           }
         }
       });
@@ -2062,10 +2283,13 @@ Page.getCrudAssociationLabelCandidatesForClass = function(className) {
 
 // Build a human-friendly label for a target instance in an association
 // selector. When preferredKey is an attribute name, we try that first;
-// when it is "__index__" we always use ClassName[index] regardless of
-// attribute values.
-Page.buildCrudAssociationLabelForInstance = function(targetClass, inst, index, labelMeta, preferredKey) {
-  var baseLabel = targetClass + "[" + (index + 1) + "]";
+// when it is "__index__" we always use ClassName[index] based on the
+// runtime class and its own index when available, falling back to the
+// declared targetClass and positional index.
+Page.buildCrudAssociationLabelForInstance = function(targetClass, inst, index, labelMeta, preferredKey, runtimeClass, runtimeIndex) {
+  var classForIndex = runtimeClass || targetClass;
+  var ordinalIndex = (typeof runtimeIndex === "number" && runtimeIndex >= 0) ? runtimeIndex : index;
+  var baseLabel = classForIndex + "[" + (ordinalIndex + 1) + "]";
   if (!inst || !labelMeta) {
     return baseLabel;
   }
@@ -2849,6 +3073,11 @@ Page.openCrudDialogForClass = function(className) {
   // Gather association ends for this class, including any inherited from
   // its superclasses, using the extends map built from the JSON.
   var assocEnds = [];
+  // Map from storageKey to the association end that is actually rendered
+  // in the form for this class. This keeps the save logic aligned with
+  // the UI (e.g., picking the single-valued end for a reflexive
+  // association like mentor instead of the many-valued opposite).
+  var assocEndByField = {};
   if (Page.crudAssociationsByClass) {
     var seenAssocKeysForClass = {};
     var currentClassName = className;
@@ -2943,8 +3172,9 @@ Page.openCrudDialogForClass = function(className) {
   }
   html += "</div>";
 
-  // Add/Edit form
-  html += "<h4>Add / Edit Instance</h4>";
+  // Add/Edit form. The heading starts in "Add" mode and is updated to
+  // "Edit Class[index] Instance" when an existing instance is selected.
+  html += "<h4 class='crud-instance-form-heading'>Add Instance</h4>";
   html += "<div class='crud-error' style='color:red;margin-bottom:6px;display:none;'></div>";
   html += "<form id='crud-instance-form' data-class='" + className + "'>";
   html += "<input type='hidden' name='instanceIndex' value='' />";
@@ -2969,53 +3199,62 @@ Page.openCrudDialogForClass = function(className) {
     html += "</div>";
   });
 
-  // Association selectors for navigable ends from this class
-  // We generally render selectors for all navigable ends, but we hide the
-  // "reverse" side of one-to-many associations (e.g., Employee -> Accident)
-  // to avoid large multi-selects when a clearer owner side exists. For true
-  // many-to-many (* to *) associations, we still show selectors so links can
-  // be edited from each navigable side.
+  // Association selectors for navigable ends from this class.
+  // Render selectors for every navigable end so that for a
+  // bidirectional association (A -- C), links are editable from
+  // both classes A and C. For self-reflexive associations we may
+  // have two navigable ends with the same storageKey; in that case
+  // choose a single canonical end (preferring single-valued over
+  // many-valued) so the UI does not show duplicate groups and so
+  // save logic can align with the rendered controls.
   var assocSelectorEnds = [];
-  var seenReflexiveAssoc = {};
+  var reflexiveByField = {};
+
   assocEnds.forEach(function(end) {
-    var multTo = end.toMultiplicity || "";
-    var multFrom = end.fromMultiplicity || "";
-    var toHasStar = multTo.indexOf("*") !== -1;
-    var fromHasStar = multFrom.indexOf("*") !== -1;
+    if (!end || !end.storageKey) { return; }
+    var fieldName = end.storageKey;
 
-    // Hide the reverse of a one-to-many: if the target side allows many (*),
-    // but the source side does not, it is clearer to edit links from the
-    // opposite end. Example: Employee -> Accident when Accident -> Employee
-    // is 1..*.
-    // Only apply this when the association is truly bidirectional; for
-    // unidirectional associations, this is the only navigable end and must
-    // remain visible (including when inherited by subclasses).
-    if (end.isBidirectional && toHasStar && !fromHasStar) {
-      return;
-    }
-
-    // For self-reflexive associations (fromClass === toClass), we can end up
-    // with two navigable ends that look identical from the UI perspective.
-    // Only keep one per association id so we don't render duplicate groups
-    // (e.g., Territory[*] borders Territory[*]).
     if (end.fromClass === end.toClass) {
-      var key = (end.assocId || end.assocName || "") + "::" + end.toClass;
-      if (seenReflexiveAssoc[key]) {
-        return;
+      var existing = reflexiveByField[fieldName];
+      if (!existing) {
+        reflexiveByField[fieldName] = end;
+      } else {
+        // Prefer the end whose target multiplicity is strictly
+        // single-valued (max <= 1). If both are multi-valued or
+        // both single-valued, keep the first.
+        var existingMax = (typeof existing.toMax === "number") ? existing.toMax : null;
+        var newMax = (typeof end.toMax === "number") ? end.toMax : null;
+        var existingMultiple = (existingMax === null || existingMax > 1);
+        var newMultiple = (newMax === null || newMax > 1);
+        if (existingMultiple && !newMultiple) {
+          reflexiveByField[fieldName] = end;
+        }
       }
-      seenReflexiveAssoc[key] = true;
+    } else {
+      assocSelectorEnds.push(end);
+      assocEndByField[fieldName] = end;
     }
+  });
 
-    // Otherwise (including many-to-many where both sides use *), show it.
-    assocSelectorEnds.push(end);
+  // Add the chosen reflexive ends (if any) after non-reflexive ones.
+  Object.keys(reflexiveByField).forEach(function(fieldName) {
+    var chosen = reflexiveByField[fieldName];
+    assocSelectorEnds.push(chosen);
+    assocEndByField[fieldName] = chosen;
   });
 
   if (assocSelectorEnds.length > 0) {
-    html += "<h4>Associations</h4>";
+    // Use a plain text label rather than a heading so this section
+    // does not visually compete with the main "Add/Edit Instance"
+    // heading or look like it refers to an existing row.
+    html += "<div class='crud-assoc-section-label' style='margin:8px 0 4px 0;font-weight:normal;'>Associations from this instance</div>";
     assocSelectorEnds.forEach(function(end) {
       var targetClass = end.toClass;
       var targetInfo = Page.crudData.classes[targetClass];
-      var targetInstances = (targetInfo && targetInfo.instances) || [];
+      // Build polymorphic target list: targetClass and all its subclasses.
+      var polyTargets = Page.getCrudPolymorphicTargets
+        ? Page.getCrudPolymorphicTargets(targetClass)
+        : [];
       var fieldName = end.storageKey;
 
       html += "<div class='crud-field crud-assoc-field'>";
@@ -3074,7 +3313,7 @@ Page.openCrudDialogForClass = function(className) {
 
       // Small dropdown to let the user choose the labelling basis.
       html += "<div class='crud-assoc-label-selector'>";
-      html += "<span class='crud-assoc-label-selector-text'>Label for " + targetClass + " options: </span>";
+      html += "<span class='crud-assoc-label-selector-text'>Label" + " options: </span>";
       html += "<select class='crud-assoc-label-select' data-target-class='" + targetClass + "'>";
 
       var indexSelected = (effectivePref === "__index__");
@@ -3151,13 +3390,17 @@ Page.openCrudDialogForClass = function(className) {
         // Multi-valued end: render a checkbox list so users can easily
         // add/remove multiple associated instances (e.g., many-to-many).
         html += "<div class='crud-assoc-options crud-assoc-multi' data-field='" + fieldName + "'>";
-        targetInstances.forEach(function(inst, idx) {
-          var optionLabel = Page.buildCrudAssociationLabelForInstance(targetClass, inst, idx, labelMeta, effectivePref);
-          var targetAttrs = (Page.crudData.classes[targetClass] && Page.crudData.classes[targetClass].attributes) || [];
-          var tooltipEsc = buildAssocOptionTooltip(end, targetClass, optionLabel, inst, targetAttrs);
+        polyTargets.forEach(function(entry, idx) {
+          var instObj = entry.instance;
+          var runtimeClass = entry.className;
+          var runtimeIndex = entry.index;
+          var optionLabel = Page.buildCrudAssociationLabelForInstance(targetClass, instObj, idx, labelMeta, effectivePref, runtimeClass, runtimeIndex);
+          var attrsForRuntime = (Page.crudData.classes[runtimeClass] && Page.crudData.classes[runtimeClass].attributes) || [];
+          var tooltipEsc = buildAssocOptionTooltip(end, runtimeClass, optionLabel, instObj, attrsForRuntime);
+          var refVal = Page.encodeCrudAssocRef({ className: runtimeClass, index: entry.index });
           html += "<label class='crud-assoc-option'>" +
-            "<input type='checkbox' name='" + fieldName + "' value='" + idx + "'>" +
-            "<span class='crud-tooltip-target crud-assoc-option-label' data-target-class='" + targetClass + "' data-index='" + idx + "' data-field='" + fieldName + "' data-crud-tooltip-html=\"" + tooltipEsc + "\">" + escapeHtml(optionLabel) + "</span>" +
+            "<input type='checkbox' name='" + fieldName + "' value='" + refVal + "'>" +
+            "<span class='crud-tooltip-target crud-assoc-option-label' data-target-class='" + targetClass + "' data-runtime-class='" + runtimeClass + "' data-runtime-index='" + entry.index + "' data-field='" + fieldName + "' data-crud-tooltip-html=\"" + tooltipEsc + "\">" + escapeHtml(optionLabel) + "</span>" +
             "</label>";
         });
         html += "</div>";
@@ -3172,20 +3415,24 @@ Page.openCrudDialogForClass = function(className) {
                    "</label>";
         }
 
-        targetInstances.forEach(function(inst, idx) {
-          var optionLabel = Page.buildCrudAssociationLabelForInstance(targetClass, inst, idx, labelMeta, effectivePref);
-          var targetAttrs = (Page.crudData.classes[targetClass] && Page.crudData.classes[targetClass].attributes) || [];
-          var tooltipEsc = buildAssocOptionTooltip(end, targetClass, optionLabel, inst, targetAttrs);
+        polyTargets.forEach(function(entry, idx) {
+          var instObj = entry.instance;
+          var runtimeClass = entry.className;
+          var runtimeIndex = entry.index;
+          var optionLabel = Page.buildCrudAssociationLabelForInstance(targetClass, instObj, idx, labelMeta, effectivePref, runtimeClass, runtimeIndex);
+          var attrsForRuntime = (Page.crudData.classes[runtimeClass] && Page.crudData.classes[runtimeClass].attributes) || [];
+          var tooltipEsc = buildAssocOptionTooltip(end, runtimeClass, optionLabel, instObj, attrsForRuntime);
+          var refVal = Page.encodeCrudAssocRef({ className: runtimeClass, index: entry.index });
           html += "<label class='crud-assoc-option'>" +
-            "<input type='radio' name='" + fieldName + "' value='" + idx + "'>" +
-            "<span class='crud-tooltip-target crud-assoc-option-label' data-target-class='" + targetClass + "' data-index='" + idx + "' data-field='" + fieldName + "' data-crud-tooltip-html=\"" + tooltipEsc + "\">" + escapeHtml(optionLabel) + "</span>" +
+            "<input type='radio' name='" + fieldName + "' value='" + refVal + "'>" +
+            "<span class='crud-tooltip-target crud-assoc-option-label' data-target-class='" + targetClass + "' data-runtime-class='" + runtimeClass + "' data-runtime-index='" + entry.index + "' data-field='" + fieldName + "' data-crud-tooltip-html=\"" + tooltipEsc + "\">" + escapeHtml(optionLabel) + "</span>" +
             "</label>";
         });
         html += "</div>";
       }
 
       // If there are no target instances and multiplicity requires one, hint to create them first
-      if (targetInstances.length < minRequired && minRequired > 0) {
+      if (polyTargets.length < minRequired && minRequired > 0) {
         html += "<div class='crud-association-hint' style='margin-top:4px;color:#a00;'>" +
                 "Not enough " + targetClass + " instances exist. Create more before adding " + className + ". " + "If this is a cyclic association, please proceed to click Save, the error messages will guide you."+
                 "</div>";
@@ -3268,18 +3515,20 @@ Page.openCrudDialogForClass = function(className) {
       $select.val(effectivePref);
     }
 
-    var targetInfo = (Page.crudData && Page.crudData.classes && Page.crudData.classes[targetClass]) ? Page.crudData.classes[targetClass] : null;
-    var instancesForClass = (targetInfo && targetInfo.instances) || [];
+    var instancesForClass = Page.getCrudPolymorphicTargets
+      ? Page.getCrudPolymorphicTargets(targetClass)
+      : [];
 
-    $panel.find(".crud-assoc-option-label[data-target-class='" + targetClass + "']").each(function() {
+    $panel.find(".crud-assoc-option-label[data-target-class='" + targetClass + "']").each(function(idx) {
       var $span = jQuery(this);
-      var idxStr = $span.attr("data-index");
-      var idx = parseInt(idxStr, 10);
-      if (isNaN(idx) || idx < 0 || idx >= instancesForClass.length) {
+      if (idx < 0 || idx >= instancesForClass.length) {
         return;
       }
-      var inst = instancesForClass[idx];
-      var newLabel = Page.buildCrudAssociationLabelForInstance(targetClass, inst, idx, labelMeta, effectivePref);
+      var entry = instancesForClass[idx];
+      var inst = entry.instance;
+      var runtimeClass = entry.className;
+      var runtimeIndex = entry.index;
+      var newLabel = Page.buildCrudAssociationLabelForInstance(targetClass, inst, idx, labelMeta, effectivePref, runtimeClass, runtimeIndex);
       $span.text(newLabel);
     });
   });
@@ -3327,6 +3576,13 @@ Page.openCrudDialogForClass = function(className) {
     var inst = instancesCurrent[index] || {};
     var $form = $panel.find("#crud-instance-form");
     $form.find("input[name='instanceIndex']").val(index);
+
+    // Update the heading to reflect that we are editing a specific
+    // instance, e.g., "Edit Person[1] Instance".
+    var $heading = $panel.find(".crud-instance-form-heading");
+    if ($heading.length) {
+      $heading.text("Edit " + className + "[" + (index + 1) + "] Instance");
+    }
 
     // When editing an existing instance, show the Cancel Edit button so
     // the user has an explicit way to abandon in-progress changes.
@@ -3413,28 +3669,20 @@ Page.openCrudDialogForClass = function(className) {
       if (multiple) {
         var $checks = $form.find("input[type='checkbox'][name='" + fieldName + "']");
         $checks.prop("checked", false);
-        if (stored !== undefined && stored !== null && stored !== "") {
-          var storedArray = [];
-          if (Array.isArray(stored)) {
-            storedArray = stored.slice();
-          } else if (typeof stored === "number") {
-            storedArray = [stored];
-          } else {
-            var parsedStored = parseInt(stored, 10);
-            if (!isNaN(parsedStored)) {
-              storedArray = [parsedStored];
-            }
-          }
-
-          if (storedArray.length > 0) {
-            $checks.each(function() {
-              var v = jQuery(this).val();
-              var idx = parseInt(v, 10);
-              if (!isNaN(idx) && storedArray.indexOf(idx) !== -1) {
+        var refs = Page.normalizeCrudAssociationRefs(end, stored);
+        if (refs.length > 0) {
+          $checks.each(function() {
+            var v = jQuery(this).val();
+            var ref = Page.decodeCrudAssocRef(v, end.toClass);
+            if (!ref) { return; }
+            for (var i = 0; i < refs.length; i++) {
+              var r = refs[i];
+              if (r.className === ref.className && r.index === ref.index) {
                 jQuery(this).prop("checked", true);
+                break;
               }
-            });
-          }
+            }
+          });
         }
       } else {
         var $radios = $form.find("input[type='radio'][name='" + fieldName + "']");
@@ -3450,15 +3698,22 @@ Page.openCrudDialogForClass = function(className) {
             });
           }
         } else {
-          var targetVal = Array.isArray(stored) ? (stored[0] || "") : stored;
-          $radios.each(function() {
-            var v = jQuery(this).val();
-            if (v === "") { return; }
-            var idx = parseInt(v, 10);
-            if (!isNaN(idx) && idx === targetVal) {
-              jQuery(this).prop("checked", true);
-            }
-          });
+          var refSingle = null;
+          var refsSingle = Page.normalizeCrudAssociationRefs(end, stored);
+          if (refsSingle.length > 0) {
+            refSingle = refsSingle[0];
+          }
+          if (refSingle) {
+            $radios.each(function() {
+              var v = jQuery(this).val();
+              if (v === "") { return; }
+              var refOpt = Page.decodeCrudAssocRef(v, end.toClass);
+              if (!refOpt) { return; }
+              if (refOpt.className === refSingle.className && refOpt.index === refSingle.index) {
+                jQuery(this).prop("checked", true);
+              }
+            });
+          }
         }
       }
     });
@@ -3522,7 +3777,6 @@ Page.openCrudDialogForClass = function(className) {
       var val = inst[fieldName];
       var targetClass = end.toClass;
       var targetInfo = Page.crudData.classes[targetClass];
-      var targetInstances = (targetInfo && targetInfo.instances) || [];
       var targetAttrs = (targetInfo && targetInfo.attributes) || [];
 
       if (val === undefined || val === null) {
@@ -3530,52 +3784,43 @@ Page.openCrudDialogForClass = function(className) {
       }
 
       // Avoid duplicate groups for self-reflexive associations where two
-      // navigable ends correspond to the same logical relationship.
+      // navigable ends correspond to the same logical relationship. When a
+      // canonical end has been chosen for this storage field (e.g., the
+      // single-valued mentor side of a mentor/mentee association), prefer
+      // that end so that role names in the header match the form.
       if (end.fromClass === end.toClass) {
         var keyF = end.assocId || end.assocName || "";
-        if (seenAssocIdsForward[keyF]) { return; }
-        seenAssocIdsForward[keyF] = true;
+        if (keyF) {
+          if (seenAssocIdsForward[keyF]) { return; }
+
+          if (assocEndByField && assocEndByField[fieldName] && assocEndByField[fieldName] !== end) {
+            return;
+          }
+
+          seenAssocIdsForward[keyF] = true;
+        }
       }
+
+      // Use canonical polymorphic refs so that associations targeting
+      // subclasses of the declared target type are also displayed.
+      var refs = Page.normalizeCrudAssociationRefs
+        ? Page.normalizeCrudAssociationRefs(end, val)
+        : [];
+
+      if (!refs.length) { return; }
 
       var items = [];
-      // Align multiplicity interpretation with form rendering/saving: treat
-      // an end as multi-valued when its max bound allows more than one.
-      var multiple = true;
-      if (typeof end.toMax === "number" && end.toMax <= 1) {
-        multiple = false;
-      }
-      if (multiple) {
-        // Support both legacy single-valued storage (a single numeric
-        // index from radio buttons) and the newer array-based storage
-        // used by checkboxes. Normalize into an array of indices.
-        var indices = [];
-        if (Array.isArray(val)) {
-          indices = val.slice();
-        } else if (val !== undefined && val !== null && val !== "") {
-          var idxSingle = (typeof val === "number") ? val : parseInt(val, 10);
-          if (!isNaN(idxSingle)) {
-            indices = [idxSingle];
-          }
-        }
+      refs.forEach(function(ref) {
+        if (!ref || typeof ref.index !== "number" || ref.index < 0) { return; }
+        var runtimeClass = ref.className || targetClass;
+        var runtimeInfo = Page.crudData.classes[runtimeClass];
+        if (!runtimeInfo || !Array.isArray(runtimeInfo.instances)) { return; }
+        var runtimeInstances = runtimeInfo.instances;
+        if (ref.index >= runtimeInstances.length) { return; }
+        items.push({ inst: runtimeInstances[ref.index], idx: ref.index, className: runtimeClass });
+      });
 
-        if (!indices.length) { return; }
-
-        indices.forEach(function(idx) {
-          if (typeof idx !== "number" || idx < 0 || idx >= targetInstances.length) { return; }
-          items.push({ inst: targetInstances[idx], idx: idx });
-        });
-      } else {
-        var idxSingle = val;
-        if (typeof idxSingle !== "number") {
-          idxSingle = parseInt(idxSingle, 10);
-        }
-        if (isNaN(idxSingle) || idxSingle < 0 || idxSingle >= targetInstances.length) { return; }
-        items.push({ inst: targetInstances[idxSingle], idx: idxSingle });
-      }
-
-      if (items.length === 0) {
-        return;
-      }
+      if (!items.length) { return; }
 
       hasContent = true;
       var headerLabel = targetClass;
@@ -3596,7 +3841,7 @@ Page.openCrudDialogForClass = function(className) {
       assocHtml += "</tr></thead><tbody>";
 
       items.forEach(function(item) {
-        var label = targetClass + "[" + (item.idx + 1) + "]";
+        var label = (item.className || targetClass) + "[" + (item.idx + 1) + "]";
         assocHtml += "<tr><td>" + label + "</td>";
         targetAttrs.forEach(function(attr) {
           var aName = attr.name;
@@ -3615,39 +3860,81 @@ Page.openCrudDialogForClass = function(className) {
     // stores the link (e.g., child -> parent), also show the reverse
     // perspective in this panel: from a parent record, list its children
     // without modifying any stored associations.
+    var seenAssocIdsHierarchy = {};
     assocEnds.forEach(function(end) {
       if (!end.reflexiveHierarchy) { return; }
       if (end.fromClass !== end.toClass) { return; }
 
       var fieldName = end.storageKey;
       var classInfo = Page.crudData.classes[className];
-      var allInstances = (classInfo && classInfo.instances) || [];
-      if (!allInstances.length) { return; }
+      if (!classInfo) { return; }
+
+      // When a reflexive association has two navigable ends that share the
+      // same underlying storage (e.g., a mentor/mentee association on
+      // Person), we only want to render a single hierarchical reverse
+      // group. Use the association id as the key and, when available,
+      // prefer the canonical end that is actually rendered in the form
+      // (so labels and tooltips stay consistent with the UI).
+      var assocKey = end.assocId || (end.assocName || "");
+      if (assocKey) {
+        if (seenAssocIdsHierarchy[assocKey]) {
+          return;
+        }
+        // If this storage field is mapped to a specific end in the form,
+        // and that end differs from the one we are currently visiting,
+        // skip this visit so that the canonical end will own the
+        // hierarchical view.
+        if (assocEndByField && assocEndByField[fieldName] && assocEndByField[fieldName] !== end) {
+          return;
+        }
+        seenAssocIdsHierarchy[assocKey] = true;
+      }
+
+      // For hierarchical self-reflexive associations that are declared on
+      // a base class (e.g., Person mentor -- Person) but whose actual
+      // instances may be subclasses (e.g., Student isA Person), search
+      // across all subclasses of this class for links pointing back to
+      // the current instance.
+      var candidateChildren = Page.getCrudPolymorphicTargets
+        ? Page.getCrudPolymorphicTargets(className)
+        : [];
+
+      if (!candidateChildren.length) { return; }
 
       var children = [];
-      allInstances.forEach(function(otherInst, otherIdx) {
-        if (otherIdx === index) { return; }
+      candidateChildren.forEach(function(entry) {
+        if (!entry || !entry.instance) { return; }
+        var otherInst = entry.instance;
+        var otherIdx = entry.index;
+        var otherClassName = entry.className;
+
+        // Skip the current instance itself (same class and index).
+        if (otherClassName === className && otherIdx === index) { return; }
+
         var linkVal = otherInst[fieldName];
         if (linkVal === undefined || linkVal === null) { return; }
-        var parentIdx = linkVal;
-        if (Array.isArray(parentIdx)) {
-          // Hierarchical patterns should store a single parent index, but
-          // handle arrays defensively by checking membership.
-          if (parentIdx.indexOf(index) === -1) { return; }
-        } else {
-          if (typeof parentIdx !== "number") {
-            parentIdx = parseInt(parentIdx, 10);
+        var refs = Page.normalizeCrudAssociationRefs
+          ? Page.normalizeCrudAssociationRefs(end, linkVal)
+          : [];
+        if (!refs.length) { return; }
+        for (var r = 0; r < refs.length; r++) {
+          var ref = refs[r];
+          if (!ref || ref.className !== className) { continue; }
+          if (typeof ref.index === "number" && ref.index === index) {
+            children.push({ inst: otherInst, idx: otherIdx, className: otherClassName });
+            break;
           }
-          if (isNaN(parentIdx) || parentIdx !== index) { return; }
         }
-        children.push({ inst: otherInst, idx: otherIdx });
       });
 
       if (!children.length) { return; }
 
       hasContent = true;
       var revHeader = className;
-      if (end.oppositeRoleName) {
+      // Only show a role name when it meaningfully differs from the
+      // forward role. This avoids confusing labels like "mentor" being
+      // reused for both mentor and mentee when only one role is named.
+      if (end.oppositeRoleName && end.oppositeRoleName !== end.roleName) {
         revHeader += " (" + end.oppositeRoleName + ")";
       }
 
@@ -3665,7 +3952,8 @@ Page.openCrudDialogForClass = function(className) {
       assocHtml += "</tr></thead><tbody>";
 
       children.forEach(function(child) {
-        var label = className + "[" + (child.idx + 1) + "]";
+        var labelClass = child.className || className;
+        var label = labelClass + "[" + (child.idx + 1) + "]";
         assocHtml += "<tr><td>" + label + "</td>";
         attrsForClass.forEach(function(attr) {
           var aName = attr.name;
@@ -3790,8 +4078,27 @@ Page.openCrudDialogForClass = function(className) {
     }
 
     // Associations: enforce multiplicity rules and capture selected links
+    var processedAssocFields = {};
     assocEnds.forEach(function(end) {
       var fieldName = end.storageKey;
+      if (!fieldName) {
+        return;
+      }
+
+      // For reflexive associations there may be two navigable ends
+      // that share the same storageKey. Only process each storage
+      // field once per save, and when a specific end was rendered in
+      // the UI for this field (via assocEndByField), use that end so
+      // multiplicity and labels match the controls.
+      if (processedAssocFields[fieldName]) {
+        return;
+      }
+      processedAssocFields[fieldName] = true;
+
+      if (assocEndByField && assocEndByField[fieldName]) {
+        end = assocEndByField[fieldName];
+      }
+
       // If this association end does not have any visible controls in the
       // current form (for example, when we intentionally hide the reverse
       // side of a one-to-many), then preserve the existing stored value
@@ -3822,28 +4129,31 @@ Page.openCrudDialogForClass = function(className) {
         $checks.each(function() {
           selectedArray.push(jQuery(this).val());
         });
-        var indices = [];
+        var refs = [];
         selectedArray.forEach(function(v) {
           if (v === "") { return; }
-          var idx = parseInt(v, 10);
-          if (!isNaN(idx)) {
-            indices.push(idx);
-          }
+          var ref = Page.decodeCrudAssocRef(v, end.toClass);
+          if (!ref) { return; }
+          refs.push(ref);
         });
 
         // Reflexive constraint: prevent self-reference in many-valued
         // self-associations (e.g., Territory borders itself).
         if (end.fromClass === end.toClass) {
-          var selfPos = indices.indexOf(index);
-          if (selfPos !== -1) {
-            indices.splice(selfPos, 1);
-            errors.push("An instance of " + className + " cannot be associated with itself for association " + end.assocName + ".");
-          }
+          var filtered = [];
+          refs.forEach(function(r) {
+            if (r.className === className && r.index === index) {
+              errors.push("An instance of " + className + " cannot be associated with itself for association " + end.assocName + ".");
+            } else {
+              filtered.push(r);
+            }
+          });
+          refs = filtered;
         }
 
-        newInst[fieldName] = indices;
+        newInst[fieldName] = refs;
 
-        var count = indices.length;
+        var count = refs.length;
         var relationLabel = end.cascadeDeleteTargets ? "composition" : "association";
         // Do not block save when mandatory associations are underfilled;
         // rely on global validation to surface multiplicity issues.
@@ -3859,8 +4169,8 @@ Page.openCrudDialogForClass = function(className) {
           // validation will report missing links.
           newInst[fieldName] = null;
         } else {
-          var idxSingle = parseInt(val, 10);
-          if (isNaN(idxSingle)) {
+          var refSingle = Page.decodeCrudAssocRef(val, end.toClass);
+          if (!refSingle || typeof refSingle.index !== "number" || refSingle.index < 0) {
             if (minRequired >= 1) {
               var relationLabelInvalid = end.cascadeDeleteTargets ? "composition" : "association";
               errors.push("Invalid selection for " + relationLabelInvalid + " " + end.assocName + ".");
@@ -3868,12 +4178,12 @@ Page.openCrudDialogForClass = function(className) {
             newInst[fieldName] = null;
           } else {
             // Reflexive constraint: prevent self-reference.
-            if (end.fromClass === end.toClass && idxSingle === index) {
+            if (end.fromClass === end.toClass && refSingle.className === className && refSingle.index === index) {
               var relationLabelSelf = end.cascadeDeleteTargets ? "composition" : "association";
               errors.push("An instance of " + className + " cannot be associated with itself for " + relationLabelSelf + " " + end.assocName + ".");
               newInst[fieldName] = null;
             } else {
-            newInst[fieldName] = idxSingle;
+            newInst[fieldName] = refSingle;
               // With a single-select, we can only ever have 0 or 1; enforce
               // any max bound < 1 as an error, and otherwise accept.
               if (maxAllowed !== null && maxAllowed < 1) {
@@ -3905,9 +4215,16 @@ Page.openCrudDialogForClass = function(className) {
         multiple = false;
       }
       if (multiple) { return; }
-      var value = newInst[end.storageKey];
-      if (typeof value !== "number") { return; }
-      Page.checkCrudReflexiveHierarchyCycle(className, instancesForCycleCheck, end, index, value, errors);
+      var rawVal = newInst[end.storageKey];
+      var refsForParent = Page.normalizeCrudAssociationRefs
+        ? Page.normalizeCrudAssociationRefs(end, rawVal)
+        : [];
+      if (!refsForParent.length) { return; }
+      var parentRef = refsForParent[0];
+      if (!parentRef || parentRef.className !== className || typeof parentRef.index !== "number") {
+        return;
+      }
+      Page.checkCrudReflexiveHierarchyCycle(className, instancesForCycleCheck, end, index, parentRef.index, errors);
     });
 
     // First, show any local validation errors for the currently edited
@@ -4448,11 +4765,13 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
 
       var assocName = assoc.name || (classOneName + "__" + classTwoName);
 
-      // For self-reflexive associations, detect hierarchical patterns
-      // where one end is many and the other is single (e.g.,
-      // FunctionalArea child * <-> 0..1 parent). These should not have
-      // symmetric reverse links in the CRUD UI; children store a parent,
-      // while parents derive their children.
+      // For self-reflexive associations, detect hierarchical or
+      // directional patterns where one end is many and the other is
+      // single (e.g., FunctionalArea child * <-> 0..1 parent, or
+      // Person 0..1 mentor -- 0..* Person). These should not have
+      // symmetric reverse links in the CRUD UI; the "many" side stores
+      // a single link to the "one" side, while the "one" side derives
+      // its linked instances by scanning those references.
       var isReflexive = (classOneName === classTwoName);
       var multOneHasStar = multOne && multOne.indexOf("*") !== -1;
       var multTwoHasStar = multTwo && multTwo.indexOf("*") !== -1;
@@ -4496,13 +4815,17 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
           }
         } else {
           if (direction === "one-to-two") {
-            // From classOne to classTwo
-            roleName = assoc.roleTwo || assoc.roleOne || "";
-            oppositeRoleName = assoc.roleOne || assoc.roleTwo || "";
+            // From classOne to classTwo: the targets are seen using
+            // the role defined on the classTwo end. Do not fall back
+            // to the opposite role when one side is unnamed; this keeps
+            // missing roles as empty strings instead of duplicating
+            // names like "mentee" on both sides.
+            roleName = assoc.roleTwo || "";
+            oppositeRoleName = assoc.roleOne || "";
           } else if (direction === "two-to-one") {
             // From classTwo to classOne
-            roleName = assoc.roleOne || assoc.roleTwo || "";
-            oppositeRoleName = assoc.roleTwo || assoc.roleOne || "";
+            roleName = assoc.roleOne || "";
+            oppositeRoleName = assoc.roleTwo || "";
           }
         }
 

--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -33,6 +33,133 @@ Page.resetCrudData = function() {
   Page.crudAssociationLabelPreference = {};
 };
 
+// Validate that key attributes for a single instance (within a class)
+// are not left blank. This is used for per-form validation when saving
+// an instance so that key fields are always populated.
+Page.validateCrudKeysForInstanceLocal = function(className, instance, keyAttributes) {
+  var messages = [];
+
+  if (!instance || !Array.isArray(keyAttributes) || !keyAttributes.length) {
+    return messages;
+  }
+
+  keyAttributes.forEach(function(attrName) {
+    if (!attrName) { return; }
+    var value = instance[attrName];
+    var isEmpty = (typeof value === "undefined" || value === null || value === "");
+    if (!isEmpty && Array.isArray(value)) {
+      isEmpty = value.length === 0;
+    }
+
+    if (isEmpty) {
+      messages.push("Please enter a value for key attribute '" + attrName + "' in class '" + className + "'.");
+    }
+  });
+
+  return messages;
+};
+
+// Validate that the new or edited instance does not duplicate the
+// value of any key within the same class. When a single key attribute
+// is defined, uniqueness is enforced per attribute. When multiple
+// attributes are listed as keys, they form a composite key and
+// uniqueness is enforced on the combination of their values.
+Page.validateCrudKeyUniquenessForClassLocal = function(className, index, isEdit, newInst) {
+  var messages = [];
+
+  if (!Page.crudData || !Page.crudData.classes || !className || !newInst) {
+    return messages;
+  }
+
+  var classInfo = Page.crudData.classes[className];
+  if (!classInfo) { return messages; }
+
+  var keyAttrs = Array.isArray(classInfo.keys) ? classInfo.keys : [];
+  if (!keyAttrs.length) { return messages; }
+
+  var instances = classInfo.instances || [];
+
+  // Helper to normalize a value for key comparison
+  var normalizeVal = function(v) {
+    if (v === undefined || v === null || v === "") { return null; }
+    if (Array.isArray(v)) {
+      return v.length ? v.join(",") : null;
+    }
+    return String(v);
+  };
+
+  // Single-attribute key: preserve existing behaviour
+  if (keyAttrs.length === 1) {
+    var singleAttr = keyAttrs[0];
+    if (!singleAttr) { return messages; }
+    var newValSingle = normalizeVal(newInst[singleAttr]);
+    if (newValSingle === null) {
+      return messages;
+    }
+
+    for (var i = 0; i < instances.length; i++) {
+      if (isEdit && i === index) { continue; }
+      var otherInst = instances[i];
+      if (!otherInst) { continue; }
+      var otherValSingle = normalizeVal(otherInst[singleAttr]);
+      if (otherValSingle === null) { continue; }
+      if (otherValSingle === newValSingle) {
+        var labelSingle = className + "[" + (i + 1) + "]";
+        messages.push(
+          "The value for key attribute '" + singleAttr + "' already exists on " + labelSingle + ". " +
+          "Please enter a unique value because '" + singleAttr + "' is defined as a key."
+        );
+        break;
+      }
+    }
+    return messages;
+  }
+
+  // Composite key: enforce uniqueness on the combination of all key attributes.
+  var keyListText = keyAttrs.join(", ");
+  var newParts = [];
+  for (var k = 0; k < keyAttrs.length; k++) {
+    var aName = keyAttrs[k];
+    if (!aName) { return messages; }
+    var part = normalizeVal(newInst[aName]);
+    if (part === null) {
+      // If any part is missing, rely on the "required key" check instead.
+      return messages;
+    }
+    newParts.push(part);
+  }
+  var newComposite = newParts.join("||");
+
+  for (var j = 0; j < instances.length; j++) {
+    if (isEdit && j === index) { continue; }
+    var otherInstance = instances[j];
+    if (!otherInstance) { continue; }
+    var otherParts = [];
+    var skipOther = false;
+    for (var m = 0; m < keyAttrs.length; m++) {
+      var aNameOther = keyAttrs[m];
+      var partOther = normalizeVal(otherInstance[aNameOther]);
+      if (partOther === null) {
+        skipOther = true;
+        break;
+      }
+      otherParts.push(partOther);
+    }
+    if (skipOther) { continue; }
+    var otherComposite = otherParts.join("||");
+    if (otherComposite === newComposite) {
+      var labelComp = className + "[" + (j + 1) + "]";
+      messages.push(
+        "The combination of key attributes '" + keyListText + "' already exists on " + labelComp + ". " +
+        "Please enter a unique combination because these attributes form a composite key."
+      );
+      break;
+    }
+  }
+
+  return messages;
+};
+
 // Updates instance count for each class
 Page.updateCrudClassCount = function(className) {
   if (!Page.crudData || !Page.crudData.classes || !Page.crudData.classes[className]) {
@@ -710,6 +837,101 @@ Page.adjustCrudAttributesForTypeChanges = function(oldCrudData) {
   });
 };
 
+// When an attribute's type remains an enum but one or more enum literals
+// are removed from the model (for example, "FullTime" is deleted from
+// enum Status { FullTime, PartTime }), clear any existing CRUD values that
+// still reference those removed literals. This prevents stale, now-invalid
+// enum values from lingering in instance data and makes the change visible
+// via an informational adjustment message.
+Page.adjustCrudEnumValuesForRemovedOptions = function() {
+  if (!Page.crudData || !Page.crudData.classes || !Page.resolveCrudEnumOptions) {
+    return;
+  }
+
+  var classesData = Page.crudData.classes;
+
+  Object.keys(classesData).forEach(function(className) {
+    var classInfo = classesData[className];
+    if (!classInfo || !Array.isArray(classInfo.instances) || !Array.isArray(classInfo.attributes)) {
+      return;
+    }
+
+    var instances = classInfo.instances;
+    if (!instances.length) { return; }
+
+    classInfo.attributes.forEach(function(attr) {
+      if (!attr || !attr.name || !attr.type) { return; }
+
+      var attrName = attr.name;
+      var rawType = attr.type;
+      var typeInfo = Page.getCrudTypeInfo(rawType);
+
+      // Only consider non-class enum attributes here. Arrays of enums
+      // are supported by treating the stored value as an array of
+      // strings and dropping any elements that are no longer valid.
+      if (typeInfo && typeInfo.base && !typeInfo.isClass) {
+        var enumOptions = Page.resolveCrudEnumOptions(rawType);
+        if (!enumOptions || !enumOptions.length) {
+          return;
+        }
+
+        var allowed = {};
+        enumOptions.forEach(function(opt) {
+          if (opt !== null && typeof opt !== "undefined") {
+            allowed[String(opt)] = true;
+          }
+        });
+
+        var adjustedInstances = 0;
+
+        instances.forEach(function(inst) {
+          if (!inst || !Object.prototype.hasOwnProperty.call(inst, attrName)) {
+            return;
+          }
+          var v = inst[attrName];
+          if (typeof v === "undefined" || v === null || v === "") {
+            return;
+          }
+
+          if (Array.isArray(v)) {
+            var kept = [];
+            v.forEach(function(elem) {
+              var key = String(elem);
+              if (allowed[key]) {
+                kept.push(elem);
+              }
+            });
+
+            if (kept.length === v.length) {
+              return; // no change for this instance
+            }
+
+            if (kept.length > 0) {
+              inst[attrName] = kept;
+            } else {
+              delete inst[attrName];
+            }
+            adjustedInstances++;
+          } else {
+            var keySingle = String(v);
+            if (allowed[keySingle]) {
+              return; // still valid
+            }
+            delete inst[attrName];
+            adjustedInstances++;
+          }
+        });
+
+        if (adjustedInstances > 0 && Array.isArray(Page.crudAdjustmentMessages)) {
+          var msg = "Info: Enum attribute '" + attrName + "' in class '" + className + "' contained values for removed enum literal(s). " +
+                    "Those values were cleared from " + adjustedInstances + " instance(s).";
+          Page.crudAdjustmentMessages.push(msg);
+        }
+      }
+    });
+  });
+};
+
 // When a class has effectively been renamed (old class name removed,
 // new class name added) and its associations to other classes are the
 // same, preserve existing association links by moving values from the
@@ -919,6 +1141,7 @@ Page.validateCrudGlobalModel = function(pendingUpdate) {
   var classesData = Page.crudData.classes;
   var totalViolations = 0;
 
+  // Association multiplicity validation
   for (var fromClass in Page.crudAssociationsByClass) {
     if (!Page.crudAssociationsByClass.hasOwnProperty(fromClass)) { continue; }
 
@@ -1072,6 +1295,128 @@ Page.validateCrudGlobalModel = function(pendingUpdate) {
         }
       }
     });
+  }
+
+  // Key uniqueness validation: ensure that, for each class, keys are unique.
+  // When a single key attribute is defined, uniqueness is enforced per
+  // attribute. When multiple attributes are listed as keys, they form a
+  // composite key and uniqueness is enforced on the combination of their
+  // values.
+  for (var className in classesData) {
+    if (!classesData.hasOwnProperty(className)) { continue; }
+
+    var classInfoKeys = classesData[className];
+    if (!classInfoKeys) { continue; }
+
+    var keyAttrs = Array.isArray(classInfoKeys.keys) ? classInfoKeys.keys : [];
+    if (!keyAttrs.length) { continue; }
+
+    var baseInstancesK = classInfoKeys.instances || [];
+    var baseCountK = baseInstancesK.length;
+
+    var isPendingForClassK = !!(pendingUpdate && pendingUpdate.className === className && pendingUpdate.newInst);
+    var virtualExtraK = (isPendingForClassK && !pendingUpdate.isEdit) ? 1 : 0;
+    var virtualCountK = baseCountK + virtualExtraK;
+
+    // Helper to normalize a value for key comparison
+    var normalizeValK = function(v) {
+      if (v === undefined || v === null || v === "") { return null; }
+      if (Array.isArray(v) && v.length === 0) { return null; }
+      if (Array.isArray(v)) { return v.join(","); }
+      return String(v);
+    };
+
+    var singleKeyMode = (keyAttrs.length === 1);
+    var seenByAttr = {};
+    var duplicateReportedByAttr = {};
+    var seenComposite = {};
+    var compositeDuplicateReported = false;
+
+    if (singleKeyMode) {
+      var onlyAttr = keyAttrs[0];
+      if (onlyAttr) {
+        seenByAttr[onlyAttr] = {};
+        duplicateReportedByAttr[onlyAttr] = false;
+      }
+    } else {
+      // Composite key mode: use seenComposite map instead of seenByAttr
+      keyAttrs.forEach(function(attrName) {
+        if (!attrName) { return; }
+        // still initialise maps so later code can rely on them if needed
+        seenByAttr[attrName] = {};
+        duplicateReportedByAttr[attrName] = false;
+      });
+    }
+
+    for (var iK = 0; iK < virtualCountK; iK++) {
+      var instK;
+      if (isPendingForClassK) {
+        if (!pendingUpdate.isEdit && iK === baseCountK) {
+          instK = pendingUpdate.newInst;
+        } else if (pendingUpdate.isEdit && iK === pendingUpdate.index) {
+          instK = pendingUpdate.newInst;
+        } else {
+          instK = baseInstancesK[iK];
+        }
+      } else {
+        instK = baseInstancesK[iK];
+      }
+
+      if (!instK) { continue; }
+
+      if (singleKeyMode) {
+        var attrNameSingle = keyAttrs[0];
+        if (attrNameSingle) {
+          var vSingle = normalizeValK(instK[attrNameSingle]);
+          if (vSingle !== null) {
+            var seenMapSingle = seenByAttr[attrNameSingle];
+            if (seenMapSingle && seenMapSingle[vSingle]) {
+              totalViolations += 1;
+              if (!duplicateReportedByAttr[attrNameSingle]) {
+                duplicateReportedByAttr[attrNameSingle] = true;
+                var labelSingleK = className + "[" + (iK + 1) + "]";
+                errors.push(
+                  "The value for key attribute '" + attrNameSingle + "' in " + labelSingleK + " already exists. " +
+                  "Please enter a unique value because '" + attrNameSingle + "' is defined as a key."
+                );
+              }
+            } else if (seenMapSingle) {
+              seenMapSingle[vSingle] = true;
+            }
+          }
+        }
+      } else {
+        // Composite key: build tuple across all key attributes for this instance
+        var partsK = [];
+        var missingPart = false;
+        for (var a = 0; a < keyAttrs.length; a++) {
+          var aNameK = keyAttrs[a];
+          if (!aNameK) { continue; }
+          var vPart = normalizeValK(instK[aNameK]);
+          if (vPart === null) {
+            missingPart = true;
+            break;
+          }
+          partsK.push(vPart);
+        }
+        if (!missingPart && partsK.length === keyAttrs.length) {
+          var tupleKey = partsK.join("||");
+          if (seenComposite[tupleKey]) {
+            totalViolations += 1;
+            if (!compositeDuplicateReported) {
+              compositeDuplicateReported = true;
+              var labelCompK = className + "[" + (iK + 1) + "]";
+              errors.push(
+                "The combination of key attributes '" + keyAttrs.join(", ") + "' in " + labelCompK + " already exists. " +
+                "Please enter a unique combination because these attributes form a composite key."
+              );
+            }
+          } else {
+            seenComposite[tupleKey] = true;
+          }
+        }
+      }
+    }
   }
 
   // De-duplicate messages so the same textual error is only shown once.
@@ -1933,7 +2278,7 @@ Page.initCrudUi = function(tabnumber, containerSelector) {
   Page.currentCrudContainer = container;
 
   // Add JSON persistence controls once per container
-  if (container.find(".crud-json-actions").length === 0) {
+    if (container.find(".crud-json-actions").length === 0) {
       var jsonHtml = "<div class='crud-json-actions' style='margin:6px 0 10px 0;'>" +
         "<div class='crud-json-row'>" +
         "<button type='button' id='crud-generate-json' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:6px;'>Download JSON</button>" +
@@ -1949,6 +2294,28 @@ Page.initCrudUi = function(tabnumber, containerSelector) {
       "</div>";
     container.prepend(jsonHtml);
 
+    // Helper to show or hide an informational message related to
+    // instance-diagram or random-data issues within this CRUD panel.
+    function showInstanceDiagramMessage(message) {
+      var $existingErr = container.find(".crud-instance-diagram-error");
+      if ($existingErr.length === 0) {
+        var jsonRow = container.find(".crud-json-actions");
+        var htmlErr = "<div class='crud-instance-diagram-error' style='color:red;margin:6px 0 10px 0;'></div>";
+        if (jsonRow.length) {
+          jsonRow.after(htmlErr);
+          $existingErr = container.find(".crud-instance-diagram-error");
+        } else {
+          $existingErr = jQuery(htmlErr).prependTo(container);
+        }
+      }
+
+      if (message) {
+        $existingErr.text(message).show();
+      } else {
+        $existingErr.hide().text("");
+      }
+    }
+
     // Wire up JSON buttons
     container.find("#crud-generate-json").off("click").on("click", function() {
       if (typeof Page.crudJsonDownload === "function") {
@@ -1956,18 +2323,12 @@ Page.initCrudUi = function(tabnumber, containerSelector) {
       }
     });
 
-    // Ask the backend Instance Diagram generator for random data and
-    // import the returned JSON using the same path as "Load JSON".
-    container.find("#crud-generate-random-data").off("click").on("click", function() {
-      if (typeof Page.getUmpleCode !== "function") {
-        console.warn("No Umple code available for random data generation.");
-        return;
-      }
-      var code = Page.getUmpleCode() || "";
-      if (!code) {
-        console.warn("Umple code is empty; cannot generate random data.");
-        return;
-      }
+    // Internal helper to call the backend Instance Diagram generator
+    // for random data, with limited automatic retries when the
+    // generator reports an empty diagram.
+    function requestRandomCrudData(code, attempt) {
+      var currentAttempt = attempt || 1;
+      var maxAutoRetries = 2; // one automatic retry after the first failure
 
       jQuery.ajax({
         url: "scripts/crud_random_data.php",
@@ -1979,6 +2340,36 @@ Page.initCrudUi = function(tabnumber, containerSelector) {
         },
         dataType: "text",
         success: function(resp) {
+          var parsed;
+          var isEmptyDiagram = false;
+          try {
+            parsed = JSON.parse(resp);
+            if (parsed && parsed.diagramIsEmpty) {
+              isEmptyDiagram = true;
+            }
+          } catch (e) {
+            // Non-JSON response; fall through to normal import path.
+          }
+
+          if (isEmptyDiagram) {
+            // The Instance Diagram generator did not produce any
+            // instances for this model. Perform a limited automatic
+            // retry without immediately flashing an error message to
+            // avoid flicker when a subsequent attempt succeeds. Only
+            // show the informational message after the final retry
+            // has also failed.
+            if (currentAttempt < maxAutoRetries) {
+              requestRandomCrudData(code, currentAttempt + 1);
+            } else {
+              showInstanceDiagramMessage("There is an issue generating random data. Please try again.");
+            }
+            return;
+          }
+
+          // Successful random data generation: clear any previous
+          // informational message and import using the normal path.
+          showInstanceDiagramMessage("");
+
           if (typeof Page.crudJsonImportFromText === "function") {
             Page.crudJsonImportFromText(resp);
             // After import, (re)open a CRUD dialog. Prefer the class
@@ -2001,13 +2392,28 @@ Page.initCrudUi = function(tabnumber, containerSelector) {
               Page.crudClassSelected = targetClass;
               Page.openCrudDialogForClass(targetClass);
             }
-            
-          } 
+          }
         },
         error: function(xhr, status, err) {
           console.error("Failed to generate random instance data:", status, err, xhr && xhr.responseText);
         }
       });
+    }
+
+    // Ask the backend Instance Diagram generator for random data and
+    // import the returned JSON using the same path as "Load JSON".
+    container.find("#crud-generate-random-data").off("click").on("click", function() {
+      if (typeof Page.getUmpleCode !== "function") {
+        console.warn("No Umple code available for random data generation.");
+        return;
+      }
+      var code = Page.getUmpleCode() || "";
+      if (!code) {
+        console.warn("Umple code is empty; cannot generate random data.");
+        return;
+      }
+
+      requestRandomCrudData(code, 1);
     });
 
     container.find("#crud-load-json").off("click").on("click", function() {
@@ -2466,33 +2872,6 @@ Page.openCrudDialogForClass = function(className) {
     container.append($panel);
   }
 
-  // If this class has mandatory (multiplicity 1) navigable associations to other
-  // classes (min bound > 0), and there are currently too few instances of those
-  // target classes to ever satisfy the multiplicity, prevent creating instances
-  // and instruct the user to create required ones first.
-  if (assocEnds.length > 0) {
-    var missingRequiredTargets = [];
-    assocEnds.forEach(function(end) {
-      var minRequired = (typeof end.toMin === "number") ? end.toMin : 0;
-      if (minRequired <= 0) { return; }
-      var targetInfo = Page.crudData.classes[end.toClass];
-      var targetInstances = (targetInfo && targetInfo.instances) || [];
-      if (targetInstances.length < minRequired) {
-        if (missingRequiredTargets.indexOf(end.toClass) === -1) {
-          missingRequiredTargets.push(end.toClass);
-        }
-      }
-    });
-    if (missingRequiredTargets.length > 0 && instances.length === 0) {
-      var msgHtml = "<div class='crud-dialog-content'>";
-      msgHtml += "<h3>" + className + "</h3>";
-      msgHtml += "<p>To create " + className + " instances, first create the following: " + missingRequiredTargets.join(", ") + ".</p>";
-      msgHtml += "</div>";
-      $panel.html(msgHtml);
-      return;
-    }
-  }
-
   var html = "<div class='crud-dialog-content'>";
   html += "<h3 style='margin-bottom:8px;'>" + className + " instances (" + instances.length + ")</h3>";
 
@@ -2569,14 +2948,22 @@ Page.openCrudDialogForClass = function(className) {
   html += "<div class='crud-error' style='color:red;margin-bottom:6px;display:none;'></div>";
   html += "<form id='crud-instance-form' data-class='" + className + "'>";
   html += "<input type='hidden' name='instanceIndex' value='' />";
+  var keyAttrsForClass = (Page.crudData && Page.crudData.classes && Page.crudData.classes[className] && Array.isArray(Page.crudData.classes[className].keys))
+    ? Page.crudData.classes[className].keys
+    : [];
 
   attrs.forEach(function(attr) {
     var attrName = attr.name;
     var typeInfo = Page.getCrudTypeInfo(attr.type);
     if (!attrName) { return; }
+    var isKeyAttr = keyAttrsForClass.indexOf(attrName) !== -1;
     html += "<div class='crud-field'>";
     var tooltipHtml = Page.buildCrudTooltip(attrName, attr.type, attr.inheritedFrom);
-    html += "<label class='crud-field-label'><span class='crud-tooltip-target' data-crud-tooltip-html=\"" + tooltipHtml + "\">" + attrName + "</span></label>";
+    html += "<label class='crud-field-label'><span class='crud-tooltip-target' data-crud-tooltip-html=\"" + tooltipHtml + "\">" + attrName + "</span>";
+    if (isKeyAttr) {
+      html += "<span class='crud-key-required-asterisk' style='color:red;' title='Key attribute (required and must be unique)'>*</span>";
+    }
+    html += "</label>";
     html += Page.buildCrudInputHtml(attrName, typeInfo);
 
     html += "</div>";
@@ -2800,7 +3187,7 @@ Page.openCrudDialogForClass = function(className) {
       // If there are no target instances and multiplicity requires one, hint to create them first
       if (targetInstances.length < minRequired && minRequired > 0) {
         html += "<div class='crud-association-hint' style='margin-top:4px;color:#a00;'>" +
-                "Not enough " + targetClass + " instances exist. Create more before adding " + className + "." +
+                "Not enough " + targetClass + " instances exist. Create more before adding " + className + ". " + "If this is a cyclic association, please proceed to click Save, the error messages will guide you."+
                 "</div>";
       }
 
@@ -2810,6 +3197,9 @@ Page.openCrudDialogForClass = function(className) {
 
   html += "<div class='crud-form-actions' style='margin-top:8px;'>";
   html += "<button type='button' id='crud-save-instance' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button primary' style='margin-right:8px;'>Save</button>";
+  // Cancel button is initially hidden and is only shown when editing an
+  // existing instance (instanceIndex is non-empty).
+  html += "<button type='button' id='crud-cancel-edit-instance' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button' style='margin-right:8px;display:none;'>Cancel Edit</button>";
   html += "<button type='button' id='crud-clear-instances' class='jQuery-palette-button ui-button ui-corner-all ui-widget crud-form-button'>Clear all " + className + "</button>";
   html += "</div>";
   html += "</form>";
@@ -2896,8 +3286,9 @@ Page.openCrudDialogForClass = function(className) {
 
   // Handle action dropdown selection for each instance row
   $panel.on("change", ".crud-instance-action", function() {
-    var action = jQuery(this).val();
-    var index = jQuery(this).data("index");
+    var $select = jQuery(this);
+    var action = $select.val();
+    var index = $select.data("index");
     if (!action) {
       return;
     }
@@ -2913,9 +3304,12 @@ Page.openCrudDialogForClass = function(className) {
     // For Edit, keep the dropdown showing Edit to reflect current mode.
     // For other actions, reset back to the placeholder.
     if (action === "edit") {
-      jQuery(this).val("edit");
+      // Ensure only the currently edited row shows "Edit" in its
+      // dropdown; reset all others back to the placeholder.
+      $panel.find(".crud-instance-action").not($select).val("");
+      $select.val("edit");
     } else {
-      jQuery(this).val("");
+      $select.val("");
     }
   });
 
@@ -2933,6 +3327,13 @@ Page.openCrudDialogForClass = function(className) {
     var inst = instancesCurrent[index] || {};
     var $form = $panel.find("#crud-instance-form");
     $form.find("input[name='instanceIndex']").val(index);
+
+    // When editing an existing instance, show the Cancel Edit button so
+    // the user has an explicit way to abandon in-progress changes.
+    var $cancelBtn = $panel.find("#crud-cancel-edit-instance");
+    if ($cancelBtn.length) {
+      $cancelBtn.show();
+    }
 
     attrsCurrent.forEach(function(attr) {
       var attrName = attr.name;
@@ -3299,6 +3700,23 @@ Page.openCrudDialogForClass = function(className) {
     }
   });
 
+  // When focus is inside a single-line field (text, number, etc.),
+  // prevent the Enter key from submitting the form or navigating to
+  // a new URL. Saving remains an explicit button click.
+  $panel.on("keydown", "#crud-instance-form input[type='text'], #crud-instance-form input[type='number'], #crud-instance-form input[type='date'], #crud-instance-form input[type='time'], #crud-instance-form input[type='datetime-local'], #crud-instance-form input[type='email'], #crud-instance-form input[type='url'], #crud-instance-form input[type='search'], #crud-instance-form input[type='tel']", function(evt) {
+    if (!evt) { return; }
+    var key = evt.which || evt.keyCode;
+    if (key === 13) { // Enter
+      if (typeof evt.preventDefault === "function") {
+        evt.preventDefault();
+      }
+      if (typeof evt.stopPropagation === "function") {
+        evt.stopPropagation();
+      }
+      return false;
+    }
+  });
+
   // Save instance (new or edited)
   $panel.on("click", "#crud-save-instance", function() {
     Page.currentCrudContainer = $panel.parent();
@@ -3356,6 +3774,21 @@ Page.openCrudDialogForClass = function(className) {
       }
     });
 
+    // Enforce that key attributes are always populated for this
+    // instance before processing associations.
+    var keyAttrsForClass = Array.isArray(currentClassInfo.keys) ? currentClassInfo.keys : [];
+    var keyRequiredErrors = Page.validateCrudKeysForInstanceLocal(className, newInst, keyAttrsForClass);
+    if (keyRequiredErrors.length > 0) {
+      errors = errors.concat(keyRequiredErrors);
+    }
+
+    // Enforce that key attributes remain unique within this class
+    // before processing associations or global validation.
+    var keyDuplicateErrors = Page.validateCrudKeyUniquenessForClassLocal(className, index, isEdit, newInst);
+    if (keyDuplicateErrors.length > 0) {
+      errors = errors.concat(keyDuplicateErrors);
+    }
+
     // Associations: enforce multiplicity rules and capture selected links
     assocEnds.forEach(function(end) {
       var fieldName = end.storageKey;
@@ -3412,13 +3845,8 @@ Page.openCrudDialogForClass = function(className) {
 
         var count = indices.length;
         var relationLabel = end.cascadeDeleteTargets ? "composition" : "association";
-        if (minRequired > 0 && count < minRequired) {
-          var remaining = minRequired - count;
-          if (remaining > 0) {
-            var instanceLabel = remaining === 1 ? " instance" : " instances";
-            errors.push("Please select " + remaining + " more " + end.toClass + instanceLabel + " for " + relationLabel + " " + end.assocName + ".");
-          }
-        }
+        // Do not block save when mandatory associations are underfilled;
+        // rely on global validation to surface multiplicity issues.
         if (maxAllowed !== null && count > maxAllowed) {
           errors.push("Please select at most " + maxAllowed + " " + end.toClass + " instance(s) for " + relationLabel + " " + end.assocName + ".");
         }
@@ -3427,11 +3855,8 @@ Page.openCrudDialogForClass = function(className) {
         var $radio = $form.find("input[type='radio'][name='" + fieldName + "']:checked");
         var val = $radio.length ? $radio.val() : "";
         if (!val || val === "") {
-          // If min bound is >= 1, this link is mandatory
-          if (minRequired >= 1) {
-            var relationLabelSingle = end.cascadeDeleteTargets ? "composition" : "association";
-            errors.push("Please select a " + end.toClass + " for " + relationLabelSingle + " " + end.assocName + ".");
-          }
+          // Leave mandatory-single associations empty locally; global
+          // validation will report missing links.
           newInst[fieldName] = null;
         } else {
           var idxSingle = parseInt(val, 10);
@@ -3463,7 +3888,16 @@ Page.openCrudDialogForClass = function(className) {
 
     // For hierarchical self-reflexive associations (like FunctionalArea
     // parent/child), ensure that choosing a parent does not introduce a
-    // parent-child cycle.
+    // parent-child cycle. Use a snapshot that includes the pending
+    // change for this instance so newly introduced cycles are caught
+    // locally before saving.
+    var instancesForCycleCheck = instancesCurrent.slice();
+    if (isEdit && index >= 0 && index < instancesForCycleCheck.length) {
+      instancesForCycleCheck[index] = newInst;
+    } else if (!isEdit && index === instancesForCycleCheck.length) {
+      instancesForCycleCheck.push(newInst);
+    }
+
     assocEnds.forEach(function(end) {
       if (end.fromClass !== end.toClass) { return; }
       var multiple = true;
@@ -3473,20 +3907,22 @@ Page.openCrudDialogForClass = function(className) {
       if (multiple) { return; }
       var value = newInst[end.storageKey];
       if (typeof value !== "number") { return; }
-      Page.checkCrudReflexiveHierarchyCycle(className, instancesCurrent, end, index, value, errors);
+      Page.checkCrudReflexiveHierarchyCycle(className, instancesForCycleCheck, end, index, value, errors);
     });
 
     // First, show any local validation errors for the currently edited
-    // instance (attributes, association choices, reflexive cycles).
+    // instance (attributes, key constraints, association choices,
+    // reflexive cycles). Local errors block saving.
     if (errors.length > 0) {
       $error.text(errors.join(" ")).show();
+      return;
     }
 
     // Next, validate the entire CRUD model (all classes and instances)
     // using a snapshot that includes this pending change. This allows
-    // us to catch conflicts introduced by association updates, such as
-    // adding a new mandatory association for a class that already has
-    // existing instances without those links.
+    // us to surface conflicts introduced by association updates or
+    // global key constraints. Global errors are reported but do not
+    // prevent saving; they are primarily summarized in the banner.
     var globalErrors = Page.validateCrudGlobalModel({
       className: className,
       index: index,
@@ -3533,6 +3969,59 @@ Page.openCrudDialogForClass = function(className) {
     Page.crudData.classes[className].instances = [];
     Page.updateCrudClassCount(className);
     Page.openCrudDialogForClass(className);
+  });
+
+  // Cancel editing the current instance: clear the form fields, reset
+  // edit state back to "add new" (no instanceIndex), hide the Cancel
+  // button, and reset the per-instance action dropdown.
+  $panel.on("click", "#crud-cancel-edit-instance", function() {
+    var $form = $panel.find("#crud-instance-form");
+    if (!$form.length) { return; }
+
+    // Reset hidden index so Save will create a new instance instead of
+    // overwriting an existing one.
+    $form.find("input[name='instanceIndex']").val("");
+
+    // Clear all attribute inputs within this form.
+    $form.find("input[type='text'], input[type='number'], input[type='date'], input[type='time'], input[type='datetime-local'], input[type='email'], input[type='url'], input[type='search'], input[type='tel'], textarea").val("");
+    $form.find("input[type='checkbox'], input[type='radio']").prop("checked", false);
+    // Reset select elements that store instance attribute/association
+    // values, but do NOT touch the small "Label for {Class} options"
+    // dropdowns that control how association options are labelled
+    // globally (those have class 'crud-assoc-label-select').
+    $form.find("select").not(".crud-assoc-label-select").each(function() {
+      var $sel = jQuery(this);
+      // Prefer an explicit empty option if present; otherwise fall back
+      // to the first option.
+      if ($sel.find("option[value='']").length) {
+        $sel.val("");
+      } else {
+        var firstVal = $sel.find("option").first().val();
+        $sel.val(firstVal);
+      }
+    });
+
+    // Clear any inline error messages for this form.
+    $panel.find(".crud-error").hide().text("");
+
+    // Hide the Cancel button now that we are no longer editing.
+    jQuery(this).hide();
+
+    // Reset any per-row action dropdowns back to the placeholder. Be
+    // explicit about the selected option to avoid any stale UI state
+    // in the browser.
+    $panel.find(".crud-instance-action").each(function() {
+      var $sel = jQuery(this);
+      // Clear current selection and then force-select the placeholder
+      // option (value="").
+      $sel.find("option").prop("selected", false);
+      $sel.val("");
+      $sel.find("option[value='']").prop("selected", true);
+      // Trigger change so any listeners that depend on the value being
+      // cleared can react, but the handler will exit early since the
+      // value is now empty.
+      $sel.trigger("change");
+    });
   });
 
   // ----- Class array (ClassType[]) element management -----
@@ -3755,6 +4244,11 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
       };
       Page.crudExtendsByClass[className] = cls.extendsClass || null;
 
+      // Capture key attributes for this class, if present. The JSON
+      // generator exposes keys as an array of attribute names.
+      var keysRaw = Array.isArray(cls.keys) ? cls.keys : [];
+      crudMetaByClass[className].keys = keysRaw.slice();
+
       // Capture local enums defined inside this class, if any
       var localEnums = (cls.enums && Array.isArray(cls.enums)) ? cls.enums : [];
       if (localEnums.length > 0) {
@@ -3774,6 +4268,63 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
           }
         });
       }
+    });
+
+    // Resolve key attributes for each class, including those inherited
+    // from ancestor classes in the extends hierarchy. This allows,
+    // for example, a key defined on superclass A to be treated as a
+    // key on subclass B that extends A in the CRUD UI.
+    var resolvedKeys = {};
+    var resolveCrudKeys = function(className, visited) {
+      if (!className || !crudMetaByClass[className]) {
+        return [];
+      }
+      if (resolvedKeys[className]) {
+        return resolvedKeys[className];
+      }
+
+      visited = visited || {};
+      if (visited[className]) {
+        // Cycle guard: fall back to this class's own keys only.
+        var ownOnly = Array.isArray(crudMetaByClass[className].keys)
+          ? crudMetaByClass[className].keys.slice()
+          : [];
+        resolvedKeys[className] = ownOnly;
+        return ownOnly;
+      }
+      visited[className] = true;
+
+      var meta = crudMetaByClass[className];
+      var result = [];
+      var seen = {};
+
+      // First, inherit keys from the parent class (if any).
+      var parentName = meta.extendsClass;
+      if (parentName && crudMetaByClass[parentName]) {
+        var parentKeys = resolveCrudKeys(parentName, visited);
+        parentKeys.forEach(function(k) {
+          if (!k || seen[k]) { return; }
+          seen[k] = true;
+          result.push(k);
+        });
+      }
+
+      // Then add this class's own key attributes, avoiding duplicates.
+      var ownKeys = Array.isArray(meta.keys) ? meta.keys : [];
+      ownKeys.forEach(function(k) {
+        if (!k || seen[k]) { return; }
+        seen[k] = true;
+        result.push(k);
+      });
+
+      resolvedKeys[className] = result;
+      return result;
+    };
+
+    Object.keys(crudMetaByClass).forEach(function(cn) {
+      var meta = crudMetaByClass[cn];
+      if (!meta) { return; }
+      meta.keys = resolveCrudKeys(cn, {});
     });
 
     // Capture global enums from the JSON payload, if any
@@ -4017,9 +4568,15 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
       var resultA = [];
       var seenKeys = {};
 
+      // Build a logical key for an association end that is stable across
+      // inheritance and does not collapse distinct directions of the same
+      // association (important for reflexive associations where both
+      // parent->child and child->parent ends exist). We intentionally
+      // avoid using storageKey here because it omits direction and would
+      // cause one end to overwrite the other when both originate from the
+      // same declaring class.
       var makeKey = function(end) {
         if (!end) { return ""; }
-        if (end.storageKey) { return end.storageKey; }
         return (end.assocId || "") + "::" + (end.toClass || "") + "::" + (end.direction || "");
       };
 
@@ -4227,7 +4784,8 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
         isAbstract: isAbstract,
         // Mark whether this class declares a main() method so that the
         // CRUD JSON exporter can treat it as a root/main class.
-        isMain: !!meta.hasMain
+        isMain: !!meta.hasMain,
+        keys: Array.isArray(meta.keys) ? meta.keys.slice() : []
       };
 
       formHtml += "</form>";
@@ -4252,6 +4810,12 @@ Page.showCrudFromJson = function(jsonText, tabnumber, containerSelector) {
       if (typeof Page.adjustCrudAttributesForTypeChanges === "function") {
         Page.adjustCrudAttributesForTypeChanges(oldCrudData);
       }
+    }
+    // After reconciling attribute renames and type changes, remove any
+    // enum values that reference literals no longer present in the
+    // current model so that stale values do not linger in CRUD data.
+    if (typeof Page.adjustCrudEnumValuesForRemovedOptions === "function") {
+      Page.adjustCrudEnumValuesForRemovedOptions();
     }
     // After reattaching any preserved instances, first normalize
     // association fields for multi-valued ends so that they are always


### PR DESCRIPTION
**The PR is for CRUD UI bug fixes reported by Connor Harrison and Professor Timothy Lethbridge. Below are the issues and their fixes.** 

**Things that should be addressed**
**`Issue 1: Generating random data sometimes results in the following error message occasionally. The selected JSON data is not compatible with the current CRUD model and cannot be loaded into CRUD.`**
**Fix:**
1. When Generate Random data is clicked, Instance diagram generator is called which returns randomly generated data in JSON format. But sometimes the Instance Diagram generator returns a response like this -  "message": "Generated InstanceDiagram is empty. For random diagrams, consider trying again or setting the initial class counts to a constant",
2. Fix made in CRUD:  When the backend returns an empty diagram: The code now silently calls Instance Diagram generator one more time without showing any error. Only if the final retry also reports an empty diagram does the message(“There is an issue generating random data. Please try again.”) appear and stay. If the use clicks on Generate Random data again, the error goes away and new random data is loaded into CRUD.
<img width="468" height="272" alt="image" src="https://github.com/user-attachments/assets/2721af40-0117-4f4c-afcb-d8de5a376451" />

**`Issue 2: Two syntactically equivalent reflexive associations produce different CRUD UI behavior depending on the order the multiplicities are written.`**
Fix: Now both the class associations behave the same
<img width="468" height="187" alt="image" src="https://github.com/user-attachments/assets/cad7257d-c016-4f63-b590-9f399ef85846" />
<img width="468" height="187" alt="image" src="https://github.com/user-attachments/assets/a2e10941-79ed-4068-87cd-4ccb93d0c9e8" />

**`Issue 3: Subclass instances that have associations inherited from a parent class are not included in CRUD UI`**
**Fix:**
Subclass instances are now added to the association section.
<img width="468" height="340" alt="image" src="https://github.com/user-attachments/assets/83b3967f-fd27-40ee-80bf-468ba99a196f" />

**`Issue 4: If you set an enum attribute on an instance, then remove that enum option from the diagram, the instance silently retains the stale value`**
**Fix:** 
Removing a value from enum, will also blank the corresponding field in the instance – if the enum value was used. An info message will also be displayed so the user is aware some fields were blanked (when enum was edited the code editor)
<img width="468" height="187" alt="image" src="https://github.com/user-attachments/assets/5264b173-7f10-45b4-a186-242a026e8e7d" />

**`Issue 5: It is possible to create two instances with the same key value, if my understanding of the key keyword in umple is correct this should not be possible`**
**Fix:** 
The key attributes were not returned in the JSON response by JSON generator. Modified the JSON generator to include key. In CRUD UI - All key attributes are mandatory, cannot be null and must be unique. In case of multiple keys: For eg- key{code, id} -> code+id (composite key) will be considered as key

<img width="468" height="205" alt="image" src="https://github.com/user-attachments/assets/28500d90-5307-4912-aed6-96ac70b7b650" />

**`Issue 6: There is no way (that I found) to stop editing an instance once the 'edit' value in the dropdown has been selected.`**
**Fix**: 
Included Cancel Edit button near Save button to stop editing. The Cancel Edit button only appears if any of the record is in Edit mode, otherwise it stays hidden
<img width="468" height="390" alt="image" src="https://github.com/user-attachments/assets/6aa245e6-1b00-4dd9-a4b1-10a06f1a933b" />


**Things that could be addressed**
**`Issue 1: It is possible for multiple 'edit' dropdowns to be displayed at once `**
**Fix:** 
When Person[1] is being edited and without being saving if Person[2] is chosen to be edited, Person1’s dropdown changes to Select Action (previously it was still showing Edit)

<img width="468" height="79" alt="image" src="https://github.com/user-attachments/assets/730d6a32-9669-4dbf-8acc-5810900e25d9" />

**`Issue2: Setting an instance as its own ancestor fails silently, could have an error message displayed (or not be possible to select itself for an association)`**

**Fix:**
Included error messages that prevent user from saving (if an instance is its own ancestor)
<img width="468" height="213" alt="image" src="https://github.com/user-attachments/assets/0ec86132-5da2-4a4d-8f29-cf13a73409c1" />
<img width="468" height="213" alt="image" src="https://github.com/user-attachments/assets/64c3120a-59e5-4dc8-b323-2e4087b50164" />

**`Issue 3: The only way to create instances when there's a circular mandatory association is via random data generation, could  inform the user in some way or add a work-around`**
**Fix:** 
Removed the constraint that prevented the user from creating instances. Instead if user creates instances without linking mandatory associations, then the error messages will guide the user
<img width="468" height="343" alt="image" src="https://github.com/user-attachments/assets/50eb30e7-8519-4461-a0cd-4303508e7cc9" />
In the above example, Witness cannot exist without Emo and vice versa.. Earlier, CRUD was blocking both classes from creating instances (deadlock situation). Removed the blocking logic. Now the user can create Witness instance, without associating to Emo class (initially). After that, the error messages at the top will guide the user to create Emo instance and associate with Witness instance. (see image below)
<img width="468" height="343" alt="image" src="https://github.com/user-attachments/assets/c67b1217-d2b6-44e0-8af5-927a35b31f8f" />


**`Issue 4:  The CRUD UI can be displayed on the right side of the screen and at the bottom of the screen at the same time, doesn't cause issues with data though`**
**Res**: 
Doesn’t need any change. CRUD UI was designed to be displayed both in Generate menu and live view.

**`Issue 5: When creating/editing an instance hitting enter redirects me to a new URL. Ideally hitting enter is the same as clicking save.`**
**Res:** 
I wasn’t able to reproduce this issue in my laptop, but I did add a piece of code to prevent Enter key action from doing anything. Hope it works.

**`Issue 6: If an association has a key, it could be listed as that value rather than Class[InstanceNumber] in the CRUD UI (The hover effect is probably good enough as is)`**
**Res:** 
Already fixed in previous PR
<img width="1530" height="676" alt="image" src="https://github.com/user-attachments/assets/d4a772c6-12e8-450a-9195-1560aaa10c0d" />


**Issues raised by Professor Timothy Lethbridge**
**`Issue 1: A secondary issue I noticed is that when editing the Association in class Person, I see Add /Edit instance in one heading, and below that another heading Associations that uses the same font. That makes it look as though the Associations might be for one of the existing objects. I think that the word 'Associations' needs to not be bold and say 'Associations from this instance'. `**
**Fix:**
Removed bold tag from Associations and renamed it to Associations from this instance.
<img width="1974" height="514" alt="image" src="https://github.com/user-attachments/assets/b66f0f6e-34e3-4a7d-852f-5b1750f519a0" />


**`Issue 2: Another thing I noticed: I think where it says Add / Edit Instance it should be changed to say 'Add Instance' in the normal case, and 'Edit Instance' if the edit action has been invoked. I think Edit Instance should be 'Edit Person[1] Instance'  or 'Edit Student[2] Instance ...`**
**Fix:**
The form now shows Add instance in normal case, and Edit classname[instance_index] Instance when edit action is invoked.
<img width="1974" height="514" alt="image" src="https://github.com/user-attachments/assets/c0b9a457-880b-4334-885a-d23aa3ecde18" />


























