### PR TITLE
Fixes #2466 sync Live View selector on example load

### DIFF
--- a/umpleonline/scripts/umple_action.js
+++ b/umpleonline/scripts/umple_action.js
@@ -4667,29 +4667,36 @@ Action.loadExample = function loadExample()
   var diagramType="";
   if(Page.useGvStateDiagram) {
     diagramType="&diagramtype=state";
+    Action.setLiveView("sd");
   }
  else if(Page.useGvFeatureDiagram) {
     diagramType="&diagramtype=GvFeature";
+    Action.setLiveView("gfd");
   }
 
   else if(Page.useGvEntityRelationshipDiagram) {
     diagramType="&diagramtype=entityRelationshipDiagram";
+    Action.setLiveView("erd");
   }
 
   else if(Page.useInstanceDiagram) {
     diagramType="&diagramtype=instanceDiagram";
+    Action.setLiveView("instanceDiagram");
   }
 
 
   else if(Page.useStateTables) {
     diagramType="&diagramtype=StateTables";
+    Action.setLiveView("stateTables");
   }
 
   else if(Page.useEventSequence) {
     diagramType="&diagramtype=eventSequence";
+    Action.setLiveView("eventSequence");
   }
   else if(Page.useStructureDiagram) {
     diagramType="&diagramtype=structure&generateDefault=cpp";
+    Action.setLiveView("std");
   }
   else {
     diagramType="&diagramtype=GvClass";


### PR DESCRIPTION
Bug -
"Live View" dropdown selection doesn't update when switching to a different example that changes the diagram type. The backend correctly switches diagram type, but the UI dropdown still shows the previous selection.

Steps to Reproduce -

Open the UmpleOnline website.
In Examples, select Feature Diagram → Feature Dependencies...
After the example loads, check the Live View dropdown in the top-left corner.

Root Cause -
Action.loadExample only called Action.setLiveView on the default GvClass branch. The other seven diagram-type branches (state, feature, ERD, instance, state tables, event sequence, structure) set the backend diagramType correctly but never synced the #liveViewSelector dropdown, so it kept showing the previous selection after an example loaded a different diagram type.

Fix -
Added the matching Action.setLiveView(...) call to each branch, using the option codes already defined in umple.php's #liveViewSelector.

Testing -
Verified manually in-browser: loaded examples across Feature/State/ERD/Instance/State Tables/Event Sequence/Structure categories and confirmed the Live View dropdown now updates correctly in each case. The existing default GvClass path was unaffected.