### PR TITLE
Issue #2378: Render structured useCase requirements in the Plain Requirements Document

### DIFF
--- a/cruise.umple/src/generators/Generator_CodePlainRequirementsDoc.ump
+++ b/cruise.umple/src/generators/Generator_CodePlainRequirementsDoc.ump
@@ -59,7 +59,6 @@ class PlainRequirementsDocGenerator
 				String mainReqText = "";
 				if ("userStory".equals(req.getLanguage())) {
 					StringBuilder userStoryText = new StringBuilder();
-
 					if (req.getWho() != null && !req.getWho().equals("")) {
 						userStoryText.append("As ").append(req.getWho());
 					}
@@ -81,9 +80,57 @@ class PlainRequirementsDocGenerator
 						}
 						userStoryText.append("So that ").append(req.getWhy());
 					}
-
 					if (userStoryText.length() > 0) {
 						mainReqText = Requirement.translateToHTML(userStoryText.toString(), req.getLanguage());
+					}
+					else {
+						mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());
+					}
+				}
+				else if ("useCase".equals(req.getLanguage())) {
+					StringBuilder useCaseText = new StringBuilder();
+					if (req.getWho() != null && !req.getWho().equals("")) {
+						useCaseText.append("As ").append(req.getWho());
+					}
+					if (req.getWhen() != null && !req.getWhen().equals("")) {
+						if (useCaseText.length() > 0) {
+							useCaseText.append("<br/>");
+						}
+						useCaseText.append("When ").append(req.getWhen());
+					}
+					if (req.getWhat() != null && !req.getWhat().equals("")) {
+						if (useCaseText.length() > 0) {
+							useCaseText.append("<br/>");
+						}
+						useCaseText.append("I want ").append(req.getWhat());
+					}
+					if (req.getWhy() != null && !req.getWhy().equals("")) {
+						if (useCaseText.length() > 0) {
+							useCaseText.append("<br/>");
+						}
+						useCaseText.append("So that ").append(req.getWhy());
+					}
+					if (req.getStatement() != null && !req.getStatement().equals("")) {
+						if (useCaseText.length() > 0) {
+							useCaseText.append("<br/>");
+						}
+						useCaseText.append(req.getStatement());
+					}
+					for (int i = 0; i < req.numberOfUseCaseSteps(); i++) {
+						UseCaseStep step = req.getUseCaseStep(i);
+						if (useCaseText.length() > 0) {
+							useCaseText.append("<br/>");
+						}
+						if (step.getStepType() == UseCaseStep.UseCaseStepType.UserStep) {
+							useCaseText.append("User step ");
+						}
+						else {
+							useCaseText.append("System response ");
+						}
+						useCaseText.append(step.getId()).append(": ").append(step.getContent());
+					}
+					if (useCaseText.length() > 0) {
+						mainReqText = Requirement.translateToHTML(useCaseText.toString(), req.getLanguage());
 					}
 					else {
 						mainReqText = Requirement.translateToHTML(req.getStatement(), req.getLanguage());

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseMultipleSteps.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseMultipleSteps.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUseCaseMultipleSteps.ump
+</p><p><b>UC4: User step 1: select product<br/>System response 1: display price<br/>User step 2: enter quantity<br/>System response 2: update total</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseMultipleSteps.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseMultipleSteps.ump
@@ -1,0 +1,6 @@
+req UC4 useCase {
+  userStep 1 { select product }
+  systemResponse 1 { display price }
+  userStep 2 { enter quantity }
+  systemResponse 2 { update total }
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCasePlain.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCasePlain.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUseCasePlain.ump
+</p><p><b>UC1: Customer checks out items and the system calculates the total.</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCasePlain.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCasePlain.ump
@@ -1,0 +1,3 @@
+req UC1 useCase {
+  Customer checks out items and the system calculates the total.
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructured.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructured.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUseCaseStructured.ump
+</p><p><b>UC2: As customer<br/>When cart is ready<br/>I want complete checkout<br/>So that purchase selected items<br/>User step 1: confirm order<br/>System response 1: display total price</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructured.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructured.ump
@@ -1,0 +1,8 @@
+req UC2 useCase {
+  who { customer }
+  when { cart is ready }
+  what { complete checkout }
+  why { purchase selected items }
+  userStep 1 { confirm order }
+  systemResponse 1 { display total price }
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructuredPartial.html.txt
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructuredPartial.html.txt
@@ -1,0 +1,4 @@
+<html xmlns="https://www.w3.org/1999/xhtml"><p>Plain Requirements Doc from ReqUseCaseStructuredPartial.ump
+</p><p><b>UC3: As salesPerson<br/>User step 1: select product<br/>System response 1: display price</b>
+</p><p>&nbsp;NOT IMPLEMENTED.
+</p></html>

--- a/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructuredPartial.ump
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/ReqUseCaseStructuredPartial.ump
@@ -1,0 +1,5 @@
+req UC3 useCase {
+  who { salesPerson }
+  userStep 1 { select product }
+  systemResponse 1 { display price }
+}

--- a/cruise.umple/test/cruise/umple/implementation/requirements/RequirementsPlainTest.java
+++ b/cruise.umple/test/cruise/umple/implementation/requirements/RequirementsPlainTest.java
@@ -40,6 +40,10 @@ public class RequirementsPlainTest extends TemplateTest
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryStructured.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryStructuredPartial.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqUserStoryWhoOnly.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUseCasePlain.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUseCaseStructured.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUseCaseStructuredPartial.html");
+    SampleFileWriter.destroy(pathToInput + "/requirements/ReqUseCaseMultipleSteps.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqHideImpl.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqHideStatements.html");
     SampleFileWriter.destroy(pathToInput + "/requirements/ReqSortStat.html");
@@ -135,6 +139,27 @@ public class RequirementsPlainTest extends TemplateTest
   public void userStoryWhoOnly()
   {
     assertUmpleTemplateFor("requirements/ReqUserStoryWhoOnly.ump","requirements/ReqUserStoryWhoOnly.html.txt");
+  }
+
+  @Test
+  public void useCasePlain()
+  {
+    assertUmpleTemplateFor("requirements/ReqUseCasePlain.ump","requirements/ReqUseCasePlain.html.txt");
+  }
+  @Test
+  public void useCaseStructured()
+  {
+    assertUmpleTemplateFor("requirements/ReqUseCaseStructured.ump","requirements/ReqUseCaseStructured.html.txt");
+  }
+  @Test
+  public void useCaseStructuredPartial()
+  {
+    assertUmpleTemplateFor("requirements/ReqUseCaseStructuredPartial.ump","requirements/ReqUseCaseStructuredPartial.html.txt");
+  }
+  @Test
+  public void useCaseMultipleSteps()
+  {
+    assertUmpleTemplateFor("requirements/ReqUseCaseMultipleSteps.ump","requirements/ReqUseCaseMultipleSteps.html.txt");
   }
 
   @Test


### PR DESCRIPTION
This PR implements the output/documentation step of Issue #2378.

## Scope

Update the Plain Requirements Document generator so structured `useCase` requirements are rendered properly.

This PR adds output support for:

* shared structured fields:

  * `who`
  * `when`
  * `what`
  * `why`
* ordered use case steps:

  * `userStep`
  * `systemResponse`

## Changes

* Extended the Plain Requirements Document generator to render structured `useCase` requirements
* Preserved use case step ordering in the rendered output
* Kept backward compatibility for:

  * plain requirements
  * `userStory` requirements
* Added implementation tests for:

  * plain use cases
  * fully structured use cases
  * partially structured use cases
  * multi-step use cases

## Notes

This PR focuses only on output generation for `useCase` requirements as part of the incremental implementation of Issue #2378.
