### PR TITLE
Restrict generateDefault to allowed values to prevent XSS

### DIFF
--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -129,9 +129,27 @@ if (isset($_REQUEST["model"]) && explode("-", $_REQUEST["model"])[0] == "task")
 }
 
 //
-$generateDefault="#genclass";
-if (isset($_REQUEST['generateDefault']) && $_REQUEST["generateDefault"] != "") {
-  $generateDefault="#gen".strip_tags($_REQUEST['generateDefault']);
+$generateDefault = "#genclass";
+
+$allowedGenerateDefaults = array(
+    "java",
+    "javadoc",
+    "php",
+    "cpp",
+    "ruby",
+    "sql",
+    "metrics",
+    "alloy",
+    "nusmv",
+    "uigu2"
+);
+
+if (isset($_REQUEST['generateDefault']) && $_REQUEST["generateDefault"] !== "") {
+    $requested = trim($_REQUEST["generateDefault"]);
+
+    if (in_array($requested, $allowedGenerateDefaults, true)) {
+        $generateDefault = "#gen" . $requested;
+    }
 }
 
 $output = $dataHandle->readData('model.ump');

--- a/umpleonline/umple.php
+++ b/umpleonline/umple.php
@@ -130,17 +130,23 @@ if (isset($_REQUEST["model"]) && explode("-", $_REQUEST["model"])[0] == "task")
 
 //
 $generateDefault = "#genclass";
-
+// The following correspond to the options in $generatemenu of compiler_config.php
 $allowedGenerateDefaults = array(
     "java",
     "javadoc",
     "php",
+    "python",
     "cpp",
     "ruby",
     "sql",
     "metrics",
     "alloy",
     "nusmv",
+    "statetables",
+    "eventsequence",
+    "plainrequirementsdoc",
+    "plainrequirementsdocqc",
+    "UmpleAnnotaiveToComposition",
     "uigu2"
 );
 


### PR DESCRIPTION
This PR addresses Bug Bounty Issue #2 by validating the `generateDefault`
request parameter against the supported generator options.

- Added a whitelist of valid `generateDefault` values.
- Invalid values now fall back to the existing default (`#genclass`).