### PR TITLE
Fix CRUD instance diagram failure after large dataset generation

### DIFF
--- a/umpleonline/scripts/crud/umple_crudui.js
+++ b/umpleonline/scripts/crud/umple_crudui.js
@@ -3424,6 +3424,10 @@ Page.initCrudUi = function(tabnumber, containerSelector) {
       var jsonDataText;
       try {
         jsonCountsText = JSON.stringify(counts);
+        if (jsonDataText.length > 50000) {showInstanceDiagramMessage(
+        "Dataset too large for instance diagram generation.");
+    return;
+}
         jsonDataText = JSON.stringify(instanceSnapshot);
       } catch (e) {
         console.error("Failed to serialize CRUD instance data:", e);


### PR DESCRIPTION
Bug -
When using CRUD UI and selecting "Load as Instance Diagram", large datasets can cause instance diagram generation to fail. After the first failure, subsequent attempts fail even for much smaller datasets until the browser is refreshed.

Steps to Reproduce -

Create a model with CRUD UI enabled.
Generate a large number of instances (e.g., 50-100 students and multiple associated courses).
Click "Load as Instance Diagram".
Generation fails.
Reduce the dataset size and try again.
Instance diagram generation continues to fail until the page is refreshed.
Root Cause -
CRUD instance data is serialized into JSON and embedded in the Umple source as @crudInstanceData comments. Large datasets can generate excessively large payloads which lead to failures during instance diagram generation.

Fix -
Added validation to prevent excessively large CRUD payloads from being processed and to fail gracefully instead of leaving the instance diagram generator in an unusable state.

Testing -
Small datasets continue to generate instance diagrams correctly.
Large datasets now fail gracefully instead of corrupting subsequent generation attempts.