### PR TITLE
Prevent arbitrary file creation through filename validation

### DIFF
--- a/umpleonline/scripts/compiler.php
+++ b/umpleonline/scripts/compiler.php
@@ -36,6 +36,17 @@ if (isset($_REQUEST["save"]))
     if(isset($_REQUEST["filename"]))
     {
       $filename = basename($_REQUEST['filename']);
+      $allowedExtensions = array( 
+    'ump',
+    'svg',
+);
+      $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+      if (!in_array($extension, $allowedExtensions, true)) {
+          http_response_code(400);
+          echo "Invalid file type."; 
+          exit;
+}
+ 
       $modelId = dirname($_REQUEST['filename']);
       $dataHandle = dataStore()->openData($modelId);
       $dataHandle->writeData($filename, $input);


### PR DESCRIPTION
This change prevents arbitrary file creation by validating user-supplied filenames before saving uploaded files.

Only supported file extensions ('.ump' and '.svg') are accepted. Requests with unsupported extensions are rejected with an HTTP 400 response.

Tested:
- Successfully saved a valid `.svg` file.
- Attempted to save `shell.php` and received `HTTP 400 Bad Request`.